### PR TITLE
[3.x] Add rexml to support Ruby 3

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -28,7 +28,7 @@ module Selenium
           # @return [Marionette::Driver, Legacy::Driver]
           #
 
-          def new(**opts)
+          def new(opts)
             if marionette?(opts)
               Firefox::Marionette::Driver.new(opts)
             else

--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 4.0']
+  s.add_runtime_dependency 'rexml'
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2']
 
   # childprocess requires ffi on windows but doesn't declare it in its dependencies


### PR DESCRIPTION
### ⚠️
First PR here, read contributing guidelines, searched for duplicates. This is also an issue in `trunk` branch. I can't run tests on my local machine. Also, Ruby 3.0 should be add to the matrix. I can't understand if the deprecated Grid 3.x is related to this branch. Feel free to close this PR and only consider #9001 

<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

<!--- Provide a general summary of your changes in the Title above -->

### Description
Add rexml to runtime dependencies and net-telnet to development dependencies

### Motivation and Context
`rexml` is a bundled gem in Ruby 3.0

This causes errors with selenium’s Firefox webdriver when requiring
`rexml/document`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

### References

- https://bugs.ruby-lang.org/issues/16485
- ruby/ruby@c3ccf23
- jnunemaker/crack#62
- https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
- #9001