### PR TITLE
[event-bus] Fix the double check for lazy initialisation of EventBus instance in EventBusOptions.

### DIFF
--- a/java/server/src/org/openqa/selenium/grid/server/EventBusOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/server/EventBusOptions.java
@@ -33,15 +33,17 @@ public class EventBusOptions {
   }
 
   public EventBus getEventBus() {
-    if (bus == null) {
+    EventBus localBus = bus;
+    if (localBus == null) {
       synchronized (this) {
-        if (bus == null) {
-          bus = createBus();
+        localBus = bus;
+        if (localBus == null) {
+          bus = localBus = createBus();
         }
       }
     }
 
-    return bus;
+    return localBus;
   }
 
   private EventBus createBus() {

--- a/java/server/src/org/openqa/selenium/grid/server/EventBusOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/server/EventBusOptions.java
@@ -38,7 +38,8 @@ public class EventBusOptions {
       synchronized (this) {
         localBus = bus;
         if (localBus == null) {
-          bus = localBus = createBus();
+          localBus = createBus();
+          bus = localBus;
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Adding a local variable in the getEventBus() method of EventBusOptions to make lazy initialisation of EventBus thread-safe.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SonarLint pointed out a double-checking issue in EventBusOptions.
https://sonarcloud.io/component_measures?id=selenium&metric=reliability_rating&selected=selenium%3Ajava%2Fserver%2Fsrc%2Forg%2Fopenqa%2Fselenium%2Fgrid%2Fserver%2FEventBusOptions.java&view=list 

In order to provide thread-safety, the issue is fixed by using a local variable inside the method and double-checking on it. The solution is per the suggestion from the Sonar linter.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
