### PR TITLE
Create WebElementWait

### DIFF
--- a/dotnet/src/webdriver/Support/WebElementWait
+++ b/dotnet/src/webdriver/Support/WebElementWait
@@ -1,0 +1,64 @@
+// <copyright file="WebElementWait.cs" company="WebDriver Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenQA.Selenium.Support.UI
+{
+    /// <summary>
+    /// Provides the ability to wait for an arbitrary condition during test execution.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// IWait wait = new WebElementWait(element, TimeSpan.FromSeconds(3))
+    /// IWebElement element = wait.Until(element => element.FindElement(By.Name("q")));
+    /// </code>
+    /// </example>
+    public class WebElementWait : DefaultWait<IWebElement>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebElementWait"/> class.
+        /// </summary>
+        /// <param name="element">The WebElement instance used to wait.</param>
+        /// <param name="timeout">The timeout value indicating how long to wait for the condition.</param>
+        public WebElementWait(IWebElement element, TimeSpan timeout) 
+            : this(new SystemClock(), element, timeout, DefaultSleepTimeout)
+        { 
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebElementWait"/> class.
+        /// </summary>
+        /// <param name="clock">An object implementing the <see cref="IClock"/> interface used to determine when time has passed.</param>
+        /// <param name="element">The WebElement instance used to wait.</param>
+        /// <param name="timeout">The timeout value indicating how long to wait for the condition.</param>
+        /// <param name="sleepInterval">A <see cref="TimeSpan"/> value indicating how often to check for the condition to be true.</param>
+        public WebElementWait(IClock clock, IWebElement element, TimeSpan timeout, TimeSpan sleepInterval) 
+            : base(element, clock)
+        {
+            this.Timeout = timeout;
+            this.PollingInterval = sleepInterval;
+            this.IgnoreExceptionTypes(typeof(NotFoundException));
+        }
+
+        private static TimeSpan DefaultSleepTimeout
+        {
+            get { return TimeSpan.FromMilliseconds(500); }
+        }
+    }
+}


### PR DESCRIPTION
Preperation for ExpectedConditions. Next step is to modify expectedConditions, ISearchContext will be used instead of the IWebDriver so that we can also wait for an element condition inside an element. This comes in handy when using the pageObjects pattern.

<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
