### PR TITLE
Update atoms to reflect Chrome TouchEvent support.

### DIFF
--- a/javascript/atoms/events.js
+++ b/javascript/atoms/events.js
@@ -62,7 +62,7 @@ bot.events.BROKEN_TOUCH_API_ = (function() {
     // Native touch api supported starting in version 4.0 (Ice Cream Sandwich).
     return !bot.userAgent.isProductVersion(4);
   }
-  return !bot.userAgent.IOS;
+  return !bot.userAgent.IOS && !goog.userAgent.product.CHROME;
 })();
 
 
@@ -588,7 +588,7 @@ bot.events.TouchEventFactory_.prototype.create = function(target, opt_args) {
   } else if (strategy == bot.events.TouchEventStrategy_.INIT_TOUCH_EVENT) {
     event = doc.createEvent('TouchEvent');
     // Different browsers have different implementations of initTouchEvent.
-    if (event.initTouchEvent.length == 0) {
+    if (goog.userAgent.product.ANDROID || goog.userAgent.product.CHROME) {
       // Chrome/Android.
       event.initTouchEvent(touches, targetTouches, changedTouches,
           this.type_, view, /*screenX*/ 0, /*screenY*/ 0, args.clientX,


### PR DESCRIPTION
Update atoms to reflect Chrome TouchEvent support.
The previous events.js logic breaks mobile Safari
because initTouchEvent.length == 0 on mobile Safari,
causing it to go erroneously down the Chrome/Android
path. This logic used to break Chrome Mobile
Emulation of ios, but not that Chrome now lacks the
initTouchEvent entirely (relies completely on the
TouchEvent constructor), we can return to the
original user agent checks without breaking Chrome
Mobile Emulation.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/4528)
<!-- Reviewable:end -->
