### PR TITLE
Add set_cookies argument to remote WebDriver

### DIFF
--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -36,7 +36,7 @@ from .webelement import FirefoxWebElement
 
 
 # Default for log_path variable. To be deleted when deprecations for arguments are removed.
-DEFAULT_LOG_PATH= None
+DEFAULT_LOG_PATH = None
 DEFAULT_EXECUTABLE_PATH = "geckodriver"
 DEFAULT_SERVICE_LOG_PATH = "geckodriver.log"
 
@@ -52,7 +52,7 @@ class WebDriver(RemoteWebDriver):
                  capabilities=None, proxy=None,
                  executable_path=DEFAULT_EXECUTABLE_PATH, options=None,
                  service_log_path=DEFAULT_SERVICE_LOG_PATH,
-                 service_args=None, service=None, desired_capabilities=None, 
+                 service_args=None, service=None, desired_capabilities=None,
                  log_path=DEFAULT_LOG_PATH, keep_alive=True):
         """Starts a new local session of Firefox.
 
@@ -126,7 +126,7 @@ class WebDriver(RemoteWebDriver):
         if service_log_path != DEFAULT_SERVICE_LOG_PATH:
             warnings.warn('service_log_path has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
-        if service_args != None:
+        if service_args is not None:
             warnings.warn('service_args has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
 

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -101,7 +101,7 @@ def _make_w3c_caps(caps):
     return {"firstMatch": [{}], "alwaysMatch": always_match}
 
 
-def get_remote_connection(capabilities, command_executor, keep_alive):
+def get_remote_connection(capabilities, command_executor, keep_alive, set_cookies):
     from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
     from selenium.webdriver.safari.remote_connection import SafariRemoteConnection
     from selenium.webdriver.firefox.remote_connection import FirefoxRemoteConnection
@@ -112,7 +112,7 @@ def get_remote_connection(capabilities, command_executor, keep_alive):
         RemoteConnection
     )
 
-    return handler(command_executor, keep_alive=keep_alive)
+    return handler(command_executor, keep_alive=keep_alive, set_cookies=set_cookies)
 
 
 class WebDriver(object):
@@ -134,7 +134,7 @@ class WebDriver(object):
 
     def __init__(self, command_executor='http://127.0.0.1:4444',
                  desired_capabilities=None, browser_profile=None, proxy=None,
-                 keep_alive=True, file_detector=None, options=None):
+                 keep_alive=True, file_detector=None, options=None, set_cookies=False):
         """
         Create a new driver that will issue commands using the wire protocol.
 
@@ -152,6 +152,8 @@ class WebDriver(object):
          - file_detector - Pass custom file detector object during instantiation. If None,
              then default LocalFileDetector() will be used.
          - options - instance of a driver options.Options class
+         - set_cookies - Whether or not to keep track of Set-Cookie headers and send those
+             cookies on subsequent requests
         """
         capabilities = {}
         if options is not None:
@@ -163,7 +165,12 @@ class WebDriver(object):
                 capabilities.update(desired_capabilities)
         self.command_executor = command_executor
         if type(self.command_executor) is bytes or isinstance(self.command_executor, str):
-            self.command_executor = get_remote_connection(capabilities, command_executor=command_executor, keep_alive=keep_alive)
+            self.command_executor = get_remote_connection(
+                capabilities,
+                command_executor=command_executor,
+                keep_alive=keep_alive,
+                set_cookies=set_cookies,
+            )
         self._is_remote = True
         self.session_id = None
         self.capabilities = {}


### PR DESCRIPTION
### Description
This adds a `set_cookies` boolean argument to the remote `WebDriver` class so that any cookies in the `Set-Cookie` header of the response are sent in subsequent requests to the remote webdriver.
<!--- Describe your changes in detail -->

### Motivation and Context
We are using AWS ALB and Kubernetes to load balance web driver requests across several replicas. We have [sticky sessions](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#sticky-sessions) enabled, meaning we need to retrieve the `AWSALB` cookie and include it in subsequent requests so that the request goes to the same machine where the browser session is running.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
