### PR TITLE
Fix the link to Open JDK in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To list all available targets, you can append the `-T` flag:
 
 ## Requirements
 
-* The latest version of the [Java 11 OpenJDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+* The latest version of the [Java 11 OpenJDK](https://openjdk.java.net/)
 * `java` and `jar` on the PATH (make sure you use `java` executable from JDK but not JRE). 
   * To test this, try running the command `javac`. This command won't exist if you only have the JRE
   installed. If you're met with a list of command-line options, you're referencing the JDK properly.


### PR DESCRIPTION
### Description
Fix the link in README to point actual Open JDK website

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
