### PR TITLE
[rb] restore default Firefox Profile settings to match 3.x

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/profile.rb
+++ b/rb/lib/selenium/webdriver/firefox/profile.rb
@@ -25,6 +25,14 @@ module Selenium
 
         VALID_PREFERENCE_TYPES = [TrueClass, FalseClass, Integer, Float, String].freeze
 
+        DEFAULT_PREFERENCES = {
+          "browser.newtabpage.enabled" => false,
+          "browser.startup.homepage" => "about:blank",
+          "browser.usedOnWindows10.introURL" => "about:blank",
+          "network.captive-portal-service.enabled" => false,
+          "security.csp.enable" => false
+        }.freeze
+
         attr_reader   :name, :log_file
         attr_writer   :secure_ssl, :load_no_focus_lib
 
@@ -179,10 +187,12 @@ module Selenium
 
         def update_user_prefs_in(directory)
           path = File.join(directory, 'user.js')
-          prefs = read_user_prefs(path).merge(@additional_prefs)
+          prefs = read_user_prefs(path)
+          prefs.merge! self.class::DEFAULT_PREFERENCES
+          prefs.merge!(@additional_prefs)
 
           # If the user sets the home page, we should also start up there
-          prefs['startup.homepage_welcome_url'] = prefs['browser.startup.homepage']
+          prefs['startup.homepage_welcome_url'] ||= prefs['browser.startup.homepage']
 
           write_prefs prefs, path
         end

--- a/rb/spec/unit/selenium/webdriver/firefox/profile_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/profile_spec.rb
@@ -33,21 +33,19 @@ module Selenium
         end
 
         it 'uses default preferences' do
-          prefs = read_generated_prefs
-          expect(prefs).to include('user_pref("browser.newtabpage.enabled", false)')
-          expect(prefs).to include('user_pref("browser.startup.homepage", "about:blank")')
-          expect(prefs).to include('user_pref("startup.homepage_welcome_url", "about:blank")')
-          expect(prefs).to include('user_pref("browser.usedOnWindows10.introURL", "about:blank")')
-          expect(prefs).to include('user_pref("network.captive-portal-service.enabled", false)')
-          expect(prefs).to include('user_pref("security.csp.enable", false)')
+          expect(read_generated_prefs).to include('user_pref("browser.newtabpage.enabled", false)',
+                                                  'user_pref("browser.startup.homepage", "about:blank")',
+                                                  'user_pref("startup.homepage_welcome_url", "about:blank")',
+                                                  'user_pref("browser.usedOnWindows10.introURL", "about:blank")',
+                                                  'user_pref("network.captive-portal-service.enabled", false)',
+                                                  'user_pref("security.csp.enable", false)')
         end
 
         it 'can override welcome page' do
           profile['startup.homepage_welcome_url'] = "http://google.com"
 
-          prefs = read_generated_prefs
-          expect(prefs).to include('user_pref("browser.startup.homepage", "about:blank")')
-          expect(prefs).to include('user_pref("startup.homepage_welcome_url", "http://google.com")')
+          expect(read_generated_prefs).to include('user_pref("browser.startup.homepage", "about:blank")',
+                                                  'user_pref("startup.homepage_welcome_url", "http://google.com")')
         end
 
         it 'should set additional preferences' do
@@ -55,32 +53,28 @@ module Selenium
           profile['foo.boolean'] = true
           profile['foo.string'] = 'bar'
 
-          string = read_generated_prefs
-          expect(string).to include('user_pref("foo.number", 123)')
-          expect(string).to include('user_pref("foo.boolean", true)')
-          expect(string).to include(%{user_pref("foo.string", "bar")})
+          expect(read_generated_prefs).to include('user_pref("foo.number", 123)',
+                                                  'user_pref("foo.boolean", true)',
+                                                  'user_pref("foo.string", "bar")')
         end
 
         it 'should be serializable to JSON' do
           profile['foo.boolean'] = true
 
           new_profile = Profile.from_json(profile.to_json)
-          string = read_generated_prefs(new_profile)
-          expect(string).to include('user_pref("foo.boolean", true)')
+          expect(read_generated_prefs(new_profile)).to include('user_pref("foo.boolean", true)')
         end
 
         it 'should properly handle escaped characters' do
           profile['foo'] = 'C:\\r\\n'
 
-          string = read_generated_prefs
-          expect(string).to include('user_pref("foo", "C:\\\\r\\\\n");')
+          expect(read_generated_prefs).to include('user_pref("foo", "C:\\\\r\\\\n");')
         end
 
         it 'should let the user override some specific prefs' do
           profile['browser.startup.page'] = 'http://example.com'
 
