### PR TITLE
[node] Fix typo: tracingCategories -> traceCategories

### DIFF
--- a/javascript/node/selenium-webdriver/chromium.js
+++ b/javascript/node/selenium-webdriver/chromium.js
@@ -394,7 +394,7 @@ class Options extends Capabilities {
    * - `enableTimeline`: Whether or not to collect events from Timeline domain.
    *     Note: when tracing is enabled, Timeline domain is implicitly disabled,
    *     unless `enableTimeline` is explicitly set to true.
-   * - `tracingCategories`: A comma-separated string of Chromium tracing
+   * - `traceCategories`: A comma-separated string of Chromium tracing
    *     categories for which trace events should be collected. An unspecified
    *     or empty string disables tracing.
    * - `bufferUsageReportingInterval`: The requested number of milliseconds
@@ -405,7 +405,7 @@ class Options extends Capabilities {
    * @param {{enableNetwork: boolean,
    *          enablePage: boolean,
    *          enableTimeline: boolean,
-   *          tracingCategories: string,
+   *          traceCategories: string,
    *          bufferUsageReportingInterval: number}} prefs The performance
    *     logging preferences.
    * @return {!Options} A self reference.


### PR DESCRIPTION
### Description

Fix a typo in the documentation for `setPerfLoggingPrefs` of the `chromium.Options` class

### Motivation and context

According the [ChromeDriver docs](https://chromedriver.chromium.org/capabilities#TOC-perfLoggingPrefs-object) this field is called `traceCategories` not `tracingCategories`. Further I'm getting the following error when trying to use `tracingCategories`. Using `traceCategories` fixes it.

This is using ChromeDriver 87.0.4280.20 (c99e81631faa0b2a448e658c0dbd8311fb04ddbd-refs/branch-heads/4280@{#355}) on Windows.

```
InvalidArgumentError: invalid argument: cannot parse capability: goog:chromeOptions
from invalid argument: cannot parse perfLoggingPrefs
from invalid argument: unrecognized performance logging option: tracingCategories
    at Object.throwDecodedError (D:\github\andrewiggins\tachometer\node_modules\selenium-webdriver\lib\error.js:517:15)
    at parseHttpResponse (D:\github\andrewiggins\tachometer\node_modules\selenium-webdriver\lib\http.js:655:13)
    at Executor.execute (D:\github\andrewiggins\tachometer\node_modules\selenium-webdriver\lib\http.js:581:28)
    at processTicksAndRejections (node:internal/process/task_queues:93:5) {
  remoteStacktrace: 'Backtrace:\n' +
    '\tOrdinal0 [0x007DECE3+3337443]\n' +
    '\tOrdinal0 [0x006BF041+2158657]\n' +
    '\tOrdinal0 [0x00546FA8+618408]\n' +
    '\tOrdinal0 [0x004B83DA+33754]\n' +
    '\tOrdinal0 [0x004BAB74+43892]\n' +
    '\tOrdinal0 [0x004B72A3+29347]\n' +
    '\tOrdinal0 [0x004BAB74+43892]\n' +
    '\tOrdinal0 [0x004B515D+20829]\n' +
    '\tOrdinal0 [0x004E4F6C+216940]\n' +
    '\tOrdinal0 [0x004E4C2E+216110]\n' +
    '\tOrdinal0 [0x004E5D4B+220491]\n' +
    '\tOrdinal0 [0x004E5BFC+220156]\n' +
    '\tOrdinal0 [0x004E181B+202779]\n' +
    '\tOrdinal0 [0x004C3D74+81268]\n' +
    '\tOrdinal0 [0x004C4D6E+85358]\n' +
    '\tOrdinal0 [0x004C4CF9+85241]\n' +
    '\tOrdinal0 [0x006D6F2C+2256684]\n' +
    '\tGetHandleVerifier [0x00962FAC+1478332]\n' +
    '\tGetHandleVerifier [0x00962AFD+1477133]\n' +
    '\tGetHandleVerifier [0x0096AAD8+1509864]\n' +
    '\tGetHandleVerifier [0x0096369E+1480110]\n' +
    '\tOrdinal0 [0x006CD6BD+2217661]\n' +
    '\tOrdinal0 [0x006D89AB+2263467]\n' +
    '\tOrdinal0 [0x006D8AEF+2263791]\n' +
    '\tOrdinal0 [0x006ED363+2347875]\n' +
    '\tBaseThreadInitThunk [0x76D3FA29+25]\n' +
    '\tRtlGetAppContainerNamedObjectPath [0x772B75F4+228]\n' +
    '\tRtlGetAppContainerNamedObjectPath [0x772B75C4+180]\n'
}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.