### PR TITLE
[JS] Enable installAddon() to install unpacked extensions

### DIFF
--- a/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/inject.js
+++ b/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/inject.js
@@ -1,0 +1,7 @@
+/* eslint-env browser */
+;(function (document) {
+  var div = document.createElement('div')
+  div.id = 'webextensions-selenium-example'
+  div.textContent = 'Content injected by webextensions-selenium-example'
+  document.body.appendChild(div)
+})(document)

--- a/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/manifest.json
+++ b/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 2,
+  "name": "webextensions-selenium-example",
+  "description": "Inject a div with id webextensions-selenium-example to verify that WebExtensions work in Firefox/Selenium" ,
+  "version": "0.1",
+  "content_scripts": [
+    {
+      "matches": ["https://*/*","http://*/*"],
+      "js": ["inject.js"]
+    }
+  ],
+  "applications": {
+   "gecko": {
+     "id": "webextensions-selenium-example@example.com"
+   }
+ }
+}

--- a/javascript/node/selenium-webdriver/test/firefox_test.js
+++ b/javascript/node/selenium-webdriver/test/firefox_test.js
@@ -34,6 +34,10 @@ const WEBEXTENSION_EXTENSION_ZIP = path.join(
   __dirname,
   '../lib/test/data/firefox/webextension.zip'
 )
+const WEBEXTENSION_EXTENSION_UNPACKED = path.join(
+  __dirname,
+  '../lib/test/data/firefox/webextension'
+)
 
 const WEBEXTENSION_EXTENSION_ID =
   'webextensions-selenium-example@example.com.xpi'
@@ -212,21 +216,14 @@ suite(
         })
       })
 
-      it('addons can be installed and uninstalled at runtime', async function () {
-        driver = env.builder().build()
+      describe('installAddon/uninstallAddon', function () {
+        it('XPI can be installed and uninstalled', async function () {
+          await testInstallAddon(WEBEXTENSION_EXTENSION_XPI)
+        })
 
-        await driver.get(Pages.echoPage)
-        await verifyWebExtensionNotInstalled()
-
-        let id = await driver.installAddon(WEBEXTENSION_EXTENSION_XPI)
-        await driver.sleep(1000) // Give extension time to install (yuck).
-
-        await driver.get(Pages.echoPage)
-        await verifyWebExtensionWasInstalled()
-
-        await driver.uninstallAddon(id)
-        await driver.get(Pages.echoPage)
-        await verifyWebExtensionNotInstalled()
+        xit('unpacked extension can be installed and uninstalled', async function () {
+          await testInstallAddon(WEBEXTENSION_EXTENSION_UNPACKED)
+        })
       })
 
       async function verifyUserAgentWasChanged() {
@@ -244,11 +241,25 @@ suite(
       }
 
       async function verifyWebExtensionWasInstalled() {
-        let footer = await driver.findElement({
+        let footer = driver.findElement({
           id: 'webextensions-selenium-example',
         })
         let text = await footer.getText()
         assert.equal(text, 'Content injected by webextensions-selenium-example')
+      }
+
+      async function testInstallAddon(path) {
+        driver = env.builder().build()
+
+        let id = await driver.installAddon(path)
+        await driver.sleep(1000) // Give extension time to install (yuck).
+
+        await driver.get(Pages.echoPage)
+        await verifyWebExtensionWasInstalled()
+
+        await driver.uninstallAddon(id)
+        await driver.get(Pages.echoPage)
+        await verifyWebExtensionNotInstalled()
       }
     })
   },


### PR DESCRIPTION
### Description
This pull request extends the `installAddon()` method of the `Driver` implementation for Firefox, so that a path to an unpacked extension can be specified alternatively to a packaged XPI or ZIP file.

### Motivation and Context
The `Driver` implementation for Firefox has an `installAddon()` method in order to install web extensions for the current session. The underlying `install addon` command can install packaged extensions using the `addon` parameter, as well as unpacked extensions using the `path` parameter. Support for the latter is missing in Selenium's `installAddon()` API.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.