### PR TITLE
 Add new locator type for Shadow Root elements

### DIFF
--- a/common/src/web/shadowElements.html
+++ b/common/src/web/shadowElements.html
@@ -1,0 +1,23 @@
+<html>
+  <body>
+  <div id="outside_shadow">
+  	<p id="inner_shadow_text">outside shadow</p>
+  </div>
+  <div id="no_shadow">
+  	<p id="inner_no_shadow">no shadow</p>
+  </div>
+  <script>
+    var nestedElement = document.createElement('nested-element');
+    nestedElement.setAttribute('nestedAttribute', 'nestedAttributeValue');
+
+    var nestedElementLevel2 = document.createElement('nested-element-level-2');
+    nestedElementLevel2.setAttribute('nestedAttribute2', 'nestedAttributeValue2');
+    
+    nestedElement.attachShadow({mode: 'open'});
+    nestedElement.shadowRoot.appendChild(nestedElementLevel2);
+
+    document.getElementById("outside_shadow").attachShadow({mode: 'open'});
+    document.getElementById("outside_shadow").shadowRoot.appendChild(nestedElement);
+  </script>
+  </body>
+</html>

--- a/java/client/src/org/openqa/selenium/By.java
+++ b/java/client/src/org/openqa/selenium/By.java
@@ -484,7 +484,7 @@ public abstract class By {
       if (cssSelector == null) {
         throw new IllegalArgumentException("Cannot find elements when the selector is null");
       }
-      
+
       this.cssSelector = cssSelector;
     }
 
