### PR TITLE
[JS] Fixes path to bazel generated files

### DIFF
--- a/javascript/node/selenium-webdriver/lib/http.js
+++ b/javascript/node/selenium-webdriver/lib/http.js
@@ -53,7 +53,7 @@ function requireAtom(module, bazelTarget) {
   } catch (ex) {
     try {
       const file = bazelTarget.slice(2).replace(':', '/');
-      return require(`../../../../bazel-genfiles/${file}`);
+      return require(`../../../../bazel-bin/${file}`);
     } catch (ex2) {
       console.log(ex2);
       throw Error(


### PR DESCRIPTION

### Description
bazel-genfiles are not available in path looks like it should be `bazel-bin` 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
