### PR TITLE
add "driverClass" in GridNodeConfiguration(-nodeConfig) capabilities

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
@@ -19,10 +19,13 @@ package org.openqa.selenium.remote.server;
 
 import com.beust.jcommander.JCommander;
 
+import org.openqa.grid.internal.utils.configuration.GridNodeConfiguration;
 import org.openqa.grid.internal.utils.configuration.StandaloneConfiguration;
 import org.openqa.grid.shared.GridNodeServer;
 import org.openqa.grid.web.servlet.DisplayHelpServlet;
 import org.openqa.grid.web.servlet.beta.ConsoleServlet;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.server.handler.DeleteSession;
 import org.seleniumhq.jetty9.server.Connector;
@@ -110,6 +113,20 @@ public class SeleniumServer implements GridNodeServer {
     ServletContextHandler handler = new ServletContextHandler();
 
     driverSessions = new DefaultDriverSessions();
+    if( configuration  instanceof GridNodeConfiguration ){
+        GridNodeConfiguration nodeConf =    (GridNodeConfiguration)configuration;
+        for( DesiredCapabilities  capabilities : nodeConf.capabilities){
+            final String driverClass = (String)capabilities.getCapability("driverClass");
+            if(driverClass != null){
+                try {
+                     Class<WebDriver> driver = ( Class<WebDriver>)Class.forName(driverClass);
+                    driverSessions.registerDriver(capabilities, driver);
+                } catch (ClassNotFoundException e) {
+                     e.printStackTrace();
+                }
+            }
+        }
+    }
     handler.setAttribute(DriverServlet.SESSIONS_KEY, driverSessions);
     handler.setContextPath("/");
     handler.addServlet(DriverServlet.class, "/wd/hub/*");


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

add "driverClass" for declare the  driver of this browser capabilities

eg:
```
{
	  "platform": "WINDOWS",
          "browserName": "opera",
	 "driverClass": "org.openqa.selenium.opera.OperaDriver",
          "maxInstances": 1,
		  "version":"36",
		  "javascriptEnabled":true,
		  "parallelSupport":false,
		  "opera.no_quit":false,
		  "operaOptions": {
		     "args":[ "--check-for-update-interval=0","--ignore-certificate-errors"],
			"binary":"E:/web-browsers/OperaPortable36/App/Opera/36.0.2130.80/opera.exe"
		   }
         }

```