@@ -511,6 +511,10 @@ public abstract class By {
     @Override
     public String toString() {
       return "By.cssSelector: " + cssSelector;
+    }
+
+    public String getCssSelector() {
+      return cssSelector;
     }
 
     private Map<String, Object> toJson() {

--- a/java/client/src/org/openqa/selenium/ShadowElementFinder.java
+++ b/java/client/src/org/openqa/selenium/ShadowElementFinder.java
@@ -1,0 +1,64 @@
+package org.openqa.selenium;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Helper to to verify if some element has a Shadow Root attached to it and allow further querying to locate nested elements attached to it.
+ */
+public class ShadowElementFinder {
+
+  private JavascriptExecutor jsExecutor;
+
+  public ShadowElementFinder(SearchContext context) {
+    jsExecutor = (JavascriptExecutor) context;
+  }
+
+  /**
+   * Verifies if the given element has a Shadow Root attached to it.
+   *
+   * @param element The element to be checked for Shadow Root
+   * @return boolean True if it has a Shadow Root, false otherwise
+   */
+  public boolean hasShadowElement(WebElement element) {
+    return extractShadowElementOf(element).isPresent();
+  }
+
+  /**
+   * Runs the script to extract the shadow root of an element.
+   * <br>This method might
+   *
+   * @param element The element verify and extract the Shadow Root from
+   * @return A WebElement if there is a Shadow Root attached to the element, null otherwise
+   */
+  public Optional<WebElement> extractShadowElementOf(WebElement element) {
+    final String SHADOW_ROOT_SCRIPT = "return arguments[0].shadowRoot";
+    WebElement shadowElement = (WebElement) jsExecutor.executeScript(SHADOW_ROOT_SCRIPT, element);
+    return Optional.ofNullable(shadowElement);
+  }
+
+  /**
+   * Safely extracts the Shadow Root of an element.
+   *
+   * @param element The element verify and extract the Shadow Root from
+   * @return The Shadow Root of the element, or the same element if it doesn't have a Shadow Root.
+   */
+  public WebElement safeExtractShadowElementOf(WebElement element) {
+    return extractShadowElementOf(element).orElse(element);
+  }
+
+  /**
+   * Safely extracts the Shadow Root of a list of elements.
+   *
+   * @param elements A list of {@link WebElement}s
+   * @return The Shadow Root of the element, or the same element if it doesn't have a Shadow Root.
+   */
+  public List<WebElement> extractShadowElements(List<WebElement> elements) {
+    List<WebElement> extractedElements = new ArrayList<>();
+    for (WebElement element : elements) {
+      extractedElements.add(safeExtractShadowElementOf(element));
+    }
+    return extractedElements;
+  }
+}

--- a/java/client/src/org/openqa/selenium/support/BUILD.bazel
+++ b/java/client/src/org/openqa/selenium/support/BUILD.bazel
@@ -42,6 +42,7 @@ java_library(
         "FindAll.java",
         "FindBy.java",
         "FindBys.java",
+        "FindShadowBy.java",
         "How.java",
         "PageFactory.java",
         "PageFactoryFinder.java",

--- a/java/client/src/org/openqa/selenium/support/FindShadowBy.java
+++ b/java/client/src/org/openqa/selenium/support/FindShadowBy.java
@@ -1,0 +1,36 @@
+package org.openqa.selenium.support;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.pagefactory.ByChainedShadow;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+@PageFactoryFinder(FindShadowBy.FindShadowByBuilder.class)
+public @interface FindShadowBy {
+
+  FindBy[] value();
+
+  public static class FindShadowByBuilder extends AbstractFindByBuilder {
+    @Override
+    public By buildIt(Object annotation, Field field) {
+      FindShadowBy findBys = (FindShadowBy) annotation;
+      for (FindBy findBy : findBys.value()) {
+        assertValidFindBy(findBy);
+      }
+
+      FindBy[] findByArray = findBys.value();
+      By[] byArray = new By[findByArray.length];
+      for (int i = 0; i < findByArray.length; i++) {
+        byArray[i] = buildByFromFindBy(findByArray[i]);
+      }
+
+      return new ByChainedShadow(byArray);
+    }
+  }
+}

--- a/java/client/src/org/openqa/selenium/support/pagefactory/ByChainedShadow.java
+++ b/java/client/src/org/openqa/selenium/support/pagefactory/ByChainedShadow.java
@@ -1,0 +1,69 @@
+package org.openqa.selenium.support.pagefactory;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.ShadowElementFinder;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Similar to {@link ByChained}, but for each {@link By} provided it will verify if it has a Shadow Root
+ * attached to it, and return it.
+ * <br> if you need to find an element that is inside a Shadow Root, use:
+ * <pre>
+ * driver.findElements(new ByChainedShadow(shadowRootBy, targetElementBy))
+ * </pre>
+ *
+ * This will locate the shadow element first using <var>shadowRootBy</var>, and from there use
+ * <var>targetElementBy</var> to locate the element inside the shadow element.
+ * <br>
+ * <br>Note that using {@link org.openqa.selenium.By.ByXPath} will throw an exception if used inside
+ * any Shadow Root. Using {@link org.openqa.selenium.By.ByXPath} on <var>shadowRootBy</var> it's ok
+ * (as it is the first find), using it on <var>targetElementBy</var> won't work and will throw an error.
+ */
+public class ByChainedShadow extends ByChained {
+
+  private By[] bys;
+
+  public ByChainedShadow(By... bys) {
+    super(bys);
+    this.bys = bys;
+  }
+
+  @Override
+  public List<WebElement> findElements(SearchContext context) {
+    if (bys.length == 0) {
+      return new ArrayList<>();
+    }
+
+    List<WebElement> elements = null;
+    ShadowElementFinder shadowElementFinder = new ShadowElementFinder(context);
+    for (By by : bys) {
+      List<WebElement> newElements = new ArrayList<>();
+      if (elements == null) {
+        newElements = by.findElements(context);
+      } else {
+        for (WebElement element : elements) {
+          newElements.addAll(element.findElements(by));
+        }
+      }
+
+      // This is important, because even if the last item has a Shadow Root and we extract it
+      // the user won't be able to do actions against it, as we are already inside the Shadow
+      // DOM of it. Instead, just return the element if it's the last By to be executed.
+      if (isLastBy(by)) {
+        elements = newElements;
+      } else {
+        elements = shadowElementFinder.extractShadowElements(newElements);
+      }
+    }
+
+    return elements;
+  }
+
+  private boolean isLastBy(By by) {
+    return bys[bys.length - 1] == by;
+  }
+}

--- a/java/client/src/org/openqa/selenium/support/pagefactory/ByChainedShadow.java
+++ b/java/client/src/org/openqa/selenium/support/pagefactory/ByChainedShadow.java
@@ -45,25 +45,12 @@ public class ByChainedShadow extends ByChained {
       if (elements == null) {
         newElements = by.findElements(context);
       } else {
-        for (WebElement element : elements) {
-          newElements.addAll(element.findElements(by));
-        }
+          List<WebElement> webElements = shadowElementFinder.extractShadowElementsWithBy(elements, by);
+          newElements.addAll(webElements);
       }
-
-      // This is important, because even if the last item has a Shadow Root and we extract it
-      // the user won't be able to do actions against it, as we are already inside the Shadow
-      // DOM of it. Instead, just return the element if it's the last By to be executed.
-      if (isLastBy(by)) {
-        elements = newElements;
-      } else {
-        elements = shadowElementFinder.extractShadowElements(newElements);
-      }
+      elements = newElements;
     }
 
     return elements;
-  }
-
-  private boolean isLastBy(By by) {
-    return bys[bys.length - 1] == by;
   }
 }

--- a/java/client/test/org/openqa/selenium/ShadowElementFinderTest.java
+++ b/java/client/test/org/openqa/selenium/ShadowElementFinderTest.java
@@ -1,0 +1,113 @@
+package org.openqa.selenium;
+
+import org.junit.Test;
+import org.openqa.selenium.testing.Ignore;
+import org.openqa.selenium.testing.JUnit4TestBase;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
+import static org.openqa.selenium.testing.drivers.Browser.MARIONETTE;
+
+/**
+ * Shadow Root is not supported by Firefox.
+ * 
+ */
+public class ShadowElementFinderTest extends JUnit4TestBase {
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testShadowElementExists() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("outside_shadow"));
+    boolean hasShadowElement = new ShadowElementFinder(driver).hasShadowElement(element);
+
+    assertThat(hasShadowElement).isTrue();
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testShadowElementDoesNotExist() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("no_shadow"));
+    boolean hasShadowElement = new ShadowElementFinder(driver).hasShadowElement(element);
+
+    assertThat(hasShadowElement).isFalse();
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testShadowElementUnsafeExtractionIsReturned() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("outside_shadow"));
+    Optional<WebElement> result = new ShadowElementFinder(driver).extractShadowElementOf(element);
+
+    assertThat(result.isPresent()).isTrue();
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testShadowElementUnsafeExtractionIsNull() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("no_shadow"));
+    Optional<WebElement> result = new ShadowElementFinder(driver).extractShadowElementOf(element);
+
+    assertThat(result.isPresent()).isFalse();
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testShadowElementSafeExtractionIsReturned() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("outside_shadow"));
+    WebElement extractedElement = new ShadowElementFinder(driver).safeExtractShadowElementOf(element);
+
+    assertThat(extractedElement).isNotNull();
+    assertThat(extractedElement).isNotEqualTo(element);
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testSafeExtractReturnsSameElementWhenElementIsNotShadow() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement element = driver.findElement(By.id("no_shadow"));
+    WebElement extractedElement = new ShadowElementFinder(driver).safeExtractShadowElementOf(element);
+
+    assertThat(extractedElement).isNotNull();
+    assertThat(extractedElement).isEqualTo(element);
+  }
+
+  @Test
+  @Ignore(FIREFOX)
+  @Ignore(MARIONETTE)
+  public void testExtractShadowElementsFromList() {
+    driver.get(pages.shadowElementsPage);
+
+    WebElement noShadow = driver.findElement(By.id("no_shadow"));
+    WebElement outsideShadow = driver.findElement(By.id("outside_shadow"));
+    List<WebElement> list = Arrays.asList(noShadow, outsideShadow);
+    List<WebElement> extractedElements = new ShadowElementFinder(driver).extractShadowElements(list);
+
+    assertThat(extractedElements).isNotNull();
+    assertThat(extractedElements).hasSize(2);
+    assertThat(extractedElements).allMatch(Objects::nonNull);
+    assertThat(extractedElements).contains(noShadow);
+    assertThat(extractedElements).doesNotContain(outsideShadow);
+  }
+}

