### PR TITLE
Add disable escaping option for json parsing. Fix string escaping for event-logs.

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/BUILD.bazel
+++ b/java/client/src/org/openqa/selenium/remote/BUILD.bazel
@@ -39,6 +39,7 @@ java_export(
         "//java/client/src/org/openqa/selenium/remote/http/netty",
         "//java/client/src/org/openqa/selenium/remote/http/reactor",
         "//java/client/src/org/openqa/selenium/remote/tracing",
+        "//java/client/src/org/openqa/selenium/json",
         artifact("com.google.guava:guava"),
         artifact("net.bytebuddy:byte-buddy"),
     ],

--- a/java/client/src/org/openqa/selenium/remote/NewSessionPayload.java
+++ b/java/client/src/org/openqa/selenium/remote/NewSessionPayload.java
@@ -208,7 +208,7 @@ public class NewSessionPayload implements Closeable {
   }
 
   public void writeTo(Appendable appendable) throws IOException {
-    try (JsonOutput json = new Json().newOutput(appendable)) {
+    try (JsonOutput json = new Json().newOutput(appendable).setPrettyPrint(false).disableEscaping(true)) {
       json.beginObject();
 
       Map<String, Object> first = getOss();

--- a/java/client/src/org/openqa/selenium/remote/RemoteTags.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteTags.java
@@ -18,6 +18,8 @@
 package org.openqa.selenium.remote;
 
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.json.Json;
+import org.openqa.selenium.json.JsonOutput;
 import org.openqa.selenium.remote.tracing.AttributeKey;
 import org.openqa.selenium.remote.tracing.EventAttribute;
 import org.openqa.selenium.remote.tracing.EventAttributeValue;
@@ -41,10 +43,15 @@ public class RemoteTags {
       span.setAttribute(AttributeKey.SESSION_ID.getKey(), String.valueOf(id));
 
   public static final BiConsumer<Map<String, EventAttributeValue>, Capabilities>
-      CAPABILITIES_EVENT =
-      (map, caps) ->
-          map.put(AttributeKey.SESSION_CAPABILITIES.getKey(),
-                  EventAttribute.setValue(String.valueOf(caps)));
+    CAPABILITIES_EVENT = (map, caps) -> {
+    StringBuilder text = new StringBuilder();
+    try (JsonOutput json = new Json().newOutput(text).setPrettyPrint(false).disableEscaping(true)) {
+      json.write(caps.asMap());
+      text.append('\n');
+    }
+    map.put(AttributeKey.SESSION_CAPABILITIES.getKey(),
+      EventAttribute.setValue(text.toString()));
+  };
 
   public static final BiConsumer<Map<String, EventAttributeValue>, SessionId>
       SESSION_ID_EVENT =

--- a/java/client/test/org/openqa/selenium/json/JsonOutputTest.java
+++ b/java/client/test/org/openqa/selenium/json/JsonOutputTest.java
@@ -640,6 +640,41 @@ public class JsonOutputTest {
   }
 
   @Test
+  public void canKeepEscapedStringIntactByDefault() {
+    String sample =
+      "{  \r\n    \"employee\": {  \r\n        \"name\":       \"bob\",   \r\n    " +
+        "    \"salary\":      56000,   \r\n        \"married\":    true  \r\n    }  \r\n}";
+    Map<String, String> map = ImmutableMap.of("key", sample);
+
+    StringBuilder json = new StringBuilder();
+    try (JsonOutput out = new Json().newOutput(json)) {
+      out.write(map);
+    }
+
+    assertThat(json.indexOf("\\n")).isPositive();
+    assertThat(json.indexOf("\\r")).isPositive();
+    assertThat(json.indexOf("\\\"")).isPositive();
+  }
+
+  @Test
+  public void canDisableStringEscaping() {
+    String sample =
+      "{  \r\n    \"employee\": {  \r\n        \"name\":       \"bob\",   \r\n    " +
+        "    \"salary\":      56000,   \r\n        \"married\":    true  \r\n    }  \r\n}";
+    Map<String, String> map = ImmutableMap.of("key", sample);
+
+    StringBuilder json = new StringBuilder();
+    try (JsonOutput out = new Json().newOutput(json)) {
+      out.disableEscaping(true);
+      out.write(map);
+    }
+
+    assertThat(json.indexOf("\\n")).isEqualTo(-1);
+    assertThat(json.indexOf("\\r")).isEqualTo(-1);
+    assertThat(json.indexOf("\\\"")).isEqualTo(-1);
+  }
+
+  @Test
   public void shouldEncodeLogLevelsAsStrings() {
     String converted = convert(Level.INFO);
 

--- a/java/server/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -265,7 +265,7 @@ public class LoggingOptions {
 
   private String getJsonString(Map<String, Object> map) {
     StringBuilder text = new StringBuilder();
-    try (JsonOutput json = JSON.newOutput(text).setPrettyPrint(false)) {
+    try (JsonOutput json = JSON.newOutput(text).setPrettyPrint(false).disableEscaping(true)) {
       json.write(map);
       text.append('\n');
     }


### PR DESCRIPTION


<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add disable escaping option for json parsing. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The event-logs attributes like session payload and capabilities leverage the built-in json parse to convert the objects to json strings. By default, the escape characters are included in the string. It resulted in inconsistent log string with some fields having escape characters and some being printed normally. The changes added, fix this by adding a disable escaping option. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
