### PR TITLE
Allow Remote WebDriver to access browser specific functionality

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -57,6 +57,7 @@ Metrics/ClassLength:
   CountComments: false
   Max: 160
   Exclude:
+    - 'lib/selenium/webdriver/common/driver.rb'
     - 'lib/selenium/webdriver/remote/bridge.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
 

--- a/rb/lib/selenium/webdriver/chrome.rb
+++ b/rb/lib/selenium/webdriver/chrome.rb
@@ -22,7 +22,7 @@ require 'net/http'
 module Selenium
   module WebDriver
     module Chrome
-      autoload :Bridge, 'selenium/webdriver/chrome/bridge'
+      autoload :Features, 'selenium/webdriver/chrome/features'
       autoload :Driver, 'selenium/webdriver/chrome/driver'
       autoload :Profile, 'selenium/webdriver/chrome/profile'
       autoload :Options, 'selenium/webdriver/chrome/options'

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -27,16 +27,16 @@ module Selenium
       #
 
       class Driver < WebDriver::Driver
-        include DriverExtensions::HasNetworkConditions
-        include DriverExtensions::HasNetworkInterception
-        include DriverExtensions::HasWebStorage
-        include DriverExtensions::HasLocation
-        include DriverExtensions::DownloadsFiles
-        include DriverExtensions::HasDevTools
-        include DriverExtensions::HasAuthentication
-        include DriverExtensions::HasLogs
-        include DriverExtensions::HasLogEvents
-        include DriverExtensions::PrintsPage
+        EXTENSIONS = [DriverExtensions::HasNetworkConditions,
+                      DriverExtensions::HasNetworkInterception,
+                      DriverExtensions::HasWebStorage,
+                      DriverExtensions::HasLocation,
+                      DriverExtensions::DownloadsFiles,
+                      DriverExtensions::HasDevTools,
+                      DriverExtensions::HasAuthentication,
+                      DriverExtensions::HasLogs,
+                      DriverExtensions::HasLogEvents,
+                      DriverExtensions::PrintsPage].freeze
 
         def browser
           :chrome

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -48,12 +48,8 @@ module Selenium
 
         private
 
-        def devtools_version
-          Integer(capabilities.browser_version.split('.').first)
-        end
-
-        def devtools_debugger_address
-          capabilities['goog:chromeOptions']['debuggerAddress']
+        def devtools_address
+          "http://#{capabilities['goog:chromeOptions']['debuggerAddress']}"
         end
 
       end # Driver

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -42,10 +42,6 @@ module Selenium
           :chrome
         end
 
-        def bridge_class
-          Bridge
-        end
-
         def execute_cdp(cmd, **params)
           @bridge.send_command(cmd: cmd, params: params)
         end

--- a/rb/lib/selenium/webdriver/chrome/features.rb
+++ b/rb/lib/selenium/webdriver/chrome/features.rb
@@ -20,9 +20,9 @@
 module Selenium
   module WebDriver
     module Chrome
-      class Bridge < WebDriver::Remote::Bridge
+      module Features
 
