### PR TITLE
Fix for documentation of ‘Actions.moveToElement’

### DIFF
--- a/java/client/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/client/src/org/openqa/selenium/interactions/Actions.java
@@ -366,13 +366,12 @@ public class Actions {
   }
 
   /**
-   * Moves the mouse to an offset from the center of the element.
-   * The element is scrolled into view and its location is calculated using getClientRects.
+   * Moves the mouse to an offset from the element's in-view center point.
    * @param target element to move to.
-   * @param xOffset Offset from the center. A negative value means coordinates left from
-   * the element.
-   * @param yOffset Offset from the center. A negative value means coordinates above
-   * the element.
+   * @param xOffset Offset from the element's in-view center point. A negative value means
+   * an offset left of the point.
+   * @param yOffset Offset from the element's in-view center point. A negative value means
+   * an offset above the point.
    * @return A self reference.
    */
   public Actions moveToElement(WebElement target, int xOffset, int yOffset) {
@@ -382,7 +381,7 @@ public class Actions {
 
     // Of course, this is the offset from the centre of the element. We have no idea what the width
     // and height are once we execute this method.
-    LOG.info("When using the W3C Action commands, offsets are from the center of element");
+    LOG.info("When using the W3C Action commands, offsets are from the element's in-view center point");
     return moveInTicks(target, xOffset, yOffset);
   }
 


### PR DESCRIPTION
Pull request as suggested by @diemol ( https://github.com/SeleniumHQ/selenium/issues/4847#issuecomment-691981122 ).

This replaces “center of the element” in the documentation of `Actions.moveToElement` with “element‘s in-view center point” to match the W3C spec.

The section on “pointer actions” in the spec says the offsets are from the element’s in-view center point, not its center:

![WebDriver 2020-09-22 12-05-25](https://user-images.githubusercontent.com/1611248/93869405-0b387a00-fccc-11ea-8652-d03b238eec29.png)

The in-view center point is defined as follows:

![WebDriver 2020-09-22 12-08-06](https://user-images.githubusercontent.com/1611248/93869589-49ce3480-fccc-11ea-89fc-d1db9215d1db.png)
