### PR TITLE
[py] Chrome options override desired capabilities

### DIFF
--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -71,15 +71,12 @@ class WebDriver(RemoteWebDriver):
                           DeprecationWarning, stacklevel=2)
             options = chrome_options
 
-        if options is None:
-            # desired_capabilities stays as passed in
-            if desired_capabilities is None:
-                desired_capabilities = self.create_options().to_capabilities()
-        else:
-            if desired_capabilities is None:
-                desired_capabilities = options.to_capabilities()
-            else:
-                desired_capabilities.update(options.to_capabilities())
+        if not options:
+            options = self.create_options()
+
+        if desired_capabilities:
+            for key, value in desired_capabilities.items():
+                options.set_capability(key, value)
 
         if service:
             self.service = service
@@ -97,7 +94,7 @@ class WebDriver(RemoteWebDriver):
                 command_executor=ChromeRemoteConnection(
                     remote_server_addr=self.service.service_url,
                     keep_alive=keep_alive),
-                desired_capabilities=desired_capabilities)
+                options=options)
         except Exception:
             self.quit()
             raise


### PR DESCRIPTION
* Pass options to the remote driver (future proof)
* Convert desired caps to options rather than the other way around

Fixes #5709

<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->




- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
