### PR TITLE
[rb] ensure options classes have defaults for accessors

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/ClassLength:
     - 'lib/selenium/webdriver/remote/capabilities.rb'
 
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Max: 9
   Exclude:
     - 'lib/selenium/webdriver/remote/capabilities.rb'
     - 'lib/selenium/webdriver/support/color.rb'

--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/ClassLength:
     - 'lib/selenium/webdriver/remote/capabilities.rb'
 
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 10
   Exclude:
     - 'lib/selenium/webdriver/remote/capabilities.rb'
     - 'lib/selenium/webdriver/support/color.rb'
@@ -86,7 +86,7 @@ Metrics/ParameterLists:
 
 # TODO: Refactor Chrome::Bridge#create_capabilities
 Metrics/PerceivedComplexity:
-  Max: 9
+  Max: 10
   Exclude:
     - 'lib/selenium/webdriver/remote/capabilities.rb'
 

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -82,11 +82,15 @@ module Selenium
         end
         browser_options = defined?(self.class::KEY) ? {self.class::KEY => options} : options
 
-        process_browser_options(browser_options) if private_methods(false).include?(:process_browser_options)
+        process_browser_options(browser_options)
         generate_as_json(w3c_options.merge(browser_options))
       end
 
       private
+
+      def process_browser_options(_browser_options)
+        nil
+      end
 
       def camelize?(_key)
         true

--- a/rb/lib/selenium/webdriver/edge_html/options.rb
+++ b/rb/lib/selenium/webdriver/edge_html/options.rb
@@ -27,16 +27,6 @@ module Selenium
                         start_page: 'ms:startPage'}.freeze
         BROWSER = 'MicrosoftEdge'
 
-        CAPABILITIES.each_key do |key|
-          define_method key do
-            @options[key]
-          end
-
-          define_method "#{key}=" do |value|
-            @options[key] = value
-          end
-        end
-
         #
         # Create a new Options instance for Edge.
         #
@@ -54,7 +44,9 @@ module Selenium
 
         def initialize(**opts)
           super(**opts)
-          @options[:extensions]&.each(&method(:validate_extension))
+
+          @options[:extension_paths] ||= []
+          @options[:extension_paths].each(&method(:validate_extension))
         end
 
         #
@@ -69,7 +61,6 @@ module Selenium
 
         def add_extension_path(path)
           validate_extension(path)
-          @options[:extension_paths] ||= []
           @options[:extension_paths] << path
         end
 

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -43,16 +43,6 @@ module Selenium
         }.freeze
         BROWSER = 'internet explorer'
 
-        CAPABILITIES.each_key do |key|
-          define_method key do
-            @options[key]
-          end
-
-          define_method "#{key}=" do |value|
-            @options[key] = value
-          end
-        end
-
         attr_reader :args
 
         #

--- a/rb/lib/selenium/webdriver/safari/options.rb
+++ b/rb/lib/selenium/webdriver/safari/options.rb
@@ -28,15 +28,6 @@ module Selenium
                         automatic_profiling: 'safari:automaticProfiling'}.freeze
         BROWSER = 'safari'
 
-        CAPABILITIES.each_key do |key|
-          define_method key do
-            @options[key]
-          end
-
-          define_method "#{key}=" do |value|
-            @options[key] = value
-          end
-        end
       end # Options
     end # Safari
   end # WebDriver

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -210,8 +210,12 @@ module Selenium
 
             it 'with Options instance with profile' do
               profile = Profile.new.tap(&:layout_on_disk)
+              allow(profile).to receive(:directory).and_return("PROF_DIR")
               options = Options.new(profile: profile)
-              expect_request(body: {capabilities: {firstMatch: [browserName: "chrome", 'goog:chromeOptions': {}]}})
+
+              expect_request(body: {capabilities:
+                                       {firstMatch: [browserName: "chrome",
+                                                     'goog:chromeOptions': {"args": ["--user-data-dir=PROF_DIR"]}]}})
 
               expect { Driver.new(capabilities: [options]) }.not_to raise_exception
             end

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -55,7 +55,7 @@ module Selenium
                                window_types: %w[normal devtools],
                                'custom:options': {foo: 'bar'})
 
