### PR TITLE
Enable extension of RemoteWebDriver and HttpCommandExecutor

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -364,6 +364,10 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor,
     return capabilities;
   }
 
+  protected void setCapabilities(Capabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+
   public void get(String url) {
     execute(DriverCommand.GET, ImmutableMap.of("url", url));
   }
@@ -559,7 +563,7 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor,
   }
 
   public Object executeScript(String script, Object... args) {
-    if (!capabilities.is(SUPPORTS_JAVASCRIPT)) {
+    if (!getCapabilities().is(SUPPORTS_JAVASCRIPT)) {
       throw new UnsupportedOperationException(
           "You must be using an underlying instance of WebDriver that supports executing javascript");
     }
@@ -596,7 +600,7 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor,
   }
 
   private boolean isJavascriptEnabled() {
-    return capabilities.is(SUPPORTS_JAVASCRIPT);
+    return getCapabilities().is(SUPPORTS_JAVASCRIPT);
   }
 
   public TargetLocator switchTo() {

--- a/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -288,7 +288,7 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor,
       returnedCapabilities.setCapability(SUPPORTS_JAVASCRIPT, true);
     }
 
-    capabilities = returnedCapabilities;
+    setCapabilities(returnedCapabilities);
     sessionId = new SessionId(response.getSessionId());
   }
 


### PR DESCRIPTION
The ability to implement sub-classes of RemoteWebDriver and
HttpCommandExecutor in the Java client is very limited, since these
classes have private data members, with no protected accessors.
In order to increase the extensibility of these classes, protected
accessors were added, and methods that accessed these fields directly
were changed to use these accessors.

The fields that are now accessible by sub-classes are:
RemoteWebDriver.capabilities
HttpCommandExecutor.commandCodec
HttpCommandExecutor.responseCodec
HttpCommandExecutor.client

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
