### PR TITLE
Preparing chrome driver to download in headless mode

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -179,9 +179,9 @@ public class ChromeDriver extends RemoteWebDriver
   @Deprecated
   public ChromeDriver(ChromeDriverService service, Capabilities capabilities) {
     super(new ChromeDriverCommandExecutor(service), capabilities);
-    if (capabilities.getCapability("chromium:enableDownloading") instanceof String) {
+    if (capabilities.getCapability("chromium:enableDownloadTo") instanceof String) {
       sendCommandForDownloadChromeHeadless(
-          (String) capabilities.getCapability("chromium:enableDownloading"));
+          (String) capabilities.getCapability("chromium:enableDownloadTo"));
     }
     locationContext = new RemoteLocationContext(getExecuteMethod());
     webStorage = new RemoteWebStorage(getExecuteMethod());

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -30,7 +30,6 @@ import org.openqa.selenium.html5.WebStorage;
 import org.openqa.selenium.interactions.HasTouchScreen;
 import org.openqa.selenium.interactions.TouchScreen;
 import org.openqa.selenium.mobile.NetworkConnection;
-import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteTouchScreen;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -173,19 +172,19 @@ public class ChromeDriver extends RemoteWebDriver
    * Creates a new ChromeDriver instance. The {@code service} will be started along with the
    * driver, and shutdown upon calling {@link #quit()}.
    *
-   * @param service The service to use.
+   * @param service      The service to use.
    * @param capabilities The capabilities required from the ChromeDriver.
    * @deprecated Use {@link ChromeDriver(ChromeDriverService, ChromeOptions)} instead.
    */
   @Deprecated
   public ChromeDriver(ChromeDriverService service, Capabilities capabilities) {
     super(new ChromeDriverCommandExecutor(service), capabilities);
-    if (capabilities.getCapability("enableDownloading")!=null){
-      sendCommandForDownloadChromeHeadLess(
-          (String) capabilities.getCapability("enableDownloading"));
+    if (capabilities.getCapability("chromium:enableDownloading") instanceof String) {
+      sendCommandForDownloadChromeHeadless(
+          (String) capabilities.getCapability("chromium:enableDownloading"));
     }
     locationContext = new RemoteLocationContext(getExecuteMethod());
-    webStorage = new  RemoteWebStorage(getExecuteMethod());
+    webStorage = new RemoteWebStorage(getExecuteMethod());
     touchScreen = new RemoteTouchScreen(getExecuteMethod());
     networkConnection = new RemoteNetworkConnection(getExecuteMethod());
   }
@@ -243,15 +242,11 @@ public class ChromeDriver extends RemoteWebDriver
 
   /**
    * Send command for browser to allow downloading in headless mode
-   *
-   * @param downloadPath
    */
-  public void sendCommandForDownloadChromeHeadLess(String downloadPath) {
-    if (downloadPath.length()>0){
-      execute(DriverCommand.SEND_COMMAND_TO_BROWSER,
-              ImmutableMap.of("cmd", "Page.setDownloadBehavior",
-                              "params",
-                              ImmutableMap.of("behavior", "allow","downloadPath", downloadPath)));
-    }
+  public void sendCommandForDownloadChromeHeadless(String downloadPath) {
+    execute(ChromeDriverCommand.SEND_COMMAND_TO_BROWSER,
+            ImmutableMap.of("cmd", "Page.setDownloadBehavior",
+                            "params",
+                            ImmutableMap.of("behavior", "allow", "downloadPath", downloadPath)));
   }
 }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -19,13 +19,6 @@ package org.openqa.selenium.chrome;
 
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
@@ -36,21 +29,14 @@ import org.openqa.selenium.html5.SessionStorage;
 import org.openqa.selenium.html5.WebStorage;
 import org.openqa.selenium.interactions.HasTouchScreen;
 import org.openqa.selenium.interactions.TouchScreen;
-import org.openqa.selenium.json.Json;
 import org.openqa.selenium.mobile.NetworkConnection;
+import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.FileDetector;
-import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteTouchScreen;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.html5.RemoteLocationContext;
 import org.openqa.selenium.remote.html5.RemoteWebStorage;
 import org.openqa.selenium.remote.mobile.RemoteNetworkConnection;
-
-import java.lang.reflect.Field;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A {@link WebDriver} implementation that controls a Chrome browser running on the local machine.
@@ -194,6 +180,10 @@ public class ChromeDriver extends RemoteWebDriver
   @Deprecated
   public ChromeDriver(ChromeDriverService service, Capabilities capabilities) {
     super(new ChromeDriverCommandExecutor(service), capabilities);
+    if (capabilities.getCapability("enableDownloading")!=null){
+      sendCommandForDownloadChromeHeadLess(
+          (String) capabilities.getCapability("enableDownloading"));
+    }
     locationContext = new RemoteLocationContext(getExecuteMethod());
     webStorage = new  RemoteWebStorage(getExecuteMethod());
     touchScreen = new RemoteTouchScreen(getExecuteMethod());
@@ -257,45 +247,11 @@ public class ChromeDriver extends RemoteWebDriver
    * @param downloadPath
    */
   public void sendCommandForDownloadChromeHeadLess(String downloadPath) {
-    Json json = new Json();
-    Map<String, Object> paramsMap = new HashMap<>();
-    paramsMap.put("cmd", "Page.setDownloadBehavior");
-    Map<String, String> cmdParamsMap = new HashMap<>();
-    cmdParamsMap.put("behavior", "allow");
-    cmdParamsMap.put("downloadPath", downloadPath);
-    paramsMap.put("params", cmdParamsMap);
-    String content = json.toJson(paramsMap);
-    URL remoteServerUri = null;
-    try {
-      Field field = HttpCommandExecutor.class.getDeclaredField("remoteServer");
-      field.setAccessible(true);
-      remoteServerUri = (URL) field.get(getCommandExecutor());
-    } catch (Exception e) {
-      return;
-    }
-    CloseableHttpClient httpclient = null;
-    try {
-      httpclient = HttpClients.createDefault();
-      URIBuilder builder = null;
-      try {
-        builder = new URIBuilder(remoteServerUri.toURI());
-      } catch (URISyntaxException e) {
-      }
-      builder.setPath("session/" + getSessionId().toString() + "/chromium/send_command");
-      HttpPost sendCommandPost = new HttpPost(builder.build());
-      sendCommandPost.setHeader("Content-Type", ContentType.APPLICATION_JSON.getMimeType());
-      StringEntity entity = new StringEntity(content, ContentType.APPLICATION_JSON);
-      sendCommandPost.setEntity(entity);
-      CloseableHttpResponse response = httpclient.execute(sendCommandPost);
-    } catch (Exception e) {
-    } finally {
-      if (httpclient != null) {
-        try {
-          httpclient.close();
-        } catch (Exception e) {
-        }
-      }
+    if (downloadPath.length()>0){
+      execute(DriverCommand.SEND_COMMAND_TO_BROWSER,
+              ImmutableMap.of("cmd", "Page.setDownloadBehavior",
+                              "params",
+                              ImmutableMap.of("behavior", "allow","downloadPath", downloadPath)));
     }
   }
-
 }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommand.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommand.java
@@ -24,4 +24,7 @@ final class ChromeDriverCommand {
   private ChromeDriverCommand() {}
 
   static final String LAUNCH_APP = "launchApp";
+  static final String SEND_COMMANDS_FOR_DOWNLOAD_CHROME_HEAD_LESS
+      = "sendCommandForDownloadChromeHeadLess";
+
 }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommand.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommand.java
@@ -24,7 +24,6 @@ final class ChromeDriverCommand {
   private ChromeDriverCommand() {}
 
   static final String LAUNCH_APP = "launchApp";
-  static final String SEND_COMMANDS_FOR_DOWNLOAD_CHROME_HEAD_LESS
-      = "sendCommandForDownloadChromeHeadLess";
+  static final String SEND_COMMAND_TO_BROWSER = "sendCommandToBrowser";
 
 }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommandExecutor.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverCommandExecutor.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.chrome;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 import org.openqa.selenium.remote.service.DriverCommandExecutor;
@@ -28,11 +29,16 @@ import org.openqa.selenium.remote.service.DriverService;
  */
 class ChromeDriverCommandExecutor extends DriverCommandExecutor {
 
-  private static final ImmutableMap<String, CommandInfo> CHROME_COMMAND_NAME_TO_URL = ImmutableMap.of(
-      ChromeDriverCommand.LAUNCH_APP,
-      new CommandInfo("/session/:sessionId/chromium/launch_app", HttpMethod.POST));
+  private static final ImmutableMap<String, CommandInfo> CHROME_SPECIFIC_COMMANDS =
+      new ImmutableMap.Builder<String, CommandInfo>()
+          .put(ChromeDriverCommand.LAUNCH_APP,
+               new CommandInfo("/session/:sessionId/chromium/launch_app", HttpMethod.POST))
+          .put(ChromeDriverCommand.SEND_COMMAND_TO_BROWSER,
+               new CommandInfo("/session/:sessionId/chromium/send_command_and_get_result",
+                               HttpMethod.POST))
+          .build();
 
   public ChromeDriverCommandExecutor(DriverService service) {
-    super(service, CHROME_COMMAND_NAME_TO_URL);
+    super(service, CHROME_SPECIFIC_COMMANDS);
   }
 }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.chrome;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADING;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
 import static org.openqa.selenium.remote.CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR;
 import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
@@ -232,6 +233,15 @@ public class ChromeOptions extends MutableCapabilities {
 
   public ChromeOptions setAcceptInsecureCerts(boolean acceptInsecureCerts) {
     setCapability(ACCEPT_INSECURE_CERTS, acceptInsecureCerts);
+    return this;
+  }
+
+  public ChromeOptions setEnableDownloading(boolean enableDownloading, String downloadPath){
+    if (enableDownloading){
+      setCapability(ENABLE_DOWNLOADING, downloadPath);
+    }else {
+      setCapability(ENABLE_DOWNLOADING, "");
+    }
     return this;
   }
 

--- a/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -20,7 +20,7 @@ package org.openqa.selenium.chrome;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
-import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADING;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOAD_TO;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
 import static org.openqa.selenium.remote.CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR;
 import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
@@ -238,9 +238,9 @@ public class ChromeOptions extends MutableCapabilities {
 
   public ChromeOptions setEnableDownloading(boolean enableDownloading, String downloadPath){
     if (enableDownloading) {
-      setCapability(ENABLE_DOWNLOADING, downloadPath);
+      setCapability(ENABLE_DOWNLOAD_TO, downloadPath);
     }else {
-      setCapability(ENABLE_DOWNLOADING, (Objects) null);
+      setCapability(ENABLE_DOWNLOAD_TO, (Objects) null);
     }
     return this;
   }

--- a/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -237,10 +237,10 @@ public class ChromeOptions extends MutableCapabilities {
   }
 
   public ChromeOptions setEnableDownloading(boolean enableDownloading, String downloadPath){
-    if (enableDownloading){
+    if (enableDownloading) {
       setCapability(ENABLE_DOWNLOADING, downloadPath);
     }else {
-      setCapability(ENABLE_DOWNLOADING, "");
+      setCapability(ENABLE_DOWNLOADING, (Objects) null);
     }
     return this;
   }

--- a/java/client/src/org/openqa/selenium/remote/CapabilityType.java
+++ b/java/client/src/org/openqa/selenium/remote/CapabilityType.java
@@ -47,7 +47,7 @@ public interface CapabilityType {
   String ELEMENT_SCROLL_BEHAVIOR = "elementScrollBehavior";
   String HAS_TOUCHSCREEN = "hasTouchScreen";
   String OVERLAPPING_CHECK_DISABLED = "overlappingCheckDisabled";
-  String ENABLE_DOWNLOADING = "enableDownloading";
+  String ENABLE_DOWNLOADING = "chromium:enableDownloading";
 
   String LOGGING_PREFS = "loggingPrefs";
 

--- a/java/client/src/org/openqa/selenium/remote/CapabilityType.java
+++ b/java/client/src/org/openqa/selenium/remote/CapabilityType.java
@@ -47,7 +47,7 @@ public interface CapabilityType {
   String ELEMENT_SCROLL_BEHAVIOR = "elementScrollBehavior";
   String HAS_TOUCHSCREEN = "hasTouchScreen";
   String OVERLAPPING_CHECK_DISABLED = "overlappingCheckDisabled";
-  String ENABLE_DOWNLOADING = "chromium:enableDownloading";
+  String ENABLE_DOWNLOAD_TO = "chromium:enableDownloadTo";
 
   String LOGGING_PREFS = "loggingPrefs";
 

--- a/java/client/src/org/openqa/selenium/remote/CapabilityType.java
+++ b/java/client/src/org/openqa/selenium/remote/CapabilityType.java
@@ -47,6 +47,7 @@ public interface CapabilityType {
   String ELEMENT_SCROLL_BEHAVIOR = "elementScrollBehavior";
   String HAS_TOUCHSCREEN = "hasTouchScreen";
   String OVERLAPPING_CHECK_DISABLED = "overlappingCheckDisabled";
+  String ENABLE_DOWNLOADING = "enableDownloading";
 
   String LOGGING_PREFS = "loggingPrefs";
 

--- a/java/client/src/org/openqa/selenium/remote/DriverCommand.java
+++ b/java/client/src/org/openqa/selenium/remote/DriverCommand.java
@@ -129,8 +129,6 @@ public interface DriverCommand {
   String SET_SCREEN_ROTATION = "setScreenRotation";
   String GET_SCREEN_ROTATION = "getScreenRotation";
 
-  String SEND_COMMAND_TO_BROWSER = "sendCommandToBrowser";
-
   // W3C Actions APIs
   String ACTIONS = "actions";
   String CLEAR_ACTIONS_STATE = "clearActionState";

--- a/java/client/src/org/openqa/selenium/remote/DriverCommand.java
+++ b/java/client/src/org/openqa/selenium/remote/DriverCommand.java
@@ -129,6 +129,8 @@ public interface DriverCommand {
   String SET_SCREEN_ROTATION = "setScreenRotation";
   String GET_SCREEN_ROTATION = "getScreenRotation";
 
+  String SEND_COMMAND_TO_BROWSER = "sendCommandToBrowser";
+
   // W3C Actions APIs
   String ACTIONS = "actions";
   String CLEAR_ACTIONS_STATE = "clearActionState";

--- a/java/client/src/org/openqa/selenium/remote/http/JsonHttpCommandCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/http/JsonHttpCommandCodec.java
@@ -47,6 +47,7 @@ import static org.openqa.selenium.remote.DriverCommand.MOUSE_UP;
 import static org.openqa.selenium.remote.DriverCommand.MOVE_TO;
 import static org.openqa.selenium.remote.DriverCommand.REMOVE_LOCAL_STORAGE_ITEM;
 import static org.openqa.selenium.remote.DriverCommand.REMOVE_SESSION_STORAGE_ITEM;
+import static org.openqa.selenium.remote.DriverCommand.SEND_COMMAND_TO_BROWSER;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_VALUE;
 import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_POSITION;
@@ -133,6 +134,8 @@ public class JsonHttpCommandCodec extends AbstractHttpCommandCodec {
     defineCommand(TOUCH_MOVE, post("/session/:sessionId/touch/move"));
     defineCommand(TOUCH_SCROLL, post("/session/:sessionId/touch/scroll"));
     defineCommand(TOUCH_UP, post("/session/:sessionId/touch/up"));
+
+    defineCommand(SEND_COMMAND_TO_BROWSER, post("/session/:sessionId/chromium/send_command_and_get_result"));
   }
 
   @Override

--- a/java/client/src/org/openqa/selenium/remote/http/JsonHttpCommandCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/http/JsonHttpCommandCodec.java
@@ -47,7 +47,6 @@ import static org.openqa.selenium.remote.DriverCommand.MOUSE_UP;
 import static org.openqa.selenium.remote.DriverCommand.MOVE_TO;
 import static org.openqa.selenium.remote.DriverCommand.REMOVE_LOCAL_STORAGE_ITEM;
 import static org.openqa.selenium.remote.DriverCommand.REMOVE_SESSION_STORAGE_ITEM;
-import static org.openqa.selenium.remote.DriverCommand.SEND_COMMAND_TO_BROWSER;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_VALUE;
 import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_POSITION;
@@ -135,7 +134,6 @@ public class JsonHttpCommandCodec extends AbstractHttpCommandCodec {
     defineCommand(TOUCH_SCROLL, post("/session/:sessionId/touch/scroll"));
     defineCommand(TOUCH_UP, post("/session/:sessionId/touch/up"));
 
-    defineCommand(SEND_COMMAND_TO_BROWSER, post("/session/:sessionId/chromium/send_command_and_get_result"));
   }
 
   @Override

--- a/java/client/test/org/openqa/selenium/chrome/ChromeHeadlessTest.java
+++ b/java/client/test/org/openqa/selenium/chrome/ChromeHeadlessTest.java
@@ -25,17 +25,13 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.environment.webserver.Page;
 import org.openqa.selenium.io.TemporaryFilesystem;
-import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.testing.JUnit4TestBase;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.Random;
 
 public class ChromeHeadlessTest extends JUnit4TestBase {
@@ -79,41 +75,6 @@ public class ChromeHeadlessTest extends JUnit4TestBase {
     }
   }
 
-  @Test
-  public void canStartChromeWithCustomOptions_Headless() {
-    String downloadFilePathath = downloaded.getAbsolutePath();
-
-    HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
-    chromePrefs.put("profile.default_content_settings.popups", 0);
-    chromePrefs.put("download.default_directory", downloadFilePathath);
-    ChromeOptions options = new ChromeOptions();
-    HashMap<String, Object> chromeOptionsMap = new HashMap<String, Object>();
-    options.setExperimentalOption("prefs", chromePrefs);
-    options.addArguments("--test-type");
-    options.addArguments("--disable-extensions"); //to disable browser extension popup
-    options.addArguments("--headless");
-
-    DesiredCapabilities cap = DesiredCapabilities.chrome();
-    cap.setCapability(ChromeOptions.CAPABILITY, chromeOptionsMap);
-    cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
-    cap.setCapability(ChromeOptions.CAPABILITY, options);
-    ChromeDriver driver = new ChromeDriver(cap);
-
-    driver.sendCommandForDownloadChromeHeadLess(downloadFilePathath);
-
-    driver.get("https://chromedriver.storage.googleapis.com/index.html?path=2.34/");
-    (new WebDriverWait(driver, 20))
-        .until(ExpectedConditions
-                   .presenceOfElementLocated(By.xpath("//a[text()='chromedriver_win32.zip']")))
-        .click();
-
-    try {
-      Thread.sleep(20000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-  }
-
   private String createDownloadingPage() {
     String pathToDownloading = fileForDownloading.getAbsolutePath();
     return appServer.create(new Page()
@@ -132,7 +93,7 @@ public class ChromeHeadlessTest extends JUnit4TestBase {
     DesiredCapabilities cap = DesiredCapabilities.chrome();
     cap.setCapability(ChromeOptions.CAPABILITY, options);
     ChromeDriver driver = new ChromeDriver(cap);
-    driver.sendCommandForDownloadChromeHeadLess(downloadFilePath);
+    driver.sendCommandForDownloadChromeHeadless(downloadFilePath);
 
     driver.get(createDownloadingPage());
 
@@ -156,7 +117,7 @@ public class ChromeHeadlessTest extends JUnit4TestBase {
     options.setHeadless(true);
 
     ChromeDriver driver = new ChromeDriver(options);
-    driver.sendCommandForDownloadChromeHeadLess(downloadFilePath);
+    driver.sendCommandForDownloadChromeHeadless(downloadFilePath);
 
     driver.get(createDownloadingPage());
 
@@ -178,6 +139,7 @@ public class ChromeHeadlessTest extends JUnit4TestBase {
 
     ChromeOptions options = new ChromeOptions();
     options.setHeadless(true);
+
     options.setEnableDownloading(true, downloadFilePath);
 
     ChromeDriver driver = new ChromeDriver(options);
@@ -195,6 +157,4 @@ public class ChromeHeadlessTest extends JUnit4TestBase {
     assertTrue("Downloaded file should be present",
                new File(downloadFilePath + "\\fileForDownloading.txt").exists());
   }
-
-
 }

--- a/java/client/test/org/openqa/selenium/chrome/ChromeHeadlessTest.java
+++ b/java/client/test/org/openqa/selenium/chrome/ChromeHeadlessTest.java
@@ -1,0 +1,200 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.chrome;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.environment.webserver.Page;
+import org.openqa.selenium.io.TemporaryFilesystem;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.testing.JUnit4TestBase;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Random;
+
+public class ChromeHeadlessTest extends JUnit4TestBase {
+
+  private File forDownloading;
+  private File downloaded;
+  private File fileForDownloading;
+  private TemporaryFilesystem tmpFs;
+
+  @Before
+  public void setUp() throws Exception {
+    File baseForTest = new File(System.getProperty("java.io.tmpdir"), "tmpTest");
+    baseForTest.mkdir();
+    tmpFs = TemporaryFilesystem.getTmpFsBasedOn(baseForTest);
+
+    forDownloading = tmpFs.createTempDir("forDownloading", "headless");
+    downloaded = tmpFs.createTempDir("downloaded", "headless");
+
+    fileForDownloading = new File(forDownloading, "fileForDownloading.txt");
+    writeTestFile(fileForDownloading);
+  }
+
+  private void writeTestFile(File file) throws IOException {
+    File parent = file.getParentFile();
+    if (!parent.exists()) {
+      assertTrue(parent.mkdirs());
+    }
+    byte[] byteArray = new byte[16];
+    new Random().nextBytes(byteArray);
+    try (OutputStream out = new FileOutputStream(file)) {
+      out.write(byteArray);
+    }
+    file.deleteOnExit();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    tmpFs.deleteTemporaryFiles();
+    if (driver != null) {
+      driver.quit();
+    }
+  }
+
+  @Test
+  public void canStartChromeWithCustomOptions_Headless() {
+    String downloadFilePathath = downloaded.getAbsolutePath();
+
+    HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+    chromePrefs.put("profile.default_content_settings.popups", 0);
+    chromePrefs.put("download.default_directory", downloadFilePathath);
+    ChromeOptions options = new ChromeOptions();
+    HashMap<String, Object> chromeOptionsMap = new HashMap<String, Object>();
+    options.setExperimentalOption("prefs", chromePrefs);
+    options.addArguments("--test-type");
+    options.addArguments("--disable-extensions"); //to disable browser extension popup
+    options.addArguments("--headless");
+
+    DesiredCapabilities cap = DesiredCapabilities.chrome();
+    cap.setCapability(ChromeOptions.CAPABILITY, chromeOptionsMap);
+    cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
+    cap.setCapability(ChromeOptions.CAPABILITY, options);
+    ChromeDriver driver = new ChromeDriver(cap);
+
+    driver.sendCommandForDownloadChromeHeadLess(downloadFilePathath);
+
+    driver.get("https://chromedriver.storage.googleapis.com/index.html?path=2.34/");
+    (new WebDriverWait(driver, 20))
+        .until(ExpectedConditions
+                   .presenceOfElementLocated(By.xpath("//a[text()='chromedriver_win32.zip']")))
+        .click();
+
+    try {
+      Thread.sleep(20000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private String createDownloadingPage() {
+    String pathToDownloading = fileForDownloading.getAbsolutePath();
+    return appServer.create(new Page()
+                                .withTitle("Download")
+                                .withBody("<a href=\"" + pathToDownloading + "\" "
+                                          + "download=\"file to download\">Download</a>"));
+  }
+
+  @Test
+  public void canDownloadInHeadlessMode() {
+    String downloadFilePath = downloaded.getAbsolutePath();
+
+    ChromeOptions options = new ChromeOptions();
+    options.addArguments("--headless");
+
+    DesiredCapabilities cap = DesiredCapabilities.chrome();
+    cap.setCapability(ChromeOptions.CAPABILITY, options);
+    ChromeDriver driver = new ChromeDriver(cap);
+    driver.sendCommandForDownloadChromeHeadLess(downloadFilePath);
+
+    driver.get(createDownloadingPage());
+
+    driver.findElement(By.tagName("a")).click();
+
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    assertTrue("Downloaded file should be present",
+               new File(downloadFilePath + "\\fileForDownloading.txt").exists());
+  }
+
+  @Test
+  public void canDownloadInHeadlessModeCommand() {
+    String downloadFilePath = downloaded.getAbsolutePath();
+
+    ChromeOptions options = new ChromeOptions();
+    options.setHeadless(true);
+
+    ChromeDriver driver = new ChromeDriver(options);
+    driver.sendCommandForDownloadChromeHeadLess(downloadFilePath);
+
+    driver.get(createDownloadingPage());
+
+    driver.findElement(By.tagName("a")).click();
+
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    assertTrue("Downloaded file should be present",
+               new File(downloadFilePath + "\\fileForDownloading.txt").exists());
+  }
+
+  @Test
+  public void canDownloadInHeadlessModeOption() {
+    String downloadFilePath = downloaded.getAbsolutePath();
+
+    ChromeOptions options = new ChromeOptions();
+    options.setHeadless(true);
+    options.setEnableDownloading(true, downloadFilePath);
+
+    ChromeDriver driver = new ChromeDriver(options);
+
+    driver.get(createDownloadingPage());
+
+    driver.findElement(By.tagName("a")).click();
+
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    assertTrue("Downloaded file should be present",
+               new File(downloadFilePath + "\\fileForDownloading.txt").exists());
+  }
+
+
+}


### PR DESCRIPTION
The method send commands to the browser to avoid blocking
of downloading in headless mode.
(The issue is described here:
https://github.com/SeleniumHQ/selenium/issues/5159)

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/5262)
<!-- Reviewable:end -->
