### PR TITLE
Attribute & Property Methods

### DIFF
--- a/dotnet/src/webdriver/Remote/RemoteWebElement.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebElement.cs
@@ -417,7 +417,7 @@ namespace OpenQA.Selenium.Remote
         /// </item>
         /// </list>
         /// The method looks both in declared attributes in the HTML markup of the page, and
-        /// in the properties of the elemnt as found when accessing the element's properties
+        /// in the properties of the element as found when accessing the element's properties
         /// via JavaScript.
         /// </remarks>
         /// <exception cref="StaleElementReferenceException">Thrown when the target element is no longer valid in the document DOM.</exception>
@@ -452,13 +452,13 @@ namespace OpenQA.Selenium.Remote
         /// <summary>
         /// Gets the value of a declared HTML attribute of this element.
         /// </summary>
-        /// <param name="attributeName">The name of the HTML attribugte to get the value of.</param>
+        /// <param name="attributeName">The name of the HTML attribute to get the value of.</param>
         /// <returns>The HTML attribute's current value. Returns a <see langword="null"/> if the
         /// value is not set or the declared attribute does not exist.</returns>
         /// <exception cref="StaleElementReferenceException">Thrown when the target element is no longer valid in the document DOM.</exception>
         /// <remarks>
         /// As opposed to the <see cref="GetAttribute(string)"/> method, this method
-        /// only returns attriibutes decalred in the element's HTML markup. To access the value
+        /// only returns attributes declared in the element's HTML markup. To access the value
         /// of an IDL property of the element, either use the <see cref="GetAttribute(string)"/>
         /// method or the <see cref="GetDomProperty(string)"/> method.
         /// </remarks>

