### PR TITLE
[JS] Kill opera service on quit

### DIFF
--- a/javascript/node/selenium-webdriver/opera.js
+++ b/javascript/node/selenium-webdriver/opera.js
@@ -47,7 +47,7 @@
  * from the current process and direct all output to /dev/null. You may obtain
  * a handle to this default service using
  * {@link #getDefaultService getDefaultService()} and change its configuration
- * with {@link #setDefaultService setDefault()}.
+ * with {@link #setDefaultService setDefaultService()}.
  *
  * You may also create a {@link Driver} with its own driver service. This is
  * useful if you need to capture the server's log output for a specific session:

--- a/javascript/node/selenium-webdriver/opera.js
+++ b/javascript/node/selenium-webdriver/opera.js
@@ -35,7 +35,7 @@
  *     session, such as which {@linkplain Options#setProxy proxy} to use,
  *     what {@linkplain Options#addExtensions extensions} to install, or
  *     what {@linkplain Options#addArguments command-line switches} to use when
- *     starting the browser.
+ *     starting the browser.Service
  *
  * 3. {@linkplain Driver}: the WebDriver client; each new instance will control
  *     a unique browser session with a clean user profile (unless otherwise
@@ -47,7 +47,7 @@
  * from the current process and direct all output to /dev/null. You may obtain
  * a handle to this default service using
  * {@link #getDefaultService getDefaultService()} and change its configuration
- * with {@link #setDefaultService setDefaultService()}.
+ * with {@link #setDefaultService setDefault()}.
  *
  * You may also create a {@link Driver} with its own driver service. This is
  * useful if you need to capture the server's log output for a specific session:
@@ -356,15 +356,13 @@ class Driver extends webdriver.WebDriver {
   /**
    * Creates a new session for Opera.
    *
-   * @param {(capabilities.Capabilities|Options)=} opt_config The configuration
+   * @param {(Capabilities|Options)=} opt_config The configuration
    *     options.
    * @param {remote.DriverService=} opt_service The session to use; will use
    *     the {@link getDefaultService default service} by default.
-   * @param {promise.ControlFlow=} opt_flow The control flow to use,
-   *     or {@code null} to use the currently active flow.
    * @return {!Driver} A new driver instance.
    */
-  static createSession(opt_config, opt_service, opt_flow) {
+  static createSession(opt_config, opt_service) {
     var service = opt_service || getDefaultService();
     var client = service.start().then(url => new http.HttpClient(url));
     var executor = new http.Executor(client);
@@ -389,7 +387,7 @@ class Driver extends webdriver.WebDriver {
     }
 
     return /** @type {!Driver} */(
-        super.createSession(executor, caps, opt_flow));
+        super.createSession(executor, caps, () => service.kill()));
   }
 
   /**


### PR DESCRIPTION

### Description
WebDriver control flow is deprecated long ago, so removing opt_flow and replacing with service.kill()

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
