### PR TITLE
[rb] implement initial support for Firefox BiDi

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -257,6 +257,7 @@ task test_rb: ['//rb:unit-test', :test_rb_local, :test_rb_remote]
 task test_rb_local: [
   '//rb:chrome-test',
   '//rb:firefox-test',
+  ('//rb:firefox-nightly-test' if ENV['FIREFOX_NIGHTLY_BINARY']),
   ('//rb:safari-preview-test' if SeleniumRake::Checks.mac?),
   ('//rb:safari-test' if SeleniumRake::Checks.mac?),
   ('//rb:ie-test' if SeleniumRake::Checks.windows?),
@@ -266,6 +267,7 @@ task test_rb_local: [
 task test_rb_remote: [
   '//rb:remote-chrome-test',
   '//rb:remote-firefox-test',
+  ('//rb:remote-firefox-nightly-test' if ENV['FIREFOX_NIGHTLY_BINARY']),
   ('//rb:remote-safari-test' if SeleniumRake::Checks.mac?),
   # BUG - https://github.com/SeleniumHQ/selenium/issues/6791
   # ('//rb:remote-safari-preview-test' if SeleniumRake::Checks.mac?),

--- a/rb/build.desc
+++ b/rb/build.desc
@@ -156,6 +156,21 @@ ruby_test(name = "firefox",
   deps = [":firefox"]
 )
 
+ruby_test(name = "firefox-nightly",
+  srcs = [
+    "spec/integration/selenium/webdriver/*_spec.rb",
+    "spec/integration/selenium/webdriver/firefox/**/*_spec.rb"
+  ],
+  include = [
+    "rb/spec/integration",
+    "build/rb/lib"
+  ],
+  deps = [
+    ":firefox",
+    ":devtools"
+  ]
+)
+
 ruby_test(name = "remote-firefox",
   srcs = [
     "spec/integration/selenium/webdriver/*_spec.rb",
@@ -279,6 +294,7 @@ ruby_library(name = "devtools",
   ],
   deps = [
     ":common",
+    ":cdp-v85",
     ":cdp-v86",
     ":cdp-v87",
     ":cdp-v88",
@@ -303,6 +319,22 @@ ruby_test(name = "unit",
     ":firefox",
     ":ie",
     ":safari",
+  ]
+)
+
+ruby_class_call(name = "cdp-v85",
+  klass = "Selenium::WebDriver::Support::CDPClientGenerator",
+  require = "rb/lib/selenium/webdriver/support/cdp_client_generator",
+  output_dir = "rb/lib/selenium/webdriver/devtools/v85",
+  version = "v85",
+  srcs = [
+    "lib/selenium/webdriver/support/cdp",
+    "lib/selenium/webdriver/support/cdp/**/*",
+    "lib/selenium/webdriver/support/cdp_client_generator.rb"
+  ],
+  resources = [
+    { "//common/devtools/chromium/v85:browser_protocol": "rb/lib/selenium/webdriver/support/cdp/browser_protocol.json" },
+    { "//common/devtools/chromium/v85:js_protocol": "rb/lib/selenium/webdriver/support/cdp/js_protocol.json" }
   ]
 )
 

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -51,6 +51,10 @@ module Selenium
 
         private
 
+        def devtools_version
+          Integer(capabilities.browser_version.split('.').first)
+        end
+
         def debugger_address
           capabilities['goog:chromeOptions']['debuggerAddress']
         end

--- a/rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb
@@ -29,9 +29,7 @@ module Selenium
         #
 
         def devtools
-          version = Integer(capabilities.browser_version.split('.').first)
-          WebDriver.logger.info "Using devtools version: #{version}"
-          @devtools ||= DevTools.new(url: debugger_address, version: version)
+          @devtools ||= DevTools.new(url: debugger_address, version: devtools_version)
         end
 
       end # HasDevTools

--- a/rb/lib/selenium/webdriver/common/driver_extensions/has_log_events.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/has_log_events.rb
@@ -89,8 +89,14 @@ module Selenium
 
         def log_exception_events
           devtools.runtime.on(:exception_thrown) do |params|
+            description = if params.dig('exceptionDetails', 'exception')
+                            params.dig('exceptionDetails', 'exception', 'description')
+                          else
+                            params.dig('exceptionDetails', 'text')
+                          end
+
             event = DevTools::ExceptionEvent.new(
-              description: params.dig('exceptionDetails', 'exception', 'description'),
+              description: description,
               timestamp: params['timestamp'],
               stacktrace: params.dig('exceptionDetails', 'stackTrace', 'callFrames')
             )

--- a/rb/lib/selenium/webdriver/devtools.rb
+++ b/rb/lib/selenium/webdriver/devtools.rb
@@ -80,6 +80,9 @@ module Selenium
             incoming_frame << socket.readpartial(1024)
 
             while (frame = incoming_frame.next)
+              # Firefox will periodically fail on unparsable empty frame
+              break if frame.to_s.empty?
+
               message = JSON.parse(frame.to_s)
               @messages << message
               WebDriver.logger.debug "DevTools <- #{message}"
@@ -112,7 +115,7 @@ module Selenium
 
       def page_target
         @page_target ||= begin
-          response = Net::HTTP.get(@uri.hostname, '/json', @uri.port)
+          response = Net::HTTP.get(@uri.hostname, '/json/list', @uri.port)
           targets = JSON.parse(response)
           targets.find { |target| target['type'] == 'page' }
         end

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -28,6 +28,8 @@ module Selenium
 
       class Driver < WebDriver::Driver
         include DriverExtensions::HasAddons
+        include DriverExtensions::HasDevTools
+        include DriverExtensions::HasLogEvents
         include DriverExtensions::HasWebStorage
         include DriverExtensions::PrintsPage
 
@@ -37,6 +39,16 @@ module Selenium
 
         def bridge_class
           Bridge
+        end
+
+        private
+
+        def devtools_version
+          85
+        end
+
+        def debugger_address
+          capabilities['moz:debuggerAddress']
         end
       end # Driver
     end # Firefox

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -21,6 +21,8 @@ module Selenium
   module WebDriver
     module Firefox
       class Options < WebDriver::Options
+        attr_accessor :debugger_address
+
         KEY = 'moz:firefoxOptions'
 
         # see: https://firefox-source-docs.mozilla.org/testing/geckodriver/Capabilities.html
@@ -50,6 +52,8 @@ module Selenium
         #
 
         def initialize(log_level: nil, **opts)
+          @debugger_address = opts.delete(:debugger_address)
+
           super(**opts)
 
           @options[:args] ||= []
@@ -130,6 +134,7 @@ module Selenium
         private
 
         def process_browser_options(browser_options)
+          browser_options['moz:debuggerAddress'] = true if @debugger_address
           options = browser_options[KEY]
           options['binary'] ||= Firefox.path if Firefox.path
           options['profile'] = @profile if @profile

--- a/rb/spec/integration/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/edge/options_spec.rb
@@ -52,14 +52,14 @@ module Selenium
           end
         end
 
-        # it 'should be able to run in headless mode with #headless!' do
-        #   options.headless!
-        #
-        #   create_driver!(capabilities: options) do |driver|
-        #     ua = driver.execute_script 'return window.navigator.userAgent'
-        #     expect(ua).to match(/HeadlessChrome/)
-        #   end
-        # end
+        it 'should be able to run in headless mode with #headless!' do
+          options.headless!
+
+          create_driver!(capabilities: options) do |driver|
+            ua = driver.execute_script 'return window.navigator.userAgent'
+            expect(ua).to match(/HeadlessChrome/)
+          end
+        end
       end
     end # Edge
   end # WebDriver

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -62,7 +62,7 @@ module Selenium
       end
 
       # https://github.com/mozilla/geckodriver/issues/245
-      it 'should send key presses chords', except: {browser: %i[firefox safari safari_preview]} do
+      it 'should send key presses chords', except: {browser: %i[firefox firefox_nightly safari safari_preview]} do
         driver.navigate.to url_for('javascriptPage.html')
         key_reporter = driver.find_element(id: 'keyReporter')
 

--- a/rb/spec/integration/selenium/webdriver/manager_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/manager_spec.rb
@@ -82,9 +82,9 @@ module Selenium
         end
 
         it 'should not allow domain to be set for localhost',
-           except: [{browser: %i[chrome edge],
-                     reason: "https://bugs.chromium.org/p/chromedriver/issues/detail?id=3733"},
-                    {browser: %i[safari safari_preview]}] do
+           exclude: [{browser: %i[chrome edge],
+                      reason: "https://bugs.chromium.org/p/chromedriver/issues/detail?id=3733"}],
+           except: {browser: %i[safari safari_preview]} do
           expect {
             driver.manage.add_cookie name: 'domain',
                                      value: 'localhost',
@@ -127,7 +127,7 @@ module Selenium
         end
 
         it 'should not add secure cookie when http',
-           except: {browser: :firefox,
+           except: {browser: %i[firefox firefox_nightly],
                     reason: 'https://github.com/mozilla/geckodriver/issues/1840'} do
           driver.manage.add_cookie name: 'secure',
                                    value: 'http',
@@ -149,7 +149,7 @@ module Selenium
         end
 
         context 'sameSite' do
-          it 'should allow adding with value Strict', only: {browser: %i[chrome edge firefox]} do
+          it 'should allow adding with value Strict', only: {browser: %i[chrome edge firefox firefox_nightly]} do
             driver.manage.add_cookie name: 'samesite',
                                      value: 'strict',
                                      same_site: 'Strict'
@@ -157,7 +157,7 @@ module Selenium
             expect(driver.manage.cookie_named('samesite')[:same_site]).to eq('Strict')
           end
 
-          it 'should allow adding with value Lax', only: {browser: %i[chrome edge firefox]} do
+          it 'should allow adding with value Lax', only: {browser: %i[chrome edge firefox firefox_nightly]} do
             driver.manage.add_cookie name: 'samesite',
                                      value: 'lax',
                                      same_site: 'Lax'
@@ -178,7 +178,7 @@ module Selenium
           end
 
           it 'should not allow adding with value None when secure is false',
-             except: [{browser: :firefox,
+             except: [{browser: %i[firefox firefox_nightly],
                        reason: "https://github.com/mozilla/geckodriver/issues/1842"},
                       {browser: %i[safari safari_preview]}] do
             expect {

--- a/rb/spec/integration/selenium/webdriver/spec_support/shared_examples/concurrent_driver.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/shared_examples/concurrent_driver.rb
@@ -18,16 +18,16 @@
 # under the License.
 
 shared_examples_for 'driver that can be started concurrently' do |guard|
-  before(:all) { quit_driver }
+  let(:drivers) { [] }
+  let(:threads) { [] }
+
+  before { quit_driver }
 
   after do
     drivers.each(&:quit)
     threads.select(&:alive?).each(&:kill)
     create_driver!
   end
-
-  let(:drivers) { [] }
-  let(:threads) { [] }
 
   it 'starts multiple drivers sequentially', guard do
     expected_count = WebDriver::Platform.ci ? 2 : 4

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -198,8 +198,14 @@ module Selenium
         end
 
         def create_firefox_driver(opt = {})
-          WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY'] if ENV['FIREFOX_BINARY']
+          WebDriver::Firefox.path = ENV['FIREFOX_BINARY'] if ENV['FIREFOX_BINARY']
           WebDriver::Driver.for :firefox, opt
+        end
+
+        def create_firefox_nightly_driver(opt = {})
+          ENV['FIREFOX_BINARY'] = ENV['FIREFOX_NIGHTLY_BINARY']
+          opt[:capabilities] = WebDriver::Firefox::Options.new(debugger_address: true)
+          create_firefox_driver(opt)
         end
 
         def create_ie_driver(opt = {})


### PR DESCRIPTION
This is a little hacky in parts, but it shows Firefox working with DevTools code;

Set `ENV["FIREFOX_NIGHT_BINARY"]` to the path of Firefox Nightly & run:
`./go //rb:firefox-nightly-test`

* Not sure what the plan is for version support from Firefox BiDi going forward, this hard codes it to v85 for now
* Chrome & Firefox log exceptions differently, so there's an ugly conditional
* Firefox registers events multiple times, so specs now say `>=` instead of `==`

It's rough, but it should be good enough to go into the beta I think.