--- a/java/client/test/org/openqa/selenium/support/pagefactory/AnnotationsTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/AnnotationsTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.support.ByIdOrName;
 import org.openqa.selenium.support.FindAll;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.FindShadowBy;
 import org.openqa.selenium.support.How;
 import org.openqa.selenium.support.PageFactoryFinder;
 
@@ -93,6 +94,14 @@ public class AnnotationsTest {
   @FindAll({@FindBy(id = "cheese", name = "fruit"),
             @FindBy(id = "crackers")})
   public WebElement findAllMultipleHows_field;
+
+  @FindShadowBy({@FindBy(xpath = "foo"),
+                 @FindBy(css = "bar")})
+  public WebElement findShadowBy_field;
+
+  @FindShadowBy({@FindBy(xpath = "foo", css = "cheese"),
+                 @FindBy(css = "bar")})
+  public WebElement findShadowMultipleHows_field;
 
   @FindBy(using = "cheese")
   public WebElement findByUnsetHow_field;
@@ -238,6 +247,19 @@ public class AnnotationsTest {
   public void findBySomethingElse() throws Exception {
     assertThat(new Annotations(getClass().getField("findBy_xxx")).buildBy().toString())
         .isEqualTo("FindByXXXX's By");
+  }
+
+  @Test
+  public void findByShadow() throws NoSuchFieldException {
+    assertThat(new Annotations(getClass().getField("findShadowBy_field")).buildBy())
+        .isEqualTo(new ByChainedShadow(By.xpath("foo"), By.cssSelector("bar")));
+  }
+
+  @Test
+  public void findByShadowMultipleHows() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .describedAs("Expected field annotated with @FindAll containing bad @FindBy to throw error")
+        .isThrownBy(() -> new Annotations(getClass().getField("findShadowMultipleHows_field")).buildBy());
   }
 
 }

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedShadowTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedShadowTest.java
@@ -81,37 +81,13 @@ public class ByChainedShadowTest {
     WebElement element2 = mock(WebElement.class);
     WebElement shadowElement1 = mock(WebElement.class);
     WebElement shadowElement2 = mock(WebElement.class);
-    WebElement innerShadow1 = mock(WebElement.class);
-    WebElement innerShadow2 = mock(WebElement.class);
 
     when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
-    when(driver.executeScript(anyString(), eq(element1))).thenReturn(shadowElement1);
-    when(driver.executeScript(anyString(), eq(element2))).thenReturn(shadowElement2);
-    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.singletonList(innerShadow1));
-    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.singletonList(innerShadow2));
+    when(driver.executeScript(anyString(), eq(element1))).thenReturn(Collections.singletonList(shadowElement1));
+    when(driver.executeScript(anyString(), eq(element2))).thenReturn(Collections.singletonList(shadowElement2));
 
     ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
