### PR TITLE
Add retry http request filter for transient errors. Integrate filter with ClientConfig.

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/BUILD.bazel
+++ b/java/src/org/openqa/selenium/remote/http/BUILD.bazel
@@ -17,5 +17,6 @@ java_export(
         "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/json",
         artifact("com.google.guava:guava"),
+        artifact("net.jodah:failsafe")
     ],
 )

--- a/java/src/org/openqa/selenium/remote/http/ClientConfig.java
+++ b/java/src/org/openqa/selenium/remote/http/ClientConfig.java
@@ -30,7 +30,7 @@ import org.openqa.selenium.internal.Require;
 
 public class ClientConfig {
 
-  private static final AddSeleniumUserAgent DEFAULT_FILTER = new AddSeleniumUserAgent();
+  private static final Filter DEFAULT_FILTER = new AddSeleniumUserAgent().andThen(new RetryRequest());
   private final URI baseUri;
   private final Duration connectionTimeout;
   private final Duration readTimeout;
@@ -58,7 +58,7 @@ public class ClientConfig {
       null,
       Duration.ofSeconds(10),
       Duration.ofMinutes(3),
-      new AddSeleniumUserAgent(),
+      DEFAULT_FILTER,
       null,
       null);
   }

--- a/java/src/org/openqa/selenium/remote/http/RetryRequest.java
+++ b/java/src/org/openqa/selenium/remote/http/RetryRequest.java
@@ -1,0 +1,83 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote.http;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.openqa.selenium.TimeoutException;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+
+public class RetryRequest implements Filter {
+
+  private static final Logger LOG = Logger.getLogger(RetryRequest.class.getName());
+
+  // Retry on connection error.
+  private static final RetryPolicy<HttpResponse> connectionFailurePolicy =
+    new RetryPolicy<HttpResponse>()
+      .handleIf(failure -> failure.getCause() instanceof ConnectException)
+      .withBackoff(1, 4, ChronoUnit.SECONDS)
+      .withMaxRetries(3)
+      .withMaxDuration(Duration.ofSeconds(10))
+      .onRetry(e -> LOG.log(
+        Level.WARNING,
+        "Connection failure #{0}. Retrying.",
+        e.getAttemptCount()));
+
+  // Retry on read timeout.
+  private static final RetryPolicy<HttpResponse> readTimeoutPolicy =
+    new RetryPolicy<HttpResponse>()
+      .handle(TimeoutException.class)
+      .withBackoff(1, 4, ChronoUnit.SECONDS)
+      .withMaxRetries(3)
+      .withMaxDuration(Duration.ofSeconds(10))
+      .onRetry(e -> LOG.log(
+        Level.WARNING,
+        "Read timeout #{0}. Retrying.",
+        e.getAttemptCount()));
+
+  // Retry if server is unavailable or an internal server error occurs without response body.
+  private static final RetryPolicy<HttpResponse> serverErrorPolicy =
+    new RetryPolicy<HttpResponse>()
+      .handleResultIf(response -> response.getStatus() == HTTP_INTERNAL_ERROR &&
+        Contents.bytes(response.getContent()).length == 0)
+      .handleResultIf(response -> response.getStatus() == HTTP_UNAVAILABLE)
+      .withBackoff(1, 2, ChronoUnit.SECONDS)
+      .withMaxRetries(2)
+      .withMaxDuration(Duration.ofSeconds(3))
+      .onRetry(e -> LOG.log(
+        Level.WARNING,
+        "Failure due to server error #{0}. Retrying.",
+        e.getAttemptCount()));
+
+  @Override
+  public HttpHandler apply(HttpHandler next) {
+    return req -> Failsafe.with(
+      connectionFailurePolicy,
+      readTimeoutPolicy,
+      serverErrorPolicy)
+      .get(() -> next.execute(req));
+  }
+}

--- a/java/src/org/openqa/selenium/remote/http/RetryRequest.java
+++ b/java/src/org/openqa/selenium/remote/http/RetryRequest.java
@@ -27,6 +27,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 
@@ -62,7 +63,7 @@ public class RetryRequest implements Filter {
   private static final RetryPolicy<HttpResponse> serverErrorPolicy =
     new RetryPolicy<HttpResponse>()
       .handleResultIf(response -> response.getStatus() == HTTP_INTERNAL_ERROR &&
-        Contents.bytes(response.getContent()).length == 0)
+                                  Integer.parseInt(response.getHeader(CONTENT_LENGTH)) == 0)
       .handleResultIf(response -> response.getStatus() == HTTP_UNAVAILABLE)
       .withBackoff(1, 2, ChronoUnit.SECONDS)
       .withMaxRetries(2)

