### PR TITLE
Handled AttributeError with ImportError for IronPython Support

### DIFF
--- a/py/selenium/selenium.py
+++ b/py/selenium/selenium.py
@@ -21,12 +21,12 @@ __docformat__ = "restructuredtext en"
 
 try:
     import http.client as http_client
-except ImportError:
+except (ImportError, AttributeError):
     import httplib as http_client
 
 try:
     import urllib.parse as urllib_parse
-except ImportError:
+except (ImportError, AttributeError):
     import urllib as urllib_parse
 
 class selenium(object):

--- a/py/selenium/webdriver/chrome/service.py
+++ b/py/selenium/webdriver/chrome/service.py
@@ -105,7 +105,7 @@ class Service(object):
         #Tell the Server to die!
         try:
             from urllib import request as url_request
-        except ImportError:
+        except (ImportError, AttributeError):
             import urllib2 as url_request
 
         url_request.urlopen("http://127.0.0.1:%d/shutdown" % self.port)

--- a/py/selenium/webdriver/common/utils.py
+++ b/py/selenium/webdriver/common/utils.py
@@ -60,7 +60,7 @@ def is_url_connectable(port):
     """
     try:
         from urllib import request as url_request
-    except ImportError:
+    except (ImportError, AttributeError):
         import urllib2 as url_request
 
     try:

--- a/py/selenium/webdriver/firefox/firefox_binary.py
+++ b/py/selenium/webdriver/firefox/firefox_binary.py
@@ -110,7 +110,7 @@ class FirefoxBinary(object):
     def _find_exe_in_registry(self):
         try:
             from _winreg import OpenKey, QueryValue, HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER
-        except ImportError:
+        except (ImportError, AttributeError):
             from winreg import OpenKey, QueryValue, HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER
         import shlex
         keys = (

--- a/py/selenium/webdriver/firefox/firefox_profile.py
+++ b/py/selenium/webdriver/firefox/firefox_profile.py
@@ -28,7 +28,7 @@ import zipfile
 
 try:
     from cStringIO import StringIO as BytesIO
-except ImportError:
+except (ImportError, AttributeError):
     from io import BytesIO
 
 from xml.dom import minidom

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -92,7 +92,7 @@ class Service(object):
         #Tell the Server to die!
         '''try:
             from urllib import request as url_request
-        except ImportError:
+        except (ImportError, AttributeError):
             import urllib2 as url_request
 
         url_request.urlopen("http://127.0.0.1:%d/shutdown" % self.port)

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -18,7 +18,7 @@
 
 try:
     import http.client as http_client
-except ImportError:
+except (ImportError, AttributeError):
     import httplib as http_client
 
 import shutil

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -89,7 +89,7 @@ class Service(object):
         #Tell the Server to die!
         try:
             from urllib import request as url_request
-        except ImportError:
+        except (ImportError, AttributeError):
             import urllib2 as url_request
 
         url_request.urlopen("http://127.0.0.1:%d/shutdown" % self.port)

--- a/py/selenium/webdriver/opera/webdriver.py
+++ b/py/selenium/webdriver/opera/webdriver.py
@@ -17,7 +17,7 @@
 
 try:
     import http.client as http_client
-except ImportError:
+except (ImportError, AttributeError):
     import httplib as http_client
 
 import os

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -24,7 +24,7 @@ try:
     import http.client as httplib
     from urllib import request as url_request
     from urllib import parse
-except ImportError: # above is available in py3+, below is py2.7
+except (ImportError, AttributeError): # above is available in py3+, below is py2.7
     import httplib as httplib
     import urllib2 as url_request
     import urlparse as parse

--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -20,7 +20,7 @@ import os
 import zipfile
 try:
     from StringIO import StringIO as IOStream
-except ImportError:  # 3+
+except (ImportError, AttributeError):  # 3+
     from io import BytesIO as IOStream
 import base64
 

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -19,7 +19,7 @@ import base64
 
 try:
     import http.client as http_client
-except ImportError:
+except (ImportError, AttributeError):
     import httplib as http_client
 
 import os

--- a/py/test/selenium/webdriver/common/webserver.py
+++ b/py/test/selenium/webdriver/common/webserver.py
@@ -25,11 +25,11 @@ import threading
 from io import open
 try:
     from urllib import request as urllib_request
-except ImportError:
+except (ImportError, AttributeError):
     import urllib as urllib_request
 try:
     from http.server import BaseHTTPRequestHandler, HTTPServer
-except ImportError:
+except (ImportError, AttributeError):
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 def updir():

--- a/py/test/selenium/webdriver/firefox/ff_profile_tests.py
+++ b/py/test/selenium/webdriver/firefox/ff_profile_tests.py
@@ -22,7 +22,7 @@ import zipfile
 
 try:
     from io import BytesIO
-except ImportError:
+except (ImportError, AttributeError):
     from cStringIO import StringIO as BytesIO
 
 try:

--- a/py/test/selenium/webdriver/support/event_firing_webdriver_tests.py
+++ b/py/test/selenium/webdriver/support/event_firing_webdriver_tests.py
@@ -18,7 +18,7 @@
 import unittest
 try:
     from io import BytesIO
-except ImportError:
+except (ImportError, AttributeError):
     from cStringIO import StringIO as BytesIO
 
 from selenium.common.exceptions import NoSuchElementException


### PR DESCRIPTION
IronPython raises AttributeError instead of ImportError exception when checking for Python 3 Import Errors. This change handles both ImportError and AttributeError when check doing imports with exception checks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/761)
<!-- Reviewable:end -->
