### PR TITLE
Make Until cancellable.

### DIFF
--- a/dotnet/src/webdriver/Support/DefaultWait{T}.cs
+++ b/dotnet/src/webdriver/Support/DefaultWait{T}.cs
@@ -141,6 +141,26 @@ namespace OpenQA.Selenium.Support.UI
         /// <returns>The delegate's return value.</returns>
         public virtual TResult Until<TResult>(Func<T, TResult> condition)
         {
+            return Until(condition, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Repeatedly applies this instance's input value to the given function until one of the following
+        /// occurs:
+        /// <para>
+        /// <list type="bullet">
+        /// <item>the function returns neither null nor false</item>
+        /// <item>the function throws an exception that is not in the list of ignored exception types</item>
+        /// <item>the timeout expires</item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TResult">The delegate's expected return type.</typeparam>
+        /// <param name="condition">A delegate taking an object of type T as its parameter, and returning a TResult.</param>
+        /// <param name="token">A cancellation token that can be used to cancel the wait.</param>
+        /// <returns>The delegate's return value.</returns>
+        public virtual TResult Until<TResult>(Func<T, TResult> condition, CancellationToken token)
+        {
             if (condition == null)
             {
                 throw new ArgumentNullException("condition", "condition cannot be null");
@@ -156,6 +176,8 @@ namespace OpenQA.Selenium.Support.UI
             var endTime = this.clock.LaterBy(this.timeout);
             while (true)
             {
+                token.ThrowIfCancellationRequested();
+
                 try
                 {
                     var result = condition(this.input);


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add a method `TResult Until<TResult>(Func<T, TResult> condition, CancellationToken token)` for cancel the wait.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes I want to abort the wait as quick as possible rather than wait to timeout.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