--- a/java/client/src/org/openqa/selenium/WebElement.java
+++ b/java/client/src/org/openqa/selenium/WebElement.java
@@ -108,8 +108,7 @@ public interface WebElement extends SearchContext, TakesScreenshot {
   }
 
   /**
-   * Get the value of the given attribute of the element. Will return the current value, even if
-   * this has been modified after the page has been loaded.
+   * Get the value of the given attribute of the element.
    * <p>
    * This method, unlike {@link #getAttribute(String)}, returns the value of the attribute with the
    * given name but not the property with the same name.
@@ -126,7 +125,7 @@ public interface WebElement extends SearchContext, TakesScreenshot {
    * for more details.
    *
    * @param name The name of the attribute.
-   * @return The attribute's current value or null if the value is not set.
+   * @return The attribute's value or null if the value is not set.
    */
   default String getDomAttribute(String name) {
     throw new UnsupportedOperationException();
@@ -158,9 +157,8 @@ public interface WebElement extends SearchContext, TakesScreenshot {
    * <li>If the given name is "readonly", the "readOnly" property is returned.
    * </ul>
    * <i>Note:</i> The reason for this behavior is that users frequently confuse attributes and
-   * properties. If you need to do something more precise, e.g., refer to an attribute even when a
-   * property of the same name exists, then you should evaluate Javascript to obtain the result
-   * you desire.
+   * properties. If you need to do something more precise, use {@link #getDomAttribute(String)}
+   * or {@link #getDomProperty(String)} to obtain the result you desire.
    * <p>
    * See <a href="https://w3c.github.io/webdriver/#get-element-attribute">W3C WebDriver specification</a>
    * for more details.

--- a/java/client/src/org/openqa/selenium/support/ui/Select.java
+++ b/java/client/src/org/openqa/selenium/support/ui/Select.java
@@ -51,7 +51,7 @@ public class Select implements ISelect, WrapsElement {
 
     this.element = element;
 
-    String value = element.getAttribute("multiple");
+    String value = element.getDomAttribute("multiple");
 
     // The atoms normalize the returned value, but check for "false"
     isMulti = (value != null && !"false".equals(value));

--- a/java/client/test/org/openqa/selenium/support/ui/SelectTest.java
+++ b/java/client/test/org/openqa/selenium/support/ui/SelectTest.java
@@ -74,7 +74,7 @@ public class SelectTest {
   private WebElement mockSelectWebElement(String multiple) {
     final WebElement element = mock(WebElement.class);
     when(element.getTagName()).thenReturn("select");
-    when(element.getAttribute("multiple")).thenReturn(multiple);
+    when(element.getDomAttribute("multiple")).thenReturn(multiple);
     return element;
   }
 
@@ -249,7 +249,7 @@ public class SelectTest {
 
     final WebElement element = mockSelectWebElement("multiple");
     when(element.getTagName()).thenReturn("select");
-    when(element.getAttribute("multiple")).thenReturn("false");
+    when(element.getDomAttribute("multiple")).thenReturn("false");
     when(element.findElements(xpath1)).thenReturn(emptyList());
     when(element.findElements(xpath2)).thenReturn(Collections.singletonList(firstOption));
     when(firstOption.getText()).thenReturn("foo bar");

--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -109,6 +109,21 @@ class WebElement(BaseWebElement):
             # if we hit an end point that doesnt understand getElementProperty lets fake it
             return self.parent.execute_script('return arguments[0][arguments[1]]', self, name)
 
+    def get_dom_attribute(self, name) -> str:
+        """
+        Gets the given attribute of the element. Unlike :func:`~selenium.webdriver.remote.BaseWebElement.get_attribute`,
+        this method only returns attributes declared in the element's HTML markup.
+
+        :Args:
+            - name - Name of the attribute to retrieve.
+
+        :Usage:
+            ::
+
+                text_length = target_element.get_dom_attribute("class")
+        """
+        return self._execute(Command.GET_ELEMENT_ATTRIBUTE, {"name": name})["value"]
+
     def get_attribute(self, name) -> str:
         """Gets the given attribute or property of the element.
 
@@ -121,6 +136,10 @@ class WebElement(BaseWebElement):
         are returned as booleans.  All other non-``None`` values are returned
         as strings.  For attributes or properties which do not exist, ``None``
         is returned.
+
+        To obtain the exact value of the attribute or property,
+        use :func:`~selenium.webdriver.remote.BaseWebElement.get_dom_attribute` or
+        :func:`~selenium.webdriver.remote.BaseWebElement.get_property` methods respectively.
 
         :Args:
             - name - Name of the attribute/property to retrieve.

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -38,7 +38,7 @@ class Select(object):
                 "Select only works on <select> elements, not on <%s>" %
                 webelement.tag_name)
         self._el = webelement
-        multi = self._el.get_attribute("multiple")
+        multi = self._el.get_dom_attribute("multiple")
         self.is_multiple = multi and multi != "false"
 
     @property

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -174,6 +174,22 @@ def testGetImplicitAttribute(driver, pages):
         assert i == int(elem.get_attribute("index"))
 
 
+def testGetDomAttribute(driver, pages):
+    url = pages.url('formPage.html')
+    driver.get(url)
+    elem = driver.find_element(By.ID, "vsearchGadget")
+    attr = elem.get_dom_attribute("accesskey")
+    assert "4" == attr
+
+
+def testGetProperty(driver, pages):
+    url = pages.url('formPage.html')
+    driver.get(url)
+    elem = driver.find_element(By.ID, "withText")
+    prop = elem.get_property("value")
+    assert "Example text" == prop
+
+
 def testExecuteSimpleScript(driver, pages):
     pages.load("xhtmlTest.html")
     title = driver.execute_script("return document.title;")

--- a/rb/lib/selenium/webdriver/common/element.rb
+++ b/rb/lib/selenium/webdriver/common/element.rb
@@ -92,13 +92,18 @@ module Selenium
       end
 
       #
-      # Get the value of a the given attribute of the element. Will return the current value, even if
-      # this has been modified after the page has been loaded. More exactly, this method will return
-      # the value of the given attribute, unless that attribute is not present, in which case the
-      # value of the property with the same name is returned. If neither value is set, nil is
-      # returned. The "style" attribute is converted as best can be to a text representation with a
-      # trailing semi-colon. The following are deemed to be "boolean" attributes, and will
-      # return either "true" or "false":
+      # This method attempts to provide the most likely desired current value for the attribute
+      # of the element, even when that desired value is actually a JavaScript property.
+      # It is implemented with a custom JavaScript atom. To obtain the exact value of the attribute or property,
+      # use #dom_attribute or #property methods respectively.
+      #
+      # More exactly, this method will return the value of the property with the given name,
+      # if it exists. If it does not, then the value of the attribute with the given name is returned.
+      # If neither exists, null is returned.
+      #
+      # The "style" attribute is converted as best can be to a text representation with a trailing semi-colon.
+      #
+      # The following are deemed to be "boolean" attributes, and will return either "true" or "false":
       #
       # async, autofocus, autoplay, checked, compact, complete, controls, declare, defaultchecked,
       # defaultselected, defer, disabled, draggable, ended, formnovalidate, hidden, indeterminate,
@@ -106,13 +111,16 @@ module Selenium
       # nowrap, open, paused, pubdate, readonly, required, reversed, scoped, seamless, seeking,
       # selected, spellcheck, truespeed, willvalidate
       #
-      # Finally, the following commonly mis-capitalized attribute/property names are evaluated as
-      # expected:
+      # Finally, the following commonly mis-capitalized attribute/property names are evaluated as expected:
       #
-      # class, readonly
+      # When the value of "class" is requested, the "className" property is returned.
+      # When the value of "readonly" is requested, the "readOnly" property is returned.
       #
       # @param [String] name attribute name
       # @return [String, nil] attribute value
+      #
+      # @see #dom_attribute
+      # @see #property
       #
 
       def attribute(name)
@@ -120,8 +128,29 @@ module Selenium
       end
 
       #
-      # Get the value of a the given property with the same name of the element. If the value is not
-      # set, nil is returned.
+      # Gets the value of a declared HTML attribute of this element.
+      #
+      # As opposed to the #attribute method, this method
+      # only returns attributes declared in the element's HTML markup.
+      #
+      # If the attribute is not set, nil is returned.
+      #
+      # @param [String] name attribute name
+      # @return [String, nil] attribute value
+      #
+      # @see #attribute
+      # @see #property
+      #
+
+      def dom_attribute(name)
+        bridge.element_dom_attribute self, name
+      end
+
+      #
+      # Gets the value of a JavaScript property of this element
+      # This will return the current value,
+      # even if this has been modified after the page has been loaded.
+      # If the value is not set, nil is returned.
       #
       # @param [String] name property name
       # @return [String, nil] property value

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -439,6 +439,10 @@ module Selenium
           execute_atom :getAttribute, element, name
         end
 
+        def element_dom_attribute(element, name)
+          execute :get_element_attribute, id: element.ref, name: name
+        end
+
         def element_property(element, name)
           execute :get_element_property, id: element.ref, name: name
         end

--- a/rb/lib/selenium/webdriver/support/select.rb
+++ b/rb/lib/selenium/webdriver/support/select.rb
@@ -31,7 +31,7 @@ module Selenium
           raise ArgumentError, "unexpected tag name #{tag_name.inspect}" unless tag_name.casecmp('select').zero?
 
           @element = element
-          @multi = ![nil, 'false'].include?(element.attribute(:multiple))
+          @multi = ![nil, 'false'].include?(element.dom_attribute(:multiple))
         end
 
         #
@@ -258,7 +258,7 @@ module Selenium
         end
 
         def find_by_index(index)
-          options.select { |option| option.attribute(:index) == index.to_s }
+          options.select { |option| option.dom_attribute(:index) == index.to_s }
         end
 
         def find_by_value(value)

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -83,19 +83,309 @@ module Selenium
         expect(element.attribute('value')).to include(File.basename(path))
       end
 
-      it 'should get attribute value' do
-        driver.navigate.to url_for('formPage.html')
-        expect(driver.find_element(id: 'withText').attribute('rows')).to eq('5')
-      end
+      describe 'properties and attributes' do
+        before { driver.navigate.to url_for('formPage.html') }
 
-      it 'should return nil for non-existent attributes' do
-        driver.navigate.to url_for('formPage.html')
-        expect(driver.find_element(id: 'withText').attribute('nonexistent')).to be_nil
-      end
+        context 'string type' do
+          let(:element) { driver.find_element(id: 'checky') }
+          let(:prop_or_attr) { 'type' }
 
-      it 'should get property value' do
-        driver.navigate.to url_for('formPage.html')
-        expect(driver.find_element(id: 'withText').property('nodeName')).to eq('TEXTAREA')
+          it '#dom_attribute returns attribute value' do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'checkbox'
+          end
+
+          it '#property returns property value' do
+            expect(element.property(prop_or_attr)).to eq 'checkbox'
+          end
+
+          it '#attribute returns value' do
+            expect(element.attribute(prop_or_attr)).to eq 'checkbox'
+          end
+        end
+
+        context 'numeric type' do
+          let(:element) { driver.find_element(id: 'withText') }
+          let(:prop_or_attr) { 'rows' }
+
+          it '#dom_attribute String' do
+            expect(element.dom_attribute(prop_or_attr)).to eq '5'
+          end
+
+          it '#property returns Number' do
+            expect(element.property(prop_or_attr)).to eq 5
+          end
+
+          it '#attribute returns String' do
+            expect(element.attribute(prop_or_attr)).to eq '5'
+          end
+        end
+
+        context 'boolean type of true' do
+          let(:element) { driver.find_element(id: 'checkedchecky') }
+          let(:prop_or_attr) { 'checked' }
+
+          it '#dom_attribute returns String', except: {browser: :safari} do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'true'
+          end
+
+          it '#property returns true' do
+            expect(element.property(prop_or_attr)).to eq true
+          end
+
+          it '#attribute returns String' do
+            expect(element.attribute(prop_or_attr)).to eq 'true'
+          end
+
+          it '#dom_attribute does not update after click',
+             except: [{browser: %i[chrome edge],
+                       reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'},
+                      {browser: :safari}] do
+            element.click
+            expect(element.dom_attribute(prop_or_attr)).to eq 'true'
+          end
+
+          it '#property updates to false after click' do
+            element.click
+            expect(element.property(prop_or_attr)).to eq false
+          end
+
+          it '#attribute updates to nil after click' do
+            element.click
+            expect(element.attribute(prop_or_attr)).to eq nil
+          end
+        end
+
+        context 'boolean type of false' do
+          let(:element) { driver.find_element(id: 'checky') }
+          let(:prop_or_attr) { 'checked' }
+
+          it '#dom_attribute returns nil' do
+            expect(element.dom_attribute(prop_or_attr)).to be_nil
+          end
+
+          it '#property returns false' do
+            expect(element.property(prop_or_attr)).to eq false
+          end
+
+          it '#attribute returns nil' do
+            expect(element.attribute(prop_or_attr)).to be_nil
+          end
+
+          it '#dom_attribute does not update after click',
+             except: [{browser: %i[chrome edge],
+                       reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'},
+                      {browser: :safari}] do
+            element.click
+            expect(element.dom_attribute(prop_or_attr)).to eq nil
+          end
+
+          it '#property updates to true after click' do
+            element.click
+            expect(element.property(prop_or_attr)).to eq true
+          end
+
+          it '#attribute updates to String after click' do
+            element.click
+            expect(element.attribute(prop_or_attr)).to eq 'true'
+          end
+        end
+
+        context 'property exists but attribute does not' do
+          let(:element) { driver.find_element(id: 'withText') }
+          let(:prop_or_attr) { 'value' }
+
+          it '#dom_attribute returns nil',
+             except: {browser: %i[chrome edge],
+                      reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'} do
+            expect(element.dom_attribute(prop_or_attr)).to be_nil
+          end
+
+          it '#property returns default property' do
+            expect(element.property(prop_or_attr)).to eq 'Example text'
+          end
+
+          it '#attribute returns default property' do
+            expect(element.attribute(prop_or_attr)).to eq 'Example text'
+          end
+
+          it '#property returns updated property' do
+            element.clear
+            expect(element.property(prop_or_attr)).to be_empty
+          end
+
+          it '#attribute returns updated property' do
+            element.clear
+            expect(element.attribute(prop_or_attr)).to be_empty
+          end
+        end
+
+        context 'attribute exists but property does not' do
+          let(:element) { driver.find_element(id: 'vsearchGadget') }
+          let(:prop_or_attr) { 'accesskey' }
+
+          it '#dom_attribute returns attribute' do
+            expect(element.dom_attribute(prop_or_attr)).to eq '4'
+          end
+
+          it '#property returns nil' do
+            expect(element.property(prop_or_attr)).to be_nil
+          end
+
+          it '#attribute returns attribute' do
+            expect(element.attribute(prop_or_attr)).to eq '4'
+          end
+        end
+
+        context 'neither attribute nor property exists' do
+          let(:element) { driver.find_element(id: 'checky') }
+          let(:prop_or_attr) { 'nonexistent' }
+
+          it '#dom_attribute returns nil' do
+            expect(element.dom_attribute(prop_or_attr)).to be_nil
+          end
+
+          it '#property returns nil' do
+            expect(element.property(prop_or_attr)).to be_nil
+          end
+
+          it '#attribute returns nil' do
+            expect(element.attribute(prop_or_attr)).to be_nil
+          end
+        end
+
+        context 'style' do
+          before { driver.navigate.to url_for('clickEventPage.html') }
+
+          let(:element) { driver.find_element(id: 'result') }
+          let(:prop_or_attr) { 'style' }
+
+          it '#dom_attribute attribute with no formatting',
+             except: {browser: %i[chrome edge],
+                      reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'} do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'width:300;height:60'
+          end
+
+          # TODO: This might not be correct behavior
+          it '#property returns object',
+             except: [{browser: :firefox,
+                       reason: 'https://github.com/mozilla/geckodriver/issues/1846'},
+                      {browser: :safari}] do
+            expect(element.property(prop_or_attr)).to eq %w[width height]
+          end
+
+          it '#attribute returns attribute with formatting' do
+            expect(element.attribute(prop_or_attr)).to eq 'width: 300px; height: 60px;'
+          end
+        end
+
+        context 'incorrect casing' do
+          let(:element) { driver.find_element(id: 'checky') }
+          let(:prop_or_attr) { 'nAme' }
+
+          it '#dom_attribute returns correctly cased attribute' do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'checky'
+          end
+
+          it '#property returns nil' do
+            expect(element.property(prop_or_attr)).to be_nil
+          end
+
+          it '#attribute returns correctly cased attribute' do
+            expect(element.attribute(prop_or_attr)).to eq 'checky'
+          end
+        end
+
+        context 'property attribute case difference with attribute casing' do
+          let(:element) { driver.find_element(name: 'readonly') }
+          let(:prop_or_attr) { 'readonly' }
+
+          it '#dom_attribute returns a String', except: {browser: :safari} do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'true'
+          end
+
+          it '#property returns nil' do
+            expect(element.property(prop_or_attr)).to be_nil
+          end
+
+          it '#attribute returns a String' do
+            expect(element.attribute(prop_or_attr)).to eq 'true'
+          end
+        end
+
+        context 'property attribute case difference with property casing' do
+          let(:element) { driver.find_element(name: 'readonly') }
+          let(:prop_or_attr) { 'readOnly' }
+
+          it '#dom_attribute returns a String',
+             except: [{browser: :firefox,
+                       reason: 'https://github.com/mozilla/geckodriver/issues/1850'},
+                      {browser: :safari}] do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'true'
+          end
+
+          it '#property returns property as true' do
+            expect(element.property(prop_or_attr)).to eq true
+          end
+
+          it '#attribute returns property as String' do
+            expect(element.attribute(prop_or_attr)).to eq 'true'
+          end
+        end
+
+        context 'property attribute name difference with attribute naming' do
+          let(:element) { driver.find_element(id: 'wallace') }
+          let(:prop_or_attr) { 'class' }
+
+          it '#dom_attribute returns attribute value' do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'gromit'
+          end
+
+          it '#property returns nil' do
+            expect(element.property(prop_or_attr)).to be_nil
+          end
+
+          it '#attribute returns attribute value' do
+            expect(element.attribute(prop_or_attr)).to eq 'gromit'
+          end
+        end
+
+        context 'property attribute name difference with property naming' do
+          let(:element) { driver.find_element(id: 'wallace') }
+          let(:prop_or_attr) { 'className' }
+
+          it '#dom_attribute returns nil',
+             except: {browser: %i[chrome edge],
+                      reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'} do
+            expect(element.dom_attribute(prop_or_attr)).to be_nil
+          end
+
+          it '#property returns property value' do
+            expect(element.property(prop_or_attr)).to eq 'gromit'
+          end
+
+          it '#attribute returns property value' do
+            expect(element.attribute(prop_or_attr)).to eq 'gromit'
+          end
+        end
+
+        context 'property attribute value difference' do
+          let(:element) { driver.find_element(tag_name: 'form') }
+          let(:prop_or_attr) { 'action' }
+
+          it '#dom_attribute returns attribute value',
+             except: {browser: %i[chrome edge],
+                      reason: 'https://bugs.chromium.org/p/chromedriver/issues/detail?id=3746'} do
+            expect(element.dom_attribute(prop_or_attr)).to eq 'resultPage.html'
+          end
+
+          it '#property returns property value' do
+            expect(element.property(prop_or_attr)).to match(%r{http://(.+)/resultPage\.html})
+          end
+
+          it '#attribute returns property value' do
+            expect(element.attribute(prop_or_attr)).to match(%r{http://(.+)/resultPage\.html})
+          end
+        end
       end
 
       it 'should clear' do

--- a/rb/spec/unit/selenium/webdriver/support/select_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/support/select_spec.rb
@@ -25,13 +25,13 @@ module Selenium
       describe Select do
         let(:select) do
           select_element = instance_double(Element, tag_name: 'select')
-          allow(select_element).to receive(:attribute).with(:multiple)
+          allow(select_element).to receive(:dom_attribute).with(:multiple)
           select_element
         end
 
         let(:multi_select) do
           select_element = instance_double(Element, tag_name: 'select')
-          allow(select_element).to receive(:attribute).with(:multiple).and_return 'multiple'
+          allow(select_element).to receive(:dom_attribute).with(:multiple).and_return 'multiple'
           select_element
         end
 
@@ -46,10 +46,10 @@ module Selenium
         it 'indicates whether a select is multiple correctly' do
           selects = Array.new(4) { instance_double(Element, tag_name: 'select') }
 
-          allow(selects[0]).to receive(:attribute).with(:multiple).and_return('false')
-          allow(selects[1]).to receive(:attribute).with(:multiple).and_return(nil)
-          allow(selects[2]).to receive(:attribute).with(:multiple).and_return('true')
-          allow(selects[3]).to receive(:attribute).with(:multiple).and_return('multiple')
+          allow(selects[0]).to receive(:dom_attribute).with(:multiple).and_return('false')
+          allow(selects[1]).to receive(:dom_attribute).with(:multiple).and_return(nil)
+          allow(selects[2]).to receive(:dom_attribute).with(:multiple).and_return('true')
+          allow(selects[3]).to receive(:dom_attribute).with(:multiple).and_return('multiple')
 
           expect(Select.new(selects[0])).not_to be_multiple
           expect(Select.new(selects[1])).not_to be_multiple
@@ -126,10 +126,10 @@ module Selenium
           first_option = instance_double(Element, selected?: true)
           second_option = instance_double(Element, selected?: false)
 
-          allow(first_option).to receive(:attribute).with(:index).and_return '0'
+          allow(first_option).to receive(:dom_attribute).with(:index).and_return '0'
           expect(first_option).not_to receive(:click)
 
-          allow(second_option).to receive(:attribute).with(:index).and_return '1'
+          allow(second_option).to receive(:dom_attribute).with(:index).and_return '1'
           expect(second_option).to receive(:click).once
 
           allow(multi_select).to receive(:find_elements)
@@ -137,8 +137,8 @@ module Selenium
             .and_return([first_option, second_option])
 
           Select.new(multi_select).select_by(:index, 1)
-          expect(first_option).to have_received(:attribute).with(:index)
-          expect(second_option).to have_received(:attribute).with(:index)
+          expect(first_option).to have_received(:dom_attribute).with(:index)
+          expect(second_option).to have_received(:dom_attribute).with(:index)
           expect(multi_select).to have_received(:find_elements).with(tag_name: 'option')
         end
 
@@ -198,8 +198,8 @@ module Selenium
             .with(tag_name: 'option')
             .and_return([first_option, second_option])
 
-          allow(first_option).to receive(:attribute).with(:index).and_return('2')
-          allow(second_option).to receive(:attribute).with(:index).and_return('1')
+          allow(first_option).to receive(:dom_attribute).with(:index).and_return('2')
+          allow(second_option).to receive(:dom_attribute).with(:index).and_return('1')
 
           expect(first_option).to receive(:click).once
           expect(second_option).not_to receive(:click)


### PR DESCRIPTION
Looking to get agreement from the other maintainers before committing...

~**Update**: Looks like Java & .NET are both converting property Boolean responses to Strings, and Ruby & Python are not. Why would we override the spec/driver result in the code?~ (Static language vs Dynamic language thing, so this is good)

### Python
* implements `get_dom_attribute` 
* Adds a test for `get_dom_attribute` and `get_property`
* I've verified tests are passing, but @AutomatedTester, can you tell me if I did the docstring method reference correctly?

### Java, Python & Ruby
* switch from using the `getAttribute.js` atom to using the  w3c `/attribute` endpoint for determining if a Select element is a multiple select list. This should be completely backward compatible, even if they use JS to remove the value, it will still return the same value as the atom.

### Ruby
* implements `#dom_attribute`
* Adds 53 tests that should well-differentiate the expected/desired behavior for the 3 different methods we now have for working with properties/attributes, along with references to the applicable Chrome & Firefox bugs