### PR TITLE
[grid] Setting Netty client pool size to 1

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/http/netty/NettyClient.java
+++ b/java/client/src/org/openqa/selenium/remote/http/netty/NettyClient.java
@@ -18,9 +18,7 @@
 package org.openqa.selenium.remote.http.netty;
 
 import com.google.auto.service.AutoService;
-import io.netty.util.HashedWheelTimer;
-import io.netty.util.Timer;
-import io.netty.util.concurrent.DefaultThreadFactory;
+
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.Dsl;
@@ -35,6 +33,10 @@ import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.WebSocket;
 
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.concurrent.ThreadFactory;
@@ -42,7 +44,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
 public class NettyClient implements HttpClient {
+
   private static final Timer TIMER;
+
   static {
     ThreadFactory threadFactory = new DefaultThreadFactory("netty-client-timer", true);
     HashedWheelTimer timer = new HashedWheelTimer(
@@ -53,6 +57,7 @@ public class NettyClient implements HttpClient {
     timer.start();
     TIMER = timer;
   }
+
   private final ClientConfig config;
   private final AsyncHttpClient client;
   private final HttpHandler handler;
@@ -76,7 +81,8 @@ public class NettyClient implements HttpClient {
         .setNettyTimer(TIMER)
         .setRequestTimeout(toClampedInt(config.readTimeout().toMillis()))
         .setConnectTimeout(toClampedInt(config.connectionTimeout().toMillis()))
-        .setReadTimeout(toClampedInt(config.readTimeout().toMillis()));
+        .setReadTimeout(toClampedInt(config.readTimeout().toMillis()))
+        .setIoThreadsCount(1);
 
     return Dsl.asyncHttpClient(builder);
   }


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The AsyncHttpClient has built in a thread pool
to handle connections and the pool was growing
based on the way we use the client. As a result,
we were having many threads that kept objects in
memory that were not getting released, a memory
leak.

This is not an issue in the AsyncHttpClient but
most likely in the way we use the client.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To prevent memory from leaking. This is a fix for #9152

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