--- a/java/test/org/openqa/selenium/remote/http/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/http/BUILD.bazel
@@ -11,8 +11,10 @@ java_test_suite(
     ],
     deps = [
         "//java:auto-service",
+        "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/remote/http",
         "//java/src/org/openqa/selenium/remote/http/netty",
+        "//java/test/org/openqa/selenium/environment",
         "//java/test/org/openqa/selenium/testing:annotations",
         artifact("org.assertj:assertj-core"),
         artifact("com.google.guava:guava"),

--- a/java/test/org/openqa/selenium/remote/http/RetryRequestTest.java
+++ b/java/test/org/openqa/selenium/remote/http/RetryRequestTest.java
@@ -1,0 +1,182 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote.http;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.environment.webserver.AppServer;
+import org.openqa.selenium.environment.webserver.NettyAppServer;
+import org.openqa.selenium.remote.http.netty.NettyClient;
+
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.remote.http.Contents.asJson;
+import static org.openqa.selenium.remote.http.HttpMethod.GET;
+
+public class RetryRequestTest {
+
+  private HttpClient client;
+  private static final String REQUEST_PATH = "http://%s:%s/hello";
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ClientConfig config = ClientConfig.defaultConfig()
+      .baseUrl(new URL("http://example.com"))
+      .readTimeout(Duration.ofMillis(1000));
+    client = new NettyClient.Factory().createClient(config);
+  }
+
+  @Test
+  public void shouldBeAbleToHandleARequest() {
+    AtomicInteger count = new AtomicInteger(0);
+    AppServer server = new NettyAppServer(req -> {
+      count.incrementAndGet();
+      return new HttpResponse();
+    });
+    server.start();
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+    HttpResponse response = client.execute(request);
+
+    assertThat(response).extracting(HttpResponse::getStatus).isEqualTo(HTTP_OK);
+
+    assertThat(count.get()).isEqualTo(1);
+    server.stop();
+  }
+
+  @Test
+  public void shouldBeAbleToRetryARequestOnInternalServerError() {
+    AtomicInteger count = new AtomicInteger(0);
+    AppServer server = new NettyAppServer(req -> {
+      count.incrementAndGet();
+      return new HttpResponse().setStatus(500);
+    });
+    server.start();
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+    HttpResponse response = client.execute(request);
+
+    assertThat(response).extracting(HttpResponse::getStatus).isEqualTo(HTTP_INTERNAL_ERROR);
+    assertThat(count.get()).isEqualTo(3);
+
+    server.stop();
+  }
+
+  @Test
+  public void shouldNotRetryRequestOnInternalServerErrorWithContent() {
+    AtomicInteger count = new AtomicInteger(0);
+    AppServer server = new NettyAppServer(req -> {
+      count.incrementAndGet();
+      return new HttpResponse()
+        .setStatus(500)
+        .setContent(asJson(ImmutableMap.of("error", "non-transient")));
+    });
+    server.start();
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+    HttpResponse response = client.execute(request);
+
+    assertThat(response).extracting(HttpResponse::getStatus).isEqualTo(HTTP_INTERNAL_ERROR);
+    assertThat(count.get()).isEqualTo(1);
+
+    server.stop();
+  }
+
+  @Test
+  public void shouldRetryRequestOnServerUnavailableError() {
+    AtomicInteger count = new AtomicInteger(0);
+    AppServer server = new NettyAppServer(req -> {
+      count.incrementAndGet();
+      return new HttpResponse()
+        .setStatus(503)
+        .setContent(asJson(ImmutableMap.of("error", "server down")));
+    });
+    server.start();
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+    HttpResponse response = client.execute(request);
+
+    assertThat(response).extracting(HttpResponse::getStatus).isEqualTo(HTTP_UNAVAILABLE);
+    assertThat(count.get()).isEqualTo(3);
+
+    server.stop();
+  }
+
+  @Test
+  public void shouldBeAbleToRetryARequestOnTimeout() {
+    AtomicInteger count = new AtomicInteger(0);
+    AppServer server = new NettyAppServer(req -> {
+      count.incrementAndGet();
+      try {
+        Thread.sleep(2000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      return new HttpResponse();
+    });
+    server.start();
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+
+    try {
+      client.execute(request);
+    } catch (TimeoutException e) {
+      assertThat(count.get()).isEqualTo(4);
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void shouldBeAbleToRetryARequestOnConnectionFailure() {
+    AppServer server = new NettyAppServer(req -> new HttpResponse());
+
+    URI uri = URI.create(server.whereIs("/"));
+    HttpRequest request = new HttpRequest(
+      GET,
+      String.format(REQUEST_PATH, uri.getHost(), uri.getPort()));
+
+    client.execute(request);
+  }
+}

--- a/java/test/org/openqa/selenium/remote/http/RetryRequestTest.java
+++ b/java/test/org/openqa/selenium/remote/http/RetryRequestTest.java
@@ -28,7 +28,6 @@ import org.openqa.selenium.remote.http.netty.NettyClient;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -47,7 +46,7 @@ public class RetryRequestTest {
   @Before
   public void setUp() throws MalformedURLException {
     ClientConfig config = ClientConfig.defaultConfig()
-      .baseUrl(new URL("http://example.com"))
+      .baseUrl(URI.create("http://localhost:2345").toURL())
       .readTimeout(Duration.ofMillis(1000));
     client = new NettyClient.Factory().createClient(config);
   }


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Related to #8167. Add retry mechanism using Failsafe.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a client makes a request to the server, it might not get fulfilled due to different errors. One category of errors is transient in nature. In such cases, the request might be fulfilled if it is reattempted with a delay. The changes introduce a retry mechanism as a filter. The retry policies handler read timeout, connection failures and server errors (server unavailable and internal server error without response body). Rest of the failures are not retried. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
