### PR TITLE
Clean up remote connection to better use urllib3.

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -44,7 +44,7 @@ class RemoteConnection(object):
     https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol"""
 
     _timeout = socket._GLOBAL_DEFAULT_TIMEOUT
-    _retries = 0
+    _retries = 0  # urllib3 defaults to 3 retries, we are essentially disabling retries
 
     @classmethod
     def get_retries(cls):
@@ -166,229 +166,14 @@ class RemoteConnection(object):
                                    .format(parsed_url.hostname))
         return remote_server_address
 
-    def __init__(self, remote_server_addr, keep_alive=False, retries=0, resolve_ip=True):
+    def __init__(self, remote_server_addr, keep_alive=False, resolve_ip=True):
         # Attempt to resolve the hostname and get an IP address.
 
         self.keep_alive = keep_alive
         self._url = self.parse_remote_server(remote_server_addr, resolve_ip)
 
         # Keep the name _conn in case someone has been clearing the pool externally with private variable
-        self._conn = PoolManager(timeout=self._timeout, retries=retries)
-
-        self._commands = {
-            Command.STATUS: ('GET', '/status'),
-            Command.NEW_SESSION: ('POST', '/session'),
-            Command.GET_ALL_SESSIONS: ('GET', '/sessions'),
-            Command.QUIT: ('DELETE', '/session/$sessionId'),
-            Command.GET_CURRENT_WINDOW_HANDLE:
-                ('GET', '/session/$sessionId/window_handle'),
-            Command.W3C_GET_CURRENT_WINDOW_HANDLE:
-                ('GET', '/session/$sessionId/window'),
-            Command.GET_WINDOW_HANDLES:
-                ('GET', '/session/$sessionId/window_handles'),
-            Command.W3C_GET_WINDOW_HANDLES:
-                ('GET', '/session/$sessionId/window/handles'),
-            Command.GET: ('POST', '/session/$sessionId/url'),
-            Command.GO_FORWARD: ('POST', '/session/$sessionId/forward'),
-            Command.GO_BACK: ('POST', '/session/$sessionId/back'),
-            Command.REFRESH: ('POST', '/session/$sessionId/refresh'),
-            Command.EXECUTE_SCRIPT: ('POST', '/session/$sessionId/execute'),
-            Command.W3C_EXECUTE_SCRIPT:
-                ('POST', '/session/$sessionId/execute/sync'),
-            Command.W3C_EXECUTE_SCRIPT_ASYNC:
-                ('POST', '/session/$sessionId/execute/async'),
-            Command.GET_CURRENT_URL: ('GET', '/session/$sessionId/url'),
-            Command.GET_TITLE: ('GET', '/session/$sessionId/title'),
-            Command.GET_PAGE_SOURCE: ('GET', '/session/$sessionId/source'),
-            Command.SCREENSHOT: ('GET', '/session/$sessionId/screenshot'),
-            Command.ELEMENT_SCREENSHOT: ('GET', '/session/$sessionId/element/$id/screenshot'),
-            Command.FIND_ELEMENT: ('POST', '/session/$sessionId/element'),
-            Command.FIND_ELEMENTS: ('POST', '/session/$sessionId/elements'),
-            Command.W3C_GET_ACTIVE_ELEMENT: ('GET', '/session/$sessionId/element/active'),
-            Command.GET_ACTIVE_ELEMENT:
-                ('POST', '/session/$sessionId/element/active'),
-            Command.FIND_CHILD_ELEMENT:
-                ('POST', '/session/$sessionId/element/$id/element'),
-            Command.FIND_CHILD_ELEMENTS:
-                ('POST', '/session/$sessionId/element/$id/elements'),
-            Command.CLICK_ELEMENT: ('POST', '/session/$sessionId/element/$id/click'),
-            Command.CLEAR_ELEMENT: ('POST', '/session/$sessionId/element/$id/clear'),
-            Command.SUBMIT_ELEMENT: ('POST', '/session/$sessionId/element/$id/submit'),
-            Command.GET_ELEMENT_TEXT: ('GET', '/session/$sessionId/element/$id/text'),
-            Command.SEND_KEYS_TO_ELEMENT:
-                ('POST', '/session/$sessionId/element/$id/value'),
-            Command.SEND_KEYS_TO_ACTIVE_ELEMENT:
-                ('POST', '/session/$sessionId/keys'),
-            Command.UPLOAD_FILE: ('POST', "/session/$sessionId/file"),
-            Command.GET_ELEMENT_VALUE:
-                ('GET', '/session/$sessionId/element/$id/value'),
-            Command.GET_ELEMENT_TAG_NAME:
-                ('GET', '/session/$sessionId/element/$id/name'),
-            Command.IS_ELEMENT_SELECTED:
-                ('GET', '/session/$sessionId/element/$id/selected'),
-            Command.SET_ELEMENT_SELECTED:
-                ('POST', '/session/$sessionId/element/$id/selected'),
-            Command.IS_ELEMENT_ENABLED:
-                ('GET', '/session/$sessionId/element/$id/enabled'),
-            Command.IS_ELEMENT_DISPLAYED:
-                ('GET', '/session/$sessionId/element/$id/displayed'),
-            Command.GET_ELEMENT_LOCATION:
-                ('GET', '/session/$sessionId/element/$id/location'),
-            Command.GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW:
-                ('GET', '/session/$sessionId/element/$id/location_in_view'),
-            Command.GET_ELEMENT_SIZE:
-                ('GET', '/session/$sessionId/element/$id/size'),
-            Command.GET_ELEMENT_RECT:
-                ('GET', '/session/$sessionId/element/$id/rect'),
-            Command.GET_ELEMENT_ATTRIBUTE:
-                ('GET', '/session/$sessionId/element/$id/attribute/$name'),
-            Command.GET_ELEMENT_PROPERTY:
-                ('GET', '/session/$sessionId/element/$id/property/$name'),
-            Command.ELEMENT_EQUALS:
-                ('GET', '/session/$sessionId/element/$id/equals/$other'),
-            Command.GET_ALL_COOKIES: ('GET', '/session/$sessionId/cookie'),
-            Command.ADD_COOKIE: ('POST', '/session/$sessionId/cookie'),
-            Command.GET_COOKIE: ('GET', '/session/$sessionId/cookie/$name'),
-            Command.DELETE_ALL_COOKIES:
-                ('DELETE', '/session/$sessionId/cookie'),
-            Command.DELETE_COOKIE:
-                ('DELETE', '/session/$sessionId/cookie/$name'),
-            Command.SWITCH_TO_FRAME: ('POST', '/session/$sessionId/frame'),
-            Command.SWITCH_TO_PARENT_FRAME: ('POST', '/session/$sessionId/frame/parent'),
-            Command.SWITCH_TO_WINDOW: ('POST', '/session/$sessionId/window'),
-            Command.CLOSE: ('DELETE', '/session/$sessionId/window'),
-            Command.GET_ELEMENT_VALUE_OF_CSS_PROPERTY:
-                ('GET', '/session/$sessionId/element/$id/css/$propertyName'),
-            Command.IMPLICIT_WAIT:
-                ('POST', '/session/$sessionId/timeouts/implicit_wait'),
-            Command.EXECUTE_ASYNC_SCRIPT: ('POST', '/session/$sessionId/execute_async'),
-            Command.SET_SCRIPT_TIMEOUT:
-                ('POST', '/session/$sessionId/timeouts/async_script'),
-            Command.SET_TIMEOUTS:
-                ('POST', '/session/$sessionId/timeouts'),
-            Command.DISMISS_ALERT:
-                ('POST', '/session/$sessionId/dismiss_alert'),
-            Command.W3C_DISMISS_ALERT:
-                ('POST', '/session/$sessionId/alert/dismiss'),
-            Command.ACCEPT_ALERT:
-                ('POST', '/session/$sessionId/accept_alert'),
-            Command.W3C_ACCEPT_ALERT:
-                ('POST', '/session/$sessionId/alert/accept'),
-            Command.SET_ALERT_VALUE:
-                ('POST', '/session/$sessionId/alert_text'),
-            Command.W3C_SET_ALERT_VALUE:
-                ('POST', '/session/$sessionId/alert/text'),
-            Command.GET_ALERT_TEXT:
-                ('GET', '/session/$sessionId/alert_text'),
-            Command.W3C_GET_ALERT_TEXT:
-                ('GET', '/session/$sessionId/alert/text'),
-            Command.SET_ALERT_CREDENTIALS:
-                ('POST', '/session/$sessionId/alert/credentials'),
-            Command.CLICK:
-                ('POST', '/session/$sessionId/click'),
-            Command.W3C_ACTIONS:
-                ('POST', '/session/$sessionId/actions'),
-            Command.W3C_CLEAR_ACTIONS:
-                ('DELETE', '/session/$sessionId/actions'),
-            Command.DOUBLE_CLICK:
-                ('POST', '/session/$sessionId/doubleclick'),
-            Command.MOUSE_DOWN:
-                ('POST', '/session/$sessionId/buttondown'),
-            Command.MOUSE_UP:
-                ('POST', '/session/$sessionId/buttonup'),
-            Command.MOVE_TO:
-                ('POST', '/session/$sessionId/moveto'),
-            Command.GET_WINDOW_SIZE:
-                ('GET', '/session/$sessionId/window/$windowHandle/size'),
-            Command.SET_WINDOW_SIZE:
-                ('POST', '/session/$sessionId/window/$windowHandle/size'),
-            Command.GET_WINDOW_POSITION:
-                ('GET', '/session/$sessionId/window/$windowHandle/position'),
-            Command.SET_WINDOW_POSITION:
-                ('POST', '/session/$sessionId/window/$windowHandle/position'),
-            Command.SET_WINDOW_RECT:
-                ('POST', '/session/$sessionId/window/rect'),
-            Command.GET_WINDOW_RECT:
-                ('GET', '/session/$sessionId/window/rect'),
-            Command.MAXIMIZE_WINDOW:
-                ('POST', '/session/$sessionId/window/$windowHandle/maximize'),
-            Command.W3C_MAXIMIZE_WINDOW:
-                ('POST', '/session/$sessionId/window/maximize'),
-            Command.SET_SCREEN_ORIENTATION:
-                ('POST', '/session/$sessionId/orientation'),
-            Command.GET_SCREEN_ORIENTATION:
-                ('GET', '/session/$sessionId/orientation'),
-            Command.SINGLE_TAP:
-                ('POST', '/session/$sessionId/touch/click'),
-            Command.TOUCH_DOWN:
-                ('POST', '/session/$sessionId/touch/down'),
-            Command.TOUCH_UP:
-                ('POST', '/session/$sessionId/touch/up'),
-            Command.TOUCH_MOVE:
-                ('POST', '/session/$sessionId/touch/move'),
-            Command.TOUCH_SCROLL:
-                ('POST', '/session/$sessionId/touch/scroll'),
-            Command.DOUBLE_TAP:
-                ('POST', '/session/$sessionId/touch/doubleclick'),
-            Command.LONG_PRESS:
-                ('POST', '/session/$sessionId/touch/longclick'),
-            Command.FLICK:
-                ('POST', '/session/$sessionId/touch/flick'),
-            Command.EXECUTE_SQL:
-                ('POST', '/session/$sessionId/execute_sql'),
-            Command.GET_LOCATION:
-                ('GET', '/session/$sessionId/location'),
-            Command.SET_LOCATION:
-                ('POST', '/session/$sessionId/location'),
-            Command.GET_APP_CACHE:
-                ('GET', '/session/$sessionId/application_cache'),
-            Command.GET_APP_CACHE_STATUS:
-                ('GET', '/session/$sessionId/application_cache/status'),
-            Command.CLEAR_APP_CACHE:
-                ('DELETE', '/session/$sessionId/application_cache/clear'),
-            Command.GET_NETWORK_CONNECTION:
-                ('GET', '/session/$sessionId/network_connection'),
-            Command.SET_NETWORK_CONNECTION:
-                ('POST', '/session/$sessionId/network_connection'),
-            Command.GET_LOCAL_STORAGE_ITEM:
-                ('GET', '/session/$sessionId/local_storage/key/$key'),
-            Command.REMOVE_LOCAL_STORAGE_ITEM:
-                ('DELETE', '/session/$sessionId/local_storage/key/$key'),
-            Command.GET_LOCAL_STORAGE_KEYS:
-                ('GET', '/session/$sessionId/local_storage'),
-            Command.SET_LOCAL_STORAGE_ITEM:
-                ('POST', '/session/$sessionId/local_storage'),
-            Command.CLEAR_LOCAL_STORAGE:
-                ('DELETE', '/session/$sessionId/local_storage'),
-            Command.GET_LOCAL_STORAGE_SIZE:
-                ('GET', '/session/$sessionId/local_storage/size'),
-            Command.GET_SESSION_STORAGE_ITEM:
-                ('GET', '/session/$sessionId/session_storage/key/$key'),
-            Command.REMOVE_SESSION_STORAGE_ITEM:
-                ('DELETE', '/session/$sessionId/session_storage/key/$key'),
-            Command.GET_SESSION_STORAGE_KEYS:
-                ('GET', '/session/$sessionId/session_storage'),
-            Command.SET_SESSION_STORAGE_ITEM:
-                ('POST', '/session/$sessionId/session_storage'),
-            Command.CLEAR_SESSION_STORAGE:
-                ('DELETE', '/session/$sessionId/session_storage'),
-            Command.GET_SESSION_STORAGE_SIZE:
-                ('GET', '/session/$sessionId/session_storage/size'),
-            Command.GET_LOG:
-                ('POST', '/session/$sessionId/log'),
-            Command.GET_AVAILABLE_LOG_TYPES:
-                ('GET', '/session/$sessionId/log/types'),
-            Command.CURRENT_CONTEXT_HANDLE:
-                ('GET', '/session/$sessionId/context'),
-            Command.CONTEXT_HANDLES:
-                ('GET', '/session/$sessionId/contexts'),
-            Command.SWITCH_TO_CONTEXT:
-                ('POST', '/session/$sessionId/context'),
-            Command.FULLSCREEN_WINDOW:
-                ('POST', '/session/$sessionId/window/fullscreen'),
-            Command.MINIMIZE_WINDOW:
-                ('POST', '/session/$sessionId/window/minimize')
-        }
+        self._conn = PoolManager(timeout=self._timeout, retries=self._retries)
 
     def execute(self, command, params):
         """
