### PR TITLE
[rb] update Selenium Logger

### DIFF
--- a/rb/lib/selenium/webdriver/chrome.rb
+++ b/rb/lib/selenium/webdriver/chrome.rb
@@ -30,13 +30,15 @@ module Selenium
 
       def self.driver_path=(path)
         WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome#driver_path=',
-                                   'Selenium::WebDriver::Chrome::Service#driver_path='
+                                   'Selenium::WebDriver::Chrome::Service#driver_path=',
+                                   id: :driver_path
         Selenium::WebDriver::Chrome::Service.driver_path = path
       end
 
       def self.driver_path
         WebDriver.logger.deprecate 'Selenium::WebDriver::Chrome#driver_path',
-                                   'Selenium::WebDriver::Chrome::Service#driver_path'
+                                   'Selenium::WebDriver::Chrome::Service#driver_path',
+                                   id: :driver_path
         Selenium::WebDriver::Chrome::Service.driver_path
       end
 

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -318,7 +318,8 @@ module Selenium
         %i[driver_opts driver_path port].each do |key|
           next unless opts.key? key
 
-          WebDriver.logger.deprecate(":#{key}", ':service with an instance of Selenium::WebDriver::Service')
+          WebDriver.logger.deprecate(":#{key}", ':service with an instance of Selenium::WebDriver::Service',
+                                     id: :service)
         end
         @service ||= Service.send(browser,
                                   args: opts.delete(:driver_opts),

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -319,7 +319,7 @@ module Selenium
           next unless opts.key? key
 
           WebDriver.logger.deprecate(":#{key}", ':service with an instance of Selenium::WebDriver::Service',
-                                     id: :service)
+                                     id: "service_#{key}".to_sym)
         end
         @service ||= Service.send(browser,
                                   args: opts.delete(:driver_opts),

--- a/rb/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb
@@ -35,7 +35,8 @@ module Selenium
           extension = File.extname(png_path).downcase
           if extension != '.png'
             WebDriver.logger.warn "name used for saved screenshot does not match file type. "\
-                                  "It should end with .png extension"
+                                  "It should end with .png extension",
+                                  id: :screenshot
           end
           File.open(png_path, 'wb') { |f| f << screenshot_as(:png) }
         end

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -45,8 +45,12 @@ module Selenium
                      :fatal, :fatal?,
                      :level, :level=
 
-      def initialize
-        @logger = create_logger($stdout)
+      #
+      # @param [String] progname Allow child projects to use Selenium's Logger pattern
+      #
+      def initialize(progname = 'Selenium')
+        @logger = create_logger(progname)
+        @ignored = []
       end
 
       #
@@ -74,27 +78,56 @@ module Selenium
       end
 
       #
+      # Will not log the provided ID.
+      #
+      # @param [Array, Symbol] id
+      #
+      def ignore(id)
+        Array(id).each { |ignore| @ignored << ignore }
+      end
+
+      #
+      # Overrides default #warn to skip ignored messages by provided id
+      #
+      # @param [String] message
+      # @param [Symbol, Array<Sybmol>] id
+      # @yield see #deprecate
+      #
+      def warn(message, id: [])
+        id = Array(id)
+        return if (@ignored & id).any?
+
+        msg = id.empty? ? message : "[#{id.map(&:inspect).join(', ')}] #{message} "
+        msg += " #{yield}" if block_given?
+
+        @logger.warn { msg }
+      end
+
+      #
       # Marks code as deprecated with/without replacement.
       #
       # @param [String] old
       # @param [String, nil] new
+      # @param [Symbol, Array<Sybmol>] id
+      # @yield appends additional message to end of provided template
       #
-      def deprecate(old, new = nil)
+      def deprecate(old, new = nil, id: [], &block)
+        return if @ignored.include?(:deprecations) || (@ignored & Array(id)).any?
+
         message = +"[DEPRECATION] #{old} is deprecated"
         message << if new
                      ". Use #{new} instead."
                    else
-                     ' and will be removed in the next releases.'
+                     ' and will be removed in a future release.'
                    end
-
-        warn message
+        warn message, id: id, &block
       end
 
       private
 
-      def create_logger(output)
-        logger = ::Logger.new(output)
-        logger.progname = 'Selenium'
+      def create_logger(name)
+        logger = ::Logger.new($stdout)
+        logger.progname = name
         logger.level = default_level
         logger.formatter = proc do |severity, time, progname, msg|
           "#{time.strftime('%F %T')} #{severity} #{progname} #{msg}\n"
@@ -104,11 +137,7 @@ module Selenium
       end
 
       def default_level
-        if $DEBUG || ENV.key?('DEBUG')
-          :debug
-        else
-          :warn
-        end
+        $DEBUG || ENV.key?('DEBUG') ? :debug : :warn
       end
     end # Logger
   end # WebDriver

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -112,15 +112,18 @@ module Selenium
       # @yield appends additional message to end of provided template
       #
       def deprecate(old, new = nil, id: [], &block)
-        return if @ignored.include?(:deprecations) || (@ignored & Array(id)).any?
+        id = Array(id)
+        return if @ignored.include?(:deprecations) || (@ignored & id).any?
 
-        message = +"[DEPRECATION] #{old} is deprecated"
+        ids = id.empty? ? '' : "[#{id.map(&:inspect).join(', ')}] "
+
+        message = +"[DEPRECATION] #{ids}#{old} is deprecated"
         message << if new
                      ". Use #{new} instead."
                    else
                      ' and will be removed in a future release.'
                    end
-        warn message, id: id, &block
+        warn message, &block
       end
 
       private

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -25,7 +25,8 @@ module Selenium
       def initialize(options: nil, **opts)
         @options = if options
                      WebDriver.logger.deprecate(":options as keyword for initializing #{self.class}",
-                                                "custom values directly in #new constructor")
+                                                "custom values directly in #new constructor",
+                                                id: :options_options)
                      opts.merge(options)
                    else
                      opts

