### PR TITLE
Init options

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -62,14 +62,12 @@ Metrics/PerceivedComplexity:
   Exclude:
     - 'lib/selenium/webdriver/chrome/driver.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
-    - 'lib/selenium/webdriver/chrome/options.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 9
   Exclude:
     - 'lib/selenium/webdriver/chrome/driver.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
-    - 'lib/selenium/webdriver/chrome/options.rb'
     - 'spec/integration/selenium/webdriver/spec_support/test_environment.rb'
 
 Metrics/ClassLength:

--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -62,12 +62,14 @@ Metrics/PerceivedComplexity:
   Exclude:
     - 'lib/selenium/webdriver/chrome/driver.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
+    - 'lib/selenium/webdriver/chrome/options.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 9
   Exclude:
     - 'lib/selenium/webdriver/chrome/driver.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
+    - 'lib/selenium/webdriver/chrome/options.rb'
     - 'spec/integration/selenium/webdriver/spec_support/test_environment.rb'
 
 Metrics/ClassLength:

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -72,6 +72,7 @@ module Selenium
           if profile
             profile = profile.as_json
 
+            options.args ||= []
             if options.args.none?(&/user-data-dir/.method(:match?))
               options.add_argument("--user-data-dir=#{profile['directory']}")
             end

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -179,7 +179,7 @@ module Selenium
         def as_json(*)
           options = super
 
-          options['binary'] ||= Chrome.path if Chrome.path
+          options['binary'] ||= binary_path if binary_path
           extensions = options['extensions'] || []
           encoded_extensions = options.delete(:encoded_extensions) || []
 
@@ -190,6 +190,10 @@ module Selenium
         end
 
         private
+
+        def binary_path
+          Chrome.path
+        end
 
         def encode_extension(path)
           File.open(path, 'rb') { |crx_file| Base64.strict_encode64 crx_file.read }

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -21,6 +21,47 @@ module Selenium
   module WebDriver
     module Common
       class Options
+        attr_accessor :options
+
+        def initialize(options: nil, **opts)
+          @options = if options
+                       WebDriver.logger.deprecate(":options as keyword for initializing #{self.class}",
+                                                  "custom values directly in #new constructor")
+                       opts.merge(options)
+                     else
+                       opts
+                     end
+        end
+
+        #
+        # Add a new option not yet handled by bindings.
+        #
+        # @example Leave Chrome open when chromedriver is killed
+        #   options = Selenium::WebDriver::Chrome::Options.new
+        #   options.add_option(:detach, true)
+        #
+        # @param [String, Symbol] name Name of the option
+        # @param [Boolean, String, Integer] value Value of the option
+        #
+
+        def add_option(name, value)
+          @options[name] = value
+        end
+
+        #
+        # @api private
+        #
+
+        def as_json(*)
+          options = @options.dup
+
+          opts = self.class::CAPABILITIES.each_with_object({}) do |(capability_alias, capability_name), hash|
+            capability_value = options.delete(capability_alias)
+            hash[capability_name] = capability_value unless capability_value.nil?
+          end
+          opts.merge(options)
+        end
+
         private
 
         def generate_as_json(value)

--- a/rb/lib/selenium/webdriver/edge_chrome/options.rb
+++ b/rb/lib/selenium/webdriver/edge_chrome/options.rb
@@ -23,27 +23,11 @@ module Selenium
   module WebDriver
     module EdgeChrome
       class Options < Selenium::WebDriver::Chrome::Options
-        #
-        # Create a new Options instance.
-        #
-        # @example
-        #   options = Selenium::WebDriver::EdgeChrome::Options.new(args: ['start-maximized', 'user-data-dir=/tmp/temp_profile'])
-        #   driver = Selenium::WebDriver.for(:edge_chrome, options: options)
-        #
-        # @param [Hash] opts the pre-defined options to create the Chrome::Options with
-        # @option opts [Array<String>] :args List of command-line arguments to use when starting Chrome
-        # @option opts [String] :binary Path to the Chrome executable to use
-        # @option opts [Hash] :prefs A hash with each entry consisting of the name of the preference and its value
-        # @option opts [Array<String>] :extensions A list of paths to (.crx) Chrome extensions to install on startup
-        # @option opts [Hash] :options A hash for raw options
-        # @option opts [Hash] :emulation A hash for raw emulation options
-        #
+        private
 
-        def initialize(**opts)
-          opts[:binary] ||= EdgeChrome.path
-          super(**opts)
+        def binary_path
+          EdgeChrome.path
         end
-
       end # Options
     end # EdgeChrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/edge_html/options.rb
