### PR TITLE
Replace slashes with backslashes in path during file upload on Windows

### DIFF
--- a/rb/lib/selenium/webdriver/common/bridge_helper.rb
+++ b/rb/lib/selenium/webdriver/common/bridge_helper.rb
@@ -74,6 +74,15 @@ module Selenium
 
         result
       end
+
+      def ensure_native_file_path(keys)
+        if WebDriver::Platform.windows?
+          keys.each do |keys_chunk|
+            keys_chunk.tr!('/', '\\') if File.exist?(keys_chunk)
+          end
+        end
+        keys
+      end
     end # BridgeHelper
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/firefox/marionette/bridge.rb
+++ b/rb/lib/selenium/webdriver/firefox/marionette/bridge.rb
@@ -20,6 +20,7 @@ module Selenium
     module Firefox
       module Marionette
         module Bridge
+          include BridgeHelper
 
           COMMANDS = {
             install_addon: [:post, 'session/:session_id/moz/addon/install'.freeze],
@@ -41,12 +42,7 @@ module Selenium
           end
 
           def send_keys_to_element(element, keys)
-            if WebDriver::Platform.windows?
-              keys.each do |keys_chunk|
-                keys_chunk.tr!('/', '\\') if File.exist?(keys_chunk)
-              end
-            end
-            super(element, keys)
+            super(element, ensure_native_file_path(keys))
           end
         end # Bridge
       end # Marionette

--- a/rb/lib/selenium/webdriver/firefox/marionette/bridge.rb
+++ b/rb/lib/selenium/webdriver/firefox/marionette/bridge.rb
@@ -40,6 +40,14 @@ module Selenium
             execute :uninstall_addon, {}, {id: id}
           end
 
+          def send_keys_to_element(element, keys)
+            if WebDriver::Platform.windows?
+              keys.each do |keys_chunk|
+                keys_chunk.tr!('/', '\\') if File.exist?(keys_chunk)
+              end
+            end
+            super(element, keys)
+          end
         end # Bridge
       end # Marionette
     end # Firefox

--- a/rb/lib/selenium/webdriver/ie/bridge.rb
+++ b/rb/lib/selenium/webdriver/ie/bridge.rb
@@ -15,22 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'selenium/webdriver/ie/driver'
-require 'selenium/webdriver/ie/bridge'
-require 'selenium/webdriver/ie/options'
-require 'selenium/webdriver/ie/service'
-
 module Selenium
   module WebDriver
     module IE
-      def self.driver_path=(path)
-        Platform.assert_executable path
-        @driver_path = path
-      end
+      module Bridge
+        include BridgeHelper
 
-      def self.driver_path
-        @driver_path ||= nil
-      end
+        def send_keys_to_element(element, keys)
+          super(element, ensure_native_file_path(keys))
+        end
+      end # Bridge
     end # IE
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -43,6 +43,7 @@ module Selenium
 
           listener = opts.delete(:listener)
           @bridge = Remote::Bridge.handshake(opts)
+          @bridge.extend IE::Bridge
           super(@bridge, listener: listener)
         end
 

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -75,12 +75,9 @@ module Selenium
         expect(element.attribute('value')).to be_empty
 
         file = Tempfile.new('file-upload')
-        path = file.path
-        path.tr!('/', '\\') if WebDriver::Platform.windows?
+        element.send_keys file.path
 
-        element.send_keys path
-
-        expect(element.attribute('value')).to include(File.basename(path))
+        expect(element.attribute('value')).to include(File.basename(file.path))
       end
 
       it 'should get attribute value' do


### PR DESCRIPTION
Although Windows allows both type of slashes in path Firefox doesn't
allow slashes. Ruby uses slashes on Windows for file path. This leads to
very frustrating exceptions and disallows writing cross-OSes tests
easily. You have to create some kind of helper to convert paths in your
tests so they would work on both OSes.

This affects capybara for example. Check out teamcapybara/capybara#1950
for the details.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/5375)
<!-- Reviewable:end -->
