### PR TITLE
Update RequestConverter upgrade header handling.

### DIFF
--- a/java/server/src/org/openqa/selenium/netty/server/RequestConverter.java
+++ b/java/server/src/org/openqa/selenium/netty/server/RequestConverter.java
@@ -68,7 +68,7 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
         return;
       }
 
-      if (nettyRequest.headers().contains("Sec-WebSocket-Version") ||
+      if (nettyRequest.headers().contains("Sec-WebSocket-Version") &&
         "upgrade".equals(nettyRequest.headers().get("Connection"))) {
         // Pass this on to later in the pipeline.
         ReferenceCountUtil.retain(msg);


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Updated header handling of upgrade and Sec-WebSocket-Version headers.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Upon receiving the request it goes through a series of handlers.
2. It goes through the WebSockethandler, https://github.com/SeleniumHQ/selenium/blob/selenium-4.0.0-alpha-6/java/server/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java#L103. 
3. To upgrade to using sockets both headers are required. All checks work without quotes only. 
4. When just upgrade or Sec-WebSocket-Version is sent, the request is passed along to .https://github.com/SeleniumHQ/selenium/blob/5f43a29cfccd9c7fb5adca5d69ed168150edb39f/java/server/src/org/openqa/selenium/netty/server/RequestConverter.java#L52 When quotes are used, the condition is always false and moved ahead to get a response.
5. When quotes are not used, the check if actually done and uses logical OR, the request is passed along further but there is nothing to handle it and it just waits.  AND fixes it because both headers are needed and if so it would be handled earlier in the pipeline.
6. Using AND will move along and response to the request using SeleniumHandler.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