+++ b/rb/lib/selenium/webdriver/edge_html/options.rb
@@ -52,7 +52,7 @@ module Selenium
         #
 
         def initialize(**opts)
-          @options = opts
+          super
           @options[:extensions]&.each(&method(:validate_extension))
         end
 
@@ -77,14 +77,7 @@ module Selenium
         #
 
         def as_json(*)
-          options = @options.dup
-
-          opts = CAPABILITIES.each_with_object({}) do |(capability_alias, capability_name), hash|
-            capability_value = options.delete(capability_alias)
-            hash[capability_name] = capability_value unless capability_value.nil?
-          end
-
-          generate_as_json(opts.merge(options))
+          generate_as_json(super)
         end
 
         private

--- a/rb/lib/selenium/webdriver/firefox/profile.rb
+++ b/rb/lib/selenium/webdriver/firefox/profile.rb
@@ -182,6 +182,10 @@ module Selenium
           Zipper.zip(layout_on_disk)
         end
 
+        def as_json
+          encoded
+        end
+
         private
 
         def assign_default_preferences

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -52,7 +52,7 @@ module Selenium
           end
         end
 
-        attr_reader :args, :options
+        attr_reader :args
 
         #
         # Create a new Options instance
@@ -85,9 +85,10 @@ module Selenium
         # @option opts [Boolean] validate_cookie_document_type
         #
 
-        def initialize(**opts)
-          @args = Set.new(opts.delete(:args) || [])
-          @options = opts
+        def initialize(args: nil, **opts)
+          super(opts)
+
+          @args = (args || []).to_set
           @options[:native_events] = true if @options[:native_events].nil?
         end
 
@@ -102,35 +103,14 @@ module Selenium
         end
 
         #
-        # Add a new option not yet handled by these bindings.
-        #
-        # @example
-        #   options = Selenium::WebDriver::IE::Options.new
-        #   options.add_option(:foo, 'bar')
-        #
-        # @param [String, Symbol] name Name of the option
-        # @param [Boolean, String, Integer] value Value of the option
-        #
-
-        def add_option(name, value)
-          @options[name] = value
-        end
-
-        #
         # @api private
         #
 
         def as_json(*)
-          opts = {}
-          options = @options.dup
+          options = super
+          options['ie.browserCommandLineSwitches'] = @args.to_a.join(' ') if @args.any?
 
-          CAPABILITIES.each do |capability_alias, capability_name|
-            capability_value = options.delete(capability_alias)
-            opts[capability_name] = capability_value unless capability_value.nil?
-          end
-          opts['ie.browserCommandLineSwitches'] = @args.to_a.join(' ') if @args.any?
-
-          {KEY => generate_as_json(opts.merge(options))}
+          {KEY => generate_as_json(options)}
         end
       end # Options
     end # IE

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -122,15 +122,15 @@ module Selenium
 
         def as_json(*)
           opts = {}
+          options = @options.dup
 
           CAPABILITIES.each do |capability_alias, capability_name|
-            capability_value = @options.delete(capability_alias)
+            capability_value = options.delete(capability_alias)
             opts[capability_name] = capability_value unless capability_value.nil?
           end
           opts['ie.browserCommandLineSwitches'] = @args.to_a.join(' ') if @args.any?
-          opts.merge!(@options)
 
-          {KEY => generate_as_json(opts)}
+          {KEY => generate_as_json(opts.merge(options))}
         end
       end # Options
     end # IE

--- a/rb/lib/selenium/webdriver/safari/options.rb
+++ b/rb/lib/selenium/webdriver/safari/options.rb
@@ -50,7 +50,7 @@ module Selenium
         #
 
         def initialize(**opts)
-          @options = opts
+          super
         end
 
         #
@@ -58,14 +58,7 @@ module Selenium
         #
 
         def as_json(*)
-          options = @options.dup
-
-          opts = CAPABILITIES.each_with_object({}) do |(capability_alias, capability_name), hash|
-            capability_value = options.delete(capability_alias)
-            hash[capability_name] = capability_value unless capability_value.nil?
-          end
-
-          generate_as_json(opts.merge(options))
+          generate_as_json(super)
         end
       end # Options
     end # Safari

--- a/rb/lib/selenium/webdriver/safari/options.rb
+++ b/rb/lib/selenium/webdriver/safari/options.rb
@@ -20,8 +20,22 @@
 module Selenium
   module WebDriver
     module Safari
