### PR TITLE
All `is None` and `is not None` removal

### DIFF
--- a/py/selenium/common/exceptions.py
+++ b/py/selenium/common/exceptions.py
@@ -32,9 +32,9 @@ class WebDriverException(Exception):
 
     def __str__(self):
         exception_msg = "Message: %s\n" % self.msg
-        if self.screen is not None:
+        if self.screen:
             exception_msg += "Screenshot: available via screen\n"
-        if self.stacktrace is not None:
+        if self.stacktrace:
             stacktrace = "\n".join(self.stacktrace)
             exception_msg += "Stacktrace:\n%s" % stacktrace
         return exception_msg

--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -58,7 +58,7 @@ class WebDriver(ChromiumDriver):
                           DeprecationWarning, stacklevel=2)
             options = chrome_options
 
-        if service is None:
+        if not service:
             service = Service(executable_path, port, service_args, service_log_path)
 
         super(WebDriver, self).__init__(DesiredCapabilities.CHROME['browserName'], "goog",

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -38,7 +38,7 @@ class ChromiumService(service.Service):
         if log_path:
             self.service_args.append('--log-path=%s' % log_path)
 
-        if start_error_message is None:
+        if not start_error_message:
             raise AttributeError("start_error_message should not be empty")
 
         service.Service.__init__(self, executable_path, port=port, env=env, start_error_message=start_error_message)

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -48,7 +48,7 @@ class ChromiumDriver(RemoteWebDriver):
          - service_log_path - Deprecated: Where to log information from the driver.
          - keep_alive - Whether to configure ChromiumRemoteConnection to use HTTP keep-alive.
         """
-        if desired_capabilities is not None:
+        if desired_capabilities:
             warnings.warn('desired_capabilities has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
         if port != DEFAULT_PORT:
@@ -60,12 +60,12 @@ class ChromiumDriver(RemoteWebDriver):
                           DeprecationWarning, stacklevel=2)
 
         _ignore_proxy = None
-        if options is None:
+        if not options:
             # desired_capabilities stays as passed in
-            if desired_capabilities is None:
+            if not desired_capabilities:
                 desired_capabilities = self.create_options().to_capabilities()
         else:
-            if desired_capabilities is None:
+            if not desired_capabilities:
                 desired_capabilities = options.to_capabilities()
             else:
                 desired_capabilities.update(options.to_capabilities())
@@ -74,7 +74,7 @@ class ChromiumDriver(RemoteWebDriver):
 
         self.vendor_prefix = vendor_prefix
 
-        if service is None:
+        if not service:
             raise AttributeError('service cannot be None')
 
         self.service = service

--- a/py/selenium/webdriver/common/actions/action_builder.py
+++ b/py/selenium/webdriver/common/actions/action_builder.py
@@ -25,9 +25,9 @@ from .pointer_input import PointerInput
 
 class ActionBuilder(object):
     def __init__(self, driver, mouse=None, keyboard=None):
-        if mouse is None:
+        if not mouse:
             mouse = PointerInput(interaction.POINTER_MOUSE, "mouse")
-        if keyboard is None:
+        if not keyboard:
             keyboard = KeyInput(interaction.KEY)
         self.devices = [mouse, keyboard]
         self._key_action = KeyActions(keyboard)

--- a/py/selenium/webdriver/common/actions/input_device.py
+++ b/py/selenium/webdriver/common/actions/input_device.py
@@ -23,7 +23,7 @@ class InputDevice(object):
         Describes the input device being used for the action.
     """
     def __init__(self, name=None):
-        if name is None:
+        if not name:
             self.name = uuid.uuid4()
         else:
             self.name = name

--- a/py/selenium/webdriver/common/actions/key_actions.py
+++ b/py/selenium/webdriver/common/actions/key_actions.py
@@ -22,7 +22,7 @@ from ..utils import keys_to_typing
 class KeyActions(Interaction):
 
     def __init__(self, source=None):
-        if source is None:
+        if not source:
             source = KeyInput(KEY)
         self.source = source
         super(KeyActions, self).__init__(source)

--- a/py/selenium/webdriver/common/actions/pointer_actions.py
+++ b/py/selenium/webdriver/common/actions/pointer_actions.py
@@ -26,7 +26,7 @@ from selenium.webdriver.remote.webelement import WebElement
 class PointerActions(Interaction):
 
     def __init__(self, source=None):
-        if source is None:
+        if not source:
             source = PointerInput(interaction.POINTER_MOUSE, "mouse")
         self.source = source
         super(PointerActions, self).__init__(source)
@@ -40,7 +40,7 @@ class PointerActions(Interaction):
     def move_to(self, element, x=None, y=None):
         if not isinstance(element, WebElement):
             raise AttributeError("move_to requires a WebElement")
-        if x is not None or y is not None:
+        if x or y:
             el_rect = element.rect
             left_offset = el_rect['width'] / 2
             top_offset = el_rect['height'] / 2

--- a/py/selenium/webdriver/common/actions/pointer_input.py
+++ b/py/selenium/webdriver/common/actions/pointer_input.py
@@ -39,7 +39,7 @@ class PointerInput(InputDevice):
         action["y"] = y
         if isinstance(origin, WebElement):
             action["origin"] = {"element-6066-11e4-a52e-4f735466cecf": origin.id}
-        elif origin is not None:
+        elif origin:
             action["origin"] = origin
 
         self.add_action(action)

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -54,7 +54,6 @@ class ProxyType:
         value = str(value).upper()
         for attr in dir(cls):
             attr_value = getattr(cls, attr)
-            # `attr_value['string'] is not None` probably not required as `attr_value['string'] == value`
             if isinstance(attr_value, dict) and 'string' in attr_value and attr_value['string'] == value:
                 return attr_value
         raise Exception(f"No proxy type is found for {value}")

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -54,10 +54,8 @@ class ProxyType:
         value = str(value).upper()
         for attr in dir(cls):
             attr_value = getattr(cls, attr)
-            if isinstance(attr_value, dict) and \
-                    'string' in attr_value and \
-                    attr_value['string'] is not None and \
-                    attr_value['string'] == value:
+            # `attr_value['string'] is not None` probably not required as `attr_value['string'] == value`
+            if isinstance(attr_value, dict) and 'string' in attr_value and attr_value['string'] == value:
                 return attr_value
         raise Exception(f"No proxy type is found for {value}")
 

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -86,28 +86,28 @@ class Proxy(object):
         :Args:
          - raw: raw proxy data. If None, default class values are used.
         """
-        if raw is not None:
-            if 'proxyType' in raw and raw['proxyType'] is not None:
+        if raw:
+            if 'proxyType' in raw and raw['proxyType']:
                 self.proxy_type = ProxyType.load(raw['proxyType'])
-            if 'ftpProxy' in raw and raw['ftpProxy'] is not None:
+            if 'ftpProxy' in raw and raw['ftpProxy']:
                 self.ftp_proxy = raw['ftpProxy']
-            if 'httpProxy' in raw and raw['httpProxy'] is not None:
+            if 'httpProxy' in raw and raw['httpProxy']:
                 self.http_proxy = raw['httpProxy']
-            if 'noProxy' in raw and raw['noProxy'] is not None:
+            if 'noProxy' in raw and raw['noProxy']:
                 self.no_proxy = raw['noProxy']
-            if 'proxyAutoconfigUrl' in raw and raw['proxyAutoconfigUrl'] is not None:
+            if 'proxyAutoconfigUrl' in raw and raw['proxyAutoconfigUrl']:
                 self.proxy_autoconfig_url = raw['proxyAutoconfigUrl']
-            if 'sslProxy' in raw and raw['sslProxy'] is not None:
+            if 'sslProxy' in raw and raw['sslProxy']:
                 self.sslProxy = raw['sslProxy']
-            if 'autodetect' in raw and raw['autodetect'] is not None:
+            if 'autodetect' in raw and raw['autodetect']:
                 self.auto_detect = raw['autodetect']
-            if 'socksProxy' in raw and raw['socksProxy'] is not None:
+            if 'socksProxy' in raw and raw['socksProxy']:
                 self.socks_proxy = raw['socksProxy']
-            if 'socksUsername' in raw and raw['socksUsername'] is not None:
+            if 'socksUsername' in raw and raw['socksUsername']:
                 self.socks_username = raw['socksUsername']
-            if 'socksPassword' in raw and raw['socksPassword'] is not None:
+            if 'socksPassword' in raw and raw['socksPassword']:
                 self.socks_password = raw['socksPassword']
-            if 'socksVersion' in raw and raw['socksVersion'] is not None:
+            if 'socksVersion' in raw and raw['socksVersion']:
                 self.socks_version = raw['socksVersion']
 
     @property

--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -109,7 +109,7 @@ class Service(object):
 
     def assert_process_still_running(self):
         return_code = self.process.poll()
-        if return_code is not None:
+        if return_code:
             raise WebDriverException(
                 'Service %s unexpectedly exited. Status code was: %s'
                 % (self.path, return_code)
@@ -148,7 +148,7 @@ class Service(object):
             except Exception:
                 pass
 
-        if self.process is None:
+        if not self.process:
             return
 
         try:

--- a/py/selenium/webdriver/common/timeouts.py
+++ b/py/selenium/webdriver/common/timeouts.py
@@ -77,7 +77,7 @@ class Timeouts(object):
         self._script = self._convert(_script)
 
     def _convert(self, timeout):
-        if timeout is not None:
+        if timeout:
             if isinstance(timeout, (int, float)):
                 return int(float(timeout) * 1000)
             else:
@@ -85,11 +85,11 @@ class Timeouts(object):
 
     def _to_json(self):
         timeouts = {}
-        if self._implicit_wait is not None:
+        if self._implicit_wait:
             timeouts["implicit"] = self._implicit_wait
-        if self._page_load is not None:
+        if self._page_load:
             timeouts["pageLoad"] = self._page_load
-        if self._script is not None:
+        if self._script:
             timeouts["script"] = self._script
 
         return timeouts

--- a/py/selenium/webdriver/firefox/extension_connection.py
+++ b/py/selenium/webdriver/firefox/extension_connection.py
@@ -37,10 +37,10 @@ class ExtensionConnection(RemoteConnection):
         HOST = host
         timeout = int(timeout)
 
-        if self.binary is None:
+        if not self.binary:
             self.binary = FirefoxBinary()
 
-        if HOST is None:
+        if not HOST:
             HOST = "127.0.0.1"
 
         PORT = utils.free_port()

--- a/py/selenium/webdriver/firefox/firefox_profile.py
+++ b/py/selenium/webdriver/firefox/firefox_profile.py
@@ -66,7 +66,7 @@ class FirefoxProfile(object):
             FirefoxProfile.DEFAULT_PREFERENCES['mutable'])
         self.profile_dir = profile_directory
         self.tempfolder = None
-        if self.profile_dir is None:
+        if not self.profile_dir:
             self.profile_dir = self._create_tempfolder()
         else:
             self.tempfolder = tempfile.mkdtemp()
@@ -340,14 +340,14 @@ class FirefoxProfile(object):
             rdf = get_namespace_id(doc, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 
             description = doc.getElementsByTagName(rdf + 'Description').item(0)
-            if description is None:
+            if not description:
                 description = doc.getElementsByTagName('Description').item(0)
             for node in description.childNodes:
                 # Remove the namespace prefix from the tag for comparison
                 entry = node.nodeName.replace(em, "")
                 if entry in details.keys():
                     details.update({entry: get_text(node)})
-            if details.get('id') is None:
+            if not details.get('id'):
                 for i in range(description.attributes.length):
                     attribute = description.attributes.item(i)
                     if attribute.name == em + 'id':
@@ -360,7 +360,7 @@ class FirefoxProfile(object):
             details['unpack'] = details['unpack'].lower() == 'true'
 
         # If no ID is set, the add-on is invalid
-        if details.get('id') is None:
+        if not details.get('id'):
             raise AddonFormatError('Add-on id could not be found.')
 
         return details

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -41,7 +41,8 @@ class Service(service.Service):
             in the services' environment.
 
         """
-        log_file = open(log_path, "a+") if log_path is not None and log_path != "" else None
+        #the condition will fail on both "" and on None, so no need of `log_path is not None and log_path != ""`
+        log_file = open(log_path, "a+") if log_path else None
 
         service.Service.__init__(
             self, executable_path, port=port, log_file=log_file, env=env)

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -103,7 +103,7 @@ class WebDriver(RemoteWebDriver):
         if executable_path != DEFAULT_EXECUTABLE_PATH:
             warnings.warn('executable_path has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
-        if capabilities is not None or desired_capabilities is not None:
+        if capabilities or desired_capabilities:
             warnings.warn('capabilities and desired_capabilities have been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
         if firefox_binary:

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -20,7 +20,6 @@ except NameError:  # Python 3.x
     basestring = str
 
 from base64 import b64decode
-import shutil
 from shutil import rmtree
 import warnings
 from contextlib import contextmanager
@@ -107,11 +106,11 @@ class WebDriver(RemoteWebDriver):
         if capabilities is not None or desired_capabilities is not None:
             warnings.warn('capabilities and desired_capabilities have been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
-        if firefox_binary is not None:
+        if firefox_binary:
             warnings.warn('firefox_binary has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
         self.binary = None
-        if firefox_profile is not None:
+        if firefox_profile:
             warnings.warn('firefox_profile has been deprecated, please pass in an Options object',
                           DeprecationWarning, stacklevel=2)
         self.profile = None
@@ -124,7 +123,7 @@ class WebDriver(RemoteWebDriver):
         if service_log_path != DEFAULT_SERVICE_LOG_PATH:
             warnings.warn('service_log_path has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
-        if service_args is not None:
+        if service_args:
             warnings.warn('service_args has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
 
@@ -132,12 +131,12 @@ class WebDriver(RemoteWebDriver):
 
         # If desired capabilities is set, alias it to capabilities.
         # If both are set ignore desired capabilities.
-        if capabilities is None and desired_capabilities:
+        if not capabilities and desired_capabilities:
             capabilities = desired_capabilities
 
-        if capabilities is None:
+        if not capabilities:
             capabilities = DesiredCapabilities.FIREFOX.copy()
-        if options is None:
+        if not options:
             options = Options()
 
         capabilities = dict(capabilities)
@@ -146,20 +145,20 @@ class WebDriver(RemoteWebDriver):
             self.binary = capabilities["binary"]
 
         # options overrides capabilities
-        if options is not None:
-            if options.binary is not None:
+        if options:
+            if options.binary:
                 self.binary = options.binary
-            if options.profile is not None:
+            if options.profile:
                 self.profile = options.profile
 
         # firefox_binary and firefox_profile
         # override options
-        if firefox_binary is not None:
+        if firefox_binary:
             if isinstance(firefox_binary, basestring):
                 firefox_binary = FirefoxBinary(firefox_binary)
             self.binary = firefox_binary
             options.binary = firefox_binary
-        if firefox_profile is not None:
+        if firefox_profile:
             if isinstance(firefox_profile, basestring):
                 firefox_profile = FirefoxProfile(firefox_profile)
             self.profile = firefox_profile
@@ -171,7 +170,7 @@ class WebDriver(RemoteWebDriver):
         if capabilities.get("acceptInsecureCerts"):
             options.accept_insecure_certs = capabilities.get("acceptInsecureCerts")
 
-        if self.service is None:
+        if not self.service:
             self.service = Service(
                 executable_path,
                 service_args=service_args,
@@ -204,10 +203,10 @@ class WebDriver(RemoteWebDriver):
         else:
             self.binary.kill()
 
-        if self.profile is not None:
+        if self.profile:
             try:
                 rmtree(self.profile.path)
-                if self.profile.tempfolder is not None:
+                if self.profile.tempfolder:
                     rmtree(self.profile.tempfolder)
             except Exception as e:
                 print(str(e))

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -36,11 +36,11 @@ class Service(service.Service):
          - log_file : Target of logging of service, may be "stdout", "stderr" or file path.
            Default is "stdout"."""
         self.service_args = []
-        if host is not None:
+        if host:
             self.service_args.append("--host=%s" % host)
-        if log_level is not None:
+        if log_level:
             self.service_args.append("--log-level=%s" % log_level)
-        if log_file is not None:
+        if log_file:
             self.service_args.append("--log-file=%s" % log_file)
 
         service.Service.__init__(self, executable_path, port=port,

--- a/py/selenium/webdriver/ie/webdriver.py
+++ b/py/selenium/webdriver/ie/webdriver.py
@@ -57,7 +57,7 @@ class WebDriver(RemoteWebDriver):
         if executable_path != 'IEDriverServer.exe':
             warnings.warn('executable_path has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
-        if capabilities is not None:
+        if capabilities:
             warnings.warn('capabilities has been deprecated, please pass in a Service object',
                           DeprecationWarning, stacklevel=2)
         if port != DEFAULT_PORT:
@@ -81,19 +81,19 @@ class WebDriver(RemoteWebDriver):
             self.port = utils.free_port()
 
         # If both capabilities and desired capabilities are set, ignore desired capabilities.
-        if capabilities is None and desired_capabilities:
+        if not capabilities and desired_capabilities:
             capabilities = desired_capabilities
 
-        if options is None:
-            if capabilities is None:
+        if not options:
+            if not capabilities:
                 capabilities = self.create_options().to_capabilities()
         else:
-            if capabilities is None:
+            if not capabilities:
                 capabilities = options.to_capabilities()
             else:
                 # desired_capabilities stays as passed in
                 capabilities.update(options.to_capabilities())
-        if service is not None:
+        if service:
             self.iedriver = service
         else:
             self.iedriver = Service(

--- a/py/selenium/webdriver/opera/webdriver.py
+++ b/py/selenium/webdriver/opera/webdriver.py
@@ -42,8 +42,7 @@ class OperaDriver(ChromiumDriver):
          - service_log_path - Where to log information from the driver.
            capabilities only, such as "proxy" or "loggingPref".
         """
-        executable_path = (executable_path if executable_path is not None
-                           else "operadriver")
+        executable_path = (executable_path if executable_path else "operadriver")
         ChromiumDriver.__init__(self,
                                 executable_path=executable_path,
                                 port=port,

--- a/py/selenium/webdriver/remote/errorhandler.py
+++ b/py/selenium/webdriver/remote/errorhandler.py
@@ -110,7 +110,7 @@ class ErrorHandler(object):
         :Raises: If the response contains an error message.
         """
         status = response.get('status', None)
-        if status is None or status == ErrorCode.SUCCESS:
+        if not status or status == ErrorCode.SUCCESS:
             return
         value = None
         message = response.get("message", "")

--- a/py/selenium/webdriver/remote/errorhandler.py
+++ b/py/selenium/webdriver/remote/errorhandler.py
@@ -125,7 +125,7 @@ class ErrorHandler(object):
                     if len(value.keys()) == 1:
                         value = value['value']
                     status = value.get('error', None)
-                    if status is None:
+                    if not status:
                         status = value["status"]
                         message = value["value"]
                         if not isinstance(message, basestring):
@@ -198,7 +198,7 @@ class ErrorHandler(object):
             exception_class = UnknownMethodException
         else:
             exception_class = WebDriverException
-        if value == '' or value is None:
+        if not value: #if value == '' or value == None, the condition will be executed
             value = response['value']
         if isinstance(value, basestring):
             raise exception_class(value)

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -139,7 +139,7 @@ class RemoteConnection(object):
             pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
             pool_manager_init_args['ca_certs'] = self._ca_certs
 
-        return urllib3.PoolManager(**pool_manager_init_args) if self._proxy_url is None else \
+        return urllib3.PoolManager(**pool_manager_init_args) if not self._proxy_url else \
             urllib3.ProxyManager(self._proxy_url, **pool_manager_init_args)
 
     def __init__(self, remote_server_addr, keep_alive=False, resolve_ip=None, ignore_proxy=False):
@@ -434,7 +434,7 @@ class RemoteConnection(object):
             if 399 < statuscode <= 500:
                 return {'status': statuscode, 'value': data}
             content_type = []
-            if resp.getheader('Content-Type') is not None:
+            if resp.getheader('Content-Type'):
                 content_type = resp.getheader('Content-Type').split(';')
             if not any([x.startswith('image/png') for x in content_type]):
 

--- a/py/selenium/webdriver/remote/utils.py
+++ b/py/selenium/webdriver/remote/utils.py
@@ -47,7 +47,7 @@ def unzip_to_temp_dir(zip_file_name):
 
     zf = zipfile.ZipFile(zip_file_name)
 
-    if zf.testzip() is not None:
+    if zf.testzip():
         return None
 
     # Unzip the files into a temporary directory

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -307,7 +307,7 @@ class WebDriver(BaseWebDriver):
             self.caps = response.get('capabilities')
 
         # Double check to see if we have a W3C Compliant browser
-        self.w3c = response.get('status') is None
+        self.w3c = not response.get('status') #using not automatically results in boolean
         self.command_executor.w3c = self.w3c
 
     def _wrap_value(self, value):
@@ -1492,7 +1492,7 @@ class WebDriver(BaseWebDriver):
 
                 async with driver.add_js_error_listener() as error:
                     driver.find_element(By.ID, "throwing-mouseover").click()
-                assert error is not None
+                assert bool(error)
                 assert error.exception_details.stack_trace.call_frames[0].function_name == "onmouseover"
         """
         assert sys.version_info >= (3, 7)

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -388,7 +388,7 @@ class WebDriver(BaseWebDriver):
                 title = driver.title
         """
         resp = self.execute(Command.GET_TITLE)
-        return resp['value'] if resp['value'] is not None else ""
+        return resp['value'] if resp['value'] else ""
 
     def find_element_by_id(self, id_):
         """Finds an element by id.
@@ -1387,7 +1387,7 @@ class WebDriver(BaseWebDriver):
         if not self.w3c:
             raise UnknownMethodException("set_window_rect is only supported for W3C compatible browsers")
 
-        if (x is None and y is None) and (height is None and width is None):
+        if (not x and not y) and (not height and not width):
             raise InvalidArgumentException("x and y or height and width need values")
 
         return self.execute(Command.SET_WINDOW_RECT, {"x": x, "y": y,

--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -158,7 +158,7 @@ class WebElement(BaseWebElement):
         else:
             resp = self._execute(Command.GET_ELEMENT_ATTRIBUTE, {'name': name})
             attribute_value = resp.get('value')
-            if attribute_value is not None:
+            if attribute_value:
                 if name != 'value' and attribute_value.lower() in ('true', 'false'):
                     attribute_value = attribute_value.lower()
         return attribute_value

--- a/py/selenium/webdriver/support/color.py
+++ b/py/selenium/webdriver/support/color.py
@@ -54,7 +54,7 @@ class Color(object):
 
             @property
             def groups(self):
-                return () if self.match_obj is None else self.match_obj.groups()
+                return () if not self.match_obj else self.match_obj.groups()
 
         m = Matcher()
 

--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -80,7 +80,7 @@ def url_matches(pattern):
     pattern is the expected pattern, which must be an exact match
     returns True if the url matches, false otherwise."""
     def _predicate(driver):
-        return re.search(pattern, driver.current_url) is not None
+        return bool(re.search(pattern, driver.current_url)) #note bool is necessary
 
     return _predicate
 

--- a/py/selenium/webdriver/support/relative_locator.py
+++ b/py/selenium/webdriver/support/relative_locator.py
@@ -20,7 +20,7 @@ from selenium.common.exceptions import WebDriverException
 
 
 def with_tag_name(tag_name):
-    if tag_name is None:
+    if not tag_name:
         raise WebDriverException("tag_name can not be null")
     return RelativeBy({"css selector": tag_name})
 
@@ -32,35 +32,35 @@ class RelativeBy(object):
         self.filters = filters or []
 
     def above(self, element_or_locator=None):
-        if element_or_locator is None:
+        if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling above method")
 
         self.filters.append({"kind": "above", "args": [element_or_locator]})
         return self
 
     def below(self, element_or_locator=None):
-        if element_or_locator is None:
+        if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling above method")
 
         self.filters.append({"kind": "below", "args": [element_or_locator]})
         return self
 
     def to_left_of(self, element_or_locator=None):
-        if element_or_locator is None:
+        if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling above method")
 
         self.filters.append({"kind": "left", "args": [element_or_locator]})
         return self
 
     def to_right_of(self, element_or_locator):
-        if element_or_locator is None:
+        if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling above method")
 
         self.filters.append({"kind": "right", "args": [element_or_locator]})
         return self
 
     def near(self, element_or_locator_distance=None):
-        if element_or_locator_distance is None:
+        if not element_or_locator_distance:
             raise WebDriverException("Element or locator or distance must be given when calling above method")
 
         self.filters.append({"kind": "near", "args": [element_or_locator_distance]})

--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -49,7 +49,7 @@ class WebDriverWait(object):
         if self._poll == 0:
             self._poll = POLL_FREQUENCY
         exceptions = list(IGNORED_EXCEPTIONS)
-        if ignored_exceptions is not None:
+        if ignored_exceptions:
             try:
                 exceptions.extend(iter(ignored_exceptions))
             except TypeError:  # ignored_exceptions is not iterable

--- a/py/selenium/webdriver/webkitgtk/service.py
+++ b/py/selenium/webdriver/webkitgtk/service.py
@@ -32,7 +32,8 @@ class Service(service.Service):
          - port : Port the service is running on
          - log_path : Path for the WebKitGTKDriver service to log to
         """
-        log_file = open(log_path, "wb") if log_path is not None and log_path != "" else None
+        #the condition will fail on both "" and on None, so no need of `log_path is not None and log_path != ""`
+        log_file = open(log_path, "wb") if log_path else None
         service.Service.__init__(self, executable_path, port, log_file)
 
     def command_line_args(self):

--- a/py/selenium/webdriver/webkitgtk/webdriver.py
+++ b/py/selenium/webdriver/webkitgtk/webdriver.py
@@ -46,12 +46,12 @@ class WebDriver(RemoteWebDriver):
          - service_log_path : Path to write service stdout and stderr output.
          - keep_alive : Whether to configure RemoteConnection to use HTTP keep-alive.
         """
-        if options is None:
-            if desired_capabilities is None:
+        if not options:
+            if not desired_capabilities:
                 desired_capabilities = Options().to_capabilities()
         else:
             capabilities = options.to_capabilities()
-            if desired_capabilities is not None:
+            if desired_capabilities:
                 capabilities.update(desired_capabilities)
             desired_capabilities = capabilities
 

--- a/py/selenium/webdriver/wpewebkit/service.py
+++ b/py/selenium/webdriver/wpewebkit/service.py
@@ -32,7 +32,8 @@ class Service(service.Service):
          - port : Port the service is running on
          - log_path : Path for the WPEWebKitDriver service to log to
         """
-        log_file = open(log_path, "wb") if log_path is not None and log_path != "" else None
+        #the condition will fail on both "" and on None, so no need of `log_path is not None and log_path != ""`
+        log_file = open(log_path, "wb") if log_path else None
         service.Service.__init__(self, executable_path, port, log_file)
 
     def command_line_args(self):

--- a/py/selenium/webdriver/wpewebkit/webdriver.py
+++ b/py/selenium/webdriver/wpewebkit/webdriver.py
@@ -45,7 +45,7 @@ class WebDriver(RemoteWebDriver):
          - desired_capabilities : Dictionary object with desired capabilities
          - service_log_path : Path to write service stdout and stderr output.
         """
-        if options is not None:
+        if options:
             capabilities = options.to_capabilities()
             capabilities.update(desired_capabilities)
             desired_capabilities = capabilities


### PR DESCRIPTION
Removal of all `is None` and `is not None` with modern conditional syntax. I have added some comments at some places to better clarification.
1. is None/is not None is deprecated
2. is None/is not None takes greater opcodes than modern conditional syntax
```
>>> dis(normal_comp)
  1           0 LOAD_FAST                0 (x)
              2 POP_JUMP_IF_FALSE        8
              4 LOAD_FAST                0 (x)
              6 RETURN_VALUE
        >>    8 LOAD_CONST               1 ('')
             10 RETURN_VALUE
>>> dis(is_not_comp)
  1           0 LOAD_FAST                0 (x)
              2 LOAD_CONST               0 (None)
              4 IS_OP                    1
              6 POP_JUMP_IF_FALSE       12
              8 LOAD_FAST                0 (x)
             10 RETURN_VALUE
        >>   12 LOAD_CONST               1 ('')
             14 RETURN_VALUE
```