### PR TITLE
Guard messages

### DIFF
--- a/rake-tasks/crazy_fun/mappings/ruby.rb
+++ b/rake-tasks/crazy_fun/mappings/ruby.rb
@@ -79,6 +79,7 @@ class RubyMappings
 
   class AddTestDependencies < Tasks
     def handle(_fun, dir, args)
+      ENV['RB_GO_EXECUTION'] = 'true'
       task = Rake::Task[task_name(dir, "#{args[:name]}-test")]
 
       if args.has_key?(:deps)

--- a/rb/spec/integration/selenium/webdriver/guard_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/guard_spec.rb
@@ -1,0 +1,161 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative 'spec_helper'
+
+module Selenium
+  module WebDriver
+    module SpecSupport
+      # This is for example purposes to describe behavior, it requires tests to fail and should only be run manually
+      xdescribe Guards do
+        context 'chrome' do
+          context 'only' do
+            it 'guards failing test as pending when only excludes', only: {browser: :not_chrome} do
+              fail
+            end
+
+            it 'fails failing test when only includes', only: {browser: :chrome} do
+              fail
+            end
+
+            it 'fails passing test when only excludes', only: {browser: :not_chrome} do
+              # do not fail me
+            end
+
+            it 'passes passing test when only includes', only: {browser: :chrome} do
+              # do not fail me
+            end
+
+          end
+
+          context 'except' do
+            it 'guards failing test as pending when except includes', except: {browser: :chrome} do
+              fail
+            end
+
+            it 'fails failing test when except excludes', except: {browser: :not_chrome} do
+              fail
+            end
+
+            it 'fails passing test as fixed when except includes', except: {browser: :chrome} do
+              # do not fail me
+            end
+
+            it 'passes passing test when except excludes', except: {browser: :not_chrome} do
+              # do not fail me
+            end
+          end
+
+          context 'mixed' do
+            it 'guards failing test when both exclude', only: {browser: :not_chrome}, except: {browser: :not_chrome} do
+              # :only overrides :except
+              fail
+            end
+
+            it 'guards failing test when both includes', only: {browser: :chrome}, except: {browser: :chrome} do
+              # :except overrides :only
+              fail
+            end
+
+            it 'fails passing test as fixed when both exclude', only: {browser: :not_chrome}, except: {browser: :not_chrome} do
+              # :only overrides :except
+              # do not fail me
+            end
+
+            it 'fails passing test as fixed when both includes', only: {browser: :chrome}, except: {browser: :chrome} do
+              # :except overrides :only
+              # do not fail me
+            end
+          end
+
+          context 'order independent' do
+            it 'guards failing test when both exclude', except: {browser: :not_chrome}, only: {browser: :not_chrome} do
+              # :only overrides :except
+              fail
+            end
+
+            it 'guards failing test when both includes', except: {browser: :chrome}, only: {browser: :chrome} do
+              # :except overrides :only
+              fail
+            end
+
+            it 'fails passing test as fixed when both exclude', except: {browser: :not_chrome}, only: {browser: :not_chrome} do
+              # :only overrides :except
+              # do not fail me
+            end
+
+            it 'fails passing test as fixed when both includes', except: {browser: :chrome}, only: {browser: :chrome} do
+              # :except overrides :only
+              # do not fail me
+            end
+          end
+
+          context 'multiple' do
+            # Throws warning when two parameters of same keyword are used
+            # Only recognizes the second one
+          end
+
+          context 'arrays' do
+            it 'guards failing test if any only exclude in an array', only: [{browser: :chrome}, {browser: :not_chrome}] do
+              fail
+            end
+
+            it 'guards failing test if any except include in an array', except: [{browser: :chrome}, {browser: :not_chrome}] do
+              fail
+            end
+
+            it 'fails passing test as fixed if any only exclude in an array', only: [{browser: :chrome}, {browser: :not_chrome}] do
+              # do not fail me
+            end
+
+            it 'fails passing test as fixed if any except include in an array', except: [{browser: :chrome}, {browser: :not_chrome}] do
+              # do not fail me
+            end
+          end
+
+          context 'guard messages on failing tests' do
+            before { fail }
+
+            it 'gives correct message with single only excludes', only: {browser: :not_chrome}, message: 'w3c implementation' do
+            end
+
+            it 'uses default if no message is passed', only: {browser: :not_chrome} do
+            end
+
+            it 'gives correct message with single except includes', except: {browser: :chrome}, message: 'chrome bug' do
+            end
+
+            it 'gives only applicable message when multiple excludes',  except: {browser: :not_chrome}, only: {browser: :not_chrome}, message: ['not_chrome bug', 'w3c implementation'] do
+            end
+
+            it 'gives only applicable message with multiple includes', except: {browser: :chrome}, only: {browser: :chrome}, message: ['chrome bug', 'limited to chrome'] do
+            end
+
+            it 'gives only applicable message with multiple exclude in an array', only: [{browser: :chrome}, {browser: :not_chrome}], message: ['limited to chrome', 'w3c implementation'] do
+            end
+
+            it 'gives only applicable message with multiple include in an array', except: [{browser: :chrome}, {browser: :not_chrome}], message: ['chrome bug', 'not_chrome bug'] do
+            end
+
+            it 'gives all applicable messages with mixed include and except', except: {browser: :chrome}, only: {browser: :not_chrome}, message: ['chrome bug', 'w3c implementation'] do
+            end
+          end
+        end
+      end
+    end # SpecSupport
+  end # WebDriver
+end # Selenium

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -50,7 +50,12 @@ RSpec.configure do |c|
     if matched.any?(&:skip?)
       skip message.empty? ? 'Bug Prevents Execution' : message.to_s
     elsif matched.any?(&:pending?)
