### PR TITLE
[rb] Fix deprecation warnings for Ruby 2.7 in 3.x

### DIFF
--- a/rb/lib/selenium/webdriver/remote/driver.rb
+++ b/rb/lib/selenium/webdriver/remote/driver.rb
@@ -36,7 +36,7 @@ module Selenium
 
         def initialize(opts = {})
           listener = opts.delete(:listener)
-          @bridge = Bridge.handshake(opts)
+          @bridge = Bridge.handshake(**opts)
           if @bridge.dialect == :oss
             extend DriverExtensions::HasTouchScreen
             extend DriverExtensions::HasLocation


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Same as https://github.com/SeleniumHQ/selenium/commit/ee994fe79e37fe6ed4050aac1bf4b0befb0d5338
but in the remote driver that was forgotten

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
