### PR TITLE
Optimizing ByChained#findElement

### DIFF
--- a/common/src/web/byChainedTest.html
+++ b/common/src/web/byChainedTest.html
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>ByChained Test Page</title>
+</head>
+<body>
+
+<div id=nav">
+  <div id="elem1" name="cheese">
+    <div id="elem3" name="photo"></div>
+  </div>
+</div>
+
+<div id="elem2" name="cheese">
+  <div id="elem5" name="click"></div>
+</div>
+
+</body>
+</html>

--- a/java/client/src/org/openqa/selenium/support/pagefactory/ByChained.java
+++ b/java/client/src/org/openqa/selenium/support/pagefactory/ByChained.java
@@ -49,10 +49,37 @@ public class ByChained extends By implements Serializable {
 
   @Override
   public WebElement findElement(SearchContext context) {
-    List<WebElement> elements = findElements(context);
-    if (elements.isEmpty())
-      throw new NoSuchElementException("Cannot locate an element using " + toString());
-    return elements.get(0);
+    if (bys.length == 0) {
+      throw new NoSuchElementException("Cannot locate an element: "
+                                       + "no Bys were specified in this ByChained");
+    }
+    if (bys.length == 1) {
+      return context.findElement(bys[0]);
+    }
+
+    List<WebElement> elements = bys[0].findElements(context);
+    for (WebElement element : elements) {
+      WebElement leftMostLeaf = findLeftMostLeaf(element, 1);
+      if (leftMostLeaf != null) {
+        return leftMostLeaf;
+      }
+    }
+    throw new NoSuchElementException("Cannot locate an element using " + toString());
+  }
+
+  private WebElement findLeftMostLeaf(WebElement root, int i) {
+    if (i == bys.length) { // reached max depth: found!
+      return root;
+    }
+
+    List<WebElement> children = root.findElements(bys[i]); // find elements at depth i
+    for (WebElement child : children) {
+      WebElement leftMostLeaf = findLeftMostLeaf(child, i + 1);
+      if (leftMostLeaf != null) {
+        return leftMostLeaf;
+      }
+    }
+    return null; // wrong path: could not reach max depth
   }
 
   @Override

--- a/java/client/src/org/openqa/selenium/support/pagefactory/ByChained.java
+++ b/java/client/src/org/openqa/selenium/support/pagefactory/ByChained.java
@@ -54,7 +54,7 @@ public class ByChained extends By implements Serializable {
                                        + "no Bys were specified in this ByChained");
     }
     if (bys.length == 1) {
-      return context.findElement(bys[0]);
+      return bys[0].findElement(context);
     }
 
     int maxDepthReached = 0;

