### PR TITLE
[build] Switch to ready-to-use Docker Super-Linter image

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,9 @@ name: Lint Code Base
 #############################
 on:
   push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
 
 
 ###############

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,7 +41,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super-Linter
-        uses: github/super-linter@v3.3.1
+        uses: docker://github/super-linter:v3
         env:
           DEFAULT_BRANCH: trunk
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
### Description
Use pre-built Docker Super-Linter image instead of building it every time

### Motivation and Context
According to the official [documentation](https://github.com/github/super-linter/blob/366771ba4ec760c65d661807be7ce507bef2ce59/README.md):
> **NOTE:**
Using the line:`uses: docker://github/super-linter:v3` will pull the image down from **DockerHub** and run the **GitHub Super-Linter**.   Using the line: `uses: github/super-linter@v3` will build and compile the **GitHub Super-Linter** at build time. *This can be far more costly in time...*

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
