### PR TITLE
Add a replacement for Platform: OperatingSystem

### DIFF
--- a/java/client/src/org/openqa/selenium/OS.java
+++ b/java/client/src/org/openqa/selenium/OS.java
@@ -1,0 +1,73 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium;
+
+/**
+ * Represents an Operating System that Selenium is running on. This is designed to support an OS
+ * that is unknown at compile time, and can be populated from a {@link Capabilities} object.
+ */
+public class OS {
+
+  private final String family;
+  private final String name;
+  private final String version;
+
+  public OS(Capabilities capabilities) {
+    String family = null;
+    String name = null;
+    String version = null;
+
+    // JSON Wire Protocol
+    Object raw = capabilities.getCapability("platform");
+    if (raw instanceof Platform) {
+      Platform platform = (Platform) raw;
+      if (platform.family() == null) {
+        family = platform.toString().toLowerCase();
+      } else {
+        family = platform.family().toString().toLowerCase();
+      }
+    }
+
+    // W3C Protocol
+
+    // SafariDriver
+
+    // Appium
+
+    // SauceLabs
+
+    // BrowserStack
+
+
+    this.family = family;
+    this.name = name;
+    this.version = version;
+  }
+
+  public String getFamily() {
+    return family;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+}

--- a/java/client/test/org/openqa/selenium/OSTest.java
+++ b/java/client/test/org/openqa/selenium/OSTest.java
@@ -1,0 +1,49 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+public class OSTest {
+
+  @Test
+  public void shouldConvertAPlatformFamilyToAnOsFamily() {
+    Capabilities caps = new ImmutableCapabilities(ImmutableMap.of("platform", Platform.WINDOWS ));
+    OS os = new OS(caps);
+
+    assertEquals("windows", os.getFamily());
+    assertNull(os.getName());
+    assertNull(os.getVersion());
+  }
+
+  @Test
+  public void shouldGetPlatformNameFromPlatformEnum() {
+    Capabilities caps = new ImmutableCapabilities(ImmutableMap.of("platform", Platform.SIERRA));
+    OS os = new OS(caps);
+
+    assertEquals("mac", os.getFamily());
+    assertEquals("sierra", os.getName());
+    assertEquals("10.12", os.getVersion());
+  }
+
+}


### PR DESCRIPTION
This is designed to allow us talk about different
Operating Systems in a meaningful way without needing
to rely on an enum.

- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