@@ -479,3 +264,219 @@ class RemoteConnection(object):
     # don't rely on gc to clean things up for you
     def close(self):
         self._conn.clear()
+
+    _commands = {
+        Command.STATUS: ('GET', '/status'),
+        Command.NEW_SESSION: ('POST', '/session'),
+        Command.GET_ALL_SESSIONS: ('GET', '/sessions'),
+        Command.QUIT: ('DELETE', '/session/$sessionId'),
+        Command.GET_CURRENT_WINDOW_HANDLE:
+            ('GET', '/session/$sessionId/window_handle'),
+        Command.W3C_GET_CURRENT_WINDOW_HANDLE:
+            ('GET', '/session/$sessionId/window'),
+        Command.GET_WINDOW_HANDLES:
+            ('GET', '/session/$sessionId/window_handles'),
+        Command.W3C_GET_WINDOW_HANDLES:
+            ('GET', '/session/$sessionId/window/handles'),
+        Command.GET: ('POST', '/session/$sessionId/url'),
+        Command.GO_FORWARD: ('POST', '/session/$sessionId/forward'),
+        Command.GO_BACK: ('POST', '/session/$sessionId/back'),
+        Command.REFRESH: ('POST', '/session/$sessionId/refresh'),
+        Command.EXECUTE_SCRIPT: ('POST', '/session/$sessionId/execute'),
+        Command.W3C_EXECUTE_SCRIPT:
+            ('POST', '/session/$sessionId/execute/sync'),
+        Command.W3C_EXECUTE_SCRIPT_ASYNC:
+            ('POST', '/session/$sessionId/execute/async'),
+        Command.GET_CURRENT_URL: ('GET', '/session/$sessionId/url'),
+        Command.GET_TITLE: ('GET', '/session/$sessionId/title'),
+        Command.GET_PAGE_SOURCE: ('GET', '/session/$sessionId/source'),
+        Command.SCREENSHOT: ('GET', '/session/$sessionId/screenshot'),
+        Command.ELEMENT_SCREENSHOT: ('GET', '/session/$sessionId/element/$id/screenshot'),
+        Command.FIND_ELEMENT: ('POST', '/session/$sessionId/element'),
+        Command.FIND_ELEMENTS: ('POST', '/session/$sessionId/elements'),
+        Command.W3C_GET_ACTIVE_ELEMENT: ('GET', '/session/$sessionId/element/active'),
+        Command.GET_ACTIVE_ELEMENT:
+            ('POST', '/session/$sessionId/element/active'),
+        Command.FIND_CHILD_ELEMENT:
+            ('POST', '/session/$sessionId/element/$id/element'),
+        Command.FIND_CHILD_ELEMENTS:
+            ('POST', '/session/$sessionId/element/$id/elements'),
+        Command.CLICK_ELEMENT: ('POST', '/session/$sessionId/element/$id/click'),
+        Command.CLEAR_ELEMENT: ('POST', '/session/$sessionId/element/$id/clear'),
+        Command.SUBMIT_ELEMENT: ('POST', '/session/$sessionId/element/$id/submit'),
+        Command.GET_ELEMENT_TEXT: ('GET', '/session/$sessionId/element/$id/text'),
+        Command.SEND_KEYS_TO_ELEMENT:
+            ('POST', '/session/$sessionId/element/$id/value'),
+        Command.SEND_KEYS_TO_ACTIVE_ELEMENT:
+            ('POST', '/session/$sessionId/keys'),
+        Command.UPLOAD_FILE: ('POST', "/session/$sessionId/file"),
+        Command.GET_ELEMENT_VALUE:
+            ('GET', '/session/$sessionId/element/$id/value'),
+        Command.GET_ELEMENT_TAG_NAME:
+            ('GET', '/session/$sessionId/element/$id/name'),
+        Command.IS_ELEMENT_SELECTED:
+            ('GET', '/session/$sessionId/element/$id/selected'),
+        Command.SET_ELEMENT_SELECTED:
+            ('POST', '/session/$sessionId/element/$id/selected'),
+        Command.IS_ELEMENT_ENABLED:
+            ('GET', '/session/$sessionId/element/$id/enabled'),
+        Command.IS_ELEMENT_DISPLAYED:
+            ('GET', '/session/$sessionId/element/$id/displayed'),
+        Command.GET_ELEMENT_LOCATION:
+            ('GET', '/session/$sessionId/element/$id/location'),
+        Command.GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW:
+            ('GET', '/session/$sessionId/element/$id/location_in_view'),
+        Command.GET_ELEMENT_SIZE:
+            ('GET', '/session/$sessionId/element/$id/size'),
+        Command.GET_ELEMENT_RECT:
+            ('GET', '/session/$sessionId/element/$id/rect'),
+        Command.GET_ELEMENT_ATTRIBUTE:
+            ('GET', '/session/$sessionId/element/$id/attribute/$name'),
+        Command.GET_ELEMENT_PROPERTY:
+            ('GET', '/session/$sessionId/element/$id/property/$name'),
+        Command.ELEMENT_EQUALS:
+            ('GET', '/session/$sessionId/element/$id/equals/$other'),
+        Command.GET_ALL_COOKIES: ('GET', '/session/$sessionId/cookie'),
+        Command.ADD_COOKIE: ('POST', '/session/$sessionId/cookie'),
+        Command.GET_COOKIE: ('GET', '/session/$sessionId/cookie/$name'),
+        Command.DELETE_ALL_COOKIES:
+            ('DELETE', '/session/$sessionId/cookie'),
+        Command.DELETE_COOKIE:
+            ('DELETE', '/session/$sessionId/cookie/$name'),
+        Command.SWITCH_TO_FRAME: ('POST', '/session/$sessionId/frame'),
+        Command.SWITCH_TO_PARENT_FRAME: ('POST', '/session/$sessionId/frame/parent'),
+        Command.SWITCH_TO_WINDOW: ('POST', '/session/$sessionId/window'),
+        Command.CLOSE: ('DELETE', '/session/$sessionId/window'),
+        Command.GET_ELEMENT_VALUE_OF_CSS_PROPERTY:
+            ('GET', '/session/$sessionId/element/$id/css/$propertyName'),
+        Command.IMPLICIT_WAIT:
+            ('POST', '/session/$sessionId/timeouts/implicit_wait'),
+        Command.EXECUTE_ASYNC_SCRIPT: ('POST', '/session/$sessionId/execute_async'),
+        Command.SET_SCRIPT_TIMEOUT:
+            ('POST', '/session/$sessionId/timeouts/async_script'),
+        Command.SET_TIMEOUTS:
+            ('POST', '/session/$sessionId/timeouts'),
+        Command.DISMISS_ALERT:
+            ('POST', '/session/$sessionId/dismiss_alert'),
+        Command.W3C_DISMISS_ALERT:
+            ('POST', '/session/$sessionId/alert/dismiss'),
+        Command.ACCEPT_ALERT:
+            ('POST', '/session/$sessionId/accept_alert'),
+        Command.W3C_ACCEPT_ALERT:
+            ('POST', '/session/$sessionId/alert/accept'),
+        Command.SET_ALERT_VALUE:
+            ('POST', '/session/$sessionId/alert_text'),
+        Command.W3C_SET_ALERT_VALUE:
+            ('POST', '/session/$sessionId/alert/text'),
+        Command.GET_ALERT_TEXT:
+            ('GET', '/session/$sessionId/alert_text'),
+        Command.W3C_GET_ALERT_TEXT:
+            ('GET', '/session/$sessionId/alert/text'),
+        Command.SET_ALERT_CREDENTIALS:
+            ('POST', '/session/$sessionId/alert/credentials'),
+        Command.CLICK:
+            ('POST', '/session/$sessionId/click'),
+        Command.W3C_ACTIONS:
+            ('POST', '/session/$sessionId/actions'),
+        Command.W3C_CLEAR_ACTIONS:
+            ('DELETE', '/session/$sessionId/actions'),
+        Command.DOUBLE_CLICK:
+            ('POST', '/session/$sessionId/doubleclick'),
+        Command.MOUSE_DOWN:
+            ('POST', '/session/$sessionId/buttondown'),
+        Command.MOUSE_UP:
+            ('POST', '/session/$sessionId/buttonup'),
+        Command.MOVE_TO:
+            ('POST', '/session/$sessionId/moveto'),
+        Command.GET_WINDOW_SIZE:
+            ('GET', '/session/$sessionId/window/$windowHandle/size'),
+        Command.SET_WINDOW_SIZE:
+            ('POST', '/session/$sessionId/window/$windowHandle/size'),
+        Command.GET_WINDOW_POSITION:
+            ('GET', '/session/$sessionId/window/$windowHandle/position'),
+        Command.SET_WINDOW_POSITION:
+            ('POST', '/session/$sessionId/window/$windowHandle/position'),
+        Command.SET_WINDOW_RECT:
+            ('POST', '/session/$sessionId/window/rect'),
+        Command.GET_WINDOW_RECT:
+            ('GET', '/session/$sessionId/window/rect'),
+        Command.MAXIMIZE_WINDOW:
+            ('POST', '/session/$sessionId/window/$windowHandle/maximize'),
+        Command.W3C_MAXIMIZE_WINDOW:
+            ('POST', '/session/$sessionId/window/maximize'),
+        Command.SET_SCREEN_ORIENTATION:
+            ('POST', '/session/$sessionId/orientation'),
+        Command.GET_SCREEN_ORIENTATION:
+            ('GET', '/session/$sessionId/orientation'),
+        Command.SINGLE_TAP:
+            ('POST', '/session/$sessionId/touch/click'),
+        Command.TOUCH_DOWN:
+            ('POST', '/session/$sessionId/touch/down'),
+        Command.TOUCH_UP:
+            ('POST', '/session/$sessionId/touch/up'),
+        Command.TOUCH_MOVE:
+            ('POST', '/session/$sessionId/touch/move'),
+        Command.TOUCH_SCROLL:
+            ('POST', '/session/$sessionId/touch/scroll'),
+        Command.DOUBLE_TAP:
+            ('POST', '/session/$sessionId/touch/doubleclick'),
+        Command.LONG_PRESS:
+            ('POST', '/session/$sessionId/touch/longclick'),
+        Command.FLICK:
+            ('POST', '/session/$sessionId/touch/flick'),
+        Command.EXECUTE_SQL:
+            ('POST', '/session/$sessionId/execute_sql'),
+        Command.GET_LOCATION:
+            ('GET', '/session/$sessionId/location'),
+        Command.SET_LOCATION:
+            ('POST', '/session/$sessionId/location'),
+        Command.GET_APP_CACHE:
+            ('GET', '/session/$sessionId/application_cache'),
+        Command.GET_APP_CACHE_STATUS:
+            ('GET', '/session/$sessionId/application_cache/status'),
+        Command.CLEAR_APP_CACHE:
+            ('DELETE', '/session/$sessionId/application_cache/clear'),
+        Command.GET_NETWORK_CONNECTION:
+            ('GET', '/session/$sessionId/network_connection'),
+        Command.SET_NETWORK_CONNECTION:
+            ('POST', '/session/$sessionId/network_connection'),
+        Command.GET_LOCAL_STORAGE_ITEM:
+            ('GET', '/session/$sessionId/local_storage/key/$key'),
+        Command.REMOVE_LOCAL_STORAGE_ITEM:
+            ('DELETE', '/session/$sessionId/local_storage/key/$key'),
+        Command.GET_LOCAL_STORAGE_KEYS:
+            ('GET', '/session/$sessionId/local_storage'),
+        Command.SET_LOCAL_STORAGE_ITEM:
+            ('POST', '/session/$sessionId/local_storage'),
+        Command.CLEAR_LOCAL_STORAGE:
+            ('DELETE', '/session/$sessionId/local_storage'),
+        Command.GET_LOCAL_STORAGE_SIZE:
+            ('GET', '/session/$sessionId/local_storage/size'),
+        Command.GET_SESSION_STORAGE_ITEM:
+            ('GET', '/session/$sessionId/session_storage/key/$key'),
+        Command.REMOVE_SESSION_STORAGE_ITEM:
+            ('DELETE', '/session/$sessionId/session_storage/key/$key'),
+        Command.GET_SESSION_STORAGE_KEYS:
+            ('GET', '/session/$sessionId/session_storage'),
+        Command.SET_SESSION_STORAGE_ITEM:
+            ('POST', '/session/$sessionId/session_storage'),
+        Command.CLEAR_SESSION_STORAGE:
+            ('DELETE', '/session/$sessionId/session_storage'),
+        Command.GET_SESSION_STORAGE_SIZE:
+            ('GET', '/session/$sessionId/session_storage/size'),
+        Command.GET_LOG:
+            ('POST', '/session/$sessionId/log'),
+        Command.GET_AVAILABLE_LOG_TYPES:
+            ('GET', '/session/$sessionId/log/types'),
+        Command.CURRENT_CONTEXT_HANDLE:
+            ('GET', '/session/$sessionId/context'),
+        Command.CONTEXT_HANDLES:
+            ('GET', '/session/$sessionId/contexts'),
+        Command.SWITCH_TO_CONTEXT:
+            ('POST', '/session/$sessionId/context'),
+        Command.FULLSCREEN_WINDOW:
+            ('POST', '/session/$sessionId/window/fullscreen'),
+        Command.MINIMIZE_WINDOW:
+            ('POST', '/session/$sessionId/window/minimize')
+    }
+

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -166,9 +166,10 @@ class RemoteConnection(object):
         return remote_server_address
 
     def __init__(self, remote_server_addr, keep_alive=False, resolve_ip=True):
