### PR TITLE
[rb] convert Bridge modules to subclasses

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/bridge.rb
+++ b/rb/lib/selenium/webdriver/chrome/bridge.rb
@@ -20,7 +20,7 @@
 module Selenium
   module WebDriver
     module Chrome
-      module Bridge
+      class Bridge < WebDriver::Remote::Bridge
 
         COMMANDS = {
           get_network_conditions: [:get, 'session/:session_id/chromium/network_conditions'],

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -38,6 +38,10 @@ module Selenium
           :chrome
         end
 
+        def bridge_class
+          Bridge
+        end
+
         def execute_cdp(cmd, **params)
           @bridge.send_command(cmd: cmd, params: params)
         end

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -319,14 +319,10 @@ module Selenium
 
         capabilities = generate_capabilities(cap_array)
 
-        bridge = Remote::Bridge.new(http_client: opts.delete(:http_client), url: opts.delete(:url))
+        bridge_opts = {http_client: opts.delete(:http_client), url: opts.delete(:url)}
         raise ArgumentError, "Unable to create a driver with parameters: #{opts}" unless opts.empty?
 
-        namespacing = self.class.to_s.split('::')
-
-        if Object.const_defined?("#{namespacing[0..-2].join('::')}::Bridge") && !namespacing.include?('Remote')
-          bridge.extend Object.const_get("#{namespacing[0, namespacing.length - 1].join('::')}::Bridge")
-        end
+        bridge = (respond_to?(:bridge_class) ? bridge_class : Remote::Bridge).new(bridge_opts)
 
         bridge.create_session(capabilities)
         bridge

--- a/rb/lib/selenium/webdriver/edge_chrome/bridge.rb
+++ b/rb/lib/selenium/webdriver/edge_chrome/bridge.rb
@@ -22,8 +22,7 @@ require 'selenium/webdriver/chrome/bridge'
 module Selenium
   module WebDriver
     module EdgeChrome
-      module Bridge
-        include Selenium::WebDriver::Chrome::Bridge
+      class Bridge < WebDriver::Chrome::Bridge
       end # Bridge
     end # EdgeChrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/edge_chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/edge_chrome/driver.rb
@@ -32,6 +32,10 @@ module Selenium
         def browser
           :edge_chrome
         end
+
+        def bridge_class
+          Bridge
+        end
       end # Driver
     end # EdgeChrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/firefox/bridge.rb
+++ b/rb/lib/selenium/webdriver/firefox/bridge.rb
@@ -20,7 +20,7 @@
 module Selenium
   module WebDriver
     module Firefox
-      module Bridge
+      class Bridge < WebDriver::Remote::Bridge
 
         COMMANDS = {
           install_addon: [:post, 'session/:session_id/moz/addon/install'],

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -34,6 +34,10 @@ module Selenium
         def browser
           :firefox
         end
+
+        def bridge_class
+          Bridge
+        end
       end # Driver
     end # Firefox
   end # WebDriver

--- a/rb/lib/selenium/webdriver/safari/bridge.rb
+++ b/rb/lib/selenium/webdriver/safari/bridge.rb
@@ -20,7 +20,7 @@
 module Selenium
   module WebDriver
     module Safari
-      module Bridge
+      class Bridge < WebDriver::Remote::Bridge
 
         # https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/WebDriverEndpointDoc/Commands/Commands.html
         COMMANDS = {

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -35,6 +35,10 @@ module Selenium
         def browser
           :safari
         end
+
+        def bridge_class
+          Bridge
+        end
       end # Driver
     end # Safari
   end # WebDriver


### PR DESCRIPTION
I think this simplifies things now that we've moved to the Drivers being subclassed. Is there any reason why we would want these Bridges to get extended as modules on `Remote::Bridge`?