### PR TITLE
Add attributeToBeNotEmpty method with locator arg

### DIFF
--- a/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -1135,6 +1135,19 @@ public class ExpectedConditions {
     return driver -> getAttributeOrCssValue(element, attribute).isPresent();
   }
 
+  /**
+   * An expectation for checking WebElement with given locator has any non empty value for given
+   * attribute.
+   *
+   * @param locator   used to find the element
+   * @param attribute used to define css or html attribute
+   * @return Boolean  true when element has css or html attribute with non empty value
+   */
+  public static ExpectedCondition<Boolean> attributeToBeNotEmpty(final By locator,
+                                                                 final String attribute) {
+    return driver -> getAttributeOrCssValue(driver.findElement(locator), attribute).isPresent();
+  }
+
   private static Optional<String> getAttributeOrCssValue(WebElement element, String name) {
     String value = element.getAttribute(name);
     if (value == null || value.isEmpty()) {

--- a/java/client/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
+++ b/java/client/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
@@ -531,7 +531,7 @@ public class ExpectedConditionsTest {
   }
 
   @Test
-  public void waitingForAttributeToBeNotEmptyForElementLocatedReturnsTrueWhenAttributeIsNotEmptyCss() {
+  public void waitingForAttributeToBeNotEmptyForWebElementReturnsTrueWhenAttributeIsNotEmptyCss() {
     String attributeName = "test";
     when(mockElement.getAttribute(attributeName)).thenReturn("");
     when(mockElement.getCssValue(attributeName)).thenReturn("test1");
@@ -540,7 +540,7 @@ public class ExpectedConditionsTest {
   }
 
   @Test
-  public void waitingForAttributeToBeNotEmptyForElementLocatedReturnsTrueWhenAttributeIsNotEmptyHtml() {
+  public void waitingForAttributeToBeNotEmptyForWebElementReturnsTrueWhenAttributeIsNotEmptyHtml() {
     String attributeName = "test";
     when(mockElement.getAttribute(attributeName)).thenReturn("test1");
     when(mockElement.getCssValue(attributeName)).thenReturn("");
@@ -559,13 +559,69 @@ public class ExpectedConditionsTest {
   }
 
   @Test
-  public void waitingForAttributetToBeNotEmptyForElementLocatedThrowsTimeoutExceptionWhenAttributeIsEmpty() {
+  public void waitingForAttributetToBeNotEmptyForWebElementThrowsTimeoutExceptionWhenAttributeIsEmpty() {
     String attributeName = "test";
     when(mockElement.getAttribute(attributeName)).thenReturn("");
     when(mockElement.getCssValue(attributeName)).thenReturn("");
 
     assertThatExceptionOfType(TimeoutException.class)
         .isThrownBy(() -> wait.until(attributeToBeNotEmpty(mockElement, attributeName)));
+  }
+
+  @Test
+  public void waitingForAttributetToBeNotEmptyForWebElementThrowsTimeoutExceptionWhenAttributeDoesntExist() {
+    String attributeName = "test";
+    when(mockElement.getAttribute(attributeName)).thenReturn(null);
+    when(mockElement.getCssValue(attributeName)).thenReturn(null);
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(attributeToBeNotEmpty(mockElement, attributeName)));
+  }
+
+  @Test
+  public void waitingForAttributeToBeNotEmptyForElementLocatedReturnsTrueWhenAttributeIsNotEmptyCss() {
+    String testSelector = "testSelector";
+    String attributeName = "test";
+    when(mockDriver.findElement(By.cssSelector(testSelector))).thenReturn(mockElement);
+    when(mockElement.getAttribute(attributeName)).thenReturn("");
+    when(mockElement.getCssValue(attributeName)).thenReturn("test1");
+
+    assertThat(wait.until(attributeToBeNotEmpty(By.cssSelector(testSelector), attributeName))).isTrue();
+  }
+
+  @Test
+  public void waitingForAttributeToBeNotEmptyForElementLocatedReturnsTrueWhenAttributeIsNotEmptyHtml() {
+    String testSelector = "testSelector";
+    String attributeName = "test";
+    when(mockDriver.findElement(By.cssSelector(testSelector))).thenReturn(mockElement);
+    when(mockElement.getAttribute(attributeName)).thenReturn("test1");
+    when(mockElement.getCssValue(attributeName)).thenReturn("");
+
+    assertThat(wait.until(attributeToBeNotEmpty(By.cssSelector(testSelector), attributeName))).isTrue();
+  }
+
+  @Test
+  public void waitingForAttributetToBeNotEmptyForElementLocatedThrowsTimeoutExceptionWhenAttributeIsEmpty() {
+    String testSelector = "testSelector";
+    String attributeName = "test";
+    when(mockDriver.findElement(By.cssSelector(testSelector))).thenReturn(mockElement);
+    when(mockElement.getAttribute(attributeName)).thenReturn("");
+    when(mockElement.getCssValue(attributeName)).thenReturn("");
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(attributeToBeNotEmpty(By.cssSelector(testSelector), attributeName)));
+  }
+
+  @Test
+  public void waitingForAttributetToBeNotEmptyForElementLocatedThrowsTimeoutExceptionWhenAttributeDoesntExist() {
+    String testSelector = "testSelector";
+    String attributeName = "test";
+    when(mockDriver.findElement(By.cssSelector(testSelector))).thenReturn(mockElement);
+    when(mockElement.getAttribute(attributeName)).thenReturn(null);
+    when(mockElement.getCssValue(attributeName)).thenReturn(null);
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(attributeToBeNotEmpty(By.cssSelector(testSelector), attributeName)));
   }
 
   @Test


### PR DESCRIPTION
Add `attributeToBeNotEmpty` method to `ExpectedConditions` with locator argument, aside from the already existing method that takes a `WebElement` as an argument.

Add tests for the new method and also rename the tests for the already existing method to better conform with the naming of other tests in the class.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6580)
<!-- Reviewable:end -->