--- a/java/client/test/org/openqa/selenium/Pages.java
+++ b/java/client/test/org/openqa/selenium/Pages.java
@@ -77,6 +77,7 @@ public class Pages {
   public String veryLargeCanvas;
   public String xhtmlFormPage;
   public String xhtmlTestPage;
+  public String byChainedPage;
 
   public Pages(AppServer appServer) {
     ajaxyPage = appServer.whereIs("ajaxy_page.html");
@@ -136,5 +137,6 @@ public class Pages {
     userDefinedProperty = appServer.whereIs("userDefinedProperty.html");
     veryLargeCanvas = appServer.whereIs("veryLargeCanvas.html");
     xhtmlTestPage = appServer.whereIs("xhtmlTest.html");
+    byChainedPage = appServer.whereIs("byChainedTest.html");
   }
 }

--- a/java/client/test/org/openqa/selenium/support/LargeTests.java
+++ b/java/client/test/org/openqa/selenium/support/LargeTests.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.support;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.openqa.selenium.support.pagefactory.ByChainedIntegrationTest;
 import org.openqa.selenium.support.pagefactory.UsingPageFactoryTest;
 import org.openqa.selenium.support.ui.SelectElementTest;
 import org.openqa.selenium.support.ui.SelectLargeTest;
@@ -28,7 +29,8 @@ import org.openqa.selenium.testing.JUnit4TestBase;
 @Suite.SuiteClasses({
     SelectLargeTest.class,
     UsingPageFactoryTest.class,
-    SelectElementTest.class
+    SelectElementTest.class,
+    ByChainedIntegrationTest.class
 })
 public class LargeTests {
 

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedIntegrationTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedIntegrationTest.java
@@ -1,0 +1,116 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.support.pagefactory;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.testing.JUnit4TestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ByChainedIntegrationTest extends JUnit4TestBase {
+
+  @Before
+  public void loadPage() {
+    driver.get(pages.byChainedPage);
+  }
+
+  @Test
+  public void findElementOneBy() {
+    ByChained by = new ByChained(By.name("cheese"));
+    assertThat(by.findElement(driver).getAttribute("id"), equalTo("elem1"));
+  }
+
+  @Test
+  public void findElementsOneBy() {
+    ByChained by = new ByChained(By.name("cheese"));
+
+    List<WebElement> foundElements = by.findElements(driver);
+    List<String> ids = new ArrayList<>();
+    for (WebElement foundElement : foundElements) {
+      ids.add(foundElement.getAttribute("id"));
+    }
+    assertThat(ids, contains("elem1", "elem2"));
+  }
+
+  @Test
+  public void findElementOneByEmpty() {
+    ByChained by = new ByChained(By.name("no-elements-with-this-name"));
+    try {
+      by.findElement(driver);
+      fail("Expected NoSuchElementException!");
+    } catch (NoSuchElementException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void findElementsOneByEmpty() {
+    ByChained by = new ByChained(By.name("no-elements-with-this-name"));
+    assertThat(by.findElements(driver), is(empty()));
+  }
+
+  @Test
+  public void findElementTwoBy() {
+    ByChained by = new ByChained(By.name("cheese"), By.name("photo"));
+    assertThat(by.findElement(driver).getAttribute("id"), equalTo("elem3"));
+  }
+
+  @Test
+  public void findElementTwoByEmptyParent() {
+    ByChained by = new ByChained(By.name("no-elements-with-this-name"), By.name("photo"));
+    try {
+      by.findElement(driver);
+      fail("Expected NoSuchElementException!");
+    } catch (NoSuchElementException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void findElementsTwoByEmptyParent() {
+    ByChained by = new ByChained(By.name("no-elements-with-this-name"), By.name("photo"));
+    assertThat(by.findElements(driver), is(empty()));
+  }
+
+  @Test
+  public void findElementTwoByEmptyChild() {
+    ByChained by = new ByChained(By.name("cheese"), By.name("click"));
+    assertThat(by.findElement(driver).getAttribute("id"), equalTo("elem5"));
+  }
+
+  @Test
+  public void findElementsTwoByEmptyChild() {
+    ByChained by = new ByChained(By.name("cheese"), By.name("click"));
+    List<WebElement> foundElements = by.findElements(driver);
+    assertThat(foundElements, hasSize(1));
+    assertThat(foundElements.get(0).getAttribute("id"), equalTo("elem5"));
+  }
+}

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.support.pagefactory;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -188,6 +189,7 @@ public class ByChainedTest {
       fail("Expected NoSuchElementException!");
     } catch (NoSuchElementException e) {
       // Expected
+      assertThat(e.getMessage(), containsString("no elements found by the locator #1"));
     }
   }
 

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
@@ -71,13 +71,8 @@ public class ByChainedTest {
   public void findElementOneBy() {
     final AllDriver driver = mock(AllDriver.class);
     final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(WebElement.class, "webElement2");
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
 
-    when(driver.findElementsByName("cheese")).thenReturn(elems12);
-    when(driver.findElement(By.name("cheese"))).thenReturn(elem1);
+    when(By.name("cheese").findElement(driver)).thenReturn(elem1);
 
     ByChained by = new ByChained(By.name("cheese"));
     assertThat(by.findElement(driver), equalTo(elem1));
@@ -101,10 +96,8 @@ public class ByChainedTest {
   @Test
   public void findElementOneByEmpty() {
     final AllDriver driver = mock(AllDriver.class);
-    final List<WebElement> elems = new ArrayList<>();
 
-    when(driver.findElementsByName("cheese")).thenReturn(elems);
-    when(driver.findElement(By.name("cheese"))).thenThrow(new NoSuchElementException("simulated"));
+    when(By.name("cheese").findElement(driver)).thenThrow(new NoSuchElementException("simulated"));
 
     ByChained by = new ByChained(By.name("cheese"));
     try {

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
@@ -20,7 +20,10 @@ package org.openqa.selenium.support.pagefactory;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
@@ -148,6 +151,11 @@ public class ByChainedTest {
 
     ByChained by = new ByChained(By.name("cheese"), By.name("photo"));
     assertThat(by.findElement(driver), equalTo(elem3));
+
+    verify(elem2, never()).findElements(any(By.class));
+    verify(elem3, never()).findElements(any(By.class));
+    verify(elem4, never()).findElements(any(By.class));
+    verify(elem5, never()).findElements(any(By.class));
   }
 
   @Test
@@ -269,6 +277,31 @@ public class ByChainedTest {
 
     ByChained by = new ByChained(By.name("cheese"), By.name("photo"));
     assertThat(by.findElements(driver), equalTo(elems5));
+  }
+
+  @Test
+  public void findElementTwoByEmptyChildren() {
+    final AllDriver driver = mock(AllDriver.class);
+    final WebElement elem1 = mock(WebElement.class, "webElement1");
+    final WebElement elem2 = mock(AllElement.class, "webElement2");
+
+    final List<WebElement> elems = new ArrayList<>();
+    final List<WebElement> elems12 = new ArrayList<>();
+    elems12.add(elem1);
+    elems12.add(elem2);
+
+    when(driver.findElementsByName("cheese")).thenReturn(elems12);
+    when(elem1.findElements(By.name("photo"))).thenReturn(elems);
+    when(elem2.findElements(By.name("photo"))).thenReturn(elems);
+
+    ByChained by = new ByChained(By.name("cheese"), By.name("photo"));
+    try {
+      by.findElement(driver);
+      fail("should throw: the second by in the chain is not returning any elements");
+    } catch (NoSuchElementException e) {
+      // Expected
+      assertThat(e.getMessage(), containsString("no elements found by the locator #2"));
+    }
   }
 
   @Test

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
@@ -73,6 +73,7 @@ public class ByChainedTest {
     elems12.add(elem2);
 
     when(driver.findElementsByName("cheese")).thenReturn(elems12);
+    when(driver.findElement(By.name("cheese"))).thenReturn(elem1);
 
     ByChained by = new ByChained(By.name("cheese"));
     assertThat(by.findElement(driver), equalTo(elem1));
@@ -99,6 +100,7 @@ public class ByChainedTest {
     final List<WebElement> elems = new ArrayList<>();
 
     when(driver.findElementsByName("cheese")).thenReturn(elems);
+    when(driver.findElement(By.name("cheese"))).thenThrow(new NoSuchElementException("simulated"));
 
     ByChained by = new ByChained(By.name("cheese"));
     try {


### PR DESCRIPTION
- optimize complexity: instead of traversing the entire "tree"
  of partial WebElements found, only travers the left-most path
- in case the bys list is empty, throw an exception with a more meaningful message

Not sure if you like the

```
assert elem != null;
```

I seem to have some issues in running the tests. They are failing, even on master. I guess it must be due to my env (?).
OSX 10.10.2, Java 1.8.0_40
Also tried java 6 but it didnt seem to help

```
Compiling: //java/client/test/org/openqa/selenium:SmallTests as build/java/client/test/org/openqa/selenium/SmallTests.jar
mkdir -p build/java/client/test/org/openqa/selenium/SmallTests.jar_temp
Compiling 1 source file to /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/SmallTests.jar_temp
Building jar: /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/SmallTests.jar
rm -rf build/java/client/test/org/openqa/selenium/SmallTests.jar_temp
** Execute //java/client/test/org/openqa/selenium:SmallTests
** Execute //java/client/test/org/openqa/selenium:SmallTests:run
Testing: //java/client/test/org/openqa/selenium:SmallTests
mkdir -p build/test_logs
Listening for transport dt_socket at address: 5005
Running org.openqa.selenium.SmallTests
Exception in thread "Thread-20" org.openqa.selenium.WebDriverException: Thread safety error; this instance of WebDriver was constructed on thread main (id 1) and is being accessed by thread Thread-20 (id 35)This is not permitted and *will* cause undefined behaviour
Build info: version: '2.45.0', revision: '17dc63a', time: '2015-03-26 03:09:18'
System info: host: 'albs-MacBook-Air.local', ip: '192.168.0.25', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.10.2', java.version: '1.8.0_40'
Driver info: driver.version: unknown
    at org.openqa.selenium.support.ThreadGuard$WebDriverInvocationHandler.invoke(ThreadGuard.java:86)
    at com.sun.proxy.$Proxy22.findElement(Unknown Source)
    at org.openqa.selenium.support.ThreadGuardTest$1.run(ThreadGuardTest.java:44)
    at java.lang.Thread.run(Thread.java:745)
Tests run: 345, Failures: 0, Errors: 0, Time elapsed: 1.831 sec
** Invoke test_support (first_time)
** Invoke //java/client/test/org/openqa/selenium/lift:test:run (first_time)
** Invoke //java/client/test/org/openqa/selenium/lift:test
** Execute //java/client/test/org/openqa/selenium/lift:test:run
Testing: //java/client/test/org/openqa/selenium/lift:test
mkdir -p build/test_logs
Listening for transport dt_socket at address: 5005
Running org.openqa.selenium.lift.SmallTests
Tests run: 23, Failures: 0, Errors: 0, Time elapsed: 0.394 sec
** Invoke //java/client/test/org/openqa/selenium/support:SmallTests:run (first_time)
** Invoke //java/client/test/org/openqa/selenium/support:SmallTests (first_time)
** Invoke build/java/client/test/org/openqa/selenium/support/SmallTests.jar (first_time)
** Invoke //java/client/test/org/openqa/selenium/support:tests
** Invoke java/client/test/org/openqa/selenium/support/SmallTests.java (not_needed)
** Execute build/java/client/test/org/openqa/selenium/support/SmallTests.jar
rm -rf build/java/client/test/org/openqa/selenium/support/SmallTests.jar_temp
Exception `Errno::ENOENT' at org/jruby/RubyFile.java:1729 - No such file or directory - build/java/client/test/org/openqa/selenium/support/SmallTests.jar_temp
Compiling: //java/client/test/org/openqa/selenium/support:SmallTests as build/java/client/test/org/openqa/selenium/support/SmallTests.jar
mkdir -p build/java/client/test/org/openqa/selenium/support/SmallTests.jar_temp
Compiling 1 source file to /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/support/SmallTests.jar_temp
Building jar: /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/support/SmallTests.jar
rm -rf build/java/client/test/org/openqa/selenium/support/SmallTests.jar_temp
** Execute //java/client/test/org/openqa/selenium/support:SmallTests
** Execute //java/client/test/org/openqa/selenium/support:SmallTests:run
Testing: //java/client/test/org/openqa/selenium/support:SmallTests
mkdir -p build/test_logs
Listening for transport dt_socket at address: 5005
Running org.openqa.selenium.support.SmallTests
Tests run: 181, Failures: 0, Errors: 0, Time elapsed: 1.158 sec
Exception in thread "Thread-1" org.openqa.selenium.WebDriverException: Thread safety error; this instance of WebDriver was constructed on thread main (id 1) and is being accessed by thread Thread-1 (id 12)This is not permitted and *will* cause undefined behaviour
Build info: version: '2.45.0', revision: '17dc63a', time: '2015-03-26 03:09:18'
System info: host: 'albs-MacBook-Air.local', ip: '192.168.0.25', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.10.2', java.version: '1.8.0_40'
Driver info: driver.version: unknown
    at org.openqa.selenium.support.ThreadGuard$WebDriverInvocationHandler.invoke(ThreadGuard.java:86)
    at com.sun.proxy.$Proxy20.findElement(Unknown Source)
    at org.openqa.selenium.support.ThreadGuardTest$1.run(ThreadGuardTest.java:44)
    at java.lang.Thread.run(Thread.java:745)
** Invoke //java/client/test/org/openqa/selenium/support:LargeTests:run (first_time)
** Invoke //java/client/test/org/openqa/selenium/support:LargeTests (first_time)
** Invoke build/java/client/test/org/openqa/selenium/support/LargeTests.jar (first_time)
** Invoke //java/client/test/org/openqa/selenium/support:tests
** Invoke java/client/test/org/openqa/selenium/support/LargeTests.java (not_needed)
** Execute build/java/client/test/org/openqa/selenium/support/LargeTests.jar
rm -rf build/java/client/test/org/openqa/selenium/support/LargeTests.jar_temp
Exception `Errno::ENOENT' at org/jruby/RubyFile.java:1729 - No such file or directory - build/java/client/test/org/openqa/selenium/support/LargeTests.jar_temp
Compiling: //java/client/test/org/openqa/selenium/support:LargeTests as build/java/client/test/org/openqa/selenium/support/LargeTests.jar
mkdir -p build/java/client/test/org/openqa/selenium/support/LargeTests.jar_temp
Compiling 1 source file to /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/support/LargeTests.jar_temp
Building jar: /Users/alb/workspace/selenium/build/java/client/test/org/openqa/selenium/support/LargeTests.jar
rm -rf build/java/client/test/org/openqa/selenium/support/LargeTests.jar_temp
** Execute //java/client/test/org/openqa/selenium/support:LargeTests
** Execute //java/client/test/org/openqa/selenium/support:LargeTests:run
Testing: //java/client/test/org/openqa/selenium/support:LargeTests
mkdir -p build/test_logs
Listening for transport dt_socket at address: 5005
Running org.openqa.selenium.support.LargeTests
Mar 26, 2015 3:12:14 AM org.openqa.selenium.testing.JUnit4TestBase$1 starting
INFO: >>> Starting selectByVisibleTextShouldNormalizeSpaces(org.openqa.selenium.support.ui.SelectLargeTest)
2015-03-26 03:12:14.709:INFO:osjs.Server:jetty-7.x.y-SNAPSHOT
2015-03-26 03:12:14.744:INFO:osjsh.ContextHandler:started o.s.j.s.ServletContextHandler{/common,file:/Users/alb/workspace/selenium/common/src/web/}
2015-03-26 03:12:14.748:INFO:/common:Aliases are enabled
2015-03-26 03:12:14.749:INFO:osjsh.ContextHandler:started o.s.j.s.ServletContextHandler{/javascript,file:/Users/alb/workspace/selenium/javascript/}
2015-03-26 03:12:14.751:INFO:/javascript:Aliases are enabled
2015-03-26 03:12:14.752:INFO:osjsh.ContextHandler:started o.s.j.s.ServletContextHandler{/third_party/closure/goog,file:/Users/alb/workspace/selenium/third_party/closure/goog/}
2015-03-26 03:12:14.752:INFO:/third_party/closure/goog:Aliases are enabled
2015-03-26 03:12:14.752:INFO:osjsh.ContextHandler:started o.s.j.s.ServletContextHandler{/third_party/js,file:/Users/alb/workspace/selenium/third_party/js/}
2015-03-26 03:12:14.752:INFO:/third_party/js:Aliases are enabled
2015-03-26 03:12:14.778:INFO:osjs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:34396
2015-03-26 03:12:14.996:INFO:osjus.SslContextFactory:Enabled Protocols [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2] of [SSLv2Hello, SSLv3, TLSv1, TLSv1.1, TLSv1.2]
2015-03-26 03:12:15.007:INFO:osjs.AbstractConnector:Started SslSocketConnector@0.0.0.0:20733
Tests run: 5, Failures: 0, Errors: 5, Time elapsed: 0.757 sec
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 finished
INFO: <<< Finished selectByVisibleTextShouldNormalizeSpaces(org.openqa.selenium.support.ui.SelectLargeTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 starting
INFO: >>> Starting multipleSelectShouldBePossibleIfMulitpleAttributeEmpty(org.openqa.selenium.support.ui.SelectLargeTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 finished
INFO: <<< Finished multipleSelectShouldBePossibleIfMulitpleAttributeEmpty(org.openqa.selenium.support.ui.SelectLargeTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 starting
INFO: >>> Starting canListDecoratedElements(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 finished
INFO: <<< Finished canListDecoratedElements(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 starting
INFO: >>> Starting testDecoratedElementsShouldBeUnwrapped(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 finished
INFO: <<< Finished testDecoratedElementsShouldBeUnwrapped(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 starting
INFO: >>> Starting canExecuteJsUsingDecoratedElements(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
Mar 26, 2015 3:12:15 AM org.openqa.selenium.testing.JUnit4TestBase$1 finished
INFO: <<< Finished canExecuteJsUsingDecoratedElements(org.openqa.selenium.support.pagefactory.UsingPageFactoryTest)
go aborted!
org.apache.tools.ant.BuildException: Test org.openqa.selenium.support.LargeTests failed
```