--- a/rb/lib/selenium/webdriver/edge.rb
+++ b/rb/lib/selenium/webdriver/edge.rb
@@ -28,13 +28,15 @@ module Selenium
 
       def self.driver_path=(path)
         WebDriver.logger.deprecate 'Selenium::WebDriver::Edge#driver_path=',
-                                   'Selenium::WebDriver::Edge::Service#driver_path='
+                                   'Selenium::WebDriver::Edge::Service#driver_path=',
+                                   id: :driver_path
         Selenium::WebDriver::Edge::Service.driver_path = path
       end
 
       def self.driver_path
         WebDriver.logger.deprecate 'Selenium::WebDriver::Edge#driver_path',
-                                   'Selenium::WebDriver::Edge::Service#driver_path'
+                                   'Selenium::WebDriver::Edge::Service#driver_path',
+                                   id: :driver_path
         Selenium::WebDriver::Edge::Service.driver_path
       end
     end # EdgeHtml

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -40,13 +40,15 @@ module Selenium
 
       def self.driver_path=(path)
         WebDriver.logger.deprecate 'Selenium::WebDriver::Firefox#driver_path=',
-                                   'Selenium::WebDriver::Firefox::Service#driver_path='
+                                   'Selenium::WebDriver::Firefox::Service#driver_path=',
+                                   id: :driver_path
         Selenium::WebDriver::Firefox::Service.driver_path = path
       end
 
       def self.driver_path
         WebDriver.logger.deprecate 'Selenium::WebDriver::Firefox#driver_path',
-                                   'Selenium::WebDriver::Firefox::Service#driver_path'
+                                   'Selenium::WebDriver::Firefox::Service#driver_path',
+                                   id: :driver_path
         Selenium::WebDriver::Firefox::Service.driver_path
       end
 

--- a/rb/lib/selenium/webdriver/ie.rb
+++ b/rb/lib/selenium/webdriver/ie.rb
@@ -26,13 +26,15 @@ module Selenium
 
       def self.driver_path=(path)
         WebDriver.logger.deprecate 'Selenium::WebDriver::IE#driver_path=',