-    assertThat(by.findElement(driver)).isEqualTo(innerShadow1);
-    verify(driver, times(2)).executeScript(anyString(), any(WebElement.class));
-  }
-
-  @Test
-  public void testMultipleBysErrorFindElement() {
-    AllDriver driver = mock(AllDriver.class);
-    WebElement element1 = mock(WebElement.class);
-    WebElement element2 = mock(WebElement.class);
-    WebElement shadowElement1 = mock(WebElement.class);
-    WebElement shadowElement2 = mock(WebElement.class);
-
-    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
-    when(driver.executeScript(anyString(), eq(element1))).thenReturn(shadowElement1);
-    when(driver.executeScript(anyString(), eq(element2))).thenReturn(shadowElement2);
-    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
-    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
-
-    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
-    assertThatExceptionOfType(NoSuchElementException.class)
-        .isThrownBy(() -> by.findElement(driver));
+    assertThat(by.findElement(driver)).isEqualTo(shadowElement1);
     verify(driver, times(2)).executeScript(anyString(), any(WebElement.class));
   }
 
@@ -122,19 +98,15 @@ public class ByChainedShadowTest {
     WebElement element2 = mock(WebElement.class);
     WebElement shadowElement1 = mock(WebElement.class);
     WebElement shadowElement2 = mock(WebElement.class);
-    WebElement innerShadow1 = mock(WebElement.class);
-    WebElement innerShadow2 = mock(WebElement.class);
 
     when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
-    when(driver.executeScript(anyString(), eq(element1))).thenReturn(shadowElement1);
-    when(driver.executeScript(anyString(), eq(element2))).thenReturn(shadowElement2);
-    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.singletonList(innerShadow1));
-    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.singletonList(innerShadow2));
+    when(driver.executeScript(anyString(), eq(element1))).thenReturn(Collections.singletonList(shadowElement1));
+    when(driver.executeScript(anyString(), eq(element2))).thenReturn(Collections.singletonList(shadowElement2));
 
     ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
     List<WebElement> elementsResult = by.findElements(driver);
     assertThat(elementsResult).hasSize(2);
-    assertThat(elementsResult).contains(innerShadow1, innerShadow2);
+    assertThat(elementsResult).contains(shadowElement1, shadowElement2);
     verify(driver, times(2)).executeScript(anyString(), any(WebElement.class));
   }
 
