### PR TITLE
Add rexml dependency

### DIFF
--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 5.0']
+  s.add_runtime_dependency 'rexml'
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2']
   s.add_runtime_dependency 'websocket', ['~> 1.0']
-  s.add_runtime_dependency 'rexml'
 
   # childprocess requires ffi on windows but doesn't declare it in its dependencies
   s.add_development_dependency 'ffi'

--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'childprocess', ['>= 0.5', '< 5.0']
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2']
   s.add_runtime_dependency 'websocket', ['~> 1.0']
+  s.add_runtime_dependency 'rexml'
 
   # childprocess requires ffi on windows but doesn't declare it in its dependencies
   s.add_development_dependency 'ffi'


### PR DESCRIPTION
### Description

Since ruby 3.0.0, rexml is a bundled gem.
So it must be depend explicitly.

### Motivation and Context

https://stackoverflow.com/questions/65479863/rails-6-1-what-is-preventing-tests-from-running/65480744#65480744

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