-          string = read_generated_prefs
-          expect(string).to include(%{user_pref("browser.startup.page", "http://example.com")})
+          expect(read_generated_prefs).to include(%{user_pref("browser.startup.page", "http://example.com")})
         end
 
         it 'should raise an error if the value given is not a string, number or boolean' do
@@ -100,34 +94,27 @@ module Selenium
           )
 
           profile.proxy = proxy
-          string = read_generated_prefs
-
-          expect(string).to include('user_pref("network.proxy.http", "foo")')
-          expect(string).to include('user_pref("network.proxy.http_port", 123)')
-
-          expect(string).to include('user_pref("network.proxy.ftp", "bar")')
-          expect(string).to include('user_pref("network.proxy.ftp_port", 234)')
-
-          expect(string).to include('user_pref("network.proxy.ssl", "baz")')
-          expect(string).to include('user_pref("network.proxy.ssl_port", 345)')
-
-          expect(string).to include('user_pref("network.proxy.no_proxies_on", "localhost")')
-          expect(string).to include('user_pref("network.proxy.type", 1)')
+          expect(read_generated_prefs).to include('user_pref("network.proxy.http", "foo")',
+                                                  'user_pref("network.proxy.http_port", 123)',
+                                                  'user_pref("network.proxy.ftp", "bar")',
+                                                  'user_pref("network.proxy.ftp_port", 234)',
+                                                  'user_pref("network.proxy.ssl", "baz")',
+                                                  'user_pref("network.proxy.ssl_port", 345)',
+                                                  'user_pref("network.proxy.no_proxies_on", "localhost")',
+                                                  'user_pref("network.proxy.type", 1)')
         end
 
         it 'can configure a PAC proxy' do
           profile.proxy = Proxy.new(pac: 'http://foo/bar.pac')
-          string = read_generated_prefs
 
-          expect(string).to include('user_pref("network.proxy.autoconfig_url", "http://foo/bar.pac")')
-          expect(string).to include('user_pref("network.proxy.type", 2)')
+          expect(read_generated_prefs).to include('user_pref("network.proxy.autoconfig_url", "http://foo/bar.pac"',
+                                                  'user_pref("network.proxy.type", 2)')
         end
 
         it 'can configure an auto-detected proxy' do
           profile.proxy = Proxy.new(auto_detect: true)
-          string = read_generated_prefs
 
-          expect(string).to include('user_pref("network.proxy.type", 4)')
+          expect(read_generated_prefs).to include('user_pref("network.proxy.type", 4)')
         end
 
         it 'can install extension' do

--- a/rb/spec/unit/selenium/webdriver/firefox/profile_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/profile_spec.rb
@@ -32,6 +32,24 @@ module Selenium
           File.read(File.join(dir, 'user.js'))
         end
 
+        it 'uses default preferences' do
+          prefs = read_generated_prefs
+          expect(prefs).to include('user_pref("browser.newtabpage.enabled", false)')
+          expect(prefs).to include('user_pref("browser.startup.homepage", "about:blank")')
+          expect(prefs).to include('user_pref("startup.homepage_welcome_url", "about:blank")')
+          expect(prefs).to include('user_pref("browser.usedOnWindows10.introURL", "about:blank")')
+          expect(prefs).to include('user_pref("network.captive-portal-service.enabled", false)')
+          expect(prefs).to include('user_pref("security.csp.enable", false)')
+        end
+
+        it 'can override welcome page' do
+          profile['startup.homepage_welcome_url'] = "http://google.com"
+
+          prefs = read_generated_prefs
+          expect(prefs).to include('user_pref("browser.startup.homepage", "about:blank")')
+          expect(prefs).to include('user_pref("startup.homepage_welcome_url", "http://google.com")')
+        end
+
         it 'should set additional preferences' do
           profile['foo.number'] = 123
           profile['foo.boolean'] = true


### PR DESCRIPTION
I think this is a better option than #9068 for maintaining backward compatibility.

These are the ones that aren't default, but make sense for testing.

* Set everything to about:blank and/or prevent extra tabs opening.

* `"network.captive-portal-service.enabled": false`:
When you launch Firefox, the browser immediately establishes a new connection to detectportal.firefox.com. This behavior is caused by Captive Portal, a special feature of Firefox. Disabling Captive Portal will stop Firefox from connecting to detectportal.firefox.com.

* `"security.csp.enable": false`:
allows including external javascript code on a page

tbh, these sound like more reasonable defaults than what geckodriver creates by default.