### PR TITLE
Fix ruby 2.7 kwargs warning in 3.x branch when using Firefox driver

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -28,7 +28,7 @@ module Selenium
           # @return [Marionette::Driver, Legacy::Driver]
           #
 
-          def new(**opts)
+          def new(opts = {})
             if marionette?(opts)
               Firefox::Marionette::Driver.new(opts)
             else


### PR DESCRIPTION
By switching back to use a hash as default param here, we can silence
the following warning:

```
 warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

This part of the codebase has been modified in 4.x branch and it does
not have the same behavior there.

<!--- Provide a general summary of your changes in the Title above -->

### Description

There is a difference in how Chrome and Firefox driver initializer is declared. In Firefox case it is using double splats, but the rest of the codebase is not prepare (in 3.x) to handle it in a way that is compatible with ruby 3, therefore in ruby 2.7 we get the following warning:

```
../.rvm/gems/ruby-2.7.2/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/common/driver.rb:54: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

../.rvm/gems/ruby-2.7.2/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/firefox/driver.rb:31: warning: The called method `new' is defined here
```

By switching back to use a hash as default param (which is what Chrome driver uses in 3.x branch), we can silence this.

### Motivation and Context

We have a deprecation toolkit in our codebase and since I've enabled Firefox driver, it flagged the warning and broke the build. I understand that the effort is in 4.x codebase, but since this is a small change, I hope this can be added to a patch release.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
