### PR TITLE
Fixed issue with Firefox browserName camelCasing

### DIFF
--- a/rb/CHANGES
+++ b/rb/CHANGES
@@ -1,3 +1,15 @@
+trunk
+=========================
+Firefox:
+  * Fixed an issue whereby using the new capabilities structure in local drivers
+  would cause the W3C check to complain that `browser_name` was an invalid
+  capability key name (issue #8832)
+
+All Browsers:
+  * Refactor to `#generate_as_json` which now will check if the structure is
+  "Hash-like" first. So that camelCasing on keys will occur earlier in the
+  conditional check
+
 4.0.0.alpha6 (2020-05-28)
 =========================
 

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -209,6 +209,11 @@ module Selenium
           raise Error::WebDriverError, "could not find extension at #{path.inspect}" unless File.file?(path)
           raise Error::WebDriverError, "file was not an extension #{path.inspect}" unless File.extname(path) == '.crx'
         end
+
+        def generate_as_json(value, camelize_keys: true)
+          camelize_keys = false if value == 'pref'
+          super
+        end
       end # Options
     end # Chrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -209,17 +209,6 @@ module Selenium
           raise Error::WebDriverError, "could not find extension at #{path.inspect}" unless File.file?(path)
           raise Error::WebDriverError, "file was not an extension #{path.inspect}" unless File.extname(path) == '.crx'
         end
-
-        def generate_as_json(value, camelize_keys: true)
-          if value.is_a?(Hash)
-            value.each_with_object({}) do |(key, val), hash|
-              key = convert_json_key(key, camelize: camelize_keys)
-              hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
-            end
-          else
-            super
-          end
-        end
       end # Options
     end # Chrome
   end # WebDriver

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -89,7 +89,8 @@ module Selenium
           value.as_json
         elsif value.is_a?(Hash)
           value.each_with_object({}) do |(key, val), hash|
-            hash[convert_json_key(key, camelize: camelize_keys)] = generate_as_json(val, camelize_keys: camelize_keys)
+            key = convert_json_key(key, camelize: camelize_keys)
+            hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
           end
         elsif value.is_a?(Array)
           value.map { |val| generate_as_json(val, camelize_keys: camelize_keys) }

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -85,13 +85,12 @@ module Selenium
       private
 
       def generate_as_json(value, camelize_keys: true)
-        if value.respond_to?(:as_json)
-          value.as_json
-        elsif value.is_a?(Hash)
+        if value.is_a?(Hash)
           value.each_with_object({}) do |(key, val), hash|
-            key = convert_json_key(key, camelize: camelize_keys)
-            hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
+            hash[convert_json_key(key, camelize: camelize_keys)] = generate_as_json(val, camelize_keys: camelize_keys)
           end
+        elsif value.respond_to?(:as_json)
+          value.as_json
         elsif value.is_a?(Array)
           value.map { |val| generate_as_json(val, camelize_keys: camelize_keys) }
         elsif value.is_a?(Symbol)

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -151,17 +151,6 @@ module Selenium
                                  Profile.from_name(profile)
                                end
         end
-
-        def generate_as_json(value, camelize_keys: true)
-          if value.is_a?(Hash)
-            value.each_with_object({}) do |(key, val), hash|
-              key = convert_json_key(key, camelize: camelize_keys)
-              hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
-            end
-          else
-            super
-          end
-        end
       end # Options
     end # Firefox
   end # WebDriver

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -151,6 +151,17 @@ module Selenium
                                  Profile.from_name(profile)
                                end
         end
+
+        def generate_as_json(value, camelize_keys: true)
+          if value.is_a?(Hash)
+            value.each_with_object({}) do |(key, val), hash|
+              key = convert_json_key(key, camelize: camelize_keys)
+              hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
+            end
+          else
+            super
+          end
+        end
       end # Options
     end # Firefox
   end # WebDriver


### PR DESCRIPTION
~Rudimentary fix by copying the legit behaviour. Can try use a more generic fix if we're happy to refactor the Common::Options class.~

After further diving, found out firefox worked all along, but because `{a_b_c: 123}` responds to as_json, and returns `self`, the clever camelCasing logic never got ran.

On ChromeOptions the hash check was first. So if we simply re-order the checks, everything slots into place perfectly.

Have also refactored the chrome one in-line with titus' suggestion.

cc / @p0deje 