-        # Attempt to resolve the hostname and get an IP address.
 
         self.keep_alive = keep_alive
+
+        # Attempt to resolve the hostname and get an IP address.
         self._url = self.parse_remote_server(remote_server_addr, resolve_ip)
 
         # Keep the name _conn in case someone has been clearing the pool externally with private variable
@@ -259,8 +260,8 @@ class RemoteConnection(object):
             if not self.keep_alive:
                 self._conn.clear()
 
-    # now can use with closing!
-    # Avoid relying on gc to clean things up
+    # now can use with contextlib.closing!
+    # Avoid relying on gc to clean up sockets
     def close(self):
         self._conn.clear()
 

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -121,7 +121,6 @@ class RemoteConnection(object):
 
         return headers
 
-    # todo See if this actually does anything - Kamaroyl
     @staticmethod
     def parse_remote_server(remote_server_address, resolve_ip):
         """If resolve ip is true, take apart remote_server_address and try to connect to address
@@ -261,7 +260,7 @@ class RemoteConnection(object):
                 self._conn.clear()
 
     # now can use with closing!
-    # don't rely on gc to clean things up for you
+    # Avoid relying on gc to clean things up
     def close(self):
         self._conn.clear()
 
@@ -479,4 +478,3 @@ class RemoteConnection(object):
         Command.MINIMIZE_WINDOW:
             ('POST', '/session/$sessionId/window/minimize')
     }
-

--- a/py/test/selenium/webdriver/remote/remote_connections_test.py
+++ b/py/test/selenium/webdriver/remote/remote_connections_test.py
@@ -1,0 +1,19 @@
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+
+
+def test_parse_remote_server():
+    url = "http://127.0.0.1:4444/wd/hub"
+    remote_address = RemoteConnection.parse_remote_server(url, False)
+    assert remote_address == url
+
+
+def test_parse_remote_server_resolve():
+    url = "http://127.0.0.1:4444/wd/hub"
+    remote_address = RemoteConnection.parse_remote_server(url, True)
+    assert remote_address == url
+
+
+def test_https_remotes():
+    url = "https://127.0.0.4:4444/wd/hub"
+    remote_address = RemoteConnection.parse_remote_server(url, True)
+    assert remote_address == url


### PR DESCRIPTION
* Poolmanager should not be created on every call, move to a class
variable for keep-alive and not keep-alive.
* Remove some extra code that attempts to check for attributes to keep backwards compatability;
  HTTPResponse from urllib.response does that work no need to duplicate.
* add a close method to clean up the connection pool. Refactored a large
  portion of code into its own method to clean up init function

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6427)
<!-- Reviewable:end -->
