### PR TITLE
[rb] skip pending by default on local

### DIFF
--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |c|
   c.include(WebDriver::SpecSupport::Helpers)
 
   c.before(:suite) do
+    ENV['SKIP_PENDING'] = 'true' unless WebDriver::Platform.ci
     $DEBUG ||= ENV['DEBUG'] == 'true'
     GlobalTestEnv.remote_server.start if GlobalTestEnv.driver == :remote
     GlobalTestEnv.print_env


### PR DESCRIPTION
@p0deje  are you ok with this code (69ee9211b437316f0114e3f98e2511f6caf9f9ee) being default when not run on a ci? I don't think there is a way to toggle this specifically for `./go` vs `IntelliJ`