-                                   'Selenium::WebDriver::IE::Service#driver_path='
+                                   'Selenium::WebDriver::IE::Service#driver_path=',
+                                   id: :driver_path
         Selenium::WebDriver::IE::Service.driver_path = path
       end
 
       def self.driver_path
         WebDriver.logger.deprecate 'Selenium::WebDriver::IE#driver_path',
-                                   'Selenium::WebDriver::IE::Service#driver_path'
+                                   'Selenium::WebDriver::IE::Service#driver_path',
+                                   id: :driver_path
         Selenium::WebDriver::IE::Service.driver_path
       end
     end # IE

--- a/rb/lib/selenium/webdriver/safari.rb
+++ b/rb/lib/selenium/webdriver/safari.rb
@@ -49,13 +49,15 @@ module Selenium
 
         def driver_path=(path)
           WebDriver.logger.deprecate 'Selenium::WebDriver::Safari#driver_path=',
-                                     'Selenium::WebDriver::Safari::Service#driver_path='
+                                     'Selenium::WebDriver::Safari::Service#driver_path=',
+                                     id: :driver_path
           Selenium::WebDriver::Safari::Service.driver_path = path
         end
 
         def driver_path
           WebDriver.logger.deprecate 'Selenium::WebDriver::Safari#driver_path',
-                                     'Selenium::WebDriver::Safari::Service#driver_path'
+                                     'Selenium::WebDriver::Safari::Service#driver_path',
+                                     id: :driver_path
           Selenium::WebDriver::Safari::Service.driver_path
         end
       end

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -57,7 +57,7 @@ module Selenium
           path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.jpg"
           message = "name used for saved screenshot does not match file type. "\
                     "It should end with .png extension"
-          expect(WebDriver.logger).to receive(:warn).with(message)
+          expect(WebDriver.logger).to receive(:warn).with(message, id: :screenshot)
 
           save_screenshot_and_assert(path)
         end

--- a/rb/spec/integration/selenium/webdriver/manager_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/manager_spec.rb
@@ -42,7 +42,8 @@ module Selenium
           expect(entries.first).to be_kind_of(LogEntry)
         end
 
-        it 'can get the driver log' do
+        # Chrome - turned off by default
+        it 'can get the driver log', except: {browser: %i[chrome edge_chrome]} do
           driver.navigate.to url_for('simpleTest.html')
 
           entries = driver.manage.logs.get(:driver)

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -30,6 +30,10 @@ include Selenium # rubocop:disable Style/MixinUsage
 GlobalTestEnv = WebDriver::SpecSupport::TestEnvironment.new
 
 RSpec.configure do |c|
+  c.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   c.include(WebDriver::SpecSupport::Helpers)
 
   c.before(:suite) do

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -23,6 +23,7 @@ require 'rspec'
 
 require 'selenium-webdriver'
 require_relative 'spec_support'
+require_relative '../../../rspec_matchers'
 
 include Selenium # rubocop:disable Style/MixinUsage
 

--- a/rb/spec/rspec_matchers.rb
+++ b/rb/spec/rspec_matchers.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+RSpec::Matchers.define :have_deprecated do |deprecation|
+  match do |actual|
+    # Not sure how else to capture stdout here
+    expect {
+      actual.call
+      std_out = File.read $stdout if $stdout.is_a?(File)
+      @deprecations_found = std_out&.scan(/DEPRECATION\] \[:([^\]]*)\]/)&.flatten&.map(&:to_sym)
+    }.to output.to_stdout_from_any_process
+    expect(Array(deprecation).sort).to eq(@deprecations_found&.sort)
+  end
+
+  failure_message do
+    but_message = if @deprecations_found.empty? || @deprecations_found.nil?
+                    'no deprecations were found'
+                  else
+                    "instead these deprecations were found: [#{@deprecations_found.join(', ')}]"
+                  end
+    "expected :#{deprecation} to have been deprecated, but #{but_message}"
+  end
+
+  failure_message_when_negated do
+    but_message = "it was found among these deprecations: [#{@deprecations_found.join(', ')}]"
+    "expected :#{deprecation} not to have been deprecated, but #{but_message}"
+  end
+
+  def supports_block_expectations?
+    true
+  end
+end

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -73,11 +73,11 @@ module Selenium
 
           expect {
             Selenium::WebDriver::Chrome.driver_path = path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Chrome#driver_path=/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           expect {
             expect(Selenium::WebDriver::Chrome.driver_path).to eq path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Chrome#driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           service = Service.chrome
 
@@ -139,7 +139,7 @@ module Selenium
 
           expect {
             driver.new(driver_path: driver_path)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_path)
         end
 
         it 'accepts :port but throws deprecation notice' do
@@ -151,7 +151,7 @@ module Selenium
 
           expect {
             driver.new(port: driver_port)
-          }.to output(/WARN Selenium \[DEPRECATION\] :port/).to_stdout_from_any_process
+          }.to have_deprecated(:service_port)
         end
 
         it 'accepts :driver_opts but throws deprecation notice' do
