### PR TITLE
[grid-ui] Update stereotype column count method

### DIFF
--- a/javascript/grid-ui/src/components/Node/Node.tsx
+++ b/javascript/grid-ui/src/components/Node/Node.tsx
@@ -75,7 +75,7 @@ export default function Node(props) {
   const currentLoad = sessionCount === 0 ? 0 :
       Math.min(((sessionCount / nodeInfo.maxSession) * 100), 100).toFixed(2);
   // Assuming we will put 3 stereotypes per column.
-  const stereotypeColumns = Math.round(nodeInfo.slotStereotypes.length / 3);
+  const stereotypeColumns = Math.ceil(nodeInfo.slotStereotypes.length / 3);
   // Then we need to know how many columns we will display.
   const columnWidth: GridSize = 12 / stereotypeColumns as any;
 


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The Grid UI was not unable to display the stereotype of the Node, if it has only one stereotype.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to ensure the stereotypes are displayed correctly, the changes use "Math.ceil" to calculate the stereotype count. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


Before
![image](https://user-images.githubusercontent.com/10705590/106870551-3cec3380-66f7-11eb-9e30-cb9aab46d5e7.png)


After

![image](https://user-images.githubusercontent.com/10705590/106870435-1fb76500-66f7-11eb-9168-f4c43d468caa.png)
