### PR TITLE
Relax childprocess dependency

### DIFF
--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.files = Dir[root + '/**/*'].reject { |e| e =~ /ruby\.iml|build\.desc/ }.map { |e| e.sub(root + '/', '') }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 4.0']
+  s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 5.0']
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2']
   s.add_runtime_dependency 'websocket', ['~> 1.0']
 


### PR DESCRIPTION
Latest version of Childprocess gem is 4.0, raise the dependency.

### Description
Newly capped at `< 5.0` (previously `< 4.0`). 

### Motivation and Context
We'd like to upgrade to Childprocess 4.0 In Fedora. Fedora does not support multiple versions of gems packaged in same Fedora version.

### Types of changes
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] ~~My change requires a change to the documentation.~~
- [ ]  ~~I have updated the documentation accordingly.~~
- [ ]  ~~I have added tests to cover my changes.~~
- [ ]  All new and existing tests passed. 