@@ -143,14 +115,10 @@ public class ByChainedShadowTest {
     AllDriver driver = mock(AllDriver.class);
     WebElement element1 = mock(WebElement.class);
     WebElement element2 = mock(WebElement.class);
-    WebElement shadowElement1 = mock(WebElement.class);
-    WebElement shadowElement2 = mock(WebElement.class);
 
     when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element1));
-    when(driver.executeScript(anyString(), eq(element1))).thenReturn(shadowElement1);
-    when(driver.executeScript(anyString(), eq(element2))).thenReturn(shadowElement2);
-    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
-    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
+    when(driver.executeScript(anyString(), eq(element1))).thenReturn(Collections.emptyList());
+    when(driver.executeScript(anyString(), eq(element2))).thenReturn(Collections.emptyList());
 
     ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
     List<WebElement> elementsResult = by.findElements(driver);

--- a/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedShadowTest.java
+++ b/java/client/test/org/openqa/selenium/support/pagefactory/ByChainedShadowTest.java
@@ -1,0 +1,164 @@
+package org.openqa.selenium.support.pagefactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.FindsByCssSelector;
+import org.openqa.selenium.internal.FindsByXPath;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class ByChainedShadowTest {
+
+  public static final String SHADOW_ROOT_SCRIPT = "arguments[0].shadowRoot";
+
+  @Test
+  public void testEmptyBysFindElement() {
+    AllDriver driver = mock(AllDriver.class);
+
+    ByChainedShadow byChainedShadow = new ByChainedShadow();
+
+    assertThatExceptionOfType(NoSuchElementException.class)
+        .isThrownBy(() -> byChainedShadow.findElement(driver));
+  }
+
+  @Test
+  public void testEmptyBysFindElements() {
+    AllDriver driver = mock(AllDriver.class);
+
+    ByChainedShadow byChainedShadow = new ByChainedShadow();
+
+    assertThat(byChainedShadow.findElements(driver))
+        .isEmpty();
+  }
+
+  @Test
+  public void testNonEmptyFindElement() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Arrays.asList(element1, element2));
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"));
+    assertThat(by.findElement(driver)).isEqualTo(element1);
+  }
+
+  @Test
+  public void testNonEmptyFindElements() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"));
+    assertThat(by.findElements(driver)).hasSize(2);
+    assertThat(by.findElements(driver)).contains(element1, element2);
+  }
+
+  @Test
+  public void testMultipleBysFindElement() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+    WebElement shadowElement1 = mock(WebElement.class);
+    WebElement shadowElement2 = mock(WebElement.class);
+    WebElement innerShadow1 = mock(WebElement.class);
+    WebElement innerShadow2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element1)).thenReturn(shadowElement1);
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element2)).thenReturn(shadowElement2);
+    when(shadowElement1.findElements(By.cssSelector("css")))
+        .thenReturn(Collections.singletonList(innerShadow1));
+    when(shadowElement2.findElements(By.cssSelector("css")))
+        .thenReturn(Collections.singletonList(innerShadow2));
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
+    verify(driver, times(2)).executeScript(any());
+    assertThat(by.findElement(driver)).isEqualTo(innerShadow1);
+  }
+
+  @Test
+  public void testMultipleBysErrorFindElement() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+    WebElement shadowElement1 = mock(WebElement.class);
+    WebElement shadowElement2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element2));
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element1)).thenReturn(shadowElement1);
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element2)).thenReturn(shadowElement2);
+    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
+    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
+    verify(driver, times(2)).executeScript(any());
+    assertThatExceptionOfType(NoSuchElementException.class)
+        .isThrownBy(() -> by.findElement(driver));
+  }
+
+  @Test
+  public void testMultipleBysFindElements() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+    WebElement shadowElement1 = mock(WebElement.class);
+    WebElement shadowElement2 = mock(WebElement.class);
+    WebElement innerShadow1 = mock(WebElement.class);
+    WebElement innerShadow2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element1));
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element1)).thenReturn(shadowElement1);
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element2)).thenReturn(shadowElement2);
+    when(shadowElement1.findElements(By.cssSelector("css")))
+        .thenReturn(Collections.singletonList(innerShadow1));
+    when(shadowElement2.findElements(By.cssSelector("css")))
+        .thenReturn(Collections.singletonList(innerShadow2));
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
+    verify(driver, times(2)).executeScript(any());
+    assertThat(by.findElements(driver)).hasSize(2);
+    assertThat(by.findElements(driver)).contains(innerShadow1, innerShadow2);
+  }
+
+  @Test
+  public void testMultipleBysEmptyFindElements() {
+    AllDriver driver = mock(AllDriver.class);
+    WebElement element1 = mock(WebElement.class);
+    WebElement element2 = mock(WebElement.class);
+    WebElement shadowElement1 = mock(WebElement.class);
+    WebElement shadowElement2 = mock(WebElement.class);
+
+    when(driver.findElementsByXPath("xpath")).thenReturn(Lists.list(element1, element1));
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element1)).thenReturn(shadowElement1);
+    when(driver.executeScript(SHADOW_ROOT_SCRIPT, element2)).thenReturn(shadowElement2);
+    when(shadowElement1.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
+    when(shadowElement2.findElements(By.cssSelector("css"))).thenReturn(Collections.emptyList());
+
+    ByChainedShadow by = new ByChainedShadow(By.xpath("xpath"), By.cssSelector("css"));
+    verify(driver, times(2)).executeScript(any());
+    assertThat(by.findElements(driver)).isNotNull();
+    assertThat(by.findElements(driver)).isEmpty();
+  }
+
+  private interface AllDriver extends
+                              FindsByXPath, FindsByCssSelector, SearchContext, JavascriptExecutor {
+    //Placeholder
+  }
+}

