### PR TITLE
Fix google options

### DIFF
--- a/java/client/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/client/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -27,10 +27,31 @@ import java.util.Map;
 import org.junit.Test;
 
 public class ChromeOptionsTest {
+  @Test
+  public void optionsAsMapAndMergeShouldNotOverwriteExistingGoogleOptions(){
+    ChromeOptions destination = new ChromeOptions();
+    ChromeOptions source = new ChromeOptions();
+    source.addArguments("--start-maximized");
+    source.setBinary("path/to/binary");
+    source.addEncodedExtensions("encodedExtension");
+    destination.merge(source);
+
+    Map<String, Object> googOptions = (Map<String, Object>)destination.asMap().get(ChromeOptions.CAPABILITY);
+
+    List<String> args = (List<String>)googOptions.get("args");
+    List<String> extensions = (List<String>)googOptions.get("extensions");
+    String binary = (String)googOptions.get("binary");
+    assertThat(args).contains("--start-maximized");
+    assertThat(extensions).contains("encodedExtension");
+    assertThat(binary).isEqualTo("path/to/binary");
+  }
 
   @Test
   public void optionsAsMapShouldBeImmutable() {
-    Map<String, Object> options = new ChromeOptions().asMap();
+    ChromeOptions chromeOptions = new ChromeOptions();
+    chromeOptions.addArguments("--argument");
+    chromeOptions.addEncodedExtensions("path/to/binary");
+    Map<String, Object> options = chromeOptions.asMap();
     assertThatExceptionOfType(UnsupportedOperationException.class)
         .isThrownBy(() -> options.put("browserType", "firefox"));
 


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
This pull request changes GoogleOptions and FirefoxOptions so that every time "merge" is called, the third party options are prevserved. 

### Motivation and Context
Issue #5279 explains that when merging two browser-specific capabilities are merged and passed to the browser-specific web driver, the browser-specific options are not carried over.
#### Reason:
Both GoogleOptions and FirefoxOptions, classes, contained private variables that represent browser-specific options but the private variables point to different data that what is stored in the internal capabilities representation.  As a result, when "merge" or "setCapability" is called, the private variables will point to different data than what is in the internal capabilities.  This would be fine except when two capabilities are merged, the target capabilities will overwrite its internal capabilities with its private variables as soon as "asMap" is called.  The is fine for singular data like strings but will it will be a problem for collections because private variables default to empty collections.  As a result, the target capabilities will always overwrite the newly added list like "args" with an empty list after "merge" and "asMap".
#### Solution:
Have both private variables and internal capabilities point to the same values.  In the case of GoogleOptions, "args" would be null until "addArgs" is called.  After that, it will already be added to the internal capabilities.  Every time an entry is added to "args", it will be added to the internal capabilities.
Downside is that every time the cababilities will be modified (in setCapability), the class needs to check if the private variables point to the right value in the capabilities.
I have also changed the data type of "args" and "extensions" to Set, because neither should allow duplicate entries and if "merge" is called on FirefoxOptions, duplicate entries might appear for "args".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
