### PR TITLE
Improvement for merging browser options

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -17,23 +17,36 @@
 
 package org.openqa.selenium.chrome;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
+import static org.openqa.selenium.remote.CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR;
+import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import org.openqa.selenium.*;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.SessionNotCreatedException;
+import org.openqa.selenium.UnexpectedAlertBehaviour;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.CapabilityType;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 import java.util.stream.Stream;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.openqa.selenium.remote.CapabilityType.*;
 
 /**
  * Class to manage options specific to {@link ChromeDriver}.
@@ -76,76 +89,7 @@ public class ChromeOptions extends MutableCapabilities {
   @Override
   public ChromeOptions merge(Capabilities extraCapabilities) {
     super.merge(extraCapabilities);
-    if (extraCapabilities instanceof ChromeOptions) {
-      Map options = (Map) extraCapabilities.asMap().get("goog:chromeOptions");
-      mergeArguments(options);
-      mergeExtensions(options);
-      mergeExtensionFiles(extraCapabilities);
-      mergeBinary(options);
-      mergeExperimentalOptions(extraCapabilities);
-    }
     return this;
-  }
-
-  private void mergeArguments(Map options) {
-    addArguments((List<String>) options.get("args"));
-    deleteDuplicates((ArrayList) args);
-  }
-
-  private void mergeExtensions(Map options) {
-    if (options.get("extensions") != null) {
-      addEncodedExtensions((List<String>) options.get("extensions"));
-      deleteDuplicates((ArrayList) extensions);
-    }
-  }
-
-  private void mergeExtensionFiles(Capabilities extraCapabilities) {
-    try {
-      Field extensionFilesField = ChromeOptions.class.getDeclaredField("extensionFiles");
-      extensionFilesField.setAccessible(true);
-      List<File> extensionFilesList = (List<File>) extensionFilesField.get(extraCapabilities);
-      for (File path: extensionFilesList) {
-        addExtensions(path);
-      }
-      deleteDuplicates((ArrayList) extensionFiles);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      e.printStackTrace();
-    }
-  }
-
-  private void mergeBinary(Map options) {
-    if (options.get("binary") != null) {
-      if (binary == null){
-        binary = (String) options.get("binary");
-      } else if (options.get("binary") != binary) {
-        throw new IllegalArgumentException("Binaries can't be merged");
-      }
-    }
-  }
-
-  private void mergeExperimentalOptions(Capabilities extraCapabilities) {
-    try {
-      Field experimentalOptionField = ChromeOptions.class.getDeclaredField("experimentalOptions");
-      experimentalOptionField.setAccessible(true);
-      HashMap<String, Object> experimentalOptionList = (HashMap<String, Object>) experimentalOptionField.get(extraCapabilities);
-      for (Map.Entry<String, Object> experimentalOption : experimentalOptionList.entrySet()) {
-        if (experimentalOptions.get(experimentalOption.getKey()) == null) {
-          experimentalOptions.put(experimentalOption.getKey(), experimentalOption.getValue());
-        } else if (!(experimentalOptions.get(experimentalOption.getKey()).toString()
-            .contentEquals(experimentalOption.getValue().toString()))) {
-          throw new IllegalArgumentException("Experimental options can't be merged");
-        }
-      }
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      e.printStackTrace();
-    }
-  }
-
-  private void deleteDuplicates(ArrayList al) {
-    Set hs = new HashSet<>();
-    hs.addAll(al);
-    al.clear();
-    al.addAll(hs);
   }
 
   /**
@@ -221,7 +165,7 @@ public class ChromeOptions extends MutableCapabilities {
       checkNotNull(path);
       checkArgument(path.exists(), "%s does not exist", path.getAbsolutePath());
       checkArgument(!path.isDirectory(), "%s is a directory",
-          path.getAbsolutePath());
+              path.getAbsolutePath());
     }
     extensionFiles.addAll(paths);
     return this;
@@ -286,6 +230,11 @@ public class ChromeOptions extends MutableCapabilities {
     return this;
   }
 
+  /**
+   * Returns ChromeOptions with the capability ACCEPT_INSECURE_CERTS set.
+   * @param acceptInsecureCerts
+   * @return ChromeOptions
+   */
   public ChromeOptions setAcceptInsecureCerts(boolean acceptInsecureCerts) {
     setCapability(ACCEPT_INSECURE_CERTS, acceptInsecureCerts);
     return this;
@@ -321,11 +270,11 @@ public class ChromeOptions extends MutableCapabilities {
   @Override
   protected int amendHashCode() {
     return Objects.hash(
-        args,
-        binary,
-        experimentalOptions,
-        extensionFiles,
-        extensions);
+            args,
+            binary,
+            experimentalOptions,
+            extensionFiles,
+            extensions);
   }
 
   @Override
@@ -343,18 +292,18 @@ public class ChromeOptions extends MutableCapabilities {
     options.put("args", ImmutableList.copyOf(args));
 
     options.put(
-        "extensions",
-        Stream.concat(
-            extensionFiles.stream()
-                .map(file -> {
-                  try {
-                    return Base64.getEncoder().encodeToString(Files.toByteArray(file));
-                  } catch (IOException e) {
-                    throw new SessionNotCreatedException(e.getMessage(), e);
-                  }
-                }),
-            extensions.stream()
-        ).collect(ImmutableList.toImmutableList()));
+            "extensions",
+            Stream.concat(
+                    extensionFiles.stream()
+                            .map(file -> {
+                              try {
+                                return Base64.getEncoder().encodeToString(Files.toByteArray(file));
+                              } catch (IOException e) {
+                                throw new SessionNotCreatedException(e.getMessage(), e);
+                              }
+                            }),
+                    extensions.stream()
+            ).collect(ImmutableList.toImmutableList()));
 
     toReturn.put(CAPABILITY, options);
 

--- a/java/client/test/org/openqa/selenium/chrome/ChromeOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/chrome/ChromeOptionsMergeUnitTest.java
@@ -1,0 +1,237 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+
+package org.openqa.selenium.chrome;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.io.TemporaryFilesystem;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link ChromeOptions}.
+ */
+
+public class ChromeOptionsMergeUnitTest {
+
+	private TemporaryFilesystem tmpFs;
+	private File tempDir;
+	private File firstTempFile;
+	private File secondTempFile;
+
+	@Before
+	public void setUp() throws Exception {
+		File baseForTest = new File(System.getProperty("java.io.tmpdir"), "tmpTest");
+		baseForTest.mkdir();
+		tmpFs = TemporaryFilesystem.getTmpFsBasedOn(baseForTest);
+		tempDir = tmpFs.createTempDir("tempDir", "");
+		firstTempFile = new File(tempDir, "firstTempFile.txt");
+		secondTempFile = new File(tempDir, "secondTempFile.txt");
+		writeTestFile(firstTempFile);
+		writeTestFile(secondTempFile);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		tmpFs.deleteTemporaryFiles();
+	}
+
+	@Test
+	public void canMergeBinariesEmptyReceiver() throws IllegalAccessException, NoSuchFieldException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options2.setBinary(secondTempFile);
+
+		options1.merge(options2);
+
+		Field binaryField = ChromeOptions.class.getDeclaredField("binary");
+		binaryField.setAccessible(true);
+
+		String binary1 = (String) binaryField.get(options1);
+		String binary2 = (String) binaryField.get(options1);
+
+		assertEquals("Binaries should be the same", binary1, binary2);
+	}
+
+	@Test
+	public void canMergeBinariesTheSame() throws NoSuchFieldException, IllegalAccessException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options1.setBinary(secondTempFile);
+		options2.setBinary(secondTempFile);
+
+		options1.merge(options2);
+
+		Field binaryField = ChromeOptions.class.getDeclaredField("binary");
+		binaryField.setAccessible(true);
+
+		String binary1 = (String) binaryField.get(options1);
+		String binary2 = (String) binaryField.get(options1);
+
+		assertEquals("Binaries should be the same", binary1, binary2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeBinaries() {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options1.setBinary(firstTempFile);
+		options2.setBinary(secondTempFile);
+
+		options1.merge(options2);
+	}
+
+	@Test
+	public void canMergeArguments() throws NoSuchFieldException, IllegalAccessException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options1.addArguments("--argument1");
+		options1.addArguments("--argument2");
+
+		options2.addArguments("--argument2");
+		options2.addArguments("--argument3");
+
+		options1.merge(options2);
+
+		Field argsField = ChromeOptions.class.getDeclaredField("args");
+		argsField.setAccessible(true);
+
+		List<String> args = (List<String>) argsField.get(options1);
+
+		assertTrue("Options should contain the first argument", args.contains("--argument1"));
+		assertTrue("Options should contain the second argument", args.contains("--argument2"));
+		assertTrue("Options should contain the third argument", args.contains("--argument3"));
+		assertEquals("Options should contain three elements", args.size(), 3);
+	}
+
+	@Test
+	public void canMergeExtensionFiles() throws NoSuchFieldException, IllegalAccessException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options1.addExtensions(firstTempFile);
+		options2.addExtensions(secondTempFile);
+
+		options1.merge(options2);
+
+		Field extensionFilesField = ChromeOptions.class.getDeclaredField("extensionFiles");
+		extensionFilesField.setAccessible(true);
+		List<File> extensionFilesList1 = (List<File>) extensionFilesField.get(options1);
+
+		assertTrue("Result list should contain the first extension file", extensionFilesList1.contains(firstTempFile));
+		assertTrue("Result list contain the second extension file", extensionFilesList1.contains(secondTempFile));
+		assertEquals("Result list should contain two elements", extensionFilesList1.size(), 2);
+	}
+
+	@Test
+	public void canMergeExtensions() throws IllegalAccessException, NoSuchFieldException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		options1.addEncodedExtensions("First encoded extension");
+		options1.addEncodedExtensions("Second encoded extension");
+
+		options2.addEncodedExtensions("Second encoded extension");
+		options2.addEncodedExtensions("Third encoded extension");
+
+		options1.merge(options2);
+
+		Field extensionsField = ChromeOptions.class.getDeclaredField("extensions");
+		extensionsField.setAccessible(true);
+		List<File> extensionFilesList1 = (List<File>) extensionsField.get(options1);
+
+		assertTrue("List should contain the first extension", extensionFilesList1.contains("First encoded extension"));
+		assertTrue("List should contain the second extension", extensionFilesList1.contains("Second encoded extension"));
+		assertTrue("List should contain the third extension", extensionFilesList1.contains("Third encoded extension"));
+		assertEquals("List should contain three elements", extensionFilesList1.size(), 3);
+	}
+
+	@Test
+	public void canMergeExperimentalOptions() throws NoSuchFieldException, IllegalAccessException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		Map<String, Object> prefs = new HashMap<String, Object>();
+		prefs.put("profile.default_content_settings.popups", 0);
+
+		options2.setExperimentalOption("prefs1", prefs);
+		options2.setExperimentalOption("prefs2", prefs);
+
+		options1.setExperimentalOption("prefs2", prefs);
+		options1.setExperimentalOption("prefs3", prefs);
+
+		options1.merge(options2);
+
+		Field experimentalOptionsField = ChromeOptions.class.getDeclaredField("experimentalOptions");
+		experimentalOptionsField.setAccessible(true);
+		Map<String, Object> experimentalOptionsList1 = (Map<String, Object>) experimentalOptionsField.get(options1);
+
+		assertTrue("Map should contain experimental option 'perfs1'", experimentalOptionsList1.get("prefs1") != null);
+		assertTrue("Map should contain experimental option 'perfs2'", experimentalOptionsList1.get("prefs2") != null);
+		assertTrue("Map should contain experimental option 'perfs3'", experimentalOptionsList1.get("prefs3") != null);
+		assertEquals("Map should contain three elements", experimentalOptionsList1.size(), 3);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeExperimentalOptions() throws NoSuchFieldException, IllegalAccessException {
+		ChromeOptions options1 = new ChromeOptions();
+		ChromeOptions options2 = new ChromeOptions();
+
+		Map<String, Object> prefs = new HashMap<String, Object>();
+		prefs.put("profile.default_content_settings.popups", 0);
+
+		Map<String, Object> prefs1 = new HashMap<String, Object>();
+		prefs1.put("profile.default_content_settings.popups", 1);
+
+		options2.setExperimentalOption("prefs1", prefs);
+		options2.setExperimentalOption("prefs2", prefs);
+
+		options1.setExperimentalOption("prefs2", prefs1);
+
+		options1.merge(options2);
+	}
+
+	private void writeTestFile(File file) throws IOException {
+		File parent = file.getParentFile();
+		if (!parent.exists()) {
+			assertTrue(parent.mkdirs());
+		}
+		byte[] byteArray = new byte[16];
+		new Random().nextBytes(byteArray);
+		try (OutputStream out = new FileOutputStream(file)) {
+			out.write(byteArray);
+		}
+		file.deleteOnExit();
+	}
+}

