### PR TITLE
java: clean up ByAll: remove #findElement

### DIFF
--- a/java/client/src/org/openqa/selenium/support/pagefactory/ByAll.java
+++ b/java/client/src/org/openqa/selenium/support/pagefactory/ByAll.java
@@ -48,15 +48,6 @@ public class ByAll extends By implements Serializable {
   }
 
   @Override
-  public WebElement findElement(SearchContext context) {
-    List<WebElement> elements = findElements(context);
-    if (elements.isEmpty()) {
-      throw new NoSuchElementException("Cannot locate an element using " + toString());
-    }
-    return elements.get(0);
-  }
-
-  @Override
   public List<WebElement> findElements(SearchContext context) {
     List<WebElement> elems = new ArrayList<>();
     for (By by : bys) {


### PR DESCRIPTION
..as it duplicates the super version.

There is one difference actually.
`By#findElement` checks the return of #findElements for null, in which case throws NoSuchEl.
Whereas ByAll#findElement didn't.
Unless it was meant, it shouldn't be a concern.