-      class Options
-        attr_accessor :automatic_inspection, :automatic_profiling
+      class Options < WebDriver::Common::Options
+        attr_accessor :options
+
+        # @see https://developer.apple.com/documentation/webkit/about_webdriver_for_safari
+        CAPABILITIES = {automatic_inspection: 'safari:automaticInspection',
+                        automatic_profiling: 'safari:automaticProfiling'}.freeze
+
+        CAPABILITIES.each_key do |key|
+          define_method key do
+            @options[key]
+          end
+
+          define_method "#{key}=" do |value|
+            @options[key] = value
+          end
+        end
 
         #
         # Create a new Options instance for W3C-capable versions of Safari.
@@ -34,12 +48,9 @@ module Selenium
         # @option opts [Boolean] :automatic_inspection Preloads Web Inspector and JavaScript debugger. Default is false
         # @option opts [Boolean] :automatic_profiling Preloads Web Inspector and starts a timeline recording. Default is false
         #
-        # @see https://developer.apple.com/documentation/webkit/about_webdriver_for_safari
-        #
 
         def initialize(**opts)
-          @automatic_inspection = opts.delete(:automatic_inspection) || false
-          @automatic_profiling = opts.delete(:automatic_profiling) || false
+          @options = opts
         end
 
         #
@@ -47,12 +58,14 @@ module Selenium
         #
 
         def as_json(*)
-          opts = {}
+          options = @options.dup
 
-          opts['safari:automaticInspection'] = true if @automatic_inspection
-          opts['safari:automaticProfiling'] = true if @automatic_profiling
+          opts = CAPABILITIES.each_with_object({}) do |(capability_alias, capability_name), hash|
+            capability_value = options.delete(capability_alias)
+            hash[capability_name] = capability_value unless capability_value.nil?
+          end
 
-          opts
+          generate_as_json(opts.merge(options))
         end
       end # Options
     end # Safari

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -67,13 +67,11 @@ module Selenium
           profile = Profile.new
 
           profile['some_pref'] = true
-          profile.add_extension(__FILE__)
 
           Driver.new(http_client: http, profile: profile)
 
           profile_data = profile.as_json
           expect(caps['goog:chromeOptions']['args'].first).to include(profile_data['directory'])
-          expect(caps['goog:chromeOptions']['extensions']).to eq(profile_data['extensions'])
         end
 
         context 'with custom desired capabilities' do

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -28,8 +28,6 @@ module Selenium
         describe '#initialize' do
           it 'accepts defined parameters' do
             allow(File).to receive(:file?).and_return(true)
