### PR TITLE
Improve the error messages output by some ExpectedConditions.

### DIFF
--- a/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -348,10 +348,12 @@ public class ExpectedConditions {
                                                                     final String text) {
 
     return new ExpectedCondition<Boolean>() {
+      private String elementText = null;
+
       @Override
       public Boolean apply(WebDriver driver) {
         try {
-          String elementText = element.getText();
+          elementText = element.getText();
           return elementText.contains(text);
         } catch (StaleElementReferenceException e) {
           return null;
@@ -360,7 +362,11 @@ public class ExpectedConditions {
 
       @Override
       public String toString() {
-        return String.format("text ('%s') to be present in element %s", text, element);
+        String renderedElementText = elementText != null && elementText.length() > 100
+            ? elementText.substring(0, 100) + "..."
+            : elementText;
+        return String.format("text ('%s') to be present in element %s which has text %s",
+            text, element, renderedElementText);
       }
     };
   }
@@ -377,10 +383,12 @@ public class ExpectedConditions {
                                                                            final String text) {
 
     return new ExpectedCondition<Boolean>() {
+      private String elementText = null;
+
       @Override
       public Boolean apply(WebDriver driver) {
         try {
-          String elementText = driver.findElement(locator).getText();
+          elementText = driver.findElement(locator).getText();
           return elementText.contains(text);
         } catch (StaleElementReferenceException e) {
           return null;
@@ -389,8 +397,11 @@ public class ExpectedConditions {
 
       @Override
       public String toString() {
-        return String.format("text ('%s') to be present in element found by %s",
-                             text, locator);
+        String renderedElementText = elementText != null && elementText.length() > 100
+            ? elementText.substring(0, 100) + "..."
+            : elementText;
+        return String.format("text ('%s') to be present in element found by %s which has text %s",
+                             text, locator, renderedElementText);
       }
     };
   }
@@ -1083,7 +1094,10 @@ public class ExpectedConditions {
       @Override
       public Boolean apply(WebDriver driver) {
         return getAttributeOrCssValue(element, attribute)
-            .map(seen -> seen.contains(value))
+            .map(seen -> {
+              currentValue = seen;
+              return seen.contains(value);
+            })
             .orElse(false);
       }
 
@@ -1112,7 +1126,10 @@ public class ExpectedConditions {
       @Override
       public Boolean apply(WebDriver driver) {
         return getAttributeOrCssValue(driver.findElement(locator), attribute)
-            .map(seen -> seen.contains(value))
+            .map(seen -> {
+              currentValue = seen;
+              return seen.contains(value);
+            })
             .orElse(false);
       }
 

--- a/java/client/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
+++ b/java/client/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
@@ -482,11 +482,14 @@ public class ExpectedConditionsTest {
     By parent = By.cssSelector("parent");
     String attributeName = "attributeName";
     when(mockDriver.findElement(parent)).thenReturn(mockElement);
-    when(mockElement.getAttribute(attributeName)).thenReturn("");
+    when(mockElement.getAttribute(attributeName)).thenReturn("actualValue");
     when(mockElement.getCssValue(attributeName)).thenReturn("");
 
     assertThatExceptionOfType(TimeoutException.class)
-        .isThrownBy(() -> wait.until(attributeContains(parent, attributeName, "test")));
+        .isThrownBy(() -> wait.until(attributeContains(parent, attributeName, "expectedValue")))
+        .withMessageContaining(String.format(
+            "value found by %s to contain \"expectedValue\". Current value: \"actualValue\"",
+            parent));
   }
 
   @Test
@@ -512,11 +515,12 @@ public class ExpectedConditionsTest {
   @Test
   public void waitingForCssAttributeToBeEqualForWebElementThrowsTimeoutExceptionWhenAttributeContainsNotEqual() {
     String attributeName = "attributeName";
-    when(mockElement.getAttribute(attributeName)).thenReturn("");
+    when(mockElement.getAttribute(attributeName)).thenReturn("actualValue");
     when(mockElement.getCssValue(attributeName)).thenReturn("");
 
     assertThatExceptionOfType(TimeoutException.class)
-        .isThrownBy(() -> wait.until(attributeContains(mockElement, attributeName, "test")));
+        .isThrownBy(() -> wait.until(attributeContains(mockElement, attributeName, "expectedValue")))
+        .withMessageContaining("value to contain \"expectedValue\". Current value: \"actualValue\"");
   }
 
   @Test
@@ -828,12 +832,70 @@ public class ExpectedConditionsTest {
 
   @Test
   public void waitingForTextToBePresentInElementLocatedThrowsTimeoutExceptionWhenTextNotPresent() {
-    String testSelector = "testSelector";
-    when(mockDriver.findElement(By.cssSelector(testSelector))).thenReturn(mockElement);
+    By locator = By.cssSelector("testSelector");
+    when(mockDriver.findElement(locator)).thenReturn(mockElement);
     when(mockElement.getText()).thenReturn("testText");
 
     assertThatExceptionOfType(TimeoutException.class)
-        .isThrownBy(() -> wait.until(textToBePresentInElementLocated(By.cssSelector(testSelector), "failText")));
+        .isThrownBy(() -> wait.until(textToBePresentInElementLocated(locator, "failText")))
+        .withMessageContaining(String.format(
+            "text ('failText') to be present in element found by %s which has text testText",
+            locator));
+  }
+
+  @Test
+  public void
+      waitingForTextToBePresentInElementLocatedThrowsTimeoutExceptionWhenTextNotPresentLongText() {
+    String longText = "";
+    for (int i = 0; i < 101; i++) {
+      longText += i;
+    }
+    String shortendText = "";
+    for (int i = 0; i < 100; i++) {
+      shortendText += i;
+    }
+    shortendText += "...";
+    By locator = By.cssSelector("testSelector");
+    when(mockDriver.findElement(locator)).thenReturn(mockElement);
+    when(mockElement.getText()).thenReturn(longText);
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(textToBePresentInElementLocated(locator, "failText")))
+        .withMessageContaining(
+            String.format(
+                "text ('failText') to be present in element found by %s which has text %s",
+                locator, shortendText));
+  }
+
+  @Test
+  public void waitingForTextToBePresentInElementThrowsTimeoutExceptionWhenTextNotPresent() {
+    when(mockElement.getText()).thenReturn("testText");
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(textToBePresentInElement(mockElement, "failText")))
+        .withMessageContaining(String.format(
+            "text ('failText') to be present in element %s which has text testText", mockElement));
+  }
+
+  @Test
+  public void waitingForTextToBePresentInElementThrowsTimeoutExceptionWhenTextNotPresentLongText() {
+    String longText = "";
+    for (int i = 0; i < 101; i++) {
+      longText += i;
+    }
+    String shortendText = "";
+    for (int i = 0; i < 100; i++) {
+      shortendText += i;
+    }
+    shortendText += "...";
+    when(mockElement.getText()).thenReturn(longText);
+
+    assertThatExceptionOfType(TimeoutException.class)
+        .isThrownBy(() -> wait.until(textToBePresentInElement(mockElement, "failText")))
+        .withMessageContaining(
+            String.format(
+                "text ('failText') to be present in element %s which has text %s",
+                mockElement, shortendText));
   }
 
   @Test


### PR DESCRIPTION
### Description
attributeContains was incorrectly reporting the current value as "null". This
change fixes that.
textToBePresentInElement was not reporting the actual element text. This change
adds the actual element text in the failure message.

### Motivation and Context
I was writing selenium tests and having trouble debugging them because of the poor output of the existing ExpectedConditions logic. This change provides more useful output for failing tests.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
Fixes bug with attributeContains condition error message.
- [X] New feature (non-breaking change which adds functionality)
Adds more useful error message for testToBePresentInElement condition.
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
