### PR TITLE
[issue-2070] Node drain feature. Complete except for process termination

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/tracing/Status.java
+++ b/java/client/src/org/openqa/selenium/remote/tracing/Status.java
@@ -38,7 +38,6 @@ public class Status {
   public static final Status OUT_OF_RANGE = new Status(Kind.OUT_OF_RANGE, "");
   public static final Status UNIMPLEMENTED = new Status(Kind.UNIMPLEMENTED, "");
   public static final Status INTERNAL = new Status(Kind.INTERNAL, "");
-  public static final Status UNAVAILABLE = new Status(Kind.UNAVAILABLE, "");
   public static final Status UNAUTHENTICATED = new Status(Kind.UNAUTHENTICATED, "");
 
 
@@ -74,7 +73,6 @@ public class Status {
     OUT_OF_RANGE,
     UNIMPLEMENTED,
     INTERNAL,
-    UNAVAILABLE,
     UNAUTHENTICATED
   }
 

--- a/java/client/src/org/openqa/selenium/remote/tracing/Status.java
+++ b/java/client/src/org/openqa/selenium/remote/tracing/Status.java
@@ -29,6 +29,7 @@ public class Status {
   public static final Status CANCELLED = new Status(Kind.CANCELLED, "");
   public static final Status NOT_FOUND = new Status(Kind.NOT_FOUND, "");
   public static final Status RESOURCE_EXHAUSTED = new Status(Kind.RESOURCE_EXHAUSTED, "");
+  public static final Status UNAVAILABLE = new Status(Kind.UNAVAILABLE, "");
   public static final Status UNKNOWN = new Status(Kind.UNKNOWN, "");
   public static final Status INVALID_ARGUMENT = new Status(Kind.INVALID_ARGUMENT, "");
   public static final Status DEADLINE_EXCEEDED = new Status(Kind.DEADLINE_EXCEEDED, "");
@@ -64,6 +65,7 @@ public class Status {
     CANCELLED,
     NOT_FOUND,
     RESOURCE_EXHAUSTED,
+    UNAVAILABLE,
     UNKNOWN,
     INVALID_ARGUMENT,
     DEADLINE_EXCEEDED,

--- a/java/client/src/org/openqa/selenium/remote/tracing/opentelemetry/OpenTelemetrySpan.java
+++ b/java/client/src/org/openqa/selenium/remote/tracing/opentelemetry/OpenTelemetrySpan.java
@@ -146,6 +146,7 @@ class OpenTelemetrySpan extends OpenTelemetryContext implements AutoCloseable, S
       .put(Status.Kind.NOT_FOUND, io.opentelemetry.trace.Status.NOT_FOUND)
       .put(Status.Kind.OK, io.opentelemetry.trace.Status.OK)
       .put(Status.Kind.RESOURCE_EXHAUSTED, io.opentelemetry.trace.Status.RESOURCE_EXHAUSTED)
+      .put(Status.Kind.UNAVAILABLE, io.opentelemetry.trace.Status.UNAVAILABLE)
       .put(Status.Kind.UNKNOWN, io.opentelemetry.trace.Status.UNKNOWN)
       .put(Status.Kind.INVALID_ARGUMENT,io.opentelemetry.trace.Status.INVALID_ARGUMENT)
       .put(Status.Kind.DEADLINE_EXCEEDED,io.opentelemetry.trace.Status.DEADLINE_EXCEEDED)

--- a/java/server/src/org/openqa/selenium/grid/data/NodeDrainingStartedEvent.java
+++ b/java/server/src/org/openqa/selenium/grid/data/NodeDrainingStartedEvent.java
@@ -1,0 +1,31 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+import org.openqa.selenium.events.Event;
+import org.openqa.selenium.events.Type;
+
+import java.util.UUID;
+
+public class NodeDrainingStartedEvent extends Event {
+  public static final Type NODE_DRAINING_STARTED = new Type("node-draining");
+
+  public NodeDrainingStartedEvent(UUID nodeId) {
+    super(NODE_DRAINING_STARTED, nodeId);
+  }
+}

--- a/java/server/src/org/openqa/selenium/grid/distributor/Distributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/Distributor.java
@@ -35,6 +35,7 @@ import org.openqa.selenium.remote.tracing.Tracer;
 import org.openqa.selenium.status.HasReadyState;
 
 import java.io.UncheckedIOException;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -93,6 +94,8 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
           .to(() -> new CreateSession(this)),
       post("/se/grid/distributor/node")
           .to(() -> new AddNode(tracer, this, json, httpClientFactory)),
+      post("/se/grid/distributor/node/{nodeId}/drain")
+          .to((Map<String, String> params) -> new DrainNode(this, UUID.fromString(params.get("nodeId")))),
       delete("/se/grid/distributor/node/{nodeId}")
           .to(params -> new RemoveNode(this, UUID.fromString(params.get("nodeId")))),
       get("/se/grid/distributor/status")
@@ -104,6 +107,8 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
     throws SessionNotCreatedException;
 
   public abstract Distributor add(Node node);
+
+  public abstract void drain(UUID nodeId);
 
   public abstract void remove(UUID nodeId);
 

--- a/java/server/src/org/openqa/selenium/grid/distributor/DrainNode.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/DrainNode.java
@@ -1,0 +1,25 @@
+package org.openqa.selenium.grid.distributor;
+
+import org.openqa.selenium.remote.http.HttpHandler;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.UUID;
+
+public class DrainNode implements HttpHandler {
+  private final Distributor distributor;
+  private final UUID nodeId;
+
+  public DrainNode(Distributor distributor, UUID nodeId) {
+    this.distributor = Objects.requireNonNull(distributor);
+    this.nodeId = Objects.requireNonNull(nodeId);
+  }
+
+  @Override
+  public HttpResponse execute(HttpRequest req) throws UncheckedIOException {
+    distributor.drain(nodeId);
+    return new HttpResponse();
+  }
+}

--- a/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -29,7 +29,7 @@ import org.openqa.selenium.grid.data.CreateSessionRequest;
 import org.openqa.selenium.grid.data.CreateSessionResponse;
 import org.openqa.selenium.grid.data.DistributorStatus;
 import org.openqa.selenium.grid.data.NodeAddedEvent;
-import org.openqa.selenium.grid.data.NodeRejectedEvent;
+import org.openqa.selenium.grid.data.NodeDrainingStartedEvent;
 import org.openqa.selenium.grid.data.NodeRemovedEvent;
 import org.openqa.selenium.grid.data.NodeStatus;
 import org.openqa.selenium.grid.distributor.Distributor;
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static org.openqa.selenium.grid.data.NodeDrainComplete.NODE_DRAIN_COMPLETE;
+import static org.openqa.selenium.grid.data.NodeDrainingStartedEvent.NODE_DRAINING_STARTED;
 import static org.openqa.selenium.grid.data.NodeStatusEvent.NODE_STATUS;
 import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
 import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES_EVENT;
@@ -119,6 +120,7 @@ public class LocalDistributor extends Distributor {
     this.registrationSecret = registrationSecret;
 
     bus.addListener(NODE_STATUS, event -> refresh(event.getData(NodeStatus.class)));
+    bus.addListener(NODE_DRAINING_STARTED, event -> drain(event.getData(UUID.class)));
     bus.addListener(NODE_DRAIN_COMPLETE, event -> remove(event.getData(UUID.class)));
   }
 
@@ -254,7 +256,7 @@ public class LocalDistributor extends Distributor {
     // check registrationSecret and stop processing if it doesn't match
     if (!Objects.equals(status.getRegistrationSecret(), registrationSecret)) {
       LOG.severe(String.format("Node at %s failed to send correct registration secret. Node NOT registered.", status.getUri()));
-      bus.fire(new NodeRejectedEvent(status.getUri()));
+      bus.fire(new NodeDrainingStartedEvent(status.getNodeId()));
       return;
     }
 
@@ -331,6 +333,18 @@ public class LocalDistributor extends Distributor {
     }
 
     return this;
+  }
+
+  @Override
+  public void drain(UUID nodeId) {
+    Lock writeLock = lock.writeLock();
+    writeLock.lock();
+    try {
+      hosts.stream().filter(node -> nodeId.equals(node.getId())).findFirst()
+          .orElseThrow().setHostStatus(Host.Status.DRAINING);
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   @Override

--- a/java/server/src/org/openqa/selenium/grid/distributor/model/Host.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/model/Host.java
@@ -165,7 +165,6 @@ public class Host {
     return new DistributorStatus.NodeSummary(
         nodeId,
         uri,
-        getHostStatus() == UP,
         node.isDraining(),
         maxSessionCount,
         stereotypes,

--- a/java/server/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
@@ -32,10 +32,10 @@ import org.openqa.selenium.remote.tracing.HttpTracing;
 import org.openqa.selenium.remote.tracing.Tracer;
 
 import java.net.URL;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import static org.openqa.selenium.net.Urls.fromUri;
 import static org.openqa.selenium.remote.http.Contents.asJson;
 import static org.openqa.selenium.remote.http.HttpMethod.DELETE;
 import static org.openqa.selenium.remote.http.HttpMethod.GET;
@@ -85,6 +85,18 @@ public class RemoteDistributor extends Distributor {
     LOG.info(String.format("Added node %s.", node.getId()));
 
     return this;
+  }
+
+  @Override
+  public void drain(UUID nodeId) {
+    Objects.requireNonNull(nodeId, "Node ID must be set");
+    HttpRequest request = new HttpRequest(POST, "/se/grid/distributor/node/" + nodeId + "/drain");
+    HttpTracing.inject(tracer, tracer.getCurrentContext(), request);
+    request.setContent(asJson(nodeId));
+
+    HttpResponse response = client.execute(request);
+
+    Values.get(response, Void.class);
   }
 
   @Override

--- a/java/server/src/org/openqa/selenium/grid/node/Drain.java
+++ b/java/server/src/org/openqa/selenium/grid/node/Drain.java
@@ -1,0 +1,28 @@
+package org.openqa.selenium.grid.node;
+
+import static org.openqa.selenium.remote.http.Contents.utf8String;
+
+import org.openqa.selenium.json.Json;
+import org.openqa.selenium.remote.http.HttpHandler;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+public class Drain implements HttpHandler {
+
+  private final Node node;
+  private final Json json;
+
+  public Drain(Node node, Json json) {
+    this.node = Objects.requireNonNull(node);
+    this.json = Objects.requireNonNull(json);
+  }
+
+  @Override
+  public HttpResponse execute(HttpRequest req) throws UncheckedIOException {
+    this.node.drain();
+    return new HttpResponse().setContent(utf8String(json.toJson(node.isDraining())));
+  }
+}

--- a/java/server/src/org/openqa/selenium/grid/node/Node.java
+++ b/java/server/src/org/openqa/selenium/grid/node/Node.java
@@ -105,6 +105,8 @@ public abstract class Node implements HasReadyState, Routable {
   private final URI uri;
   private final Route routes;
 
+  protected boolean draining = false;
+
   protected Node(Tracer tracer, UUID id, URI uri) {
     this.tracer = Require.nonNull("Tracer", tracer);
     this.id = Require.nonNull("Node id", id);
@@ -113,7 +115,7 @@ public abstract class Node implements HasReadyState, Routable {
     Json json = new Json();
     routes = combine(
         // "getSessionId" is aggressive about finding session ids, so this needs to be the last
-        // route the is checked.
+        // route that is checked.
         matching(req -> getSessionId(req.getUri()).map(SessionId::new).map(this::isSessionOwner).orElse(false))
             .to(() -> new ForwardWebDriverCommand(this))
             .with(spanDecorator("node.forward_command")),
@@ -135,6 +137,9 @@ public abstract class Node implements HasReadyState, Routable {
         post("/se/grid/node/session")
             .to(() -> new NewNodeSession(this, json))
             .with(spanDecorator("node.new_session")),
+        post("/se/grid/node/drain")
+            .to(() -> new Drain(this, json))
+            .with(new SpanDecorator(tracer, req -> "node.drain")),
         get("/se/grid/node/status")
             .to(() -> req -> new HttpResponse().setContent(asJson(getStatus())))
             .with(spanDecorator("node.node_status")),
@@ -180,6 +185,10 @@ public abstract class Node implements HasReadyState, Routable {
   public abstract NodeStatus getStatus();
 
   public abstract HealthCheck getHealthCheck();
+
+  public boolean isDraining() { return draining; }
+
+  public abstract void drain();
 
   @Override
   public boolean matches(HttpRequest req) {

--- a/java/server/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/server/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -65,6 +65,7 @@ public class RemoteNode extends Node {
   private final URI externalUri;
   private final Set<Capabilities> capabilities;
   private final HealthCheck healthCheck;
+  private boolean draining = false;
 
   public RemoteNode(
       Tracer tracer,
@@ -198,6 +199,11 @@ public class RemoteNode extends Node {
   @Override
   public HealthCheck getHealthCheck() {
     return healthCheck;
+  }
+
+  @Override
+  public void drain() {
+    draining = true;
   }
 
   private Map<String, Object> toJson() {

--- a/java/server/test/org/openqa/selenium/grid/data/NodeStatusTest.java
+++ b/java/server/test/org/openqa/selenium/grid/data/NodeStatusTest.java
@@ -42,6 +42,7 @@ public class NodeStatusTest {
         100,
         ImmutableMap.of(stereotype, 1),
         ImmutableSet.of(new NodeStatus.Active(stereotype, new SessionId(UUID.randomUUID()), new ImmutableCapabilities("peas", "sausages"))),
+        false,
         "cheese");
 
     Json json = new Json();

--- a/java/server/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
@@ -196,6 +196,7 @@ public class AddingNodesTest {
         status.getMaxSessionCount(),
         status.getStereotypes(),
         ImmutableSet.of(new NodeStatus.Active(CAPS, new SessionId(UUID.randomUUID()), CAPS)),
+        false,
         null);
 
     bus.fire(new NodeStatusEvent(crafted));
@@ -291,12 +292,17 @@ public class AddingNodesTest {
           1,
           ImmutableMap.of(CAPS, 1),
           actives,
+          false,
           "cheese");
     }
 
     @Override
     public HealthCheck getHealthCheck() {
       return () -> new HealthCheck.Result(true, "tl;dr");
+    }
+
+    @Override
+    public void drain() {
     }
   }
 

--- a/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
@@ -65,7 +65,7 @@ public class LocalDistributorTest {
   private EventBus bus;
   private HttpClient.Factory clientFactory;
   private URI uri;
-  private Node local;
+  private Node localNode;
 
   @Before
   public void setUp() throws URISyntaxException {
@@ -75,7 +75,7 @@ public class LocalDistributorTest {
 
     Capabilities caps = new ImmutableCapabilities("browserName", "cheese");
     uri = new URI("http://localhost:1234");
-    local = LocalNode.builder(tracer, bus, uri, uri, null)
+    localNode = LocalNode.builder(tracer, bus, uri, uri, null)
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
         .maximumConcurrentSessions(2)
         .build();
@@ -84,7 +84,7 @@ public class LocalDistributorTest {
   @Test
   public void testAddNodeToDistributor() {
     Distributor distributor = new LocalDistributor(tracer, bus, clientFactory, new LocalSessionMap(tracer, bus), null);
-    distributor.add(local);
+    distributor.add(localNode);
     DistributorStatus status = distributor.getStatus();
 
     //Check the size
@@ -93,14 +93,14 @@ public class LocalDistributorTest {
 
     //Check a couple attributes
     final DistributorStatus.NodeSummary distributorNode = nodes.iterator().next();
-    assertThat(distributorNode.getNodeId()).isEqualByComparingTo(local.getId());
+    assertThat(distributorNode.getNodeId()).isEqualByComparingTo(localNode.getId());
     assertThat(distributorNode.getUri()).isEqualTo(uri);
   }
 
   @Test
   public void testRemoveNodeFromDistributor() {
     Distributor distributor = new LocalDistributor(tracer, bus, clientFactory, new LocalSessionMap(tracer, bus), null);
-    distributor.add(local);
+    distributor.add(localNode);
 
     //Check the size
     DistributorStatus statusBefore = distributor.getStatus();
@@ -108,7 +108,7 @@ public class LocalDistributorTest {
     assertThat(nodesBefore.size()).isEqualTo(1);
 
     //Recheck the status--should be zero
-    distributor.remove(local.getId());
+    distributor.remove(localNode.getId());
     DistributorStatus statusAfter = distributor.getStatus();
     final Set<DistributorStatus.NodeSummary> nodesAfter = statusAfter.getNodes();
     assertThat(nodesAfter.size()).isEqualTo(0);
@@ -117,8 +117,8 @@ public class LocalDistributorTest {
   @Test
   public void testAddSameNodeTwice() {
     Distributor distributor = new LocalDistributor(tracer, bus, clientFactory, new LocalSessionMap(tracer, bus), null);
-    distributor.add(local);
-    distributor.add(local);
+    distributor.add(localNode);
+    distributor.add(localNode);
     DistributorStatus status = distributor.getStatus();
 
     //Should only be one node after dupe check
@@ -159,6 +159,56 @@ public class LocalDistributorTest {
       .build();
     distributor.add(node);
 
+  @Test
+  public void testDrainNodeFromDistributor() {
+    Distributor distributor = new LocalDistributor(tracer, bus, clientFactory, new LocalSessionMap(tracer, bus), null);
+    distributor.add(localNode);
+    assertThat(localNode.isDraining()).isFalse();
+
+    //Check the size - there should be one node
+    DistributorStatus statusBefore = distributor.getStatus();
+    final Set<DistributorStatus.NodeSummary> nodesBefore = statusBefore.getNodes();
+    assertThat(nodesBefore.size()).isEqualTo(1);
+    DistributorStatus.NodeSummary nodeBefore = nodesBefore.iterator().next();
+    assertThat(nodeBefore.isDraining()).isFalse();
+
+    distributor.drain(localNode.getId());
+    assertThat(localNode.isDraining()).isTrue();
+
+    //Recheck the status - there should still be one node, but it's listed as draining
+    DistributorStatus statusAfter = distributor.getStatus();
+    final Set<DistributorStatus.NodeSummary> nodesAfter = statusAfter.getNodes();
+    assertThat(nodesAfter.size()).isEqualTo(1);
+
+    //The node should be draining
+    DistributorStatus.NodeSummary nodeAfter = nodesAfter.iterator().next();
+    assertThat(nodeAfter.isDraining()).isTrue();
+  }
+
+  @Test
+  public void testDrainNodeFromNode() {
+    assertThat(localNode.isDraining()).isFalse();
+
+    Distributor distributor = new LocalDistributor(tracer, bus, clientFactory, new LocalSessionMap(tracer, bus), null);
+    distributor.add(localNode);
+
+    localNode.drain();
+    assertThat(localNode.isDraining()).isTrue();
+
+    DistributorStatus statusAfter = distributor.getStatus();
+    final Set<DistributorStatus.NodeSummary> nodesAfter = statusAfter.getNodes();
+    assertThat(nodesAfter.size()).isEqualTo(1);
+
+    //The node should be draining
+    DistributorStatus.NodeSummary nodeAfter = nodesAfter.iterator().next();
+    assertThat(nodeAfter.isDraining()).isTrue();
+  }
+
+  //Build a few Host Buckets of different sizes
+  private Map<String, Set<Host>> buildBuckets(int...sizes) {
+    Map<String, Set<Host>> hostBuckets = new HashMap<>();
+    //The fact that it's re-using the same node doesn't matter--we're calculating "sameness"
+    // based purely on the number of hosts in the Set
     HttpRequest req = new HttpRequest(HttpMethod.POST, "/session")
       .setContent(Contents.asJson(ImmutableMap.of(
         "capabilities", ImmutableMap.of(

--- a/java/server/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/server/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -424,6 +424,17 @@ public class NodeTest {
     return baseDir;
   }
 
+  //Test that the draining command sets Host status to DRAINING
+  @Test
+  public void drainingNodeStatusDraining() {
+
+  }
+
+  //Test that a draining node doesn't accept new sessions by any means
+  //Test that a draining node continues to run its sessions and accept new WebDriver commands
+  //Test that a node will shut down once all sessions are finished
+  //Test that RemoteNode will post the correct command oto the LocalNode
+
   private CreateSessionRequest createSessionRequest(Capabilities caps) {
     return new CreateSessionRequest(
             ImmutableSet.copyOf(Dialect.values()),

--- a/java/server/test/org/openqa/selenium/grid/node/local/LocalNodeTest.java
+++ b/java/server/test/org/openqa/selenium/grid/node/local/LocalNodeTest.java
@@ -109,6 +109,21 @@ public class LocalNodeTest {
   }
 
   @Test
+  public void cannotAcceptNewSessionsWhileDraining() {
+    node.drain();
+    assertThat(node.isDraining()).isTrue();
+    node.stop(session.getId()); //stop the default session
+
+    Capabilities stereotype = new ImmutableCapabilities("cheese", "brie");
+    Optional<CreateSessionResponse> sessionResponse = node.newSession(
+        new CreateSessionRequest(
+            ImmutableSet.of(W3C),
+            stereotype,
+            ImmutableMap.of()));
+    assertThat(sessionResponse).isEmpty();
+  }
+
+  @Test
   public void canReturnStatusInfo() {
     NodeStatus status = node.getStatus();
     assertThat(status.getCurrentSessions().stream()


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
This is 2 endpoints:
- One on the distributor (node/{nodeId}/drain)
Sets the distributor HOST to DRAINING, which in turn sets the node flag to "draining"

- One on the node (/drain)
Sends a new event (NODE_DRAINING_STARTED) to the Distributor via event bus

As long as the node is draining, it will not accept new sessions, and the Distributor will
filter it out of all new session requests.

Still need to terminate the Node process, but this does (arguably) the most important bit


### Motivation and Context
Feature related to issue 2070: adding the ability to kill a node slowly, by forcing it to stop accepting new sessions, but allowing it to finish its current sessions before it dies.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
