### PR TITLE
Fix javadocs

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.remote.html5.RemoteWebStorage;
  * This class is provided as a convenience for easily testing the Chrome browser. The control server
  * which each instance communicates with will live and die with the instance.
  *
+ * <p>
  * To avoid unnecessarily restarting the ChromeDriver server with each instance, use a
  * {@link RemoteWebDriver} coupled with the desired {@link ChromeDriverService}, which is managed
  * separately. For example: <pre>{@code

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -40,25 +40,16 @@ import org.openqa.selenium.remote.html5.RemoteWebStorage;
  * <p>
  * To avoid unnecessarily restarting the ChromeDriver server with each instance, use a
  * {@link RemoteWebDriver} coupled with the desired {@link ChromeDriverService}, which is managed
- * separately. For example: <pre>{@code
+ * separately. For example:
  *
- * import static org.junit.Assert.assertEquals;
- *
- * import org.junit.*;
- * import org.junit.runner.RunWith;
- * import org.junit.runners.JUnit4;
- * import org.openqa.selenium.chrome.ChromeDriverService;
- * import org.openqa.selenium.remote.DesiredCapabilities;
- * import org.openqa.selenium.remote.RemoteWebDriver;
- *
- * {@literal @RunWith(JUnit4.class)}
- * public class ChromeTest extends TestCase {
+ * <pre>
+ * public class ChromeTest {
  *
  *   private static ChromeDriverService service;
  *   private WebDriver driver;
  *
- *   {@literal @BeforeClass}
- *   public static void createAndStartService() {
+ *   &#064;BeforeClass
+ *   public static void createAndStartService() throws IOException {
  *     service = new ChromeDriverService.Builder()
  *         .usingDriverExecutable(new File("path/to/my/chromedriver.exe"))
  *         .usingAnyFreePort()
@@ -66,32 +57,32 @@ import org.openqa.selenium.remote.html5.RemoteWebStorage;
  *     service.start();
  *   }
  *
- *   {@literal @AfterClass}
- *   public static void createAndStopService() {
+ *   &#064;AfterClass
+ *   public static void stopService() {
  *     service.stop();
  *   }
  *
- *   {@literal @Before}
+ *   &#064;Before
  *   public void createDriver() {
  *     driver = new RemoteWebDriver(service.getUrl(),
  *         DesiredCapabilities.chrome());
  *   }
  *
- *   {@literal @After}
+ *   &#064;After
  *   public void quitDriver() {
  *     driver.quit();
  *   }
  *
- *   {@literal @Test}
+ *   &#064;Test
  *   public void testGoogleSearch() {
  *     driver.get("http://www.google.com");
  *     WebElement searchBox = driver.findElement(By.name("q"));
- *     searchBox.sendKeys("webdriver");
- *     searchBox.quit();
- *     assertEquals("webdriver - Google Search", driver.getTitle());
+ *     searchBox.sendKeys("webdriver" + Keys.ENTER);
+ *     new WebDriverWait(driver, 5).until(
+ *        ExpectedConditions.titleIs("webdriver - Google Search"));
  *   }
  * }
- * }</pre>
+ * </pre>
  *
  * Note that unlike ChromeDriver, RemoteWebDriver doesn't directly implement
  * role interfaces such as {@link LocationContext} and {@link WebStorage}.

--- a/java/client/src/org/openqa/selenium/edge/EdgeDriver.java
+++ b/java/client/src/org/openqa/selenium/edge/EdgeDriver.java
@@ -18,8 +18,6 @@ package org.openqa.selenium.edge;
 
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.edge.EdgeDriverService;
-import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.service.DriverCommandExecutor;
 
@@ -30,25 +28,16 @@ import org.openqa.selenium.remote.service.DriverCommandExecutor;
  *
  * To avoid unnecessarily restarting the MicrosoftEdgeDriver server with each instance, use a
  * {@link RemoteWebDriver} coupled with the desired {@link EdgeDriverService}, which is managed
- * separately. For example: <pre>{@code
+ * separately. For example:
  *
- * import static org.junit.Assert.assertEquals;
- *
- * import org.junit.*;
- * import org.junit.runner.RunWith;
- * import org.junit.runners.JUnit4;
- * import org.openqa.selenium.edge.EdgeDriverService;
- * import org.openqa.selenium.remote.DesiredCapabilities;
- * import org.openqa.selenium.remote.RemoteWebDriver;
- *
- * {@literal @RunWith(JUnit4.class)}
- * public class EdgeTest extends TestCase {
+ * <pre>
+ * public class EdgeTest {
  *
  *   private static EdgeDriverService service;
  *   private WebDriver driver;
  *
- *   {@literal @BeforeClass}
- *   public static void createAndStartService() {
+ *   &#064;BeforeClass
+ *   public static void createAndStartService() throws IOException {
  *     service = new EdgeDriverService.Builder()
  *         .usingDriverExecutable(new File("path/to/my/MicrosoftWebDriver.exe"))
  *         .usingAnyFreePort()
@@ -56,32 +45,32 @@ import org.openqa.selenium.remote.service.DriverCommandExecutor;
  *     service.start();
  *   }
  *
- *   {@literal @AfterClass}
- *   public static void createAndStopService() {
+ *   &#064;AfterClass
+ *   public static void stopService() {
  *     service.stop();
  *   }
  *
- *   {@literal @Before}
+ *   &#064;Before
  *   public void createDriver() {
  *     driver = new RemoteWebDriver(service.getUrl(),
  *         DesiredCapabilities.edge());
  *   }
  *
- *   {@literal @After}
+ *   &#064;After
  *   public void quitDriver() {
  *     driver.quit();
  *   }
  *
- *   {@literal @Test}
+ *   &#064;Test
  *   public void testGoogleSearch() {
  *     driver.get("http://www.google.com");
  *     WebElement searchBox = driver.findElement(By.name("q"));
- *     searchBox.sendKeys("webdriver");
- *     searchBox.quit();
- *     assertEquals("webdriver - Google Search", driver.getTitle());
+ *     searchBox.sendKeys("webdriver" + Keys.ENTER);
+ *     new WebDriverWait(driver, 5).until(
+ *        ExpectedConditions.titleIs("webdriver - Google Search"));
  *   }
  * }
- * }</pre>
+ * </pre>
  *
  *
  * @see EdgeDriverService#createDefaultService
@@ -140,7 +129,7 @@ public class EdgeDriver extends RemoteWebDriver {
 	  public EdgeDriver(EdgeDriverService service, EdgeOptions options) {
 	    this(service, options.toCapabilities());
 	  }
-	  
+
 	  /**
 	   * Creates a new EdgeDriver instance. The {@code service} will be started along with the
 	   * driver, and shutdown upon calling {@link #quit()}.

--- a/java/client/src/org/openqa/selenium/lift/HamcrestWebDriverTestCase.java
+++ b/java/client/src/org/openqa/selenium/lift/HamcrestWebDriverTestCase.java
@@ -97,8 +97,13 @@ public abstract class HamcrestWebDriverTestCase extends TestCase {
   }
 
   /**
-   * Syntactic sugar to use with {@link org.openqa.selenium.lift.HamcrestWebDriverTestCase}, e.g.
-   * type("cheese", into(textbox())); The into() method simply returns its argument.
+   * Syntactic sugar to use with
+   * {@link org.openqa.selenium.lift.HamcrestWebDriverTestCase#type(String, Finder)},
+   * e.g.
+   * <pre>
+   * type("cheese", into(textbox()));
+   * </pre>
+   * The into() method simply returns its argument.
    *
    * @param input finder input
    * @return the finder

--- a/java/client/src/org/openqa/selenium/net/NetworkInterfaceProvider.java
+++ b/java/client/src/org/openqa/selenium/net/NetworkInterfaceProvider.java
@@ -20,7 +20,7 @@ package org.openqa.selenium.net;
 
 /**
  * Provides information about the local network interfaces.
- *
+ * <p>
  * Basically an abstraction created to allow stubbing of java.net.NetworkInterface, also soothes
  * some of the jdk1.2 idioms from this interface into jdk1.5 idioms.
  */

--- a/java/client/src/org/openqa/selenium/opera/OperaDriver.java
+++ b/java/client/src/org/openqa/selenium/opera/OperaDriver.java
@@ -39,25 +39,16 @@ import org.openqa.selenium.remote.service.DriverCommandExecutor;
  * <p>
  * To avoid unnecessarily restarting the OperaDriver server with each instance, use a
  * {@link RemoteWebDriver} coupled with the desired {@link OperaDriverService}, which is managed
- * separately. For example: <pre>{@code
+ * separately. For example:
  *
- * import static org.junit.Assert.assertEquals;
- *
- * import org.junit.*;
- * import org.junit.runner.RunWith;
- * import org.junit.runners.JUnit4;
- * import org.openqa.selenium.opera.OperaDriverService;
- * import org.openqa.selenium.remote.DesiredCapabilities;
- * import org.openqa.selenium.remote.RemoteWebDriver;
- *
- * {@literal @RunWith(JUnit4.class)}
- * public class OperaTest extends TestCase {
+ * <pre>
+ * public class OperaTest {
  *
  *   private static OperaDriverService service;
  *   private WebDriver driver;
  *
- *   {@literal @BeforeClass}
- *   public static void createAndStartService() {
+ *   &#064;BeforeClass
+ *   public static void createAndStartService() throws IOException {
  *     service = new OperaDriverService.Builder()
  *         .usingDriverExecutable(new File("path/to/my/operadriver.exe"))
  *         .usingAnyFreePort()
@@ -65,32 +56,32 @@ import org.openqa.selenium.remote.service.DriverCommandExecutor;
  *     service.start();
  *   }
  *
- *   {@literal @AfterClass}
- *   public static void createAndStopService() {
+ *   &#064;AfterClass
+ *   public static void stopService() {
  *     service.stop();
  *   }
  *
- *   {@literal @Before}
+ *   &#064;Before
  *   public void createDriver() {
  *     driver = new RemoteWebDriver(service.getUrl(),
  *         DesiredCapabilities.opera());
  *   }
  *
- *   {@literal @After}
+ *   &#064;After
  *   public void quitDriver() {
  *     driver.quit();
  *   }
  *
- *   {@literal @Test}
+ *   &#064;Test
  *   public void testGoogleSearch() {
  *     driver.get("http://www.google.com");
  *     WebElement searchBox = driver.findElement(By.name("q"));
- *     searchBox.sendKeys("webdriver");
- *     searchBox.quit();
- *     assertEquals("webdriver - Google Search", driver.getTitle());
+ *     searchBox.sendKeys("webdriver" + Keys.ENTER);
+ *     new WebDriverWait(driver, 5).until(
+ *        ExpectedConditions.titleIs("webdriver - Google Search"));
  *   }
  * }
- * }</pre>
+ * </pre>
  *
  * Note that unlike OperaDriver, RemoteWebDriver doesn't directly implement
  * role interfaces such as {@link LocationContext} and {@link WebStorage}.

--- a/java/client/src/org/openqa/selenium/opera/OperaDriver.java
+++ b/java/client/src/org/openqa/selenium/opera/OperaDriver.java
@@ -36,6 +36,7 @@ import org.openqa.selenium.remote.service.DriverCommandExecutor;
  * machine. This class is provided as a convenience for easily testing the Chrome browser. The
  * control server which each instance communicates with will live and die with the instance.
  *
+ * <p>
  * To avoid unnecessarily restarting the OperaDriver server with each instance, use a
  * {@link RemoteWebDriver} coupled with the desired {@link OperaDriverService}, which is managed
  * separately. For example: <pre>{@code

--- a/java/client/src/org/openqa/selenium/support/FindBy.java
+++ b/java/client/src/org/openqa/selenium/support/FindBy.java
@@ -37,17 +37,17 @@ import java.lang.annotation.Target;
  *
  * For example, these two annotations point to the same element:
  *
- * <pre>{@code
+ * <pre>
  * &#64;FindBy(id = "foobar") WebElement foobar;
  * &#64;FindBy(how = How.ID, using = "foobar") WebElement foobar;
- * }</pre>
+ * </pre>
  *
  * and these two annotations point to the same list of elements:
  *
- * <pre>{@code
+ * <pre>
  * &#64;FindBy(tagName = "a") List<WebElement> links;
  * &#64;FindBy(how = How.TAG_NAME, using = "a") List<WebElement> links;
- * }</pre>
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})

--- a/java/client/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/client/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -47,15 +47,16 @@ import java.util.concurrent.TimeUnit;
  * element on the page.
  *
  * <p>
- * Sample usage: <pre>
+ * Sample usage:
+ * <pre>
  *   // Waiting 30 seconds for an element to be present on the page, checking
  *   // for its presence once every 5 seconds.
- *   Wait{@literal<WebDriver>} wait = new FluentWait{@literal<WebDriver>}(driver)
+ *   Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
  *       .withTimeout(30, SECONDS)
  *       .pollingEvery(5, SECONDS)
  *       .ignoring(NoSuchElementException.class);
  *
- *   WebElement foo = wait.until(new Function{@literal<WebDriver, WebElement>}() {
+ *   WebElement foo = wait.until(new Function<WebDriver, WebElement>() {
  *     public WebElement apply(WebDriver driver) {
  *       return driver.findElement(By.id("foo"));
  *     }


### PR DESCRIPTION
Various fixes to javadocs.

In particular, fix how '@' (for annotations) is rendered in code samples. See e.g.
- http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/chrome/ChromeDriver.html
- http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/FindBy.html

[X ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/2447)
<!-- Reviewable:end -->
