### PR TITLE
Fixes #8587 - Include original stack trace when throwing TimeoutException

### DIFF
--- a/java/client/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/client/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -208,7 +208,7 @@ public class FluentWait<T> implements Wait<T> {
           .get(deriveSafeTimeout(), TimeUnit.MILLISECONDS);
     } catch (ExecutionException cause) {
       if (cause.getCause() instanceof RuntimeException) {
-        throw (RuntimeException) cause.getCause();
+        throw (RuntimeException) cause.getCause().fillInStackTrace();
       } else if (cause.getCause() instanceof Error) {
         throw (Error) cause.getCause();
       }

--- a/java/client/test/org/openqa/selenium/support/ui/WebDriverWaitTest.java
+++ b/java/client/test/org/openqa/selenium/support/ui/WebDriverWaitTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.NoSuchElementException;
@@ -86,6 +87,15 @@ public class WebDriverWaitTest {
 
     assertThatExceptionOfType(TimeoutException.class)
         .isThrownBy(() -> wait.until(d -> false));
+  }
+
+  @Test
+  public void shouldThrowAnExceptionFromCorrectThreadIfTheTimerRunsOut() {
+    System.out.println("running: shouldThrowAnExceptionFromCorrectThreadIfTheTimerRunsOut");
+    WebDriverWait wait = new WebDriverWait(mockDriver, Duration.ofSeconds(1));
+    assertThatExceptionOfType(TimeoutException.class)
+      .isThrownBy(() -> wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(By.cssSelector(".doesntexist"))))
+      .withStackTraceContaining(this.getClass().getName());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes #8587 - Include original stack trace when throwing TimeoutException. Added new test to check if stack trace contains test name

### Description
Original stacktrace was not returned as part of the thrown TimeoutException. 

### Motivation and Context
Based on reported issue #8587, the TimeoutException was not reporting the correct details in the stacktrace.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue 8587) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