@@ -164,7 +164,7 @@ module Selenium
 
           expect {
             driver.new(driver_opts: driver_opts)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_opts/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_opts)
         end
 
         it 'accepts :service without creating a new instance' do

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -22,6 +22,8 @@ require File.expand_path('../spec_helper', __dir__)
 module Selenium
   module WebDriver
     describe Logger do
+      subject(:logger) { Logger.new('Selenium') }
+
       around do |example|
         debug = $DEBUG
         $DEBUG = false
@@ -30,46 +32,110 @@ module Selenium
         WebDriver.instance_variable_set(:@logger, nil) # reset cache
       end
 
-      it 'logs warnings by default' do
-        expect(WebDriver.logger.level).to eq(2)
-        expect(WebDriver.logger).to be_warn
-      end
-
-      it 'logs everything if $DEBUG is set to true' do
-        $DEBUG = true
-        expect(WebDriver.logger.level).to eq(0)
-        expect(WebDriver.logger).to be_debug
-      end
-
-      it 'allows to change level during execution' do
-        WebDriver.logger.level = :info
-        expect(WebDriver.logger.level).to eq(1)
-        expect(WebDriver.logger).to be_info
-      end
-
-      it 'outputs to stdout by default' do
-        expect { WebDriver.logger.warn('message') }.to output(/WARN Selenium message/).to_stdout
-      end
-
-      it 'allows to output to file' do
-        begin
-          WebDriver.logger.output = 'test.log'
-          WebDriver.logger.warn('message')
-          expect(File.read('test.log')).to include('WARN Selenium message')
-        ensure
-          WebDriver.logger.close
-          File.delete('test.log')
+      describe '#new' do
+        it 'allows creating a logger with a different progname' do
+          other_logger = Logger.new('NotSelenium')
+          msg = /WARN NotSelenium message/
+          expect { other_logger.warn('message') }.to output(msg).to_stdout_from_any_process
         end
       end
 
-      it 'allows to deprecate functionality with replacement' do
-        message = /WARN Selenium \[DEPRECATION\] #old is deprecated\. Use #new instead\./
-        expect { WebDriver.logger.deprecate('#old', '#new') }.to output(message).to_stdout
+      describe '#level' do
+        it 'logs at warning level by default' do
+          expect(logger.level).to eq(2)
+          expect(logger).to be_warn
+        end
+
+        it 'logs at debug level if $DEBUG is set to true' do
+          $DEBUG = true
+          expect(logger.level).to eq(0)
+          expect(logger).to be_debug
+        end
+
+        it 'allows changing level by name during execution' do
+          logger.level = :info
+          expect(logger.level).to eq(1)
+          expect(logger).to be_info
+        end
+
+        it 'allows changing level by integer during execution' do
+          logger.level = 1
+          expect(logger).to be_info
+        end
       end
 
