### PR TITLE
[rb] initialize all of the drivers in superclass

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -33,22 +33,6 @@ module Selenium
         include DriverExtensions::TakesScreenshot
         include DriverExtensions::DownloadsFiles
 
-        def initialize(opts = {})
-          opts[:desired_capabilities] ||= Remote::Capabilities.send(browser)
-
-          opts[:url] ||= service_url(opts)
-
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities)
-          options = opts.delete(:options)
-
-          @bridge = Remote::Bridge.new(opts)
-          @bridge.extend Bridge
-          @bridge.create_session(desired_capabilities, options)
-
-          super(@bridge, listener: listener)
-        end
-
         def browser
           :chrome
         end

--- a/rb/lib/selenium/webdriver/edge_html/driver.rb
+++ b/rb/lib/selenium/webdriver/edge_html/driver.rb
@@ -30,20 +30,6 @@ module Selenium
         include DriverExtensions::HasWebStorage
         include DriverExtensions::TakesScreenshot
 
-        def initialize(opts = {})
-          opts[:desired_capabilities] ||= Remote::Capabilities.edge
-
-          opts[:url] ||= service_url(opts)
-
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities)
-
-          @bridge = Remote::Bridge.new(opts)
-          @bridge.create_session(desired_capabilities)
-
-          super(@bridge, listener: listener)
-        end
-
         def browser
           :edge
         end

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -31,22 +31,6 @@ module Selenium
         include DriverExtensions::HasWebStorage
         include DriverExtensions::TakesScreenshot
 
-        def initialize(opts = {})
-          opts[:desired_capabilities] ||= Remote::Capabilities.firefox
-
-          opts[:url] ||= service_url(opts)
-
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities)
-          options = opts.delete(:options)
-
-          @bridge = Remote::Bridge.new(opts)
-          @bridge.extend Bridge
-          @bridge.create_session(desired_capabilities, options)
-
-          super(@bridge, listener: listener)
-        end
-
         def browser
           :firefox
         end

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -31,21 +31,6 @@ module Selenium
         include DriverExtensions::HasWebStorage
         include DriverExtensions::TakesScreenshot
 
-        def initialize(opts = {})
-          opts[:desired_capabilities] ||= Remote::Capabilities.internet_explorer
-
-          opts[:url] ||= service_url(opts)
-
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities)
-          options = opts.delete(:options)
-
-          @bridge = Remote::Bridge.new(opts)
-          @bridge.create_session(desired_capabilities, options)
-
-          super(@bridge, listener: listener)
-        end
-
         def browser
           :internet_explorer
         end

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -30,30 +30,17 @@ module Selenium
 
         #
         # Initializes the bridge with the given server URL
-        # @param [Hash] opts options for the driver
-        # @option opts [String] :url url for the remote server
-        # @option opts [Object] :http_client an HTTP client instance that implements the same protocol as Http::Default
-        # @option opts [Capabilities] :desired_capabilities an instance of Remote::Capabilities describing the capabilities you want
+        # @param [String, URI] :url url for the remote server
+        # @param [Object] :http_client an HTTP client instance that implements the same protocol as Http::Default
         # @api private
         #
 
-        def initialize(opts = {})
-          opts = opts.dup
-
-          http_client = opts.delete(:http_client) { Http::Default.new }
-          url = opts.delete(:url) { "http://#{Platform.localhost}:#{PORT}/wd/hub" }
-          opts.delete(:options)
-
-          unless opts.empty?
-            raise ArgumentError, "unknown option#{'s' if opts.size != 1}: #{opts.inspect}"
-          end
-
-          uri = url.is_a?(URI) ? url : URI.parse(url)
+        def initialize(http_client: nil, url: nil)
+          uri = url.is_a?(URI) ? url : URI.parse(url || "http://#{Platform.localhost}:#{PORT}/wd/hub")
           uri.path += '/' unless %r{\/$}.match?(uri.path)
 
-          http_client.server_url = uri
-
-          @http = http_client
+          @http = http_client || Http::Default.new
+          @http.server_url = uri
           @file_detector = nil
         end
 

--- a/rb/lib/selenium/webdriver/remote/driver.rb
+++ b/rb/lib/selenium/webdriver/remote/driver.rb
@@ -33,25 +33,6 @@ module Selenium
         include DriverExtensions::Rotatable
         include DriverExtensions::HasRemoteStatus
         include DriverExtensions::HasWebStorage
-
-        def initialize(opts = {})
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities) { Capabilities.new }
-
-          if desired_capabilities.is_a?(Symbol)
-            unless Capabilities.respond_to?(desired_capabilities)
-              raise Error::WebDriverError, "invalid desired capability: #{desired_capabilities.inspect}"
-            end
-
-            desired_capabilities = Capabilities.__send__(desired_capabilities)
-          end
-
-          @bridge = Bridge.new(opts)
-          @bridge.create_session(desired_capabilities, opts.delete(:options))
-
-          super(@bridge, listener: listener)
-        end
-
       end # Driver
     end # Remote
   end # WebDriver

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -32,22 +32,6 @@ module Selenium
         include DriverExtensions::HasWebStorage
         include DriverExtensions::TakesScreenshot
 
-        def initialize(opts = {})
-          opts[:desired_capabilities] ||= Remote::Capabilities.safari
-
-          opts[:url] ||= service_url(opts)
-
-          listener = opts.delete(:listener)
-          desired_capabilities = opts.delete(:desired_capabilities)
-          options = opts.delete(:options)
-
-          @bridge = Remote::Bridge.new(opts)
-          @bridge.extend Bridge
-          @bridge.create_session(desired_capabilities, options)
-
-          super(@bridge, listener: listener)
-        end
-
         def browser
           :safari
         end

--- a/rb/lib/selenium/webdriver/support/event_firing_bridge.rb
+++ b/rb/lib/selenium/webdriver/support/event_firing_bridge.rb
@@ -109,7 +109,7 @@ module Selenium
         end
 
         def driver
-          @driver ||= Driver.new(self)
+          @driver ||= Driver.new(bridge: self)
         end
 
         def dispatch(name, *args)

--- a/rb/spec/unit/selenium/webdriver/support/event_firing_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/support/event_firing_spec.rb
@@ -26,7 +26,7 @@ module Selenium
         let(:bridge) { instance_double(Remote::Bridge) }
         let(:listener) { instance_double('EventListener') }
         let(:event_firing_bridge) { EventFiringBridge.new(bridge, listener) }
-        let(:driver) { Driver.new(event_firing_bridge) }
+        let(:driver) { Driver.new(bridge: event_firing_bridge) }
         let(:element) { Element.new(event_firing_bridge, 'ref') }
 
         context 'navigation' do


### PR DESCRIPTION
All of the drivers are now pretty much doing the exact same thing, so there isn't a need to have the code duplicated in each file.

The only major issue I had was extending the browser-specific Bridge modules. This code changes them into subclasses, which works, but I don't love, especially because it is adding files that don't actually do anything (right now), just so that the superclass can  make all the method calls it needs. 

Should we define the subclasses at the end of `remote/bridge.rb` file rather than creating 2 extra files? Or is the a better approach entirely?