### PR TITLE
Driver path

### DIFF
--- a/rb/lib/selenium/webdriver/chrome.rb
+++ b/rb/lib/selenium/webdriver/chrome.rb
@@ -28,12 +28,15 @@ module Selenium
   module WebDriver
     module Chrome
       def self.driver_path=(path)
-        Platform.assert_executable path
-        @driver_path = path
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome#driver_path=',
+                                   'Selenium::WebDriver::Chrome::Service#driver_path='
+        Selenium::WebDriver::Chrome::Service.driver_path = path
       end
 
       def self.driver_path
-        @driver_path ||= nil
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome#driver_path',
+                                   'Selenium::WebDriver::Chrome::Service#driver_path'
+        Selenium::WebDriver::Chrome::Service.driver_path
       end
 
       def self.path=(path)

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -35,7 +35,7 @@ module Selenium
         @shutdown_supported = true
 
         def self.driver_path=(path)
-          Platform.assert_executable path
+          Platform.assert_executable path if path.is_a?(String)
           @driver_path = path
         end
 

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -26,7 +26,6 @@ module Selenium
 
       class Service < WebDriver::Service
         @default_port = 9515
-        @driver_path = Chrome.driver_path
         @executable = 'chromedriver'
         @missing_text = <<~ERROR
           Unable to find chromedriver. Please download the server from
@@ -34,6 +33,11 @@ module Selenium
           More info at https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver.
         ERROR
         @shutdown_supported = true
+
+        def self.driver_path=(path)
+          Platform.assert_executable path
+          @driver_path = path
+        end
 
         private
 

--- a/rb/lib/selenium/webdriver/common/service.rb
+++ b/rb/lib/selenium/webdriver/common/service.rb
@@ -117,7 +117,9 @@ module Selenium
       private
 
       def binary_path(path = nil)
-        path = Platform.find_binary(self.class.executable) if path.nil?
+        path = path.call if path.is_a?(Proc)
+        path ||= Platform.find_binary(self.class.executable)
+
         raise Error::WebDriverError, self.class.missing_text unless path
 
         Platform.assert_executable path

--- a/rb/lib/selenium/webdriver/common/service.rb
+++ b/rb/lib/selenium/webdriver/common/service.rb
@@ -57,6 +57,11 @@ module Selenium
         def safari(*args)
           Safari::Service.new(*args)
         end
+
+        def driver_path=(path)
+          Platform.assert_executable path if path.is_a?(String)
+          @driver_path = path
+        end
       end
 
       attr_accessor :host

--- a/rb/lib/selenium/webdriver/edge.rb
+++ b/rb/lib/selenium/webdriver/edge.rb
@@ -27,12 +27,15 @@ module Selenium
   module WebDriver
     module Edge
       def self.driver_path=(path)
-        Platform.assert_executable path
-        @driver_path = path
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Edge#driver_path=',
+                                   'Selenium::WebDriver::Edge::Service#driver_path='
+        Selenium::WebDriver::Edge::Service.driver_path = path
       end
 
-      def self.driver_path(_warning = true)
-        @driver_path ||= nil
+      def self.driver_path
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Edge#driver_path',
+                                   'Selenium::WebDriver::Edge::Service#driver_path'
+        Selenium::WebDriver::Edge::Service.driver_path
       end
     end # Edge
   end # WebDriver

--- a/rb/lib/selenium/webdriver/edge/service.rb
+++ b/rb/lib/selenium/webdriver/edge/service.rb
@@ -26,7 +26,6 @@ module Selenium
 
       class Service < WebDriver::Service
         @default_port = 17556
-        @driver_path = Edge.driver_path
         @executable = 'MicrosoftWebDriver'
         @missing_text = <<~ERROR
           Unable to find MicrosoftWebDriver. Please download the server from

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -45,12 +45,15 @@ module Selenium
       DEFAULT_LOAD_NO_FOCUS_LIB = false
 
       def self.driver_path=(path)
-        Platform.assert_executable path
-        @driver_path = path
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Firefox#driver_path=',
+                                   'Selenium::WebDriver::Firefox::Service#driver_path='
+        Selenium::WebDriver::Firefox::Service.driver_path = path
       end
 
       def self.driver_path
-        @driver_path ||= nil
+        WebDriver.logger.deprecate 'Selenium::WebDriver::Firefox#driver_path',
+                                   'Selenium::WebDriver::Firefox::Service#driver_path'
+        Selenium::WebDriver::Firefox::Service.driver_path
       end
 
       def self.path=(path)

--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -26,7 +26,6 @@ module Selenium
 
       class Service < WebDriver::Service
         @default_port = 4444
-        @driver_path = Firefox.driver_path
         @executable = 'geckodriver'
         @missing_text = <<~ERROR
           Unable to find Mozilla geckodriver. Please download the server from