-            # allow_any_instance_of(Options).to receive(:encode_file).with('foo.crx').and_return("encoded_foo")
-            # allow_any_instance_of(Options).to receive(:encode_file).with('bar.crx').and_return("encoded_bar")
 
             opt = Options.new(args: %w[foo bar],
                               prefs: {foo: 'bar'},
@@ -50,9 +48,8 @@ module Selenium
             expect(opt.prefs[:foo]).to eq('bar')
             expect(opt.binary).to eq('/foo/bar')
             expect(opt.extensions).to eq(['foo.crx', 'bar.crx'])
-            expect(opt.encoded_extensions).to eq(%w[encoded_foobar])
             expect(opt.instance_variable_get('@options')[:foo]).to eq('bar')
-            expect(opt.mobile_emulation[:device_name]).to eq(:bar)
+            expect(opt.emulation[:device_name]).to eq(:bar)
             expect(opt.local_state[:foo]).to eq('bar')
             expect(opt.detach).to eq(true)
             expect(opt.debugger_address).to eq('127.0.0.1:8181')
@@ -89,7 +86,7 @@ module Selenium
         describe '#add_encoded_extension' do
           it 'adds an encoded extension' do
             options.add_encoded_extension('foo')
-            expect(options.encoded_extensions).to include('foo')
+            expect(options.instance_variable_get('@options')[:encoded_extensions]).to include('foo')
           end
         end
 

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -26,43 +26,51 @@ module Selenium
         subject(:options) { described_class.new }
 
         describe '#initialize' do
-          it 'sets passed args' do
-            opt = Options.new(args: %w[foo bar])
+          it 'accepts defined parameters' do
+            allow(File).to receive(:file?).and_return(true)
+            # allow_any_instance_of(Options).to receive(:encode_file).with('foo.crx').and_return("encoded_foo")
+            # allow_any_instance_of(Options).to receive(:encode_file).with('bar.crx').and_return("encoded_bar")
+
+            opt = Options.new(args: %w[foo bar],
+                              prefs: {foo: 'bar'},
+                              binary: '/foo/bar',
+                              extensions: ['foo.crx', 'bar.crx'],
+                              encoded_extensions: ['encoded_foobar'],
+                              foo: 'bar',
+                              emulation: {device_name: :bar},
+                              local_state: {foo: 'bar'},
+                              detach: true,
+                              debugger_address: '127.0.0.1:8181',
+                              exclude_switches: %w[foobar barfoo],
+                              minidump_path: 'linux/only',
+                              perf_logging_prefs: {enable_network: true},
+                              window_types: %w[normal devtools])
+
             expect(opt.args.to_a).to eq(%w[foo bar])
-          end
-
-          it 'sets passed prefs' do
-            opt = Options.new(prefs: {foo: 'bar'})
             expect(opt.prefs[:foo]).to eq('bar')
-          end
-
-          it 'sets passed binary value' do
-            opt = Options.new(binary: '/foo/bar')
             expect(opt.binary).to eq('/foo/bar')
-          end
-
-          it 'sets passed extensions' do
-            opt = Options.new(extensions: ['foo.crx', 'bar.crx'])
             expect(opt.extensions).to eq(['foo.crx', 'bar.crx'])
-          end
-
-          it 'sets passed options' do
-            opt = Options.new(options: {foo: 'bar'})
-            expect(opt.options[:foo]).to eq('bar')
-          end
-
-          it 'sets passed emulation options' do
-            opt = Options.new(emulation: {foo: 'bar'})
-            expect(opt.emulation[:foo]).to eq('bar')
+            expect(opt.encoded_extensions).to eq(%w[encoded_foobar])
+            expect(opt.instance_variable_get('@options')[:foo]).to eq('bar')
+            expect(opt.mobile_emulation[:device_name]).to eq(:bar)
+            expect(opt.local_state[:foo]).to eq('bar')
+            expect(opt.detach).to eq(true)
+            expect(opt.debugger_address).to eq('127.0.0.1:8181')
+            expect(opt.exclude_switches).to eq(%w[foobar barfoo])
+            expect(opt.minidump_path).to eq('linux/only')
+            expect(opt.perf_logging_prefs[:enable_network]).to eq(true)
+            expect(opt.window_types).to eq(%w[normal devtools])
           end
         end
 
         describe '#add_extension' do
           it 'adds an extension' do
-            allow(File).to receive(:file?).with('/foo/bar.crx').and_return(true)
+            allow(File).to receive(:file?).and_return(true)
+            ext = 'foo.crx'
+            allow_any_instance_of(Options).to receive(:encode_file).with(ext).and_return("encoded_#{ext[/([^\.]*)/]}")
 
-            options.add_extension('/foo/bar.crx')
-            expect(options.extensions).to include('/foo/bar.crx')
+            options.add_extension(ext)
+            expect(options.extensions).to eq([ext])
           end
 
           it 'raises error when the extension file is missing' do
@@ -109,7 +117,7 @@ module Selenium
         describe '#add_option' do
           it 'adds an option' do
             options.add_option(:foo, 'bar')
-            expect(options.options[:foo]).to eq('bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
           end
         end
 
@@ -123,45 +131,55 @@ module Selenium
         describe '#add_emulation' do
           it 'add an emulated device by name' do
             options.add_emulation(device_name: 'iPhone 6')
-            expect(options.emulation).to eq(deviceName: 'iPhone 6')
+            expect(options.emulation).to eq(device_name: 'iPhone 6')
           end
 
           it 'adds emulated device metrics' do
             options.add_emulation(device_metrics: {width: 400})
-            expect(options.emulation).to eq(deviceMetrics: {width: 400})
+            expect(options.emulation).to eq(device_metrics: {width: 400})
           end
 
           it 'adds emulated user agent' do
             options.add_emulation(user_agent: 'foo')
-            expect(options.emulation).to eq(userAgent: 'foo')
+            expect(options.emulation).to eq(user_agent: 'foo')
           end
         end
 
         describe '#as_json' do
-          it 'encodes extensions to base64' do
-            allow(File).to receive(:file?).and_return(true)
-            options.add_extension('/foo.crx')
-
-            allow(File).to receive(:open).and_yield(instance_double(File, read: :foo))
-            expect(Base64).to receive(:strict_encode64).with(:foo)
-            options.as_json
-          end
-
           it 'returns a JSON hash' do
-            allow(File).to receive(:open).and_return('bar')
-            opts = Options.new(args: ['foo'],
+            allow(File).to receive(:file?).and_return(true)
+            allow_any_instance_of(Options).to receive(:encode_extension).with('foo.crx').and_return("encoded_foo")
+            allow_any_instance_of(Options).to receive(:encode_extension).with('bar.crx').and_return("encoded_bar")
+
+            opts = Options.new(args: %w[foo bar],
+                               prefs: {foo: 'bar'},
                                binary: '/foo/bar',
-                               prefs: {a: 1},
-                               extensions: ['/foo.crx'],
-                               options: {foo: :bar},
-                               emulation: {device_name: 'mine'})
+                               extensions: ['foo.crx', 'bar.crx'],
+                               encoded_extensions: ['encoded_foobar'],
+                               foo: 'bar',
+                               emulation: {device_name: :mine},
+                               local_state: {foo: 'bar'},
+                               detach: true,
+                               debugger_address: '127.0.0.1:8181',
+                               exclude_switches: %w[foobar barfoo],
+                               minidump_path: 'linux/only',
+                               perf_logging_prefs: {'enable_network': true},
+                               window_types: %w[normal devtools])
 
             json = opts.as_json['goog:chromeOptions']
-            expect(json).to eq('args' => ['foo'], 'binary' => '/foo/bar',
-                               'prefs' => {'a' => 1},
-                               'extensions' => ['bar'],
+            expect(json).to eq('args' => %w[foo bar],
+                               'prefs' => {'foo' => 'bar'},
+                               'binary' => '/foo/bar',
+                               'extensions' => %w[encoded_foo encoded_bar encoded_foobar],
                                'foo' => 'bar',
-                               'mobileEmulation' => {'deviceName' => 'mine'})
+                               'mobileEmulation' => {'deviceName' => 'mine'},
+                               'localState' => {'foo' => 'bar'},
+                               'detach' => true,
+                               'debuggerAddress' => '127.0.0.1:8181',
+                               'excludeSwitches' => %w[foobar barfoo],
+                               'minidumpPath' => 'linux/only',
+                               'perfLoggingPrefs' => {'enableNetwork' => true},
+                               'windowTypes' => %w[normal devtools])
           end
         end
       end # Options

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -25,6 +25,20 @@ module Selenium
       describe Options do
         subject(:options) { described_class.new }
 
+        describe '#initialize' do
+          it 'accepts defined parameters' do
+            allow(File).to receive(:directory?).and_return(true)
+
+            options = Options.new(in_private: true,
+                                  extension_paths: ['/path1', '/path2'],
+                                  start_page: 'http://seleniumhq.org')
+
+            expect(options.in_private).to eq(true)
+            expect(options.extension_paths).to eq(['/path1', '/path2'])
+            expect(options.start_page).to eq('http://seleniumhq.org')
+          end
+        end
+
         describe '#add_extension path' do
           it 'adds extension path to the list' do
             options.add_extension_path(__dir__)
@@ -38,13 +52,15 @@ module Selenium
 
         describe '#as_json' do
           it 'returns JSON hash' do
+            allow(File).to receive(:directory?).and_return(true)
+
             options = Options.new(in_private: true,
+                                  extension_paths: ['/path1', '/path2'],
                                   start_page: 'http://seleniumhq.org')
-            options.add_extension_path(__dir__)
 
             json = options.as_json
             expect(json).to eq('ms:inPrivate' => true,
-                               'ms:extensionPaths' => [__dir__],
+                               'ms:extensionPaths' => ['/path1', '/path2'],
                                'ms:startPage' => 'http://seleniumhq.org')
           end
         end

--- a/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
@@ -26,11 +26,19 @@ module Selenium
         describe '#as_json' do
           it 'returns JSON hash' do
             options = Options.new(automatic_inspection: true,
-                                  automatic_profiling: true)
+                                  automatic_profiling: false)
 
             json = options.as_json
             expect(json).to eq('safari:automaticInspection' => true,
-                               'safari:automaticProfiling' => true)
+                               'safari:automaticProfiling' => false)
+          end
+
+          it 'accepts a non-documented value' do
+            options = Options.new
+            options.options['safari:fooBar'] = true
+
+            json = options.as_json
+            expect(json).to eq('safari:fooBar' => true)
           end
         end
       end # Options


### PR DESCRIPTION
I don't like the current approach for initializing requiring undefined parameters as "options" which is already overloaded. I would like to deprecate it.

This might be overkill if we want to just allow anything in the constructor, but this also provides users with an `attr_accessor` if they want to add known supported things rather than using `#add_option` for it.

Also, IE takes a distinctly different approach because there is a map for most of the settings (e.g. `ignore_zoom_level: 'ignoreZoomSetting'`) that we iterate through. We could possibly implement something similar for these drivers, though.