### PR TITLE
Removed obsolete browsers from BrowserType

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/BrowserType.java
+++ b/java/client/src/org/openqa/selenium/remote/BrowserType.java
@@ -22,9 +22,6 @@ package org.openqa.selenium.remote;
  */
 public interface BrowserType {
   String FIREFOX = "firefox";
-  String FIREFOX_PROXY = "firefoxproxy";
-  String FIREFOX_CHROME = "firefoxchrome";
-  String GOOGLECHROME = "googlechrome";
   String SAFARI = "safari";
   /**
    * @deprecated Use {@link #OPERA}
@@ -35,17 +32,11 @@ public interface BrowserType {
   String EDGE = "MicrosoftEdge";
   String EDGEHTML = "EdgeHTML";
   String IEXPLORE= "iexplore";
-  String IEXPLORE_PROXY= "iexploreproxy";
-  String SAFARI_PROXY = "safariproxy";
   String CHROME = "chrome";
-  String KONQUEROR = "konqueror";
-  String MOCK = "mock";
-  String IE_HTA="iehta";
 
   String ANDROID = "android";
   String HTMLUNIT = "htmlunit";
   String IE = "internet explorer";
   String IPHONE = "iPhone";
   String IPAD = "iPad";
-  String PHANTOMJS = "phantomjs";
 }

--- a/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
@@ -47,7 +47,6 @@ import static org.openqa.selenium.remote.BrowserType.HTMLUNIT;
 import static org.openqa.selenium.remote.BrowserType.IE;
 import static org.openqa.selenium.remote.BrowserType.OPERA;
 import static org.openqa.selenium.remote.BrowserType.OPERA_BLINK;
-import static org.openqa.selenium.remote.BrowserType.PHANTOMJS;
 import static org.openqa.selenium.remote.BrowserType.SAFARI;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 
@@ -93,7 +92,6 @@ public class ActiveSessionFactory implements SessionFactory {
         .put(containsKey("se:ieOptions"), "org.openqa.selenium.ie.InternetExplorerDriverService")
         .put(browserName(OPERA), "org.openqa.selenium.opera.OperaDriverService")
         .put(browserName(OPERA_BLINK), "org.openqa.selenium.opera.OperaDriverService")
-        .put(browserName(PHANTOMJS), "org.openqa.selenium.phantomjs.PhantomJSDriverService")
         .put(browserName(SAFARI), "org.openqa.selenium.safari.SafariDriverService")
         .put(containsKey(Pattern.compile("^safari\\..*")), "org.openqa.selenium.safari.SafariDriverService")
         .build()

--- a/java/server/src/org/openqa/selenium/remote/server/DefaultDriverFactory.java
+++ b/java/server/src/org/openqa/selenium/remote/server/DefaultDriverFactory.java
@@ -27,7 +27,6 @@ import static org.openqa.selenium.remote.BrowserType.HTMLUNIT;
 import static org.openqa.selenium.remote.BrowserType.IE;
 import static org.openqa.selenium.remote.BrowserType.OPERA;
 import static org.openqa.selenium.remote.BrowserType.OPERA_BLINK;
-import static org.openqa.selenium.remote.BrowserType.PHANTOMJS;
 import static org.openqa.selenium.remote.BrowserType.SAFARI;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
@@ -63,7 +62,6 @@ public class DefaultDriverFactory implements DriverFactory {
             .put(CHROME, "org.openqa.selenium.chrome.ChromeDriver")
             .put(OPERA, "com.opera.core.systems.OperaDriver")
             .put(OPERA_BLINK, "org.openqa.selenium.opera.OperaDriver")
-            .put(PHANTOMJS, "org.openqa.selenium.phantomjs.PhantomJSDriver")
             .put(HTMLUNIT, "org.openqa.selenium.htmlunit.HtmlUnitDriver")
             .build().entrySet().stream()
             .map(e -> createProvider(new ImmutableCapabilities(BROWSER_NAME, e.getKey()), e.getValue()))


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Removes all references to obsolete browsers. Removed browser types are as below :

```
String FIREFOX_PROXY = "firefoxproxy";
String FIREFOX_CHROME = "firefoxchrome";
String GOOGLECHROME = "googlechrome";
String IEXPLORE_PROXY= "iexploreproxy";
String SAFARI_PROXY = "safariproxy";
String KONQUEROR = "konqueror";
String MOCK = "mock";
String IE_HTA="iehta";
```

### Motivation and Context
Fixes issue raised under #8317

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