-      pending message.empty? ? 'Guarded' : message.to_s
+      msg = message.empty? ? 'Guarded' : message.to_s
+      if matched.map(&:type).include?(:only) && ENV['RB_GO_EXECUTION'] != 'true'
+        skip(msg)
+      else
+        pending(msg)
+      end
     end
   end
 

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -43,10 +43,14 @@ RSpec.configure do |c|
 
   c.before do |example|
     guards = WebDriver::SpecSupport::Guards.new(example)
-    if guards.exclude.any?
-      skip 'Bug Prevents Execution.'
-    elsif guards.except.satisfied.any? || guards.only.unsatisfied.any?
-      pending 'Guarded.'
+
+    matched = guards.matched
+    message = matched.each_with_object([]) { |m, a| a << m.message if m.message }
+
+    if matched.any?(&:skip?)
+      skip message.empty? ? 'Bug Prevents Execution' : message.to_s
+    elsif matched.any?(&:pending?)
+      pending message.empty? ? 'Guarded' : message.to_s
     end
   end
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
@@ -20,7 +20,7 @@ module Selenium
     module SpecSupport
       class Guards
         class Guard
-          attr_accessor :skip, :pending, :message
+          attr_accessor :skip, :pending, :message, :type
 
           def initialize(guard, type, message = nil)
             @type = type

--- a/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
@@ -20,12 +20,15 @@ module Selenium
     module SpecSupport
       class Guards
         class Guard
-          def initialize(guard, type)
+          attr_accessor :skip, :pending, :message
+
+          def initialize(guard, type, message = nil)
             @type = type
 
             @drivers = []
             @browsers = []
             @platforms = []
+            @message = message
 
             set_window_manager(guard)
             expand_drivers(guard)
@@ -47,6 +50,14 @@ module Selenium
 
           def satisfied?
             satisfies_driver? && satisfies_browser? && satisfies_platform? && satisfies_window_manager?
+          end
+
+          def skip?
+            @skip
+          end
+
+          def pending?
+            @pending
           end
 
           private


### PR DESCRIPTION
I added specs that specify behavior but have to be run manually because it requires verifying tests are failing, which kind of defeats the purpose of having them in the test suite.

The idea is to try to encourage each guard to be for the same reason, and add a message to explain why (ideally URL to bug  report)
This implementation would require guards to be placed in same order as `GUARD_TYPES` (alphabetically), and each guard to have a matching message (or a `nil`).

I was going to add more info in the message about which guard applied, but thought this was a better place to start at least.

This also allows to continue skipping non-applicable specs when running via RSpec or RubyMine directly. (`./go` only executes certain folders, where running `rspec` directly will attempt to run and pending out the Firefox tests using Chrome, etc)

I'm not sure when the `#uniq` is necessary when constructing the guard array. I didn't test the `example_group` thoroughly, does that result in multiple of the same guard in places? That might break this implementation. Let me know your feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/5074)
<!-- Reviewable:end -->