-      it 'allows to deprecate functionality without replacement' do
-        message = /WARN Selenium \[DEPRECATION\] #old is deprecated and will be removed in the next releases\./
-        expect { WebDriver.logger.deprecate('#old') }.to output(message).to_stdout
+      describe '#output' do
+        it 'outputs to stdout by default' do
+          expect { logger.warn('message') }.to output(/WARN Selenium message/).to_stdout
+        end
+
+        it 'allows output to file' do
+          begin
+            logger.output = 'test.log'
+            logger.warn('message')
+            expect(File.read('test.log')).to include('WARN Selenium message')
+          ensure
+            logger.close
+            File.delete('test.log')
+          end
+        end
+      end
+
+      describe '#warn' do
+        it 'logs with String' do
+          expect { logger.warn "String Value" }.to output(/WARN Selenium String Value/).to_stdout
+        end
+
+        it 'logs single id when set' do
+          msg = /WARN Selenium \[:foo\] warning message/
+          expect { logger.warn('warning message', id: :foo) }.to output(msg).to_stdout
+        end
+
+        it 'logs multiple ids when set' do
+          msg = /WARN Selenium \[:foo, :bar\] warning message/
+          expect { logger.warn('warning message', id: %i[foo bar]) }.to output(msg).to_stdout
+        end
+      end
+
+      describe '#deprecate' do
+        it 'allows to deprecate functionality with replacement' do
+          message = /WARN Selenium \[DEPRECATION\] #old is deprecated\. Use #new instead\./
+          expect { logger.deprecate('#old', '#new') }.to output(message).to_stdout
+        end
+
+        it 'allows to deprecate functionality without replacement' do
+          message = /WARN Selenium \[DEPRECATION\] #old is deprecated and will be removed in a future release\./
+          expect { logger.deprecate('#old') }.to output(message).to_stdout
+        end
+
+        it 'appends deprecation message with provided block' do
+          message = /WARN Selenium \[DEPRECATION\] #old is deprecated\. Use #new instead\. More Details\./
+          expect { logger.deprecate('#old', '#new') { 'More Details.' } }.to output(message).to_stdout
+        end
+      end
+
+      describe '#ignore' do
+        it 'prevents logging when ignoring single id' do
+          logger.ignore(:foo)
+          expect { logger.deprecate('#old', '#new', id: :foo) }.not_to output.to_stdout_from_any_process
+        end
+
+        it 'prevents logging when ignoring multiple ids' do
+          logger.ignore(:foo)
+          logger.ignore(:bar)
+          expect { logger.deprecate('#old', '#new', id: :foo) }.not_to output.to_stdout_from_any_process
+          expect { logger.deprecate('#old', '#new', id: :bar) }.not_to output.to_stdout_from_any_process
+        end
+
+        it 'prevents logging when ignoring Array of ids' do
+          logger.ignore(%i[foo bar])
+          expect { logger.deprecate('#old', '#new', id: %i[foo foobar]) }.not_to output.to_stdout_from_any_process
+        end
+
+        it 'prevents logging any deprecation when ignoring :deprecations' do
+          logger.ignore(:deprecations)
+          expect { logger.deprecate('#old', '#new') }.not_to output.to_stdout_from_any_process
+        end
       end
     end
   end # WebDriver

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -66,7 +66,7 @@ module Selenium
 
       describe '#output' do
         it 'outputs to stdout by default' do
-          expect { logger.warn('message') }.to output(/WARN Selenium message/).to_stdout
+          expect { logger.warn('message') }.to output(/WARN Selenium message/).to_stdout_from_any_process
         end
 
         it 'allows output to file' do
@@ -83,34 +83,44 @@ module Selenium
 
       describe '#warn' do
         it 'logs with String' do
-          expect { logger.warn "String Value" }.to output(/WARN Selenium String Value/).to_stdout
+          expect { logger.warn "String Value" }.to output(/WARN Selenium String Value/).to_stdout_from_any_process
         end
 
         it 'logs single id when set' do
           msg = /WARN Selenium \[:foo\] warning message/
-          expect { logger.warn('warning message', id: :foo) }.to output(msg).to_stdout
+          expect { logger.warn('warning message', id: :foo) }.to output(msg).to_stdout_from_any_process
         end
 
         it 'logs multiple ids when set' do
           msg = /WARN Selenium \[:foo, :bar\] warning message/
