### PR TITLE
Created ExpectedCondition that checks if an element is clickable

### DIFF
--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -225,10 +225,13 @@ class clickability_of(object):
         self.element = element
 
     def __call__(self, driver):
-        element = visibility_of(self.element)(driver)
-        if element and element.is_enabled():
-            return element
-        else:
+        try:
+            element = visibility_of(self.element)(driver)
+            if element and element.is_enabled():
+                return element
+            else:
+                return False
+        except StaleElementReferenceException:
             return False
 
 

--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -217,6 +217,21 @@ class element_to_be_clickable(object):
             return False
 
 
+class clickability_of(object):
+    """ An Expectation for checking an element is visible and enabled such that
+    you can click it."""
+
+    def __init__(self, element):
+        self.element = element
+
+    def __call__(self, driver):
+        element = visibility_of(self.element)(driver)
+        if element and element.is_enabled():
+            return element
+        else:
+            return False
+
+
 class staleness_of(object):
     """ Wait until an element is no longer attached to the DOM.
     element is the element to wait for.

--- a/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -251,6 +251,17 @@ class WebDriverWaitTest(unittest.TestCase):
         WebDriverWait(self.driver, 3.5).until(EC.invisibility_of_element_located((By.ID, 'clickToHide')))
         self.assertFalse(element.is_displayed())
 
+    def testExpectedConditionClickabilityOf(self):
+        self._loadPage("javascriptPage")
+        with self.assertRaises(TimeoutException):
+            element = self.driver.find_element_by_id('clickToHide')
+            WebDriverWait(self.driver, 0.7).until(EC.clickability_of(element))
+        self.driver.execute_script("delayedShowHide(200, true)")
+        element = self.driver.find_element_by_id('clickToHide')
+        WebDriverWait(self.driver, 0.7).until(EC.clickability_of(element)).click()
+        WebDriverWait(self.driver, 3.5).until(EC.invisibility_of_element_located((By.ID, 'clickToHide')))
+        self.assertFalse(element.is_displayed())
+
     def testExpectedConditionStalenessOf(self):
         self._loadPage('dynamicallyModifiedPage')
         element = self.driver.find_element_by_id('element-to-remove')


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

This `expected condition` checks if a `WebElement` is clickable. Much like `element_to_be_clickable` except it takes a `WebElement` instead of a `locator`.
Made following the `Java` implementation of this `expected condition` which can be found [here](https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java#L675)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/2356)
<!-- Reviewable:end -->
