### PR TITLE
[rb] remove unnecessary methods

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -34,7 +34,7 @@ module Selenium
         include DriverExtensions::DownloadsFiles
 
         def initialize(opts = {})
-          opts[:desired_capabilities] = create_capabilities(opts)
+          opts[:desired_capabilities] ||= Remote::Capabilities.send(browser)
 
           opts[:url] ||= service_url(opts)
 
@@ -60,42 +60,6 @@ module Selenium
 
         def execute_cdp(cmd, **params)
           @bridge.send_command(cmd: cmd, params: params)
-        end
-
-        private
-
-        def create_capabilities(opts)
-          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.chrome }
-          options = opts.delete(:options) { Options.new }
-
-          profile = opts.delete(:profile)
-          if profile
-            profile = profile.as_json
-
-            options.args ||= []
-            if options.args.none?(&/user-data-dir/.method(:match?))
-              options.add_argument("--user-data-dir=#{profile['directory']}")
-            end
-
-            if profile['extensions']
-              WebDriver.logger.deprecate 'Using Selenium::WebDriver::Chrome::Profile#extensions',
-                                         'Selenium::WebDriver::Chrome::Options#add_extension'
-              profile['extensions'].each do |extension|
-                options.add_encoded_extension(extension)
-              end
-            end
-          end
-
-          detach = opts.delete(:detach)
-          options.add_option(:detach, true) if detach
-
-          options = options.as_json
-          caps.merge!(options) unless options[Options::KEY].empty?
-
-          caps[:proxy] = opts.delete(:proxy) if opts.key?(:proxy)
-          caps[:proxy] ||= opts.delete('proxy') if opts.key?('proxy')
-
-          caps
         end
       end # Driver
     end # Chrome

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -21,6 +21,7 @@ module Selenium
   module WebDriver
     module Chrome
       class Options < WebDriver::Common::Options
+        attr_accessor :profile
 
         KEY = 'goog:chromeOptions'
 
@@ -70,9 +71,10 @@ module Selenium
         # @option opts [Array<String>] :window_types A list of window types to appear in the list of window handles
         #
 
-        def initialize(encoded_extensions: nil, **opts)
+        def initialize(profile: nil, encoded_extensions: nil, **opts)
           super(opts)
 
+          @profile = profile
           @options[:encoded_extensions] = encoded_extensions if encoded_extensions
           @options[:extensions]&.each(&method(:validate_extension))
         end
@@ -178,6 +180,11 @@ module Selenium
 
         def as_json(*)
           options = super
+
+          if @profile
+            options['args'] ||= []
+            options['args'] << "--user-data-dir=#{@profile[:directory]}"
+          end
 
           options['binary'] ||= binary_path if binary_path
           extensions = options['extensions'] || []

--- a/rb/lib/selenium/webdriver/edge_chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/edge_chrome/driver.rb
@@ -32,14 +32,6 @@ module Selenium
         def browser
           :edge_chrome
         end
-
-        private
-
-        def create_capabilities(opts)
-          opts[:desired_capabilities] ||= Remote::Capabilities.edge_chrome
-          opts[:options] ||= Options.new
-          super(opts)
-        end
       end # Driver
     end # Chrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/edge_html/driver.rb
+++ b/rb/lib/selenium/webdriver/edge_html/driver.rb
@@ -31,7 +31,7 @@ module Selenium
         include DriverExtensions::TakesScreenshot
 
         def initialize(opts = {})
-          opts[:desired_capabilities] = create_capabilities(opts)
+          opts[:desired_capabilities] ||= Remote::Capabilities.edge
 
           opts[:url] ||= service_url(opts)
 
@@ -52,17 +52,6 @@ module Selenium
           super
         ensure
           @service&.stop
-        end
-
-        private
-
-        def create_capabilities(opts)
-          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.edge }
-          options = opts.delete(:options) { Options.new }
-          options = options.as_json
-          caps.merge!(options) unless options.empty?
-
-          caps
         end
       end # Driver
     end # Edge

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -32,7 +32,7 @@ module Selenium
         include DriverExtensions::TakesScreenshot
 
         def initialize(opts = {})
-          opts[:desired_capabilities] = create_capabilities(opts)
+          opts[:desired_capabilities] ||= Remote::Capabilities.firefox
 
           opts[:url] ||= service_url(opts)
 
@@ -54,17 +54,6 @@ module Selenium
           super
         ensure
           @service&.stop
-        end
-
-        private
-
-        def create_capabilities(opts)
-          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.firefox }
-          options = opts.delete(:options) { Options.new }
-          options = options.as_json
-          caps.merge!(options) unless options.empty?
-
-          caps
         end
       end # Driver
     end # Firefox

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -32,7 +32,7 @@ module Selenium
         include DriverExtensions::TakesScreenshot
 
         def initialize(opts = {})
-          opts[:desired_capabilities] = create_capabilities(opts)
+          opts[:desired_capabilities] ||= Remote::Capabilities.internet_explorer
 
           opts[:url] ||= service_url(opts)
 
@@ -54,18 +54,6 @@ module Selenium
         ensure
           @service&.stop
         end
-
-        private
-
-        def create_capabilities(opts)
-          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.internet_explorer }
-          options = opts.delete(:options) { Options.new }
-          options = options.as_json
-          caps.merge!(options) unless options.empty?
-
-          caps
-        end
-
       end # Driver
     end # IE
   end # WebDriver

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -32,7 +32,7 @@ module Selenium
         include DriverExtensions::TakesScreenshot
 
         def initialize(opts = {})
-          opts[:desired_capabilities] = create_capabilities(opts)
+          opts[:desired_capabilities] ||= Remote::Capabilities.safari
 
           opts[:url] ||= service_url(opts)
 
@@ -55,16 +55,6 @@ module Selenium
         ensure
           @service&.stop
         end
-
-        private
-
-        def create_capabilities(opts = {})
-          caps = opts.delete(:desired_capabilities) { Remote::Capabilities.safari }
-          options = opts.delete(:options) { Options.new }
-          caps.merge!(options.as_json)
-          caps
-        end
-
       end # Driver
     end # Safari
   end # WebDriver

--- a/rb/spec/integration/selenium/webdriver/edge_chrome/profile_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/edge_chrome/profile_spec.rb
@@ -61,8 +61,8 @@ module Selenium
 
           expect(profile).to receive(:layout_on_disk).and_return 'ignored'
 
-          expect(profile.as_json).to eq(directory: 'ignored',
-                                        extensions: [Base64.strict_encode64('test')])
+          expect(profile.as_json).to eq('directory' => 'ignored',
+                                        'extensions' => [Base64.strict_encode64('test')])
         end
 
         it "raises an error if the extension doesn't exist" do


### PR DESCRIPTION
Main issue here is that any given capabilities/options should do the same thing locally that it does remotely, so we need to remove unnecessary processing that doesn't happen in Remote class.

`Remote::Bridge#create_capabilities` merges options & capabilities, so there is no need to do it in any of these classes.
https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/remote/bridge.rb#L65

3 of the items I removed in `Chrome::Driver#create_capabilities` need to be deprecated in 3.x before we just remove them, which I proposed in #7307