### PR TITLE
[rb] update default cookie setting behavior with thorough documentati…

### DIFF
--- a/rb/lib/selenium/webdriver/common/manager.rb
+++ b/rb/lib/selenium/webdriver/common/manager.rb
@@ -46,7 +46,7 @@ module Selenium
         raise ArgumentError, 'name is required' unless opts[:name]
         raise ArgumentError, 'value is required' unless opts[:value]
 
-        opts[:path] ||= '/'
+        # NOTE: This is required because of https://bugs.chromium.org/p/chromedriver/issues/detail?id=3732
         opts[:secure] ||= false
 
         same_site = opts.delete(:same_site)

--- a/rb/spec/integration/selenium/webdriver/guard_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/guard_spec.rb
@@ -122,7 +122,7 @@ module Selenium
 
         it 'Uses correct message for exclusive' do
           guard = Guards::Guard.new({reason: "Foo is bad"}, :exclusive)
-          expect(guard.message).to eq 'Test does not apply to this configuration'
+          expect(guard.message).to eq 'Test does not apply to this configuration; Foo is bad'
         end
 
         it 'Uses correct message for exclude' do

--- a/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/guards/guard.rb
@@ -54,7 +54,7 @@ module Selenium
             when :exclude
               "Test not guarded because it breaks test run; #{details}"
             when :exclusive
-              'Test does not apply to this configuration'
+              "Test does not apply to this configuration; #{details}"
             else
               "Test guarded; #{details}"
             end


### PR DESCRIPTION
I went down a rabbit hole exploring desired cookie behavior.

I added all the specs, filed all the bugs, and referenced them in the guards as applicable.

The main change I want to get reviewed is overriding the defaults when we create the cookies.
Per the WebDriver spec only name & value are required, and per the Cookie RFC, the path & the secure value are the expected defaults from the browser. As such I don't think we should be overriding the behavior, even if it might not be backward compatible (Chrome has a bug that sets secure to true by default on non-localhost sites)

@luke-hill you should be happy with this. :)