### PR TITLE
[py] Allow running the test suite with WPE WebDrivers and add a bazel target for it and GTK

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -303,3 +303,53 @@ py_test_suite(
         "//third_party/py:pytest",
     ],
 )
+
+py_test_suite(
+    name = "test-webkitgtk",
+    size = "large",
+    srcs = glob([
+        "test/selenium/webdriver/common/**/*.py",
+        "test/selenium/webdriver/support/**/*.py",
+    ]),
+    args = [
+        "--instafail",
+        "--driver=WebKitGTK",
+        "--browser-binary=MiniBrowser",
+        "--browser-args=--automation",
+    ],
+    tags = [
+        "exclusive",
+        "no-sandbox",
+    ],
+    deps = [
+        ":init-tree",
+        ":selenium",
+        ":webserver",
+        "//third_party/py:pytest",
+    ],
+)
+
+py_test_suite(
+    name = "test-wpewebkit",
+    size = "large",
+    srcs = glob([
+        "test/selenium/webdriver/common/**/*.py",
+        "test/selenium/webdriver/support/**/*.py",
+    ]),
+    args = [
+        "--instafail",
+        "--driver=WPEWebKit",
+        "--browser-binary=MiniBrowser",
+        "--browser-args=--automation --headless",
+    ],
+    tags = [
+        "exclusive",
+        "no-sandbox",
+    ],
+    deps = [
+        ":init-tree",
+        ":selenium",
+        ":webserver",
+        "//third_party/py:pytest",
+    ],
+)

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -45,6 +45,7 @@ drivers = (
     'Safari',
     'WebKitGTK',
     'ChromiumEdge',
+    'WPEWebKit',
 )
 
 
@@ -119,6 +120,8 @@ def driver(request):
         if driver_class == 'WebKitGTK':
             options = get_options(driver_class, request.config)
         if driver_class == 'ChromiumEdge':
+            options = get_options(driver_class, request.config)
+        if driver_class == 'WPEWebKit':
             options = get_options(driver_class, request.config)
         if driver_path is not None:
             kwargs['executable_path'] = driver_path

--- a/py/selenium/webdriver/wpewebkit/options.py
+++ b/py/selenium/webdriver/wpewebkit/options.py
@@ -16,14 +16,15 @@
 # under the License.
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.common.options import ArgOptions
 
 
-class Options(object):
+class Options(ArgOptions):
     KEY = 'wpe:browserOptions'
 
     def __init__(self):
+        super(Options, self).__init__()
         self._binary_location = ''
-        self._arguments = []
         self._caps = DesiredCapabilities.WPEWEBKIT.copy()
 
     @property
@@ -50,25 +51,6 @@ class Options(object):
          - value : path to the browser binary
         """
         self._binary_location = value
-
-    @property
-    def arguments(self):
-        """
-        Returns a list of arguments needed for the browser
-        """
-        return self._arguments
-
-    def add_argument(self, argument):
-        """
-        Adds an argument to the list
-
-        :Args:
-         - Sets the arguments
-        """
-        if argument:
-            self._arguments.append(argument)
-        else:
-            raise ValueError("argument can not be null")
 
     def to_capabilities(self):
         """

--- a/py/test/unit/selenium/webdriver/wpewebkit/wpewebkit_options_tests.py
+++ b/py/test/unit/selenium/webdriver/wpewebkit/wpewebkit_options_tests.py
@@ -1,0 +1,51 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from selenium.webdriver.wpewebkit.options import Options
+
+
+@pytest.fixture
+def options():
+    return Options()
+
+
+def test_set_binary_location(options):
+    options.binary_location = '/foo/bar'
+    assert options._binary_location == '/foo/bar'
+
+
+def test_get_binary_location(options):
+    options._binary_location = '/foo/bar'
+    assert options.binary_location == '/foo/bar'
+
+
+def test_creates_capabilities(options):
+    options._arguments = ['foo']
+    options._binary_location = '/bar'
+    caps = options.to_capabilities()
+    opts = caps.get(Options.KEY)
+    assert opts
+    assert 'foo' in opts['args']
+    assert opts['binary'] == '/bar'
+
+
+def test_is_a_baseoptions(options):
+    from selenium.webdriver.common.options import BaseOptions
+    assert isinstance(options, BaseOptions)
+


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

### Description
<!--- Describe your changes in detail -->

These changes allow using the WPE WebDriver to run the Selenium pytest suite.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The selenium test suite is imported into the [WebKit](https://webkit.org/) to make it easier to run WebDriver (Selenium's and WPT's) tests against WebKit changes. Recently we [enabled](https://bugs.webkit.org/show_bug.cgi?id=212527) the tests for WPE build bots but only the WPT suite is actually being tested. The WPE webdriver is not listed in the `conftest.py` as one of the options to be tested.

Also, this request added bazel rules to make it easier to run both the GTK and WPE tests. Will these rules be automatically executed by CI? (Requiring a working WPE/GTK setup). If so, is there any way to make them optional?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
    - Covered by existing tests.
- [ ] All new and existing tests passed.
    - No changes in other browsers, some failures in the test suite with both GTK and WPE.
<!--- Provide a general summary of your changes in the Title above -->
