### PR TITLE
Rb server toggle

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -263,7 +263,10 @@ task test_rb_remote: [
   '//rb:remote-chrome-test',
   '//rb:remote-firefox-test',
   ('//rb:remote-safari-test' if SeleniumRake::Checks.mac?),
+  # BUG - https://github.com/SeleniumHQ/selenium/issues/6791
+  # ('//rb:remote-safari-preview-test' if SeleniumRake::Checks.mac?),
   ('//rb:remote-ie-test' if SeleniumRake::Checks.windows?),
+  ('//rb:remote-edge-test' unless SeleniumRake::Checks.linux?)
 ].compact
 
 task test_py: [:py_prep_for_install_release, 'py:marionette_test']

--- a/rb/build.desc
+++ b/rb/build.desc
@@ -59,6 +59,17 @@ ruby_library(name = "chrome",
   deps = [":common"]
 )
 
+ruby_library(name = "remote",
+  srcs = [
+      "lib/selenium/webdriver/remote/**/*.rb",
+      "lib/selenium/webdriver/remote.rb"
+  ],
+  resources = [
+    {"//java/server/src/org/openqa/selenium/grid:selenium_server_deploy.jar": "rb/selenium_server_deploy.jar"}
+  ],
+  deps = [":common"]
+)
+
 ruby_test(name = "chrome",
   srcs = [
     "spec/integration/selenium/webdriver/*_spec.rb",
@@ -84,7 +95,10 @@ ruby_test(name = "remote-chrome",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":chrome"]
+  deps = [
+    ":chrome",
+    ":remote"
+  ]
 )
 
 ruby_library(name = "edge-html",
@@ -125,7 +139,10 @@ ruby_test(name = "remote-edge",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":edge-chrome"]
+  deps = [
+    ":edge-chrome",
+    ":remote"
+  ]
 )
 
 ruby_library(name = "firefox",
@@ -158,7 +175,10 @@ ruby_test(name = "remote-firefox",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":firefox"]
+  deps = [
+    ":firefox",
+    ":remote"
+  ]
 )
 
 ruby_library(name = "ie",
@@ -191,7 +211,10 @@ ruby_test(name = "remote-ie",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":ie"]
+  deps = [
+    ":ie",
+    ":remote"
+  ]
 )
 
 ruby_library(name = "safari",
@@ -224,7 +247,10 @@ ruby_test(name = "remote-safari",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":safari"]
+  deps = [
+    ":safari",
+    ":remote"
+  ]
 )
 
 ruby_test(name = "safari-preview",
@@ -249,7 +275,10 @@ ruby_test(name = "remote-safari-preview",
     "rb/spec/integration",
     "build/rb/lib"
   ],
-  deps = [":safari"]
+  deps = [
+    ":safari",
+    ":remote"
+  ]
 )
 
 ruby_library(name = "devtools",

--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -135,6 +135,13 @@ module Selenium
     end
 
     #
+    # The Mode of the Server
+    # :standalone, #hub, #node
+    #
+
+    attr_accessor :role
+
+    #
     # The server port
     #
 
@@ -175,6 +182,7 @@ module Selenium
 
       @jar        = jar
       @host       = '127.0.0.1'
+      @role       = opts.fetch(:role, 'standalone')
       @port       = opts.fetch(:port, 4444)
       @timeout    = opts.fetch(:timeout, 30)
       @background = opts.fetch(:background, false)
@@ -216,6 +224,10 @@ module Selenium
 
     private
 
+    def selenium4?
+      @jar.match?(/[^\.][4]\./) || @jar.include?('deploy')
+    end
+
     def stop_process
       return unless @process.alive?
 
@@ -234,7 +246,11 @@ module Selenium
       @process ||= begin
         # extract any additional_args that start with -D as options
         properties = @additional_args.dup - @additional_args.delete_if { |arg| arg[/^-D/] }
-        server_command = ['java'] + properties + ['-jar', @jar, '-port', @port.to_s] + @additional_args
+        args = ['-jar', @jar]
+        args << @role if selenium4?
+        args << (selenium4? ? '--port' : '-port')
+        args << @port.to_s
+        server_command = ['java'] + properties + args + @additional_args
         cp = ChildProcess.build(*server_command)
         WebDriver.logger.debug("Executing Process #{server_command}")
 

--- a/rb/spec/integration/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/options_spec.rb
@@ -25,6 +25,8 @@ module Selenium
       describe Options, exclusive: {browser: :chrome} do
         subject(:options) { Options.new }
 
+        before { quit_driver }
+
         it 'passes emulated device correctly' do
           options.add_emulation(device_name: 'Nexus 5')
 

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -22,7 +22,8 @@ require_relative 'spec_helper'
 module Selenium
   module WebDriver
     describe Driver do
-      it_behaves_like 'driver that can be started concurrently', except: {browser: %i[safari safari_preview]}
+      it_behaves_like 'driver that can be started concurrently', except: [{browser: %i[safari safari_preview]},
+                                                                          {driver: :remote, reason: 8524}]
 
       it 'creates default capabilities' do
         reset_driver! do |driver|

--- a/rb/spec/integration/selenium/webdriver/firefox/profile_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/profile_spec.rb
@@ -45,7 +45,8 @@ module Selenium
           end
         end
 
-        it 'should be able to use the same profile more than once' do
+        it 'should be able to use the same profile more than once', except: {driver: :remote,
+                                                                             reason: "Likely related to #8524"} do
           create_driver!(capabilities: Options.new(profile: profile)) do |driver1|
             expect { wait(5).until { driver1.find_element(id: 'oneline') } }.not_to raise_error
             create_driver!(capabilities: Options.new(profile: profile)) do |driver2|

--- a/rb/spec/integration/selenium/webdriver/remote/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/remote/element_spec.rb
@@ -21,7 +21,8 @@ require_relative '../spec_helper'
 
 module Selenium
   module WebDriver
-    describe Element, exclusive: {driver: :remote} do
+    describe Element, {exclusive: {driver: :remote},
+                       except: {driver: :remote, reason: 8525}} do
       before do
         driver.file_detector = ->(filename) { File.join(__dir__, filename) }
       end

--- a/rb/spec/integration/selenium/webdriver/remote/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/remote/element_spec.rb
@@ -30,7 +30,7 @@ module Selenium
         driver.file_detector = nil
       end
 
-      context 'when uploading one file', only: {browser: %i[chrome firefox ie safari]} do
+      context 'when uploading one file' do
         it 'uses the file detector' do
           driver.navigate.to url_for('upload.html')
 
@@ -46,7 +46,7 @@ module Selenium
         end
       end
 
-      context 'when uploading multiple files', only: {browser: %i[chrome firefox safari]} do
+      context 'when uploading multiple files' do
         it 'uses the file detector' do
           driver.navigate.to url_for('upload_multiple.html')
 

--- a/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
@@ -28,9 +28,7 @@ module Selenium
 
       let(:new_window) { driver.window_handles.find { |handle| handle != driver.window_handle } }
 
-      # Safari is using GET instead of POST (W3C vs JWP)
-      # Server - https://github.com/SeleniumHQ/selenium/issues/1795
-      it 'should find the active element', except: {driver: :remote, browser: :edge} do
+      it 'should find the active element' do
         driver.navigate.to url_for('xhtmlTest.html')
         expect(driver.switch_to.active_element).to be_an_instance_of(WebDriver::Element)
       end

--- a/rb/spec/unit/selenium/server_spec.rb
+++ b/rb/spec/unit/selenium/server_spec.rb
@@ -32,26 +32,26 @@ module Selenium
     end
 
     it 'uses the given jar file and port' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
 
       expect(ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium-server-test.jar', '-port', '1234')
+        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
         .and_return(mock_process)
 
-      server = Selenium::Server.new('selenium-server-test.jar', port: 1234, background: true)
+      server = Selenium::Server.new('selenium_server_deploy.jar', port: 1234, background: true)
       allow(server).to receive(:socket).and_return(mock_poller)
 
       server.start
     end
 
     it 'waits for the server process by default' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
 
       expect(ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium-server-test.jar', '-port', '4444')
+        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '4444')
         .and_return(mock_process)
 
-      server = Selenium::Server.new('selenium-server-test.jar')
+      server = Selenium::Server.new('selenium_server_deploy.jar')
       allow(server).to receive(:socket).and_return(mock_poller)
 
       expect(mock_process).to receive(:wait)
@@ -59,13 +59,13 @@ module Selenium
     end
 
     it 'adds additional args' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
 
       expect(ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium-server-test.jar', '-port', '4444', 'foo', 'bar')
+        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '4444', 'foo', 'bar')
         .and_return(mock_process)
 
-      server = Selenium::Server.new('selenium-server-test.jar', background: true)
+      server = Selenium::Server.new('selenium_server_deploy.jar', background: true)
       allow(server).to receive(:socket).and_return(mock_poller)
 
       server << %w[foo bar]
@@ -74,18 +74,19 @@ module Selenium
     end
 
     it 'adds additional JAVA options args' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
 
       expect(ChildProcess).to receive(:build)
         .with('java',
               '-Dwebdriver.chrome.driver=/bin/chromedriver',
-              '-jar', 'selenium-server-test.jar',
-              '-port', '4444',
+              '-jar', 'selenium_server_deploy.jar',
+              'standalone',
+              '--port', '4444',
               'foo',
               'bar')
         .and_return(mock_process)
 
-      server = Selenium::Server.new('selenium-server-test.jar', background: true)
+      server = Selenium::Server.new('selenium_server_deploy.jar', background: true)
       allow(server).to receive(:socket).and_return(mock_poller)
 
       server << %w[foo bar]
@@ -173,20 +174,20 @@ module Selenium
     end
 
     it 'raises Selenium::Server::Error if the server is not launched within the timeout' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
 
       poller = instance_double('SocketPoller')
       expect(poller).to receive(:connected?).and_return(false)
 
-      server = Selenium::Server.new('selenium-server-test.jar', background: true)
+      server = Selenium::Server.new('selenium_server_deploy.jar', background: true)
       allow(server).to receive(:socket).and_return(poller)
 
       expect { server.start }.to raise_error(Selenium::Server::Error)
     end
 
     it 'sets options after instantiation' do
-      expect(File).to receive(:exist?).with('selenium-server-test.jar').and_return(true)
-      server = Selenium::Server.new('selenium-server-test.jar')
+      expect(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
+      server = Selenium::Server.new('selenium_server_deploy.jar')
       expect(server.port).to eq(4444)
       expect(server.timeout).to eq(30)
       expect(server.background).to be false


### PR DESCRIPTION
~This relies on #8504, so this PR is in draft until I get that merged/rebased~ 

1. Using go for a remote test will build the latest server
2. If the latest server is found, this code will use it, unless `ENV['DOWNLOAD_SERVER']` is set, then it will download and use latest
3. Syntax for starting server is different between 3.x/2.x and 4.x so I'm parsing; we need this even after 4.x is released since someone may pass in a 3.x jar
4. STP should be toggled by the new browser name, which makes the code more simple, but also current STP is broken on both 3.x and 4.x servers (#6791)
5. And I'm undoing the removal of remote as a build library since we need the server to get built in `deps`, but that doesn't work in a test; so remote is only being called from remote tests, not from any of the libs and not for building the gem.

