### PR TITLE
changing default node id behavior to match ProxyStatusServlet

### DIFF
--- a/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
+++ b/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
@@ -139,7 +139,7 @@ public class BaseRemoteProxy implements RemoteProxy {
       this.id = id;
     } else {
       // otherwise assign the remote host as id.
-      this.id = remoteHost.toExternalForm();
+      this.id = id = "http://" + remoteHost.getHost() + ":" + remoteHost.getPort();
     }
 
     maxConcurrentSession = getConfigInteger(RegistrationRequest.MAX_SESSION);

--- a/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
+++ b/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
@@ -139,7 +139,7 @@ public class BaseRemoteProxy implements RemoteProxy {
       this.id = id;
     } else {
       // otherwise assign the remote host as id.
-      this.id = id = "http://" + remoteHost.getHost() + ":" + remoteHost.getPort();
+      this.id = "http://" + remoteHost.getHost() + ":" + remoteHost.getPort();
     }
 
     maxConcurrentSession = getConfigInteger(RegistrationRequest.MAX_SESSION);


### PR DESCRIPTION
Fixes an issue where if remoteHost has a trailing slash the node will constantly re-register itself because the status servlet strips slashes and registration does not. This caused much frustration trying to setup a docker based grid on multiple hosts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/1252)
<!-- Reviewable:end -->
