### PR TITLE
[logging] Add an option to pass encoding for log configuration.

### DIFF
--- a/java/server/src/org/openqa/selenium/grid/log/LoggingFlags.java
+++ b/java/server/src/org/openqa/selenium/grid/log/LoggingFlags.java
@@ -50,6 +50,10 @@ public class LoggingFlags implements HasRoles {
   @ConfigValue(section = "logging", name = "log-file", example = "true")
   private String logFile;
 
+  @Parameter(description = "Log encoding", names = "--log-encoding", arity = 1)
+  @ConfigValue(section = "logging", name = "log-encoding", example = "UTF-8")
+  private String logEncoding = null;
+
   @Override
   public Set<Role> getRoles() {
     return ALL_ROLES;

--- a/java/server/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -41,6 +41,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -82,6 +83,10 @@ public class LoggingOptions {
 
   public boolean isUsingPlainLogs() {
     return config.getBool(LOGGING_SECTION, "plain-logs").orElse(true);
+  }
+
+  public String getLogEncoding() {
+    return config.get(LOGGING_SECTION, "log-encoding").orElse(null);
   }
 
   public Tracer getTracer() {
@@ -217,17 +222,44 @@ public class LoggingOptions {
     // Now configure the root logger, since everything should flow up to that
     Logger logger = logManager.getLogger("");
     OutputStream out = getOutputStream();
+    String encoding = getLogEncoding();
 
     if (isUsingPlainLogs()) {
+      String message;
       Handler handler = new FlushingHandler(out);
       handler.setFormatter(new TerseFormatter());
+      try {
+        if (encoding != null) {
+          handler.setEncoding(encoding);
+          message = String.format("Using encoding %s", encoding);
+        } else {
+          message = "Using the system default encoding";
+        }
+      } catch (UnsupportedEncodingException e) {
+        message =
+            String.format("Using the system default encoding. Unsupported encoding %s", encoding);
+      }
       logger.addHandler(handler);
-  }
+      logger.log(Level.INFO, message);
+    }
 
     if (isUsingStructuredLogging()) {
+      String message;
       Handler handler = new FlushingHandler(out);
       handler.setFormatter(new JsonFormatter());
+      try {
+        if (encoding != null) {
+          handler.setEncoding(encoding);
+          message = String.format("Using encoding %s", encoding);
+        } else {
+          message = "Using the system default encoding";
+        }
+      } catch (UnsupportedEncodingException e) {
+        message =
+            String.format("Using the system default encoding. Unsupported encoding %s", encoding);
+      }
       logger.addHandler(handler);
+      logger.log(Level.INFO, message);
     }
   }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add option to pass log-encoding else use default system log encoding.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changes are related to #8812.  With the changes above, log encoding can be configured as needed. In the case of unsupported encoding, the logger will use the system default encoding.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
