### PR TITLE
Fix windowSize option in Firefox in Javascript

### DIFF
--- a/javascript/node/selenium-webdriver/firefox.js
+++ b/javascript/node/selenium-webdriver/firefox.js
@@ -315,7 +315,7 @@ class Options extends Capabilities {
     }
     checkArg(width);
     checkArg(height);
-    return this.addArguments(`--window-size=${width},${height}`);
+    return this.addArguments(`--width=${width}`,`--height=${height}`);
   }
 
   /**

--- a/javascript/node/selenium-webdriver/firefox.js
+++ b/javascript/node/selenium-webdriver/firefox.js
@@ -315,7 +315,7 @@ class Options extends Capabilities {
     }
     checkArg(width);
     checkArg(height);
-    return this.addArguments(`--width=${width}`,`--height=${height}`);
+    return this.addArguments(`--width=${width}`, `--height=${height}`);
   }
 
   /**


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Hi guys. 

"--window-size" is for screenshots only in Firefox, not the size of the Firefox window itself. 
"--width" and "--height" are the proper way to set the dimensions of a Firefox window from the CLI.

Proof:
```bash
firefox -h | grep screenshot
 --screenshot [<path>] Save screenshot to <path> or in working directory.
 --window-size width[,height] Width and optionally height of screenshot.
```

Works (after my change):
```bash
firefox --width=1920 --height=1080
```

Doesn't work (before my change):
```bash
firefox --window-size=1920,1080
```