### PR TITLE
[JS] Removing deprecated selector tagName from tests

### DIFF
--- a/javascript/node/selenium-webdriver/lib/test/fileserver.js
+++ b/javascript/node/selenium-webdriver/lib/test/fileserver.js
@@ -17,7 +17,6 @@
 
 'use strict';
 
-const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const url = require('url');

--- a/javascript/node/selenium-webdriver/lib/test/index.js
+++ b/javascript/node/selenium-webdriver/lib/test/index.js
@@ -17,16 +17,10 @@
 
 'use strict';
 
-const assert = require('assert');
-
 const build = require('./build');
 const fileserver = require('./fileserver');
-const firefox = require('../../firefox');
 const logging = require('../../lib/logging');
-const remote = require('../../remote');
-const safari = require('../../safari');
 const testing = require('../../testing');
-const webdriver = require('../../');
 
 const NO_BUILD = /^1|true$/i.test(process.env['SELENIUM_NO_BUILD']);
 

--- a/javascript/node/selenium-webdriver/test/element_finding_test.js
+++ b/javascript/node/selenium-webdriver/test/element_finding_test.js
@@ -375,7 +375,7 @@ suite(function(env) {
         await driver.get(Pages.javascriptPage);
 
         let link = await driver.findElement(function(driver) {
-          let links = driver.findElements(By.tagName('a'));
+          let links = driver.findElements(By.css('a'));
           return promise.filter(links, function(link) {
             return link.getAttribute('id').then(id => id === 'updatediv');
           }).then(links => links[0]);
@@ -390,7 +390,7 @@ suite(function(env) {
         await driver.get(Pages.javascriptPage);
 
         let link = await driver.findElement(function() {
-          return driver.findElements(By.tagName('a'));
+          return driver.findElements(By.css('a'));
         });
 
         assert.equal(await link.getText(), 'Change the page title!');

--- a/javascript/node/selenium-webdriver/test/execute_script_test.js
+++ b/javascript/node/selenium-webdriver/test/execute_script_test.js
@@ -18,8 +18,6 @@
 'use strict';
 
 const assert = require('assert');
-const {fail} = require('assert');
-
 const {Browser, By, WebElement, error} = require('..');
 const {Pages, ignore, suite} = require('../lib/test');
 
@@ -225,7 +223,7 @@ suite(function(env) {
       });
 
       it('WebElement arguments are passed as DOM elements', async function() {
-        let el = await driver.findElement(By.tagName('div'));
+        let el = await driver.findElement(By.css('div'));
         let result =
             await execute('return arguments[0].tagName.toLowerCase();', el);
         assert.equal(result, 'div');
@@ -324,7 +322,7 @@ suite(function(env) {
       it('fails if script took too long', function() {
         return executeTimeOutScript(TOO_LONG_WAIT)
           .then(function() {
-            fail('it should have timed out');
+            assert.fail('it should have timed out');
           }).catch(function(e) {
             if (env.browser.name === Browser.SAFARI) {
               assert.equal(e.name, error.TimeoutError.name);

--- a/javascript/node/selenium-webdriver/test/lib/webdriver_test.js
+++ b/javascript/node/selenium-webdriver/test/lib/webdriver_test.js
@@ -719,7 +719,7 @@ describe('WebDriver', function() {
       var driver = executor.createDriver();
       var element = driver.findElement(function(d) {
         assert.equal(driver, d);
-        return d.findElements(By.tagName('a'));
+        return d.findElements(By.css('a'));
       });
       return element.click();
     });
@@ -744,7 +744,7 @@ describe('WebDriver', function() {
           end();
 
       var driver = executor.createDriver();
-      return driver.findElements(By.tagName('a'))
+      return driver.findElements(By.css('a'))
           .then(function(elements) {
             return Promise.all(elements.map(function(e) {
               assert.ok(e instanceof WebElement);

--- a/javascript/node/selenium-webdriver/test/proxy_test.js
+++ b/javascript/node/selenium-webdriver/test/proxy_test.js
@@ -112,7 +112,7 @@ test.suite(function(env) {
       await driver.get(helloServer.url());
       assert.equal(await driver.getTitle(), 'Proxy page');
       assert.equal(
-          await driver.findElement({tagName: 'h3'}).getText(),
+          await driver.findElement({css: 'h3'}).getText(),
           'This is the proxy landing page');
     });
 
@@ -125,7 +125,7 @@ test.suite(function(env) {
       await driver.get(helloServer.url());
       assert.equal(await driver.getTitle(), 'Hello');
       assert.equal(
-          await driver.findElement({tagName: 'h3'}).getText(),
+          await driver.findElement({css: 'h3'}).getText(),
           'Hello, world!');
 
       // For firefox the no proxy settings appear to match on hostname only.
@@ -133,7 +133,7 @@ test.suite(function(env) {
       await driver.get(url);
       assert.equal(await driver.getTitle(), 'Proxy page');
       assert.equal(
-          await driver.findElement({tagName: 'h3'}).getText(),
+          await driver.findElement({css: 'h3'}).getText(),
           'This is the proxy landing page');
     });
 
@@ -150,13 +150,13 @@ test.suite(function(env) {
       await driver.get(helloServer.url());
       assert.equal(await driver.getTitle(), 'Proxy page');
       assert.equal(
-          await driver.findElement({tagName: 'h3'}).getText(),
+          await driver.findElement({css: 'h3'}).getText(),
           'This is the proxy landing page');
 
       await driver.get(goodbyeServer.url());
       assert.equal(await driver.getTitle(), 'Goodbye');
       assert.equal(
-          await driver.findElement({tagName: 'h3'}).getText(),
+          await driver.findElement({css: 'h3'}).getText(),
           'Goodbye, world!');
     });
   });


### PR DESCRIPTION

### Description
tagName is deprecated in JS bindings, so replacing it with css selector

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