-            expect(opts.args.to_a).to eq(%w[foo bar])
+            expect(opts.args).to eq(%w[foo bar])
             expect(opts.prefs[:foo]).to eq('bar')
             expect(opts.binary).to eq('/foo/bar')
             expect(opts.extensions).to eq(['foo.crx', 'bar.crx'])
@@ -78,6 +78,57 @@ module Selenium
             expect(opts.timeouts).to eq(script: 40000, page_load: 400000, implicit: 1)
             expect(opts.set_window_rect).to eq(false)
             expect(opts.options[:'custom:options']).to eq(foo: 'bar')
+          end
+        end
+
+        describe 'accessors' do
+          it 'adds a command-line argument' do
+            options.args << 'foo'
+            expect(options.args).to eq(['foo'])
+          end
+
+          it 'adds an extension' do
+            allow(File).to receive(:file?).and_return(true)
+            ext = 'foo.crx'
+            allow_any_instance_of(Options).to receive(:encode_file).with(ext).and_return("encoded_#{ext[/([^.]*)/]}")
+
+            options.extensions << ext
+            expect(options.extensions).to eq([ext])
+          end
+
+          it 'sets the binary path' do
+            options.binary = '/foo/bar'
+            expect(options.binary).to eq('/foo/bar')
+          end
+
+          it 'adds a preference' do
+            options.prefs[:foo] = 'bar'
+            expect(options.prefs[:foo]).to eq('bar')
+          end
+
+          it 'add an emulated device by name' do
+            options.emulation[:device_name] = 'iPhone 6'
+            expect(options.emulation).to eq(device_name: 'iPhone 6')
+          end
+
+          it 'adds local state' do
+            options.local_state[:foo] = 'bar'
+            expect(options.local_state).to eq(foo: 'bar')
+          end
+
+          it 'adds a switch to exclude' do
+            options.exclude_switches << 'exclude-this'
+            expect(options.exclude_switches).to eq(['exclude-this'])
+          end
+
+          it 'adds performance logging preferences' do
+            options.perf_logging_prefs[:enable_network] = true
+            expect(options.perf_logging_prefs).to eq('enable_network': true)
+          end
+
+          it 'adds a window type' do
+            options.window_types << 'normal'
+            expect(options.window_types).to eq(['normal'])
           end
         end
 
@@ -111,24 +162,17 @@ module Selenium
           end
         end
 
-        describe '#binary=' do
-          it 'sets the binary path' do
-            options.binary = '/foo/bar'
-            expect(options.binary).to eq('/foo/bar')
-          end
-        end
-
         describe '#add_argument' do
           it 'adds a command-line argument' do
             options.add_argument('foo')
-            expect(options.args.to_a).to eq(['foo'])
+            expect(options.args).to eq(['foo'])
           end
         end
 
         describe '#headless!' do
           it 'should add necessary command-line arguments' do
             options.headless!
-            expect(options.args.to_a).to eql(['--headless'])
+            expect(options.args).to eql(['--headless'])
           end
         end
 

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -158,7 +158,7 @@ module Selenium
         describe '#add_encoded_extension' do
           it 'adds an encoded extension' do
             options.add_encoded_extension('foo')
-            expect(options.instance_variable_get('@options')[:encoded_extensions]).to include('foo')
+            expect(options.instance_variable_get('@encoded_extensions')).to include('foo')
           end
         end
 
@@ -264,7 +264,7 @@ module Selenium
                                                'prefs' => {'foo' => 'bar',
                                                            'key_that_should_not_be_camelcased' => 'baz'},
                                                'binary' => '/foo/bar',
