### PR TITLE
include accessibility id in FindBy

### DIFF
--- a/java/client/src/org/openqa/selenium/support/FindBy.java
+++ b/java/client/src/org/openqa/selenium/support/FindBy.java
@@ -76,6 +76,8 @@ public @interface FindBy {
 
   String xpath() default "";
 
+  String accessibility() default "";
+
   class FindByBuilder extends AbstractFindByBuilder {
     @Override
     public By buildIt(Object annotation, Field field) {


### PR DESCRIPTION
When you are using a cross platform mobile framework like react native, we usually need to declare two ID's, one for Android and another for IOS. With this changes, we can use just the **accessibility Id** in both. 
> Example:
```
@AndroidFindBy(accessibility ="Login_phone")
@iOSXCUITFindBy(xpath ="//*[@name='Login_phone']/preceding-sibling::*[1]/*[2]")
private MobileElement FIELD_PHONE;
```
_AndroidFindBy and iOSXCUITFindBy from Appium._

> With the changes:
```
@FindBy(accessibility ="Login_phone")
private MobileElement FIELD_PHONE;
```
_FindBy from Selenium._

This will provide a much clean code and make it easier to automate tests.






- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