--- a/rb/lib/selenium/webdriver/ie.rb
+++ b/rb/lib/selenium/webdriver/ie.rb
@@ -24,12 +24,15 @@ module Selenium
   module WebDriver
     module IE
       def self.driver_path=(path)
-        Platform.assert_executable path
-        @driver_path = path
+        WebDriver.logger.deprecate 'Selenium::WebDriver::IE#driver_path=',
+                                   'Selenium::WebDriver::IE::Service#driver_path='
+        Selenium::WebDriver::IE::Service.driver_path = path
       end
 
       def self.driver_path
-        @driver_path ||= nil
+        WebDriver.logger.deprecate 'Selenium::WebDriver::IE#driver_path',
+                                   'Selenium::WebDriver::IE::Service#driver_path'
+        Selenium::WebDriver::IE::Service.driver_path
       end
     end # IE
   end # WebDriver

--- a/rb/lib/selenium/webdriver/ie/service.rb
+++ b/rb/lib/selenium/webdriver/ie/service.rb
@@ -26,7 +26,6 @@ module Selenium
 
       class Service < WebDriver::Service
         @default_port = 5555
-        @driver_path = IE.driver_path
         @executable = 'IEDriverServer'
         @missing_text = <<~ERROR
           Unable to find IEDriverServer. Please download the server from

--- a/rb/lib/selenium/webdriver/safari.rb
+++ b/rb/lib/selenium/webdriver/safari.rb
@@ -47,12 +47,15 @@ module Selenium
         end
 
         def driver_path=(path)
-          Platform.assert_executable path
-          @driver_path = path
+          WebDriver.logger.deprecate 'Selenium::WebDriver::Safari#driver_path=',
+                                     'Selenium::WebDriver::Safari::Service#driver_path='
+          Selenium::WebDriver::Safari::Service.driver_path = path
         end
 
         def driver_path
-          @driver_path ||= nil
+          WebDriver.logger.deprecate 'Selenium::WebDriver::Safari#driver_path',
+                                     'Selenium::WebDriver::Safari::Service#driver_path'
+          Selenium::WebDriver::Safari::Service.driver_path
         end
       end
     end # Safari

--- a/rb/lib/selenium/webdriver/safari/service.rb
+++ b/rb/lib/selenium/webdriver/safari/service.rb
@@ -26,7 +26,6 @@ module Selenium
 
       class Service < WebDriver::Service
         @default_port = 7050
-        @driver_path = Safari.driver_path
         @executable = 'safaridriver'
         @missing_text = <<~ERROR
           Unable to find Apple's safaridriver which comes with Safari 10.

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -254,7 +254,7 @@ module Selenium
           WebDriver::Chrome.path = binary if binary
 
           server = ENV['CHROMEDRIVER'] || ENV['chrome_server']
-          WebDriver::Chrome.driver_path = server if server
+          WebDriver::Chrome::Service.driver_path = server if server
 
           WebDriver::Driver.for :chrome, opt
         end

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -49,9 +49,19 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
-        it 'uses #driver_path=' do
+        it 'allows #driver_path= with String value' do
           path = '/path/to/driver'
           Chrome::Service.driver_path = path