-          expect { logger.warn('warning message', id: %i[foo bar]) }.to output(msg).to_stdout
+          expect { logger.warn('warning message', id: %i[foo bar]) }.to output(msg).to_stdout_from_any_process
         end
       end
 
       describe '#deprecate' do
         it 'allows to deprecate functionality with replacement' do
           message = /WARN Selenium \[DEPRECATION\] #old is deprecated\. Use #new instead\./
-          expect { logger.deprecate('#old', '#new') }.to output(message).to_stdout
+          expect { logger.deprecate('#old', '#new') }.to output(message).to_stdout_from_any_process
         end
 
         it 'allows to deprecate functionality without replacement' do
           message = /WARN Selenium \[DEPRECATION\] #old is deprecated and will be removed in a future release\./
-          expect { logger.deprecate('#old') }.to output(message).to_stdout
+          expect { logger.deprecate('#old') }.to output(message).to_stdout_from_any_process
         end
 
         it 'appends deprecation message with provided block' do
           message = /WARN Selenium \[DEPRECATION\] #old is deprecated\. Use #new instead\. More Details\./
-          expect { logger.deprecate('#old', '#new') { 'More Details.' } }.to output(message).to_stdout
+          expect { logger.deprecate('#old', '#new') { 'More Details.' } }.to output(message).to_stdout_from_any_process
+        end
+
+        it 'logs single id when set' do
+          msg = /WARN Selenium \[:foo\] warning message/
+          expect { logger.warn('warning message', id: :foo) }.to output(msg).to_stdout_from_any_process
+        end
+
+        it 'logs multiple ids when set' do
+          msg = /WARN Selenium \[:foo, :bar\] warning message/
+          expect { logger.warn('warning message', id: %i[foo bar]) }.to output(msg).to_stdout_from_any_process
         end
       end
 

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -72,11 +72,11 @@ module Selenium
           path = '/path/to/driver'
           expect {
             Selenium::WebDriver::Edge.driver_path = path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Edge#driver_path=/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           expect {
             expect(Selenium::WebDriver::Edge.driver_path).to eq path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Edge#driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           service = Service.edge
 
@@ -140,7 +140,7 @@ module Selenium
 
           expect {
             driver.new(driver_path: driver_path)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_path)
         end
 
         it 'accepts :port but throws deprecation notice' do
@@ -152,7 +152,7 @@ module Selenium
 
           expect {
             driver.new(port: driver_port)
-          }.to output(/WARN Selenium \[DEPRECATION\] :port/).to_stdout_from_any_process
+          }.to have_deprecated(:service_port)
         end
 
         it 'accepts :driver_opts but throws deprecation notice' do
@@ -165,7 +165,7 @@ module Selenium
 
           expect {
             driver.new(driver_opts: driver_opts)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_opts/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_opts)
         end
 
         it 'accepts :service without creating a new instance' do

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -73,11 +73,11 @@ module Selenium
 
           expect {
             Selenium::WebDriver::Firefox.driver_path = path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Firefox#driver_path=/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           expect {
             expect(Selenium::WebDriver::Firefox.driver_path).to eq path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Firefox#driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           service = Service.firefox
 
@@ -141,7 +141,7 @@ module Selenium
 
           expect {
             driver.new(driver_path: driver_path)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_path)
         end
 
         it 'accepts :port but throws deprecation notice' do
@@ -153,7 +153,7 @@ module Selenium
 
           expect {
             driver.new(port: driver_port)
-          }.to output(/WARN Selenium \[DEPRECATION\] :port/).to_stdout_from_any_process
+          }.to have_deprecated(:service_port)
         end
 
         it 'accepts :driver_opts but throws deprecation notice' do
@@ -166,7 +166,7 @@ module Selenium
 
           expect {
             driver.new(driver_opts: driver_opts)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_opts/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_opts)
         end
 
         it 'accepts :service without creating a new instance' do