--- a/java/client/test/org/openqa/selenium/chrome/ChromeOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/chrome/ChromeOptionsMergeUnitTest.java
@@ -17,54 +17,28 @@
 
 package org.openqa.selenium.chrome;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.openqa.selenium.io.TemporaryFilesystem;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Unit tests for {@link ChromeOptions}.
- */
-
 public class ChromeOptionsMergeUnitTest {
 
-	private TemporaryFilesystem tmpFs;
-	private File tempDir;
-	private File firstTempFile;
-	private File secondTempFile;
-
-	@Before
-	public void setUp() throws Exception {
-		File baseForTest = new File(System.getProperty("java.io.tmpdir"), "tmpTest");
-		baseForTest.mkdir();
-		tmpFs = TemporaryFilesystem.getTmpFsBasedOn(baseForTest);
-		tempDir = tmpFs.createTempDir("tempDir", "");
-		firstTempFile = new File(tempDir, "firstTempFile.txt");
-		secondTempFile = new File(tempDir, "secondTempFile.txt");
-		writeTestFile(firstTempFile);
-		writeTestFile(secondTempFile);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		tmpFs.deleteTemporaryFiles();
-	}
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
 
 	@Test
-	public void canMergeBinariesEmptyReceiver() throws IllegalAccessException, NoSuchFieldException {
+	public void canMergeBinariesEmptyReceiver() throws IllegalAccessException, NoSuchFieldException, IOException {
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
 		ChromeOptions options1 = new ChromeOptions();
 		ChromeOptions options2 = new ChromeOptions();
 
@@ -79,10 +53,14 @@ public class ChromeOptionsMergeUnitTest {
 		String binary2 = (String) binaryField.get(options1);
 
 		assertEquals("Binaries should be the same", binary1, binary2);
+
+		secondTempFile.delete();
 	}
 
 	@Test
-	public void canMergeBinariesTheSame() throws NoSuchFieldException, IllegalAccessException {
+	public void canMergeBinariesTheSame() throws NoSuchFieldException, IllegalAccessException, IOException {
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
+
 		ChromeOptions options1 = new ChromeOptions();
 		ChromeOptions options2 = new ChromeOptions();
 
@@ -98,10 +76,15 @@ public class ChromeOptionsMergeUnitTest {
 		String binary2 = (String) binaryField.get(options1);
 
 		assertEquals("Binaries should be the same", binary1, binary2);
+
+		secondTempFile.delete();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeBinaries() {
+	@Test
+	public void canMergeBinariesDifferent() throws NoSuchFieldException, IllegalAccessException, IOException {
+		File firstTempFile = testFolder.newFile("firstTempFile.txt");
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
+
 		ChromeOptions options1 = new ChromeOptions();
 		ChromeOptions options2 = new ChromeOptions();
 
@@ -109,6 +92,18 @@ public class ChromeOptionsMergeUnitTest {
 		options2.setBinary(secondTempFile);
 
 		options1.merge(options2);
+
+		Field binaryField = ChromeOptions.class.getDeclaredField("binary");
+		binaryField.setAccessible(true);
+
+		String binary1 = (String) binaryField.get(options1);
+		String binary2 = (String) binaryField.get(options1);
+
+		assertEquals("Binaries should be the same", binary1, binary2);
+		assertEquals("Options #1 should have second file as a binary", binary1, secondTempFile.getAbsolutePath());
+
+		firstTempFile.delete();
+		secondTempFile.delete();
 	}
 
 	@Test
@@ -129,14 +124,17 @@ public class ChromeOptionsMergeUnitTest {
 
 		List<String> args = (List<String>) argsField.get(options1);
 
-		assertTrue("Options should contain the first argument", args.contains("--argument1"));
-		assertTrue("Options should contain the second argument", args.contains("--argument2"));
-		assertTrue("Options should contain the third argument", args.contains("--argument3"));
-		assertEquals("Options should contain three elements", args.size(), 3);
+		assertTrue("Option #1 should contain the first argument", args.contains("--argument1"));
+		assertTrue("Option #1 should contain the second argument", args.contains("--argument2"));
+		assertTrue("Option #1 should contain the third argument", args.contains("--argument3"));
+		assertEquals("Option #1 should contain three elements", args.size(), 3);
 	}
 
 	@Test
-	public void canMergeExtensionFiles() throws NoSuchFieldException, IllegalAccessException {
+	public void canMergeExtensionFiles() throws NoSuchFieldException, IllegalAccessException, IOException {
+		File firstTempFile = testFolder.newFile("firstTempFile.txt");
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
+
 		ChromeOptions options1 = new ChromeOptions();
 		ChromeOptions options2 = new ChromeOptions();
 
@@ -152,6 +150,9 @@ public class ChromeOptionsMergeUnitTest {
 		assertTrue("Result list should contain the first extension file", extensionFilesList1.contains(firstTempFile));
 		assertTrue("Result list contain the second extension file", extensionFilesList1.contains(secondTempFile));
 		assertEquals("Result list should contain two elements", extensionFilesList1.size(), 2);
+
+		firstTempFile.delete();
+		secondTempFile.delete();
 	}
 
 	@Test
@@ -201,37 +202,5 @@ public class ChromeOptionsMergeUnitTest {
 		assertTrue("Map should contain experimental option 'perfs2'", experimentalOptionsList1.get("prefs2") != null);
 		assertTrue("Map should contain experimental option 'perfs3'", experimentalOptionsList1.get("prefs3") != null);
 		assertEquals("Map should contain three elements", experimentalOptionsList1.size(), 3);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeExperimentalOptions() throws NoSuchFieldException, IllegalAccessException {
-		ChromeOptions options1 = new ChromeOptions();
-		ChromeOptions options2 = new ChromeOptions();
-
-		Map<String, Object> prefs = new HashMap<String, Object>();
-		prefs.put("profile.default_content_settings.popups", 0);
-
-		Map<String, Object> prefs1 = new HashMap<String, Object>();
-		prefs1.put("profile.default_content_settings.popups", 1);
-
-		options2.setExperimentalOption("prefs1", prefs);
-		options2.setExperimentalOption("prefs2", prefs);
-
-		options1.setExperimentalOption("prefs2", prefs1);
-
-		options1.merge(options2);
-	}
-
-	private void writeTestFile(File file) throws IOException {
-		File parent = file.getParentFile();
-		if (!parent.exists()) {
-			assertTrue(parent.mkdirs());
-		}
-		byte[] byteArray = new byte[16];
-		new Random().nextBytes(byteArray);
-		try (OutputStream out = new FileOutputStream(file)) {
-			out.write(byteArray);
-		}
-		file.deleteOnExit();
 	}
 }

--- a/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
@@ -1,0 +1,174 @@
+package org.openqa.selenium.firefox;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class FirefoxOptionsMergeUnitTest {
+	@Test
+	public void canMergeArguments() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addArguments("--argument1");
+		options1.addArguments("--argument2");
+
+		options2.addArguments("--argument2");
+		options2.addArguments("--argument3");
+
+		options1.merge(options2);
+
+		Field argsField = FirefoxOptions.class.getDeclaredField("args");
+		argsField.setAccessible(true);
+
+		List<String> args = (List<String>) argsField.get(options1);
+
+		assertTrue("Options should contain the first argument", args.contains("--argument1"));
+		assertTrue("Options should contain the second argument", args.contains("--argument2"));
+		assertTrue("Options should contain the third argument", args.contains("--argument3"));
+		assertEquals("Options should contain three elements", args.size(), 3);
+	}
+
+	@Test
+	public void canMergeBooleanPreferences() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("booleanPref1", true);
+		options1.addPreference("booleanPref2", true);
+
+		options2.addPreference("booleanPref2", true);
+		options2.addPreference("booleanPref3", true);
+
+		options1.merge(options2);
+
+		Field booleanPrefsField =FirefoxOptions.class.getDeclaredField("booleanPrefs");
+		booleanPrefsField.setAccessible(true);
+		Map<String, Boolean> booleanPrefsList = (Map<String, Boolean>) booleanPrefsField.get(options1);
+
+		assertTrue("Option should contain boolean preference 'booleanPref1'", booleanPrefsList.containsKey("booleanPref1"));
+		assertTrue("Option should contain boolean preference 'booleanPref2'", booleanPrefsList.containsKey("booleanPref2"));
+		assertTrue("Option should contain boolean preference 'booleanPref3'", booleanPrefsList.containsKey("booleanPref3"));
+		assertTrue("Option should contain 3 boolean preferences", booleanPrefsList.size() == 3);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeBooleanPreferences() {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("booleanPref1", true);
+		options1.addPreference("booleanPref2", true);
+
+		options2.addPreference("booleanPref2", false);
+		options2.addPreference("booleanPref3", true);
+
+		options1.merge(options2);
+	}
+
+	@Test
+	public void canMergeIntPreferences() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("intPref1", 1);
+		options1.addPreference("intPref2", 2);
+
+		options2.addPreference("intPref2", 2);
+		options2.addPreference("intPref3", 3);
+
+		options1.merge(options2);
+
+		Field intPrefsField =FirefoxOptions.class.getDeclaredField("intPrefs");
+		intPrefsField.setAccessible(true);
+		Map<String, Integer> intPrefsList = (Map<String, Integer>) intPrefsField.get(options1);
+
+		assertTrue("Option should contain int preference 'intPref1'", intPrefsList.containsKey("intPref1"));
+		assertTrue("Option should contain int preference 'intPref2'", intPrefsList.containsKey("intPref2"));
+		assertTrue("Option should contain int preference 'intPref3'", intPrefsList.containsKey("intPref3"));
+		assertTrue("Option should contain 3 int preferences", intPrefsList.size() == 3);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeIntPreferences() {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("intPref1", 1);
+		options1.addPreference("intPref2", 2);
+
+		options2.addPreference("intPref2", 1);
+		options2.addPreference("intPref3", 3);
+
+		options1.merge(options2);
+	}
+
+	@Test
+	public void canMergeStringPreferences() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("stringPref1", "s1");
+		options1.addPreference("stringPref2", "s2");
+
+		options2.addPreference("stringPref2", "s2");
+		options2.addPreference("stringPref3", "s3");
+
+		options1.merge(options2);
+
+		Field stringPrefsField =FirefoxOptions.class.getDeclaredField("stringPrefs");
+		stringPrefsField.setAccessible(true);
+		Map<String, String> stringPrefsList = (Map<String, String>) stringPrefsField.get(options1);
+
+		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option should contain 3 string preferences", stringPrefsList.size() == 3);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeStringPreferences() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.addPreference("stringPref1", "s1");
+		options1.addPreference("stringPref2", "s2");
+
+		options2.addPreference("stringPref2", "s1");
+		options2.addPreference("stringPref3", "s3");
+
+		options1.merge(options2);
+	}
+
+	@Test
+	public void canMergeLogLevels() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options2.setLogLevel(FirefoxDriverLogLevel.INFO);
+
+		options1.merge(options2);
+
+		Field LogLevelField =FirefoxOptions.class.getDeclaredField("logLevel");
+		LogLevelField.setAccessible(true);
+		FirefoxDriverLogLevel logLevel = (FirefoxDriverLogLevel) LogLevelField.get(options1);
+
+		assertEquals("Log level should be the same", logLevel,FirefoxDriverLogLevel.INFO);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void canNotMergeLogLevels() {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.setLogLevel(FirefoxDriverLogLevel.CONFIG);
+		options2.setLogLevel(FirefoxDriverLogLevel.INFO);
+
+		options1.merge(options2);
+	}
+}

--- a/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
@@ -1,15 +1,25 @@
 package org.openqa.selenium.firefox;
 
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openqa.selenium.MutableCapabilities;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
 public class FirefoxOptionsMergeUnitTest {
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
+
 	@Test
 	public void canMergeArguments() throws NoSuchFieldException, IllegalAccessException {
 		FirefoxOptions options1 = new FirefoxOptions();
@@ -28,10 +38,51 @@ public class FirefoxOptionsMergeUnitTest {
 
 		List<String> args = (List<String>) argsField.get(options1);
 
-		assertTrue("Options should contain the first argument", args.contains("--argument1"));
-		assertTrue("Options should contain the second argument", args.contains("--argument2"));
-		assertTrue("Options should contain the third argument", args.contains("--argument3"));
-		assertEquals("Options should contain three elements", args.size(), 3);
+		assertTrue("Option #1 should contain the first argument", args.contains("--argument1"));
+		assertTrue("Option #1 should contain the second argument", args.contains("--argument2"));
+		assertTrue("Option #1 should contain the third argument", args.contains("--argument3"));
+		assertEquals("Option #1 should contain three elements", args.size(), 3);
+	}
+
+	@Test
+	public void canMergeBinaries() throws NoSuchFieldException, IllegalAccessException, IOException {
+		File firstTempFile = testFolder.newFile("firstTempFile.txt");
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
+
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+
+		options1.setBinary(firstTempFile.getAbsolutePath());
+		options2.setBinary(secondTempFile.getAbsolutePath());
+
+		options1.merge(options2);
+
+		Field binaryField = FirefoxOptions.class.getDeclaredField("binary");
+		binaryField.setAccessible(true);
+
+		assertEquals("Binaries should be the same", binaryField.get(options1), binaryField.get(options1));
+
+		firstTempFile.delete();
+		secondTempFile.delete();
+	}
+
+	@Test
+	public void canMergeLegacy() throws NoSuchFieldException, IllegalAccessException {
+		FirefoxOptions options1 = new FirefoxOptions();
+		FirefoxOptions options2 = new FirefoxOptions();
+
+		options1.setLegacy(true);
+		options2.setLegacy(false);
+
+		options1.merge(options2);
+
+		Field argsField = FirefoxOptions.class.getDeclaredField("legacy");
+		argsField.setAccessible(true);
+
+		boolean legacy = (boolean) argsField.get(options1);
+
+		assertFalse("Option #1 should have false legacy", legacy);
 	}
 
 	@Test
@@ -51,24 +102,10 @@ public class FirefoxOptionsMergeUnitTest {
 		booleanPrefsField.setAccessible(true);
 		Map<String, Boolean> booleanPrefsList = (Map<String, Boolean>) booleanPrefsField.get(options1);
 
-		assertTrue("Option should contain boolean preference 'booleanPref1'", booleanPrefsList.containsKey("booleanPref1"));
-		assertTrue("Option should contain boolean preference 'booleanPref2'", booleanPrefsList.containsKey("booleanPref2"));
-		assertTrue("Option should contain boolean preference 'booleanPref3'", booleanPrefsList.containsKey("booleanPref3"));
-		assertTrue("Option should contain 3 boolean preferences", booleanPrefsList.size() == 3);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeBooleanPreferences() {
-		FirefoxOptions options1 = new FirefoxOptions();
-		FirefoxOptions options2 = new FirefoxOptions();
-
-		options1.addPreference("booleanPref1", true);
-		options1.addPreference("booleanPref2", true);
-
-		options2.addPreference("booleanPref2", false);
-		options2.addPreference("booleanPref3", true);
-
-		options1.merge(options2);
+		assertTrue("Option #1 should contain boolean preference 'booleanPref1'", booleanPrefsList.containsKey("booleanPref1"));
+		assertTrue("Option #1 should contain boolean preference 'booleanPref2'", booleanPrefsList.containsKey("booleanPref2"));
+		assertTrue("Option #1 should contain boolean preference 'booleanPref3'", booleanPrefsList.containsKey("booleanPref3"));
+		assertTrue("Option #1 should contain 3 boolean preferences", booleanPrefsList.size() == 3);
 	}
 
 	@Test
@@ -88,24 +125,10 @@ public class FirefoxOptionsMergeUnitTest {
 		intPrefsField.setAccessible(true);
 		Map<String, Integer> intPrefsList = (Map<String, Integer>) intPrefsField.get(options1);
 
-		assertTrue("Option should contain int preference 'intPref1'", intPrefsList.containsKey("intPref1"));
-		assertTrue("Option should contain int preference 'intPref2'", intPrefsList.containsKey("intPref2"));
-		assertTrue("Option should contain int preference 'intPref3'", intPrefsList.containsKey("intPref3"));
-		assertTrue("Option should contain 3 int preferences", intPrefsList.size() == 3);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeIntPreferences() {
-		FirefoxOptions options1 = new FirefoxOptions();
-		FirefoxOptions options2 = new FirefoxOptions();
-
-		options1.addPreference("intPref1", 1);
-		options1.addPreference("intPref2", 2);
-
-		options2.addPreference("intPref2", 1);
-		options2.addPreference("intPref3", 3);
-
-		options1.merge(options2);
+		assertTrue("Option #1 should contain int preference 'intPref1'", intPrefsList.containsKey("intPref1"));
+		assertTrue("Option #1 should contain int preference 'intPref2'", intPrefsList.containsKey("intPref2"));
+		assertTrue("Option #1 should contain int preference 'intPref3'", intPrefsList.containsKey("intPref3"));
+		assertTrue("Option #1 should contain 3 int preferences", intPrefsList.size() == 3);
 	}
 
 	@Test
@@ -125,24 +148,10 @@ public class FirefoxOptionsMergeUnitTest {
 		stringPrefsField.setAccessible(true);
 		Map<String, String> stringPrefsList = (Map<String, String>) stringPrefsField.get(options1);
 
-		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
-		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
-		assertTrue("Option should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
-		assertTrue("Option should contain 3 string preferences", stringPrefsList.size() == 3);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeStringPreferences() throws NoSuchFieldException, IllegalAccessException {
-		FirefoxOptions options1 = new FirefoxOptions();
-		FirefoxOptions options2 = new FirefoxOptions();
-
-		options1.addPreference("stringPref1", "s1");
-		options1.addPreference("stringPref2", "s2");
-
-		options2.addPreference("stringPref2", "s1");
-		options2.addPreference("stringPref3", "s3");
-
-		options1.merge(options2);
+		assertTrue("Option #1 should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option #1 should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option #1 should contain string preference 'stringPref1'", stringPrefsList.containsKey("stringPref1"));
+		assertTrue("Option #1 should contain 3 string preferences", stringPrefsList.size() == 3);
 	}
 
 	@Test
@@ -154,21 +163,10 @@ public class FirefoxOptionsMergeUnitTest {
 
 		options1.merge(options2);
 
-		Field LogLevelField =FirefoxOptions.class.getDeclaredField("logLevel");
-		LogLevelField.setAccessible(true);
-		FirefoxDriverLogLevel logLevel = (FirefoxDriverLogLevel) LogLevelField.get(options1);
+		Field logLevelField = FirefoxOptions.class.getDeclaredField("logLevel");
+		logLevelField.setAccessible(true);
+		FirefoxDriverLogLevel logLevel = (FirefoxDriverLogLevel) logLevelField.get(options1);
 
 		assertEquals("Log level should be the same", logLevel,FirefoxDriverLogLevel.INFO);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotMergeLogLevels() {
-		FirefoxOptions options1 = new FirefoxOptions();
-		FirefoxOptions options2 = new FirefoxOptions();
-
-		options1.setLogLevel(FirefoxDriverLogLevel.CONFIG);
-		options2.setLogLevel(FirefoxDriverLogLevel.INFO);
-
-		options1.merge(options2);
 	}
 }

--- a/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/firefox/FirefoxOptionsMergeUnitTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class FirefoxOptionsMergeUnitTest {
 	@Rule

--- a/java/client/test/org/openqa/selenium/opera/OperaOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/opera/OperaOptionsMergeUnitTest.java
@@ -1,0 +1,159 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.opera;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OperaOptionsMergeUnitTest {
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
+
+	@Test
+	public void canMergeBinaries() throws IOException, NoSuchFieldException, IllegalAccessException {
+		OperaOptions options1 = new OperaOptions();
+		OperaOptions options2 = new OperaOptions();
+
+		Path fakeBinary = Files.createTempFile("fake", "binary");
+
+		options2.setBinary(fakeBinary.toString());
+
+		options1.merge(options2);
+
+		Field binaryField = OperaOptions.class.getDeclaredField("binary");
+		binaryField.setAccessible(true);
+		String binaryValue = (String) binaryField.get(options1);
+
+		assertEquals("Binaries should be the same", binaryValue, fakeBinary.toString());
+
+		if (new File(fakeBinary.toString()).exists()) {
+			new File(fakeBinary.toString()).delete();
+		}
+	}
+
+	@Test
+	public void canMergeExperimentalOptions() throws NoSuchFieldException, IllegalAccessException {
+		OperaOptions options1 = new OperaOptions();
+		OperaOptions options2 = new OperaOptions();
+
+		Map<String, Object> prefs = new HashMap<String, Object>();
+		prefs.put("profile.default_content_settings.popups", 0);
+
+		options2.setExperimentalOption("prefs1", prefs);
+		options2.setExperimentalOption("prefs2", prefs);
+
+		options1.setExperimentalOption("prefs2", prefs);
+		options1.setExperimentalOption("prefs3", prefs);
+
+		options1.merge(options2);
+
+		Field experimentalOptionsField = OperaOptions.class.getDeclaredField("experimentalOptions");
+		experimentalOptionsField.setAccessible(true);
+		Map<String, Object> experimentalOptionsList1 = (Map<String, Object>) experimentalOptionsField.get(options1);
+
+		assertTrue("Map should contain experimental option 'perfs1'", experimentalOptionsList1.get("prefs1") != null);
+		assertTrue("Map should contain experimental option 'perfs2'", experimentalOptionsList1.get("prefs2") != null);
+		assertTrue("Map should contain experimental option 'perfs3'", experimentalOptionsList1.get("prefs3") != null);
+		assertEquals("Map should contain three elements", experimentalOptionsList1.size(), 3);
+	}
+
+	@Test
+	public void canMergeArguments() throws NoSuchFieldException, IllegalAccessException {
+		OperaOptions options1 = new OperaOptions();
+		OperaOptions options2 = new OperaOptions();
+
+		options1.addArguments("--argument1");
+		options1.addArguments("--argument2");
+
+		options2.addArguments("--argument2");
+		options2.addArguments("--argument3");
+
+		options1.merge(options2);
+
+		Field argsField = OperaOptions.class.getDeclaredField("args");
+		argsField.setAccessible(true);
+
+		List<String> args = (List<String>) argsField.get(options1);
+
+		assertTrue("Option #1 should contain the first argument", args.contains("--argument1"));
+		assertTrue("Option #1 should contain the second argument", args.contains("--argument2"));
+		assertTrue("Option #1 should contain the third argument", args.contains("--argument3"));
+		assertEquals("Option #1 should contain three elements", args.size(), 3);
+	}
+
+	@Test
+	public void canMergeExtensionFiles() throws NoSuchFieldException, IllegalAccessException, IOException {
+		File firstTempFile = testFolder.newFile("firstTempFile.txt");
+		File secondTempFile = testFolder.newFile("secondTempFile.txt");
+
+		OperaOptions options1 = new OperaOptions();
+		OperaOptions options2 = new OperaOptions();
+
+		options1.addExtensions(firstTempFile);
+		options2.addExtensions(secondTempFile);
+
+		options1.merge(options2);
+
+		Field extensionFilesField = OperaOptions.class.getDeclaredField("extensionFiles");
+		extensionFilesField.setAccessible(true);
+		List<File> extensionFilesList1 = (List<File>) extensionFilesField.get(options1);
+
+		assertTrue("Result list should contain the first extension file", extensionFilesList1.contains(firstTempFile));
+		assertTrue("Result list contain the second extension file", extensionFilesList1.contains(secondTempFile));
+		assertEquals("Result list should contain two elements", extensionFilesList1.size(), 2);
+
+		firstTempFile.delete();
+		secondTempFile.delete();
+	}
+
+	@Test
+	public void canMergeExtensions() throws IllegalAccessException, NoSuchFieldException {
+		OperaOptions options1 = new OperaOptions();
+		OperaOptions options2 = new OperaOptions();
+
+		options1.addEncodedExtensions("First encoded extension");
+		options1.addEncodedExtensions("Second encoded extension");
+
+		options2.addEncodedExtensions("Second encoded extension");
+		options2.addEncodedExtensions("Third encoded extension");
+
+		options1.merge(options2);
+
+		Field extensionsField = OperaOptions.class.getDeclaredField("extensions");
+		extensionsField.setAccessible(true);
+		List<File> extensionFilesList1 = (List<File>) extensionsField.get(options1);
+
+		assertTrue("List should contain the first extension", extensionFilesList1.contains("First encoded extension"));
+		assertTrue("List should contain the second extension", extensionFilesList1.contains("Second encoded extension"));
+		assertTrue("List should contain the third extension", extensionFilesList1.contains("Third encoded extension"));
+		assertEquals("List should contain three elements", extensionFilesList1.size(), 3);
+	}
+}

--- a/java/client/test/org/openqa/selenium/safari/SafariOptionsMergeUnitTest.java
+++ b/java/client/test/org/openqa/selenium/safari/SafariOptionsMergeUnitTest.java
@@ -1,0 +1,55 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.safari;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.opera.OperaOptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SafariOptionsMergeUnitTest {
+	@Test
+	public void canMergeOptions() throws IllegalAccessException, NoSuchFieldException {
+		SafariOptions options1 = new SafariOptions();
+		SafariOptions options2 = new SafariOptions(
+				new ImmutableCapabilities("cleanSession", false, "technologyPreview", false));
+
+		options1.merge(options2);
+
+		Field optionsField = SafariOptions.class.getDeclaredField("options");
+		optionsField.setAccessible(true);
+		Map <?, ?> optionsValue = (Map <?, ?>) optionsField.get(options1);
+
+		assertEquals("Clear session option should be false", optionsValue.get("cleanSession"), false);
+		assertEquals("Technology preview option should be false", optionsValue.get("technologyPreview"), false);
+	}
+}


### PR DESCRIPTION
(issue #5279)
https://github.com/SeleniumHQ/selenium/issues/5279

The issue is improved only for Chrome; it will improved
 by me for other browsers a bit later.

The following logic for merging was implemented:
1. For ‘binary’ field: if this fields are both not empty
 and their values are different, the IllegalArgumentException
 should be thrown;
2. For ‘experimentalOptions’ field: if the source options
and receiver options have the same experimental option with
different values, the IllegalArgumentException should be thrown;
3. After merging all duplicates in all collections should be deleted.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/5390)
<!-- Reviewable:end -->