+
+          service = Service.chrome
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'allows #driver_path= with Proc value' do
+          path = '/path/to/driver'
+          proc = proc { path }
+          Chrome::Service.driver_path = proc
 
           service = Service.chrome
 

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -49,6 +49,31 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
+        it 'uses #driver_path=' do
+          path = '/path/to/driver'
+          Chrome::Service.driver_path = path
+
+          service = Service.chrome
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'accepts Chrome#driver_path= and Chrome#driver_path but throws deprecation notices' do
+          path = '/path/to/driver'
+
+          expect {
+            Selenium::WebDriver::Chrome.driver_path = path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Chrome#driver_path=/).to_stdout_from_any_process
+
+          expect {
+            expect(Selenium::WebDriver::Chrome.driver_path).to eq path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Chrome#driver_path/).to_stdout_from_any_process
+
+          service = Service.chrome
+
+          expect(service.executable_path).to eq path
+        end
+
         it 'does not create args by default' do
           allow(Platform).to receive(:find_binary).and_return(service_path)
 

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -49,6 +49,30 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
+        it 'uses #driver_path=' do
+          path = '/path/to/driver'
+          Edge::Service.driver_path = path
+
+          service = Service.chrome
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'accepts Edge#driver_path= but throws deprecation notice' do
+          path = '/path/to/driver'
+          expect {
+            Selenium::WebDriver::Edge.driver_path = path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Edge#driver_path=/).to_stdout_from_any_process
+
+          expect {
+            expect(Selenium::WebDriver::Edge.driver_path).to eq path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Edge#driver_path/).to_stdout_from_any_process
+
+          service = Service.chrome
+
+          expect(service.executable_path).to eq path
+        end
+
         it 'does not create args by default' do
           allow(Platform).to receive(:find_binary).and_return(service_path)
 

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -49,11 +49,21 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
-        it 'uses #driver_path=' do
+        it 'allows #driver_path= with String value' do
           path = '/path/to/driver'
           Edge::Service.driver_path = path
 
-          service = Service.chrome
+          service = Service.edge
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'allows #driver_path= with Proc value' do
+          path = '/path/to/driver'
+          proc = proc { path }
+          Edge::Service.driver_path = proc
+
+          service = Service.edge
 
           expect(service.executable_path).to eq path
         end
@@ -68,7 +78,7 @@ module Selenium
             expect(Selenium::WebDriver::Edge.driver_path).to eq path
           }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Edge#driver_path/).to_stdout_from_any_process
 
-          service = Service.chrome
+          service = Service.edge
 
           expect(service.executable_path).to eq path
         end

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -49,9 +49,19 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
-        it 'uses #driver_path=' do
+        it 'allows #driver_path= with String value' do
           path = '/path/to/driver'
           Firefox::Service.driver_path = path
+
+          service = Service.firefox
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'allows #driver_path= with Proc value' do
+          path = '/path/to/driver'
+          proc = proc { path }
+          Firefox::Service.driver_path = proc
 
           service = Service.firefox
 

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -49,6 +49,31 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
+        it 'uses #driver_path=' do
+          path = '/path/to/driver'
+          Firefox::Service.driver_path = path
+
+          service = Service.firefox
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'accepts Firefox#driver_path= but throws deprecation notice' do
+          path = '/path/to/driver'
+
+          expect {
+            Selenium::WebDriver::Firefox.driver_path = path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Firefox#driver_path=/).to_stdout_from_any_process
+
+          expect {
+            expect(Selenium::WebDriver::Firefox.driver_path).to eq path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Firefox#driver_path/).to_stdout_from_any_process
+
+          service = Service.firefox
+
+          expect(service.executable_path).to eq path
+        end
+
         it 'does not create args by default' do
           allow(Platform).to receive(:find_binary).and_return(service_path)
 

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -49,6 +49,31 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
+        it 'uses #driver_path=' do
+          path = '/path/to/driver'
+          IE::Service.driver_path = path
+
+          service = Service.ie
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'accepts IE#driver_path= but throws deprecation notice' do
+          path = '/path/to/driver'
+
+          expect {
+            Selenium::WebDriver::IE.driver_path = path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::IE#driver_path=/).to_stdout_from_any_process
+
+          expect {
+            expect(Selenium::WebDriver::IE.driver_path).to eq path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::IE#driver_path/).to_stdout_from_any_process
+
+          service = Service.ie
+
+          expect(service.executable_path).to eq path
+        end
+
         it 'does not create args by default' do
           allow(Platform).to receive(:find_binary).and_return(service_path)
 

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -49,9 +49,19 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
-        it 'uses #driver_path=' do
+        it 'allows #driver_path= with String value' do
           path = '/path/to/driver'
           IE::Service.driver_path = path
+
+          service = Service.ie
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'allows #driver_path= with Proc value' do
+          path = '/path/to/driver'
+          proc = proc { path }
+          IE::Service.driver_path = proc
 
           service = Service.ie
 

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -49,9 +49,19 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
-        it 'uses #driver_path=' do
+        it 'allows #driver_path= with String value' do
           path = '/path/to/driver'
           Safari::Service.driver_path = path
+
+          service = Service.safari
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'allows #driver_path= with Proc value' do
+          path = '/path/to/driver'
+          proc = proc { path }
+          Safari::Service.driver_path = proc
 
           service = Service.safari
 

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -49,6 +49,31 @@ module Selenium
           expect(service.uri.to_s).to eq "http://#{Platform.localhost}:#{port}"
         end
 
+        it 'uses #driver_path=' do
+          path = '/path/to/driver'
+          Safari::Service.driver_path = path
+
+          service = Service.safari
+
+          expect(service.executable_path).to eq path
+        end
+
+        it 'accepts Safari#driver_path= but throws deprecation notice' do
+          path = '/path/to/driver'
+
+          expect {
+            Selenium::WebDriver::Safari.driver_path = path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Safari#driver_path=/).to_stdout_from_any_process
+
+          expect {
+            expect(Selenium::WebDriver::Safari.driver_path).to eq path
+          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Safari#driver_path/).to_stdout_from_any_process
+
+          service = Service.safari
+
+          expect(service.executable_path).to eq path
+        end
+
         it 'does not create args by default' do
           allow(Platform).to receive(:find_binary).and_return(service_path)
 


### PR DESCRIPTION
First, it makes more sense now to do:
```ruby
Selenium::WebDriver::Chrome::Service.driver_path = '/path/to/driver'
```
rather than to do:
```ruby
Selenium::WebDriver::Chrome.driver_path = '/path/to/driver'
```

Second, this allows `#driver_path=` to take a `Proc` value. The reason for this is to be able to lazy load an auto-generated path file. (Essentially this allows webdrivers gem to remove its Monkey Patches).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/7106)
<!-- Reviewable:end -->
