### PR TITLE
Attempt UTF-8 encoding in logger formatter

### DIFF
--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -122,7 +122,7 @@ module Selenium
         logger.progname = 'Selenium'
         logger.level = default_level
         logger.formatter = proc do |severity, time, progname, msg|
-          "#{time.strftime('%F %T')} #{severity} #{progname} #{msg}\n"
+          "#{time.strftime('%F %T')} #{severity} #{progname} #{msg.try(:force_encoding, 'UTF-8')}\n"
         end
 
         logger


### PR DESCRIPTION
While running specs with Capybara and Selenium I've been experiencing a stream of `log writing failed. "\xC2" from ASCII-8BIT to UTF-8` errors; not sure of all the context, but adding this encoding to the formatter seems to be a fix--any reason not to add this to the formatter? 

<img width="383" alt="image" src="https://user-images.githubusercontent.com/18707714/52809155-74620100-3044-11e9-9bb0-11e49681827f.png">

- [X ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6937)
<!-- Reviewable:end -->
