### PR TITLE
Avoid deadlock when tests are run on XUnit

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -146,11 +146,10 @@ namespace OpenQA.Selenium.Remote
             HttpResponseInfo responseInfo = null;
             try
             {
-                responseInfo = new
-                        TaskFactory(CancellationToken.None,
-                            TaskCreationOptions.None,
-                            TaskContinuationOptions.None,
-                            TaskScheduler.Default)
+                responseInfo = new TaskFactory(CancellationToken.None,
+                        TaskCreationOptions.None,
+                        TaskContinuationOptions.None,
+                        TaskScheduler.Default)
                     .StartNew(() => this.MakeHttpRequest(requestInfo))
                     .Unwrap()
                     .GetAwaiter()

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -24,6 +24,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenQA.Selenium.Internal;
 
@@ -145,7 +146,15 @@ namespace OpenQA.Selenium.Remote
             HttpResponseInfo responseInfo = null;
             try
             {
-                responseInfo = this.MakeHttpRequest(requestInfo).GetAwaiter().GetResult();
+                responseInfo = new
+                        TaskFactory(CancellationToken.None,
+                            TaskCreationOptions.None,
+                            TaskContinuationOptions.None,
+                            TaskScheduler.Default)
+                    .StartNew(() => this.MakeHttpRequest(requestInfo))
+                    .Unwrap()
+                    .GetAwaiter()
+                    .GetResult();
             }
             catch (HttpRequestException ex)
             {

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -146,6 +146,7 @@ namespace OpenQA.Selenium.Remote
             HttpResponseInfo responseInfo = null;
             try
             {
+                //workaround to avoid deadlock
                 responseInfo = new TaskFactory(CancellationToken.None,
                         TaskCreationOptions.None,
                         TaskContinuationOptions.None,


### PR DESCRIPTION
The fix solves a problem with deadlock on Selenium 4.x. The requirement is that we cannot change HttpClient to something else + we cannot make other methods async, that's why I believe the only possible way to solve it is to use TaskFactory workaround. 


<!--- Provide a general summary of your changes in the Title above -->

### Description
This fix solves #7916 

### Motivation and Context
It's required because on XUnit, we get a deadlock (when parallelism is used). 
Similar case is discussed here: https://github.com/xunit/xunit/issues/88

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
