### PR TITLE
firefox: Throw error when element cannot be clicked

### DIFF
--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -26,6 +26,15 @@ describe "Element" do
     driver.find_element(:id, "imageButton").click
   end
 
+  compliant_on :browser => [:chrome, :firefox] do
+    it "should raise if different element receives click" do
+      driver.navigate.to url_for("click_tests/overlapping_elements.html")
+      expect { driver.find_element(:id, "contents").click }
+        .to raise_error(Selenium::WebDriver::Error::UnknownError,
+          /Element is not clickable at point \(\d+, \d+\)\. Other element would receive the click: <div id="over"><\/div>/)
+    end
+  end
+
   # Marionette BUG - AutomatedTester: "known bug with execute script"
   not_compliant_on :driver => :marionette do
     it "should submit" do


### PR DESCRIPTION
Current behavior is that when element is overlapped by another one,
trying to click it will silent fail because click is happening on
overlapping element. This commit changes the behavior so instead error
is thrown telling that overlapping element would receive click. It makes
the behavior mostly similar to ChromeDriver.

I've implemented this after it was [mentioned on IRC](https://botbot.me/freenode/selenium/2015-10-23/?msg=52586420&page=3) that this behavior might make sense and after a bunch of issues were reported (#1202, #1204, #1166).

That is my first time I deal with FirefoxDriver, so the code may not be the best. Also, there is now some duplication with `webdriver.chrome.isElementClickable` function so maybe it makes sense to DRY it up. Also, since I don't have much experience with Java/JavaScript testing of Selenium, it was easier for me to add regression test in Ruby.

@barancev @lukeis Please, take a look.
