### PR TITLE
[py] Don't override browser options with desired capabilities by defa…

### DIFF
--- a/py/selenium/webdriver/webkitgtk/webdriver.py
+++ b/py/selenium/webdriver/webkitgtk/webdriver.py
@@ -20,9 +20,9 @@ try:
 except ImportError:
     import httplib as http_client
 
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 from .service import Service
+from .options import Options
 
 
 class WebDriver(RemoteWebDriver):
@@ -31,7 +31,7 @@ class WebDriver(RemoteWebDriver):
     """
 
     def __init__(self, executable_path="WebKitWebDriver", port=0, options=None,
-                 desired_capabilities=DesiredCapabilities.WEBKITGTK,
+                 desired_capabilities=None,
                  service_log_path=None, keep_alive=False):
         """
         Creates a new instance of the WebKitGTK driver.
@@ -46,9 +46,13 @@ class WebDriver(RemoteWebDriver):
          - service_log_path : Path to write service stdout and stderr output.
          - keep_alive : Whether to configure RemoteConnection to use HTTP keep-alive.
         """
-        if options is not None:
+        if options is None:
+            if desired_capabilities is None:
+                desired_capabilities = Options().to_capabilities()
+        else:
             capabilities = options.to_capabilities()
-            capabilities.update(desired_capabilities)
+            if desired_capabilities is not None:
+                capabilities.update(desired_capabilities)
             desired_capabilities = capabilities
 
         self.service = Service(executable_path, port=port, log_path=service_log_path)


### PR DESCRIPTION
…ult in WebKitGTK

When desired_capabilities parameter is omitted in WebKitGTK driver, the
default capabilities are used. If options are also passed they are
updated from desired capabilities, overriding the passed options. The
desired_capabalities parameter should default to None instead.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6814)
<!-- Reviewable:end -->
