### PR TITLE
deprecate parameters getting passed into the driver directly

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -76,12 +76,15 @@ module Selenium
 
           profile = opts.delete(:profile)
           if profile
+            WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome::Driver#new with `:profile` parameter',
+                                       'Selenium::WebDriver::Chrome::Options#profile or Options#add_option'
+
             profile = profile.as_json
 
             options.add_argument("--user-data-dir=#{profile[:directory]}") if options.args.none? { |arg| arg =~ /user-data-dir/ }
 
             if profile[:extensions]
-              WebDriver.logger.deprecate 'Using Selenium::WebDriver::Chrome::Profile#extensions',
+              WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome::Profile#extensions',
                                          'Selenium::WebDriver::Chrome::Options#add_extension'
               profile[:extensions].each do |extension|
                 options.add_encoded_extension(extension)
@@ -89,8 +92,12 @@ module Selenium
             end
           end
 
-          detach = opts.delete(:detach)
-          options.add_option(:detach, true) if detach
+          if opts.key?(:detach)
+            WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome::Driver#new with `:detach` parameter',
+                                       'Selenium::WebDriver::Chrome::Options#new or Options#add_option'
+            detach = opts.delete(:detach)
+            options.add_option(:detach, true) if detach
+          end
 
           prefs = opts.delete(:prefs)
           if prefs
@@ -103,8 +110,13 @@ module Selenium
           options = options.as_json
           caps.merge!(options) unless options[Options::KEY].empty?
 
-          caps[:proxy] = opts.delete(:proxy) if opts.key?(:proxy)
-          caps[:proxy] ||= opts.delete('proxy') if opts.key?('proxy')
+          if opts.key?(:proxy) || opts.key?('proxy')
+            WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome::Driver#new with `:proxy` parameter',
+                                       'Selenium::WebDriver::Chrome::Capabilities#proxy='
+
+            caps[:proxy] = opts.delete(:proxy) if opts.key?(:proxy)
+            caps[:proxy] ||= opts.delete('proxy') if opts.key?('proxy')
+          end
 
           caps
         end

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -22,7 +22,7 @@ module Selenium
     module Chrome
       class Options
         attr_reader :args, :prefs, :options, :emulation, :extensions, :encoded_extensions
-        attr_accessor :binary
+        attr_accessor :binary, :profile, :detach
 
         KEY = 'goog:chromeOptions'
 
@@ -49,6 +49,8 @@ module Selenium
           @extensions = opts.delete(:extensions) || []
           @options = opts.delete(:options) || {}
           @emulation = opts.delete(:emulation) || {}
+          @detach = opts.delete(:detach)
+          @profile = opts.delete(:profile)
           @encoded_extensions = []
         end
 
@@ -170,6 +172,7 @@ module Selenium
             File.open(crx_path, 'rb') { |crx_file| Base64.strict_encode64 crx_file.read }
           end
           extensions.concat(@encoded_extensions)
+          add_argument("--user-data-dir=#{@profile[:directory]}") if @profile
 
           opts = @options
           opts[:binary] = @binary if @binary
@@ -177,6 +180,7 @@ module Selenium
           opts[:extensions] = extensions if extensions.any?
           opts[:mobileEmulation] = @emulation unless @emulation.empty?
           opts[:prefs] = @prefs unless @prefs.empty?
+          opts[:detach] = @detach != false
 
           {KEY => opts}
         end


### PR DESCRIPTION
Note that this is for adding deprecations to latest 3.x code (and PR is to that branch, not master) so we can delete it all in 4.x

Essentially looking to get rid of things getting passed directly into driver initialization that belong in the Options or Capabilities classes.