--- a/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
@@ -123,8 +123,8 @@ module Selenium
           expect_request(body: {capabilities: {firstMatch: ["browserName": "internet explorer",
                                                             "platformName": "windows",
                                                             "invalid": "foobar",
-                                                            "se:ieOptions":{"nativeEvents":true,
-                                                                            "ie.browserCommandLineSwitches":"-f"}]}})
+                                                            "se:ieOptions": {"nativeEvents": true,
+                                                                             "ie.browserCommandLineSwitches": "-f"}]}})
 
           expect {
             Driver.new(options: Options.new(browser_opts), desired_capabilities: caps)

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -73,11 +73,11 @@ module Selenium
 
           expect {
             Selenium::WebDriver::IE.driver_path = path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::IE#driver_path=/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           expect {
             expect(Selenium::WebDriver::IE.driver_path).to eq path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::IE#driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           service = Service.ie
 
@@ -141,7 +141,7 @@ module Selenium
 
           expect {
             driver.new(driver_path: driver_path)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_path)
         end
 
         it 'accepts :port but throws deprecation notice' do
@@ -153,7 +153,7 @@ module Selenium
 
           expect {
             driver.new(port: driver_port)
-          }.to output(/WARN Selenium \[DEPRECATION\] :port/).to_stdout_from_any_process
+          }.to have_deprecated(:service_port)
         end
 
         it 'accepts :driver_opts but throws deprecation notice' do
@@ -166,7 +166,7 @@ module Selenium
 
           expect {
             driver.new(driver_opts: driver_opts)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_opts/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_opts)
         end
 
         it 'accepts :service without creating a new instance' do

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -73,11 +73,11 @@ module Selenium
 
           expect {
             Selenium::WebDriver::Safari.driver_path = path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Safari#driver_path=/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           expect {
             expect(Selenium::WebDriver::Safari.driver_path).to eq path
-          }.to output(/WARN Selenium \[DEPRECATION\] Selenium::WebDriver::Safari#driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:driver_path)
 
           service = Service.safari
 
@@ -131,7 +131,7 @@ module Selenium
 
           expect {
             driver.new(driver_path: driver_path)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_path/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_path)
         end
 
         it 'accepts :port but throws deprecation notice' do
@@ -143,7 +143,7 @@ module Selenium
 
           expect {
             driver.new(port: driver_port)
-          }.to output(/WARN Selenium \[DEPRECATION\] :port/).to_stdout_from_any_process
+          }.to have_deprecated(:service_port)
         end
 
         it 'accepts :driver_opts but throws deprecation notice' do
@@ -156,7 +156,7 @@ module Selenium
 
           expect {
             driver.new(driver_opts: driver_opts)
-          }.to output(/WARN Selenium \[DEPRECATION\] :driver_opts/).to_stdout_from_any_process
+          }.to have_deprecated(:service_driver_opts)
         end
 
         it 'accepts :service without creating a new instance' do

--- a/rb/spec/unit/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/unit/selenium/webdriver/spec_helper.rb
@@ -24,6 +24,7 @@ require 'webmock/rspec'
 require 'selenium-webdriver'
 require 'securerandom'
 require 'pathname'
+require_relative '../../../rspec_matchers'
 
 module Selenium
   module WebDriver

--- a/rb/spec/unit/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/unit/selenium/webdriver/spec_helper.rb
@@ -40,6 +40,10 @@ module Selenium
 end
 
 RSpec.configure do |c|
+  c.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   c.include Selenium::WebDriver::UnitSpecHelper
 
   c.filter_run focus: true if ENV['focus']


### PR DESCRIPTION
Finally got around to this.

1. Allow creating a separate Logger instance with a different progname so we can remove the "duplicate" logging wrappers in Watir, Webdrivers and others

2. Supports adding ids so if someone wants to silence specific warnings/deprecations they can

3. Allows #deprecate to take a block that will append to the logged message (e.g. reasons for deprecation or link to blog / documentation, etc)

4. Added Custom RSpec Matchers to make it easier to filter out noise from STDOUT

5. I also threw in `aggregate_failures` in spec_helpers because I was playing with it. Let me know if there's a reason we might now want it there.