### PR TITLE
[grid] Fix flaky Distributor and GraphqlHandlerTest. Add queuer config to DistributedCdpTest

### DIFF
--- a/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -104,6 +104,7 @@ public class DistributorTest {
   private Capabilities stereotype;
   private Capabilities caps;
   private final Secret registrationSecret = new Secret("hellim");
+  private final Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
 
   @Before
   public void setUp() {
@@ -309,7 +310,6 @@ public class DistributorTest {
         queuer,
         registrationSecret);
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     distributor.drain(node.getId());
@@ -355,7 +355,6 @@ public class DistributorTest {
         registrationSecret);
     distributor.add(node);
 
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     NewSessionPayload payload = NewSessionPayload.create(caps);
@@ -400,7 +399,6 @@ public class DistributorTest {
         registrationSecret);
     distributor.add(node);
 
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     NewSessionPayload payload = NewSessionPayload.create(caps);
@@ -513,7 +511,6 @@ public class DistributorTest {
         .add(lightest)
         .add(massive);
 
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {
@@ -669,7 +666,6 @@ public class DistributorTest {
         registrationSecret);
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     // Use up the one slot available
@@ -710,7 +706,6 @@ public class DistributorTest {
         registrationSecret);
     distributor.add(node);
 
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     // Use up the one slot available
@@ -802,7 +797,6 @@ public class DistributorTest {
         registrationSecret);
     distributor.add(node);
 
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {

--- a/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -309,6 +309,9 @@ public class DistributorTest {
         queuer,
         registrationSecret);
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     distributor.drain(node.getId());
 
     latch.await(5, TimeUnit.SECONDS);
@@ -352,6 +355,9 @@ public class DistributorTest {
         registrationSecret);
     distributor.add(node);
 
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     NewSessionPayload payload = NewSessionPayload.create(caps);
     distributor.newSession(createRequest(payload));
 
@@ -393,6 +399,9 @@ public class DistributorTest {
         queuer,
         registrationSecret);
     distributor.add(node);
+
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     NewSessionPayload payload = NewSessionPayload.create(caps);
     CreateSessionResponse firstResponse = distributor.newSession(createRequest(payload));
@@ -503,6 +512,9 @@ public class DistributorTest {
         .add(medium)
         .add(lightest)
         .add(massive);
+
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {
       Session session = distributor.newSession(createRequest(payload)).getSession();
@@ -633,7 +645,9 @@ public class DistributorTest {
   }
 
   @Test
-  public void shouldNotScheduleAJobIfAllSlotsAreBeingUsed() {
+  public void shouldNotScheduleAJobIfAllSlotsAreBeingUsed() throws URISyntaxException {
+    URI nodeUri = new URI("http://example:5678");
+    URI routableUri = new URI("http://localhost:1234");
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     LocalNewSessionQueue localNewSessionQueue = new LocalNewSessionQueue(
       tracer,
@@ -642,19 +656,21 @@ public class DistributorTest {
       Duration.ofSeconds(2));
     LocalNewSessionQueuer queuer = new LocalNewSessionQueuer(tracer, bus, localNewSessionQueue);
 
-    CombinedHandler handler = new CombinedHandler();
+    LocalNode node = LocalNode.builder(tracer, bus, routableUri, routableUri, registrationSecret)
+      .add(caps, new TestSessionFactory((id, c) -> new Session(
+        id, nodeUri, stereotype, c, Instant.now())))
+      .build();
     Distributor distributor = new LocalDistributor(
         tracer,
         bus,
-        new PassthroughHttpClient.Factory(handler),
+        new PassthroughHttpClient.Factory(node),
         sessions,
         queuer,
         registrationSecret);
-    handler.addHandler(distributor);
 
-    Node node = createNode(caps, 1, 0);
-    handler.addHandler(node);
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     // Use up the one slot available
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {
@@ -669,7 +685,9 @@ public class DistributorTest {
   }
 
   @Test
-  public void shouldReleaseSlotOnceSessionEnds() {
+  public void shouldReleaseSlotOnceSessionEnds() throws URISyntaxException {
+    URI nodeUri = new URI("http://example:5678");
+    URI routableUri = new URI("http://localhost:1234");
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     LocalNewSessionQueue localNewSessionQueue = new LocalNewSessionQueue(
       tracer,
@@ -678,19 +696,22 @@ public class DistributorTest {
       Duration.ofSeconds(2));
     LocalNewSessionQueuer queuer = new LocalNewSessionQueuer(tracer, bus, localNewSessionQueue);
 
-    CombinedHandler handler = new CombinedHandler();
+    LocalNode node = LocalNode.builder(tracer, bus, routableUri, routableUri, registrationSecret)
+      .add(caps, new TestSessionFactory((id, c) -> new Session(
+        id, nodeUri, stereotype, c, Instant.now())))
+      .build();
+
     Distributor distributor = new LocalDistributor(
         tracer,
         bus,
-        new PassthroughHttpClient.Factory(handler),
+        new PassthroughHttpClient.Factory(node),
         sessions,
         queuer,
         registrationSecret);
-    handler.addHandler(distributor);
-
-    Node node = createNode(caps, 1, 0);
-    handler.addHandler(node);
     distributor.add(node);
+
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     // Use up the one slot available
     Session session;
@@ -702,9 +723,7 @@ public class DistributorTest {
     sessions.get(session.getId());
 
     node.stop(session.getId());
-
     // Now wait for the session map to say the session is gone.
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(2));
     wait.until(obj -> {
       try {
         sessions.get(session.getId());
@@ -756,8 +775,9 @@ public class DistributorTest {
   }
 
   @Test
-  public void attemptingToStartASessionWhichFailsMarksAsTheSlotAsAvailable() {
-    CombinedHandler handler = new CombinedHandler();
+  public void attemptingToStartASessionWhichFailsMarksAsTheSlotAsAvailable() throws URISyntaxException {
+    URI nodeUri = new URI("http://example:5678");
+    URI routableUri = new URI("http://localhost:1234");
 
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     LocalNewSessionQueue localNewSessionQueue = new LocalNewSessionQueue(
@@ -766,25 +786,24 @@ public class DistributorTest {
       Duration.ofSeconds(2),
       Duration.ofSeconds(2));
     LocalNewSessionQueuer queuer = new LocalNewSessionQueuer(tracer, bus, localNewSessionQueue);
-    handler.addHandler(sessions);
 
-    URI uri = createUri();
-    Node node = LocalNode.builder(tracer, bus, uri, uri, registrationSecret)
-        .add(caps, new TestSessionFactory((id, caps) -> {
-          throw new SessionNotCreatedException("OMG");
-        }))
-        .build();
-    handler.addHandler(node);
+    LocalNode node = LocalNode.builder(tracer, bus, routableUri, routableUri, registrationSecret)
+      .add(caps, new TestSessionFactory((id, caps) -> {
+        throw new SessionNotCreatedException("OMG");
+      }))
+      .build();
 
     Distributor distributor = new LocalDistributor(
         tracer,
         bus,
-        new PassthroughHttpClient.Factory(handler),
+        new PassthroughHttpClient.Factory(node),
         sessions,
         queuer,
         registrationSecret);
-    handler.addHandler(distributor);
     distributor.add(node);
+
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {
       assertThatExceptionOfType(SessionNotCreatedException.class)

--- a/java/server/test/org/openqa/selenium/grid/graphql/BUILD.bazel
+++ b/java/server/test/org/openqa/selenium/grid/graphql/BUILD.bazel
@@ -14,6 +14,7 @@ java_test_suite(
     deps = [
         "//java/client/src/org/openqa/selenium/json",
         "//java/client/src/org/openqa/selenium/remote",
+        "//java/client/src/org/openqa/selenium/support",
         "//java/client/test/org/openqa/selenium/remote/tracing:tracing-support",
         "//java/server/src/org/openqa/selenium/events",
         "//java/server/src/org/openqa/selenium/events/local",

--- a/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
+++ b/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
@@ -48,6 +48,8 @@ import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.tracing.DefaultTestTracer;
 import org.openqa.selenium.remote.tracing.Tracer;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -146,6 +148,8 @@ public class GraphqlHandlerTest {
       })
       .build();
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     GraphqlHandler handler = new GraphqlHandler(distributor, publicUri);
     Map<String, Object> topLevel = executeQuery(handler, "{ grid { nodes { uri } } }");
@@ -169,6 +173,9 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     Session session = distributor.newSession(createRequest(payload)).getSession();
 
     assertThat(session).isNotNull();
@@ -215,6 +222,9 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     Session session = distributor.newSession(createRequest(payload)).getSession();
 
     assertThat(session).isNotNull();
@@ -260,6 +270,9 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     Session session = distributor.newSession(createRequest(payload)).getSession();
 
     assertThat(session).isNotNull();
@@ -311,6 +324,9 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
+
     Session session = distributor.newSession(createRequest(payload)).getSession();
 
     assertThat(session).isNotNull();
@@ -341,6 +357,8 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     String randomSessionId = UUID.randomUUID().toString();
     String query = "{ session (id: \"" + randomSessionId + "\") { sessionDurationMillis } }";
@@ -376,6 +394,8 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
+    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
+    wait.until(obj -> distributor.getStatus().hasCapacity());
 
     String query = "{ session (id: \"\") { sessionDurationMillis } }";
 

--- a/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
+++ b/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
@@ -79,6 +79,7 @@ public class GraphqlHandlerTest {
   private ImmutableCapabilities caps;
   private ImmutableCapabilities stereotype;
   private NewSessionPayload payload;
+  private final Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
 
   public GraphqlHandlerTest() throws URISyntaxException {
   }
@@ -148,7 +149,6 @@ public class GraphqlHandlerTest {
       })
       .build();
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     GraphqlHandler handler = new GraphqlHandler(distributor, publicUri);
@@ -173,7 +173,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     Session session = distributor.newSession(createRequest(payload)).getSession();
@@ -222,7 +221,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     Session session = distributor.newSession(createRequest(payload)).getSession();
@@ -270,7 +268,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     Session session = distributor.newSession(createRequest(payload)).getSession();
@@ -324,7 +321,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     Session session = distributor.newSession(createRequest(payload)).getSession();
@@ -357,7 +353,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     String randomSessionId = UUID.randomUUID().toString();
@@ -394,7 +389,6 @@ public class GraphqlHandlerTest {
             Instant.now()))).build();
 
     distributor.add(node);
-    Wait<Object> wait = new FluentWait<>(new Object()).withTimeout(Duration.ofSeconds(5));
     wait.until(obj -> distributor.getStatus().hasCapacity());
 
     String query = "{ session (id: \"\") { sessionDurationMillis } }";


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The changes are related to failed tests reported in https://travis-ci.com/github/SeleniumHQ/selenium/jobs/431435876.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The failed build indicated flaky tests for GraphqlHandlerTest and DistributorTest. I suspect the issue was arising that session creation request was made before the grid model was updated by the distributor when a new node is added.
To fix it the test is made to wait until the distributor can handle sessions. Now session creation requests can be made and unit test assertions can proceed as expected. 

Note: First tried the fix with 100 test runs in a branch before the NewSessionQueuer was introduced. After confirming issue is not due to the queuer changes, attempted the fix in the current Grid.

The DistributedCdp did not have queuer config and hence it was failing to create the Distributor. Fixed it by adding the queuer config.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