-                                               'extensions' => %w[encoded_foo encoded_bar encoded_foobar],
+                                               'extensions' => %w[encoded_foobar encoded_foo encoded_bar],
                                                'foo' => 'bar',
                                                'mobileEmulation' => {'deviceName' => 'mine'},
                                                'localState' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/edge_chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge_chrome/driver_spec.rb
@@ -210,8 +210,11 @@ module Selenium
 
             it 'with Options instance with profile' do
               profile = Profile.new.tap(&:layout_on_disk)
+              allow(profile).to receive(:directory).and_return("PROF_DIR")
               options = Options.new(profile: profile)
-              expect_request(body: {capabilities: {firstMatch: [browserName: "MicrosoftEdge", 'ms:edgeOptions': {}]}})
+              expect_request(body: {capabilities:
+                                      {firstMatch: [browserName: "MicrosoftEdge",
+                                                    'ms:edgeOptions': {"args": ["--user-data-dir=PROF_DIR"]}]}})
 
               expect { Driver.new(capabilities: [options]) }.not_to raise_exception
             end

--- a/rb/spec/unit/selenium/webdriver/edge_chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge_chrome/options_spec.rb
@@ -107,7 +107,7 @@ module Selenium
         describe '#add_encoded_extension' do
           it 'adds an encoded extension' do
             options.add_encoded_extension('foo')
-            expect(options.instance_variable_get('@options')[:encoded_extensions]).to include('foo')
+            expect(options.instance_variable_get('@encoded_extensions')).to include('foo')
           end
         end
 
@@ -220,10 +220,7 @@ module Selenium
                                                'prefs' => {'foo' => 'bar',
                                                            'key_that_should_not_be_camelcased' => 'baz'},
                                                'binary' => '/foo/bar',
-                                               # TODO: verify this is correct behavior;
-                                               # I would expect extensions to come back encoded
-                                               'extensions' => %w[foo.crx bar.crx],
-                                               'encodedExtensions' => %w[encoded_foobar],
+                                               'extensions' => %w[encoded_foobar encoded_foo encoded_bar],
                                                'foo' => 'bar',
                                                'mobileEmulation' => {'deviceName' => 'mine'},
                                                'localState' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -67,10 +67,20 @@ module Selenium
           end
         end
 
-        describe '#binary=' do
+        describe 'accessors' do
+          it 'adds a command-line argument' do
+            options.args << 'foo'
+            expect(options.args).to eq(['foo'])
+          end
+
           it 'sets the binary path' do
             options.binary = '/foo/bar'
             expect(options.binary).to eq('/foo/bar')
+          end
+
+          it 'adds a preference' do
+            options.prefs[:foo] = 'bar'
+            expect(options.prefs[:foo]).to eq('bar')
           end
         end
 
@@ -94,8 +104,8 @@ module Selenium
             profile = Profile.new
             allow(profile).to receive(:encoded).and_return('encoded_profile')
 
-            allow(Profile).to receive(:from_name).with('foo').and_return(profile)
-            options.profile = 'foo'
+            allow(Profile).to receive(:from_name).with('custom_profile_name').and_return(profile)
+            options.profile = 'custom_profile_name'
             expect(options.profile).to eq(profile)
           end
         end


### PR DESCRIPTION
The impetus of this refactor was to allow:
```
ChromeOptions.new.args << 'new-arg'
```
Since I accidentally removed these defaults 2 summers ago when I moved to the dynamic setters/getters approach.

This PR
1. Removes duplication for dynamically adding accessors from `CAPABILITIES` 
2. Creates the accessors during class construction instead of when file loads
3. Adds defaults in constructor for all of the `Array` & `Hash` objects, and removes from the specific methods
4. Fixes a bug where Chrome profiles were getting completely ignored in existing code
5. `#generate_as_json` now ignores any capabilities that are empty, so we don't have to put that logic in multiple laces elsewhere
6. Added specs for everything

The only weird capability now is Firefox's `profile` since we want to evaluate it when we add it instead of when we use it.

Everything else should be straightforward assuming I didn't miss some specs failing