### PR TITLE
py: break Mobile and SwitchTo reference cycle with weakref proxy.

### DIFF
--- a/py/selenium/webdriver/remote/mobile.py
+++ b/py/selenium/webdriver/remote/mobile.py
@@ -43,7 +43,8 @@ class Mobile(object):
     AIRPLANE_MODE = ConnectionType(1)
 
     def __init__(self, driver):
-        self._driver = driver
+        from weakref import proxy
+        self._driver = proxy(driver)
 
     @property
     def network_connection(self):

--- a/py/selenium/webdriver/remote/switch_to.py
+++ b/py/selenium/webdriver/remote/switch_to.py
@@ -21,7 +21,8 @@ from selenium.webdriver.common.alert import Alert
 
 class SwitchTo:
     def __init__(self, driver):
-        self._driver = driver
+        from weakref import proxy
+        self._driver = proxy(driver)
 
     @property
     def active_element(self):


### PR DESCRIPTION
- [X ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Browser now closes immediately when driver object is deleted.

Not tested with full test suite, but it's a patch I have been using for a while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/2425)
<!-- Reviewable:end -->