--- a/java/client/test/org/openqa/selenium/testing/Pages.java
+++ b/java/client/test/org/openqa/selenium/testing/Pages.java
@@ -77,6 +77,7 @@ public class Pages {
   public String veryLargeCanvas;
   public String xhtmlFormPage;
   public String xhtmlTestPage;
+  public String shadowElementsPage;
 
   public Pages(AppServer appServer) {
     ajaxyPage = appServer.whereIs("ajaxy_page.html");
@@ -136,5 +137,6 @@ public class Pages {
     userDefinedProperty = appServer.whereIs("userDefinedProperty.html");
     veryLargeCanvas = appServer.whereIs("veryLargeCanvas.html");
     xhtmlTestPage = appServer.whereIs("xhtmlTest.html");
+    shadowElementsPage = appServer.whereIs("shadowElements.html");
   }
 }


### PR DESCRIPTION
### Description
Adds support to locate elements that have Shadow Roots.  
Adds new annotation `@FindShadowBy`, which can be used to locate and elements that are inside a Shadow Root.  
Adds a helper class `ShadowElementFinder`, which can be used to verify if an element has a Shadow Root attached to it.

### Motivation and Context
Right now Selenium doesn't support PageObject annotations in elements that have Shadow Root.  
#### The current approach:
```java
@FindBy(css = "foo")
WebElement fieldWithShadowRoot;

public WebElement getSomeShadow() {
  JavascriptExecutor js = (JavascriptExecutor) driver;
  WebElement shadowElement = (WebElement) js.executeScript("arguments[0].shadowRoot", fieldWithShadowRoot);
  WebElement elementInsideShadowRoot = shadowElement.findElement(By.css("innerShadowSelector"));
  return elementInsideShadowRoot;
}
```

#### New implementation allows:
```java
@FindShadowBy({@FindBy(css = "foo"),  @FindBy(css = "innerShadowSelector")})
WebElement element;
```
As in `@FindBy`, it also allows to retrieve lists:
```java
@FindShadowBy({@FindBy(css = "foo"),  @FindBy(css = "innerShadowSelector")})
List<WebElement> element;
```
If nested Shadow Roots are present, the same will work, the only thing that needs to be provided is the selector for each Shadow Root in the correct order that they are nested:
```html
<div id="shadow1">
  #shadow-root
    <div id="shadow2">
      #shadow-root
        <div id="insideShadow2">
        </div>
    </div>
</div>
```
```java
@FindShadowBy({@FindBy(css = "#shadow1"),  
    @FindBy(css = "#shadow2"), 
    @FindBy(css= "#insideShadow2")})
WebElement element;
```



#### Notes
The elements returned by the last `@FindBy` won't have their shadow roots extracted automatically, this is to allow the user to use methods such as `getAttribute`, which would throw an error if inside the shadow root. If the user wants to extract it, `ShadowElementFinder` can be used to do so.  
This also means that providing just one locator to`@FindShadowBy` will yield the same result as using `@FindBy`, which is not a concern.

Once inside a Shadow Root, it's not possible to use xpath selector.  
I didn't add any validations to `FindShadowBy` as this could limit the usage of the chain selectors, and Selenium already throws an exception if the user tries to use an invalid selector type.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