-        COMMANDS = {
+        CHROME_COMMANDS = {
           get_network_conditions: [:get, 'session/:session_id/chromium/network_conditions'],
           set_network_conditions: [:post, 'session/:session_id/chromium/network_conditions'],
           send_command: [:post, 'session/:session_id/goog/cdp/execute'],
@@ -31,7 +31,7 @@ module Selenium
         }.freeze
 
         def commands(command)
-          COMMANDS[command] || super
+          CHROME_COMMANDS[command] || self.class::COMMANDS[command]
         end
 
         def network_conditions

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -330,7 +330,7 @@ module Selenium
         bridge_opts = {http_client: opts.delete(:http_client), url: opts.delete(:url)}
         raise ArgumentError, "Unable to create a driver with parameters: #{opts}" unless opts.empty?
 
-        bridge = (respond_to?(:bridge_class) ? bridge_class : Remote::Bridge).new(**bridge_opts)
+        bridge = Remote::Bridge.new(**bridge_opts)
 
         bridge.create_session(capabilities)
         bridge

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -71,6 +71,7 @@ module Selenium
       def initialize(bridge: nil, listener: nil, **opts)
         @service = nil
         bridge ||= create_bridge(**opts)
+        add_extensions(bridge.browser)
         @bridge = listener ? Support::EventFiringBridge.new(bridge, listener) : bridge
       end
 
@@ -372,6 +373,20 @@ module Selenium
 
       def screenshot
         bridge.screenshot
+      end
+
+      def add_extensions(browser)
+        extensions = case browser
+                     when :chrome, :msedge
+                       Chrome::Driver::EXTENSIONS
+                     when :firefox
+                       Firefox::Driver::EXTENSIONS
+                     when :safari
+                       Safari::Driver::EXTENSIONS
+                     else
+                       []
+                     end
+        extensions.each { |extension| extend extension }
       end
     end # Driver
   end # WebDriver

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -381,7 +381,7 @@ module Selenium
                        Chrome::Driver::EXTENSIONS
                      when :firefox
                        Firefox::Driver::EXTENSIONS
-                     when :safari
+                     when :safari, :safari_technology_preview
                        Safari::Driver::EXTENSIONS
                      else
                        []

--- a/rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb
@@ -34,8 +34,16 @@ module Selenium
 
         private
 
+        def devtools_version
+          return Firefox::DEVTOOLS_VERSION if browser == :firefox
+
+          Integer(capabilities.browser_version.split('.').first)
+        end
+
         def devtools_url
-          uri = URI("http://#{devtools_debugger_address}")
+          return devtools_address if devtools_address.include?('/session/')
+
+          uri = URI(devtools_address)
           response = Net::HTTP.get(uri.hostname, '/json/version', uri.port)
 
           JSON.parse(response)['webSocketDebuggerUrl']

--- a/rb/lib/selenium/webdriver/edge.rb
+++ b/rb/lib/selenium/webdriver/edge.rb
@@ -22,7 +22,7 @@ require 'net/http'
 module Selenium
   module WebDriver
     module Edge
-      autoload :Bridge, 'selenium/webdriver/edge/bridge'
+      autoload :Features, 'selenium/webdriver/edge/features'
       autoload :Driver, 'selenium/webdriver/edge/driver'
       autoload :Profile, 'selenium/webdriver/edge/profile'
       autoload :Options, 'selenium/webdriver/edge/options'

--- a/rb/lib/selenium/webdriver/edge/driver.rb
+++ b/rb/lib/selenium/webdriver/edge/driver.rb
@@ -33,10 +33,6 @@ module Selenium
           :edge
         end
 
-        def bridge_class
-          Bridge
-        end
-
         private
 
         def devtools_debugger_address

--- a/rb/lib/selenium/webdriver/edge/driver.rb
+++ b/rb/lib/selenium/webdriver/edge/driver.rb
@@ -35,8 +35,8 @@ module Selenium
 
         private
 
-        def devtools_debugger_address
-          capabilities['ms:edgeOptions']['debuggerAddress']
+        def devtools_address
+          "http://#{capabilities['ms:edgeOptions']['debuggerAddress']}"
         end
       end # Driver
     end # Edge

--- a/rb/lib/selenium/webdriver/edge/features.rb
+++ b/rb/lib/selenium/webdriver/edge/features.rb
@@ -17,35 +17,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'selenium/webdriver/chrome/features'
+
 module Selenium
   module WebDriver
-    module Safari
-      class Bridge < WebDriver::Remote::Bridge
+    module Edge
+      module Features
 
-        # https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/WebDriverEndpointDoc/Commands/Commands.html
-        COMMANDS = {
-          get_permissions: [:get, 'session/:session_id/apple/permissions'],
-          set_permissions: [:post, 'session/:session_id/apple/permissions'],
-          attach_debugger: [:post, 'session/:session_id/apple/attach_debugger']
+        include WebDriver::Chrome::Features
+
+        EDGE_COMMANDS = {
+          send_command: [:post, 'session/:session_id/ms/cdp/execute']
         }.freeze
 
         def commands(command)
-          COMMANDS[command] || super
+          EDGE_COMMANDS[command] || Chrome::Features::CHROME_COMMANDS[command] || self.class::COMMANDS[command]
         end
-
-        def permissions
-          execute(:get_permissions)['permissions']
-        end
-
-        def permissions=(permissions)
-          execute :set_permissions, {}, {permissions: permissions}
-        end
-
-        def attach_debugger
-          execute :attach_debugger, {}, {}
-        end
-
       end # Bridge
-    end # Safari
+    end # Edge
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -27,7 +27,7 @@ module Selenium
       autoload :Extension, 'selenium/webdriver/firefox/extension'
       autoload :ProfilesIni, 'selenium/webdriver/firefox/profiles_ini'
       autoload :Profile, 'selenium/webdriver/firefox/profile'
-      autoload :Bridge, 'selenium/webdriver/firefox/bridge'
+      autoload :Features, 'selenium/webdriver/firefox/features'
       autoload :Driver, 'selenium/webdriver/firefox/driver'
       autoload :Options, 'selenium/webdriver/firefox/options'
       autoload :Service, 'selenium/webdriver/firefox/service'

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -27,12 +27,12 @@ module Selenium
       #
 
       class Driver < WebDriver::Driver
-        include DriverExtensions::HasAddons
-        include DriverExtensions::HasDevTools
-        include DriverExtensions::HasLogEvents
-        include DriverExtensions::HasNetworkInterception
-        include DriverExtensions::HasWebStorage
-        include DriverExtensions::PrintsPage
+        EXTENSIONS = [DriverExtensions::HasAddons,
+                      DriverExtensions::HasDevTools,
+                      DriverExtensions::HasLogEvents,
+                      DriverExtensions::HasNetworkInterception,
+                      DriverExtensions::HasWebStorage,
+                      DriverExtensions::PrintsPage].freeze
 
         def browser
           :firefox

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -38,10 +38,6 @@ module Selenium
           :firefox
         end
 
-        def bridge_class
-          Bridge
-        end
-
         private
 
         def devtools_version

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -40,12 +40,8 @@ module Selenium
 
         private
 
-        def devtools_version
-          DEVTOOLS_VERSION
-        end
-
-        def devtools_debugger_address
-          capabilities['moz:debuggerAddress']
+        def devtools_address
+          "http://#{capabilities['moz:debuggerAddress']}"
         end
       end # Driver
     end # Firefox

--- a/rb/lib/selenium/webdriver/firefox/features.rb
+++ b/rb/lib/selenium/webdriver/firefox/features.rb
@@ -17,21 +17,31 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'selenium/webdriver/chrome/bridge'
-
 module Selenium
   module WebDriver
-    module Edge
-      class Bridge < WebDriver::Chrome::Bridge
+    module Firefox
+      module Features
 
-        COMMANDS = WebDriver::Chrome::Bridge::COMMANDS.merge(
-          send_command: [:post, 'session/:session_id/ms/cdp/execute']
-        ).freeze
+        FIREFOX_COMMANDS = {
+          install_addon: [:post, 'session/:session_id/moz/addon/install'],
+          uninstall_addon: [:post, 'session/:session_id/moz/addon/uninstall']
+        }.freeze
 
         def commands(command)
-          COMMANDS[command] || super
+          FIREFOX_COMMANDS[command] || self.class::COMMANDS[command]
         end
+
+        def install_addon(path, temporary)
+          payload = {path: path}
+          payload[:temporary] = temporary unless temporary.nil?
+          execute :install_addon, {}, payload
+        end
+
+        def uninstall_addon(id)
+          execute :uninstall_addon, {}, {id: id}
+        end
+
       end # Bridge
-    end # Edge
+    end # Firefox
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -28,7 +28,7 @@ module Selenium
       #
 
       class Driver < WebDriver::Driver
-        include DriverExtensions::HasWebStorage
+        EXTENSIONS = [DriverExtensions::HasWebStorage].freeze
 
         def browser
           :internet_explorer

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -57,6 +57,17 @@ module Selenium
           raise Error::WebDriverError, 'no sessionId in returned payload' unless @session_id
 
           @capabilities = Capabilities.json_create(capabilities)
+
+          case @capabilities[:browser_name]
+          when 'chrome'
+            extend(WebDriver::Chrome::Features)
+          when 'firefox'
+            extend(WebDriver::Firefox::Features)
+          when 'msedge'
+            extend(WebDriver::Edge::Features)
+          when 'safari'
+            extend(WebDriver::Safari::Features)
+          end
         end
 
         #

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -65,7 +65,7 @@ module Selenium
             extend(WebDriver::Firefox::Features)
           when 'msedge'
             extend(WebDriver::Edge::Features)
-          when 'safari'
+          when 'Safari', 'Safari Technology Preview'
             extend(WebDriver::Safari::Features)
           end
         end
@@ -81,7 +81,7 @@ module Selenium
         def browser
           @browser ||= begin
             name = @capabilities.browser_name
-            name ? name.tr(' ', '_').to_sym : 'unknown'
+            name ? name.tr(' ', '_').downcase.to_sym : 'unknown'
           end
         end
 

--- a/rb/lib/selenium/webdriver/remote/driver.rb
+++ b/rb/lib/selenium/webdriver/remote/driver.rb
@@ -52,13 +52,7 @@ module Selenium
 
         private
 
-        def devtools_version
-          return Firefox::DEVTOOLS_VERSION if browser == :firefox
-
-          Integer(capabilities.browser_version.split('.').first)
-        end
-
-        def devtools_url
+        def devtools_address
           capabilities['se:cdp']
         end
       end # Driver

--- a/rb/lib/selenium/webdriver/remote/driver.rb
+++ b/rb/lib/selenium/webdriver/remote/driver.rb
@@ -30,11 +30,6 @@ module Selenium
         include DriverExtensions::UploadsFiles
         include DriverExtensions::HasSessionId
         include DriverExtensions::HasRemoteStatus
-        include DriverExtensions::HasWebStorage
-        include DriverExtensions::HasDevTools
-        include DriverExtensions::HasAuthentication
-        include DriverExtensions::HasLogEvents
-        include DriverExtensions::HasNetworkInterception
 
         def initialize(bridge: nil, listener: nil, **opts)
           desired_capabilities = opts[:desired_capabilities]

--- a/rb/lib/selenium/webdriver/safari.rb
+++ b/rb/lib/selenium/webdriver/safari.rb
@@ -20,7 +20,7 @@
 module Selenium
   module WebDriver
     module Safari
-      autoload :Bridge, 'selenium/webdriver/safari/bridge'
+      autoload :Features, 'selenium/webdriver/safari/features'
       autoload :Driver, 'selenium/webdriver/safari/driver'
       autoload :Options, 'selenium/webdriver/safari/options'
       autoload :Service, 'selenium/webdriver/safari/service'

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -34,10 +34,6 @@ module Selenium
         def browser
           :safari
         end
-
-        def bridge_class
-          Bridge
-        end
       end # Driver
     end # Safari
   end # WebDriver

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -27,9 +27,9 @@ module Selenium
       #
 
       class Driver < WebDriver::Driver
-        include DriverExtensions::HasDebugger
-        include DriverExtensions::HasPermissions
-        include DriverExtensions::HasWebStorage
+        EXTENSIONS = [DriverExtensions::HasDebugger,
+                      DriverExtensions::HasPermissions,
+                      DriverExtensions::HasWebStorage].freeze
 
         def browser
           :safari

--- a/rb/lib/selenium/webdriver/safari/features.rb
+++ b/rb/lib/selenium/webdriver/safari/features.rb
@@ -19,29 +19,33 @@
 
 module Selenium
   module WebDriver
-    module Firefox
-      class Bridge < WebDriver::Remote::Bridge
+    module Safari
+      module Features
 
-        COMMANDS = {
-          install_addon: [:post, 'session/:session_id/moz/addon/install'],
-          uninstall_addon: [:post, 'session/:session_id/moz/addon/uninstall']
+        # https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/WebDriverEndpointDoc/Commands/Commands.html
+        SAFARI_COMMANDS = {
+          get_permissions: [:get, 'session/:session_id/apple/permissions'],
+          set_permissions: [:post, 'session/:session_id/apple/permissions'],
+          attach_debugger: [:post, 'session/:session_id/apple/attach_debugger']
         }.freeze
 
         def commands(command)
-          COMMANDS[command] || super
+          SAFARI_COMMANDS[command] || self.class::COMMANDS[command]
         end
 
-        def install_addon(path, temporary)
-          payload = {path: path}
-          payload[:temporary] = temporary unless temporary.nil?
-          execute :install_addon, {}, payload
+        def permissions
+          execute(:get_permissions)['permissions']
         end
 
-        def uninstall_addon(id)
-          execute :uninstall_addon, {}, {id: id}
+        def permissions=(permissions)
+          execute :set_permissions, {}, {permissions: permissions}
+        end
+
+        def attach_debugger
+          execute :attach_debugger, {}, {}
         end
 
       end # Bridge
-    end # Firefox
+    end # Safari
   end # WebDriver
 end # Selenium

--- a/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
@@ -22,7 +22,7 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module Chrome
-      describe Driver, exclusive: {driver: :chrome} do
+      describe Driver, exclusive: {browser: :chrome} do
         it 'gets and sets network conditions' do
           driver.network_conditions = {offline: false, latency: 56, throughput: 789}
           expect(driver.network_conditions).to eq(
@@ -39,7 +39,7 @@ module Selenium
           # at least it doesn't crash
         end
 
-        it 'can execute CDP commands' do
+        it 'can execute CDP commands', only: {driver: :chrome} do
           res = driver.execute_cdp('Page.addScriptToEvaluateOnNewDocument', source: 'window.was_here="TW";')
           expect(res).to have_key('identifier')
 

--- a/rb/spec/integration/selenium/webdriver/edge/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/edge/driver_spec.rb
@@ -22,7 +22,7 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module Edge
-      describe Driver, exclusive: {driver: :edge} do
+      describe Driver, exclusive: {browser: :edge} do
         it 'gets and sets network conditions' do
           driver.network_conditions = {offline: false, latency: 56, throughput: 789}
           expect(driver.network_conditions).to eq(

--- a/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
@@ -22,7 +22,7 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module Firefox
-      describe Driver, exclusive: {driver: :firefox} do
+      describe Driver, exclusive: {browser: :firefox} do
         describe '#print_options' do
           let(:magic_number) { 'JVBER' }
 

--- a/rb/spec/integration/selenium/webdriver/safari/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/safari/driver_spec.rb
@@ -22,7 +22,7 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module Safari
-      describe Driver, exclusive: {driver: %i[safari safari_preview]} do
+      describe Driver, exclusive: {browser: %i[safari safari_preview]} do
         it 'gets and sets permissions' do
           driver.permissions = {'getUserMedia' => false}
           expect(driver.permissions).to eq('getUserMedia' => false)

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -119,7 +119,10 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
 
-        before { allow(Remote::Bridge).to receive(:new).and_return(bridge) }
+        before do
+          allow(Remote::Bridge).to receive(:new).and_return(bridge)
+          allow(bridge).to receive(:browser).and_return(:chrome)
+        end
 
         it 'is not created when :url is provided' do
           expect(Service).not_to receive(:new)

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -108,7 +108,10 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
 
-        before { allow(Remote::Bridge).to receive(:new).and_return(bridge) }
+        before do
+          allow(Remote::Bridge).to receive(:new).and_return(bridge)
+          allow(bridge).to receive(:browser).and_return(:msedge)
+        end
 
         it 'is not created when :url is provided' do
           expect(Service).not_to receive(:new)

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -119,6 +119,7 @@ module Selenium
 
         before do
           allow(Remote::Bridge).to receive(:new).and_return(bridge)
+          allow(bridge).to receive(:browser).and_return(:firefox)
         end
 
         it 'is not created when :url is provided' do

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -121,6 +121,7 @@ module Selenium
         before do
           allow(Remote::Bridge).to receive(:new).and_return(bridge)
           allow(ServiceManager).to receive(:new).and_return(service_manager)
+          allow(bridge).to receive(:browser).and_return(:internet_explorer)
         end
 
         it 'is not created when :url is provided' do

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -112,6 +112,7 @@ module Selenium
         before do
           allow(Remote::Bridge).to receive(:new).and_return(bridge)
           allow(ServiceManager).to receive(:new).and_return(service_manager)
+          allow(bridge).to receive(:browser).and_return(:safari)
         end
 
         it 'is not created when :url is provided' do

--- a/rb/spec/unit/selenium/webdriver/support/event_firing_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/support/event_firing_spec.rb
@@ -29,6 +29,8 @@ module Selenium
         let(:driver) { Driver.new(bridge: event_firing_bridge) }
         let(:element) { Element.new(event_firing_bridge, 'ref') }
 
+        before { allow(bridge).to receive(:browser) }
+
         context 'navigation' do
           it 'fires events for navigate.to' do
             url = 'http://example.com'


### PR DESCRIPTION
Current code prevents accessing browser specific functionality via remote server, which should be fixed.

This works, but I'm not sure if it is the best solution. Any suggestions?

`Bridge` is a private API, and it doesn't look like this affects Ruby Appium, Watir or Capybara. 
