### PR TITLE
Restore encoding magic comment which broke Ruby 1.8 and Ruby 1.9

### DIFF
--- a/rb/CHANGES
+++ b/rb/CHANGES
@@ -9,6 +9,9 @@ Firefox:
   * Support for Firefox 38
   * Fix performance bug by not forcing garbage collection in httpd.js
 
+Chrome:
+  * Fixed ChromeDriver port race condition (#449 - thanks Jason Anderson)
+
 Ruby changes:
   * Retry binding to ports unavailable by EADDRNOTAVAIL (#394).
   * Remove Presto-Opera support (Blink-based Opera still supported)

--- a/rb/lib/selenium/webdriver/common/keys.rb
+++ b/rb/lib/selenium/webdriver/common/keys.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Licensed to the Software Freedom Conservancy (SFC) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/rb/spec/integration/selenium/client/api/screenshot_spec.rb
+++ b/rb/spec/integration/selenium/client/api/screenshot_spec.rb
@@ -1,3 +1,5 @@
+# encoding: binary
+
 # Licensed to the Software Freedom Conservancy (SFC) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
We also need to release `2.46.2` with this fix because `#send_keys` is broken on Ruby 1.8 and Ruby 1.9.
