### PR TITLE
Ensure Firefox capabilities are proper instance by default

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/bridge.rb
+++ b/rb/lib/selenium/webdriver/firefox/bridge.rb
@@ -28,7 +28,7 @@ module Selenium
           http_client = opts.delete(:http_client)
           proxy       = opts.delete(:proxy)
 
-          caps = opts.delete(:desired_capabilities) || {}
+          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.firefox }
 
           @launcher = create_launcher(port, profile)
 


### PR DESCRIPTION
This fixes a regression introduced with https://github.com/SeleniumHQ/selenium/commit/00801a07 when default capabilities is an instance of `Hash`, while it should be `Remote::Capabilities`.

Fixes currently failing spec:

```
  1) Selenium::WebDriver::Firefox::Bridge sets the proxy capability
     Failure/Error: Bridge.new(:http_client => http, :proxy => proxy)
     NoMethodError:
       undefined method `proxy=' for {}:Hash
     # ./build/rb/lib/selenium/webdriver/firefox/bridge.rb:41:in `initialize'
     # ./rb/spec/unit/selenium/webdriver/firefox/bridge_spec.rb:41:in `new'
     # ./rb/spec/unit/selenium/webdriver/firefox/bridge_spec.rb:41:in `block (2 levels) in <module:Firefox>'
```
