### PR TITLE
Move all remote uploaded files to the same directory so remote IE works with multiple file upload

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/commandhandler/UploadFile.java
+++ b/java/server/src/org/openqa/selenium/remote/server/commandhandler/UploadFile.java
@@ -65,8 +65,8 @@ public class UploadFile implements CommandHandler {
           (allFiles == null ? 0 : allFiles.length)));
     } else {
       // IE requires multiple uploads to all be from the same directory - move files into one location
-      Path uploads_dir = Files.createDirectories(tempDir.toPath().getParent().resolve("remote_uploads"));
-      Path dest = uploads_dir.resolve(allFiles[0].getName());
+      Path uploadsDir = Files.createDirectories(tempDir.toPath().getParent().resolve("remote_uploads"));
+      Path dest = uploadsDir.resolve(allFiles[0].getName());
 
       if (Files.exists(dest)){
         // IE maintains a lock on previously uploaded files so we can't delete/overwrite - move it instead


### PR DESCRIPTION
- [ X ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

Currently remote IE can't send multiple files to a an `<input type="file">` field because it requires all files to be from the same directory.  With the way remote file upload currently works each file is uploaded to it's own temporary directory.  This PR changes that behavior to leave all upload files in a single directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6843)
<!-- Reviewable:end -->
