### PR TITLE
Loosen max version for childprocess

### DIFF
--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.files = Dir[root + '/**/*'].reject { |e| e =~ /ruby\.iml|build\.desc/ }.map { |e| e.sub(root + '/', '') }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 4.0']
+  s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 5.0']
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2']
   s.add_runtime_dependency 'websocket', ['~> 1.0']
 


### PR DESCRIPTION
childprocess 4.0 is out and seems to work ok with selenium-driver.

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.