### PR TITLE
[rb] separate guards from conditions for more general use case

### DIFF
--- a/rb/lib/selenium/webdriver/support/guards.rb
+++ b/rb/lib/selenium/webdriver/support/guards.rb
@@ -37,8 +37,8 @@ module Selenium
           @messages = {}
         end
 
-        def add_condition(name, &blk)
-          @guard_conditions << GuardCondition.new(name, &blk)
+        def add_condition(name, condition = nil, &blk)
+          @guard_conditions << GuardCondition.new(name, condition, &blk)
         end
 
         def add_message(name, message)

--- a/rb/lib/selenium/webdriver/support/guards/guard_condition.rb
+++ b/rb/lib/selenium/webdriver/support/guards/guard_condition.rb
@@ -17,10 +17,32 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'pathname'
-require 'selenium/server'
-require_relative 'spec_support/test_environment'
-require 'selenium/webdriver/support/guards'
-require_relative 'spec_support/helpers'
-require_relative 'spec_support/rack_server'
-require_relative 'spec_support/shared_examples/concurrent_driver'
+module Selenium
+  module WebDriver
+    module Support
+      class Guards
+
+        #
+        # Guard derived from RSpec example metadata.
+        # @api private
+        #
+
+        class GuardCondition
+          attr_accessor :name, :execution
+
+          def initialize(name, condition = nil, &blk)
+            @name = name
+            @execution = proc(&blk)
+          end
+
+          def satisfied?(guard)
+            list = Array(guard.guarded[@name])
+
+            list.empty? || @execution.call(list)
+          end
+
+        end # GuardCondition
+      end # Guards
+    end # Support
+  end # WebDriver
+end # Selenium

--- a/rb/lib/selenium/webdriver/support/guards/guard_condition.rb
+++ b/rb/lib/selenium/webdriver/support/guards/guard_condition.rb
@@ -32,7 +32,11 @@ module Selenium
 
           def initialize(name, condition = nil, &blk)
             @name = name
-            @execution = proc(&blk)
+            @execution = if block_given?
+                           proc(&blk)
+                         else
+                           proc { |guarded| guarded.include?(condition) }
+                         end
           end
 
           def satisfied?(guard)

--- a/rb/spec/integration/selenium/webdriver/guard_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/guard_spec.rb
@@ -29,13 +29,13 @@ module Selenium
           end
 
           it 'skips without running', exclude: {browser: :chrome} do
-            puts "This code will not get executed"
+            fail 'This code will not get executed so it will not fail'
           end
         end
 
         describe '#exclusive' do
           it 'skips without running if it does not match', exclusive: {browser: :not_chrome} do
-            puts "This code will not get executed"
+            fail 'This code will not get executed so it will not fail'
           end
 
           it 'does not guard if it does match', exclusive: {browser: :chrome} do
@@ -45,7 +45,7 @@ module Selenium
 
         describe '#only' do
           it 'guards when value does not match', only: {browser: :not_chrome} do
-            fail
+            fail 'This code is executed but expected to fail'
           end
 
           it 'does not guard when value matches', only: {browser: :chrome} do
@@ -55,7 +55,7 @@ module Selenium
 
         describe '#except' do
           it 'guards when value matches and test fails', except: {browser: :chrome} do
-            fail
+            fail 'This code is executed but expected to fail'
           end
 
           it 'does not guard when value does not match and test passes', except: {browser: :not_chrome} do
@@ -66,17 +66,17 @@ module Selenium
         context 'when multiple guards' do
           it 'guards if neither only nor except match and test fails', only: {browser: :not_chrome},
                                                                        except: {browser: :not_chrome} do
-            fail
+            fail 'This code is executed but expected to fail'
           end
 
           it 'guards if both only and except match', only: {browser: :chrome},
                                                      except: {browser: :chrome} do
-            fail
+            fail 'This code is executed but expected to fail'
           end
 
           it 'guards if except matches and only does not', only: {browser: :not_chrome},
                                                            except: {browser: :chrome} do
-            fail
+            fail 'This code is executed but expected to fail'
           end
 
           it 'does not guard if only matches and except does not', only: {browser: :chrome},
@@ -87,52 +87,15 @@ module Selenium
 
         context 'when array of hashes' do
           it 'guards if any Hash value is satisfied', only: [{browser: :chrome}, {browser: :not_chrome}] do
-            fail
+            fail 'This code is executed but expected to fail'
           end
         end
 
         context 'guard messages' do
           it 'gives correct reason with single only excludes', except: [{browser: :chrome, reason: 'bug1'},
                                                                         {browser: :not_chrome, reason: 'bug2'}] do
-            fail
+            fail 'This code is executed but expected to fail'
           end
-        end
-      end
-
-      describe Guards::Guard do
-        it 'Uses default message' do
-          guard = Guards::Guard.new({}, :except)
-          expect(guard.message).to eq 'Test guarded; no reason given'
-        end
-
-        it 'Creates message from Integer' do
-          bug_tracker = 'https://github.com/SeleniumHQ/selenium/issues'
-          guards = instance_double(Guards, bug_tracker: bug_tracker, messages: {})
-
-          guard = Guards::Guard.new({reason: 1}, :except, guards)
-          expect(guard.message).to eq "Test guarded; Bug Filed: #{bug_tracker}/1"
-        end
-
-        it 'Creates message from Symbol' do
-          guards = instance_double(Guards, bug_tracker: '', messages: {})
-
-          guard = Guards::Guard.new({reason: :unknown}, :except, guards)
-          expect(guard.message).to eq 'Test guarded; TODO: Investigate why this is failing and file a bug report'
-        end
-
-        it 'Creates message from String' do
-          guard = Guards::Guard.new({reason: "Foo is bad"}, :except)
-          expect(guard.message).to eq 'Test guarded; Foo is bad'
-        end
-
-        it 'Uses correct message for exclusive' do
-          guard = Guards::Guard.new({reason: "Foo is bad"}, :exclusive)
-          expect(guard.message).to eq 'Test does not apply to this configuration; Foo is bad'
-        end
-
-        it 'Uses correct message for exclude' do
-          guard = Guards::Guard.new({reason: "Foo is bad"}, :exclude)
-          expect(guard.message).to eq 'Test not guarded because it breaks test run; Foo is bad'
         end
       end
     end # Support

--- a/rb/spec/integration/selenium/webdriver/guard_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/guard_spec.rb
@@ -106,13 +106,18 @@ module Selenium
         end
 
         it 'Creates message from Integer' do
-          guard = Guards::Guard.new({reason: 1}, :except)
-          expect(guard.message).to eq 'Test guarded; Bug Filed: https://github.com/SeleniumHQ/selenium/issues/1'
+          bug_tracker = 'https://github.com/SeleniumHQ/selenium/issues'
+          guards = instance_double(Guards, bug_tracker: bug_tracker, messages: {})
+
+          guard = Guards::Guard.new({reason: 1}, :except, guards)
+          expect(guard.message).to eq "Test guarded; Bug Filed: #{bug_tracker}/1"
         end
 
         it 'Creates message from Symbol' do
-          guard = Guards::Guard.new({reason: :unk}, :except)
-          expect(guard.message).to eq 'Test guarded; TODO: Investigate why this is failing and file bug'
+          guards = instance_double(Guards, bug_tracker: '', messages: {})
+
+          guard = Guards::Guard.new({reason: :unknown}, :except, guards)
+          expect(guard.message).to eq 'Test guarded; TODO: Investigate why this is failing and file a bug report'
         end
 
         it 'Creates message from String' do

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -50,12 +50,14 @@ RSpec.configure do |c|
 
   c.before do |example|
     guards = WebDriver::Support::Guards.new(example, bug_tracker: 'https://github.com/SeleniumHQ/selenium/issues')
-    guards.add_condition(:driver) { |guarded| guarded.include?(GlobalTestEnv.driver) }
-    guards.add_condition(:browser) { |guarded| guarded.include?(GlobalTestEnv.browser) }
-    guards.add_condition(:platform) { |guarded| guarded.include?(WebDriver::Platform.os) }
-    guards.add_condition(:window_manager) { |bool| bool.first == !WebDriver::Platform.linux? || !!ENV['DESKTOP_SESSION'] }
+    guards.add_condition(:driver, GlobalTestEnv.driver)
+    guards.add_condition(:browser, GlobalTestEnv.browser)
+    guards.add_condition(:platform, WebDriver::Platform.os)
+    window_manager = !WebDriver::Platform.linux? || !ENV['DESKTOP_SESSION'].nil?
+    guards.add_condition(:window_manager, window_manager)
 
-    guards.disposition.tap { |results| send(*results) if results }
+    results = guards.disposition
+    send(*results) if results
   end
 
   c.after do |example|

--- a/rb/spec/unit/selenium/webdriver/guard_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/guard_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative 'spec_helper'
+require 'selenium/webdriver/support/guards'
+
+module Selenium
+  module WebDriver
+    module Support
+      describe Guards do
+        describe '#new' do
+          it 'collects guards from example only for known guard types',
+             except: {}, only: {}, exclusive: {}, exclude: {}, ignored: {} do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            types = guards.instance_variable_get(:@guards).map { |g| g.instance_variable_get(:@type) }
+            expect(types).to include :except, :only, :exclusive, :exclude
+            expect(types).not_to include :ignored
+          end
+
+          it 'accepts bug tracker value' do |example|
+            guards = WebDriver::Support::Guards.new(example, bug_tracker: 'https://example.com/bugs')
+            expect(guards.instance_variable_get(:@bug_tracker)).to eq 'https://example.com/bugs'
+          end
+
+          it 'accepts conditions' do |example|
+            condition1 = WebDriver::Support::Guards::GuardCondition.new(:foo)
+            condition2 = WebDriver::Support::Guards::GuardCondition.new(:bar)
+
+            guards = WebDriver::Support::Guards.new(example, conditions: [condition1, condition2])
+            expect(guards.instance_variable_get(:@guard_conditions)).to include condition1, condition2
+          end
+        end
+
+        describe '#add_conditions' do
+          it 'sets multiple' do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_condition :foo, true
+            guards.add_condition :bar, false
+
+            expect(guards.instance_variable_get(:@guard_conditions).map(&:name)).to include :foo, :bar
+          end
+        end
+
+        describe '#add_message' do
+          it 'sets multiple custom messages' do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_message(:foo, 'The problem is foo')
+            guards.add_message(:bar, 'The problem is bar')
+
+            expect(guards.messages).to include({foo: 'The problem is foo'}, {bar: 'The problem is bar'})
+          end
+        end
+
+        describe '#disposition' do
+          it 'returns nothing' do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            expect(guards.disposition).to be_nil
+          end
+
+          it 'is pending without provided reason', except: {foo: false} do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_condition(:foo, false)
+
+            expect(guards.disposition).to eq [:pending, 'Test guarded; no reason given']
+          end
+
+          it 'is skipped without provided reason', exclusive: {foo: true} do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_condition(:foo, false)
+
+            message = 'Test does not apply to this configuration; no reason given'
+            expect(guards.disposition).to eq [:skip, message]
+          end
+        end
+
+        describe '#satisfied?' do
+          it 'evaluates guard' do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_condition(:foo, true)
+            guards.add_condition(:bar, false)
+
+            guard = Guards::Guard.new({foo: true, bar: false}, :only)
+
+            expect(guards.satisfied?(guard)).to eq true
+          end
+        end
+      end
+
+      describe Guards::GuardCondition do
+        describe '#new' do
+          it 'accepts condition' do
+            condition = Guards::GuardCondition.new(:foo, true)
+            expect(condition.name).to eq :foo
+            expect(condition.execution).to be_a Proc
+            expect(condition.execution.call([true])).to eq true
+          end
+
+          it 'accepts block' do
+            condition = Guards::GuardCondition.new(:foo) { |guarded| guarded.include?(7) }
+            expect(condition.name).to eq :foo
+            expect(condition.execution).to be_a Proc
+            expect(condition.execution.call([7])).to eq true
+          end
+        end
+
+        describe '#satisfied' do
+          it 'returns true with corresponding guard' do
+            condition = Guards::GuardCondition.new(:foo) { |guarded| guarded.include?(7) }
+            guard = Guards::Guard.new({foo: 7}, :only)
+            expect(condition.satisfied?(guard)).to eq true
+          end
+
+          it 'returns false with corresponding guard' do
+            condition = Guards::GuardCondition.new(:foo) { |guarded| guarded.include?(7) }
+            guard = Guards::Guard.new({foo: 8}, :except)
+            expect(condition.satisfied?(guard)).to eq false
+          end
+        end
+      end
+
+      describe Guards::Guard do
+        describe '#new' do
+          it 'requires guarded Hash and type' do
+            guard = Guards::Guard.new({foo: 7}, :only)
+            expect(guard.guarded).to eq(foo: 7)
+            expect(guard.type).to eq :only
+          end
+
+          it 'creates unknown message by default' do
+            guard = Guards::Guard.new({foo: 7}, :only)
+            expect(guard.messages).to include(unknown: 'TODO: Investigate why this is failing and file a bug report')
+          end
+
+          it 'accepts a reason in guarded' do
+            guard = Guards::Guard.new({foo: 7, reason: 'because'}, :only)
+            expect(guard.reason).to eq 'because'
+          end
+        end
+
+        describe '#message' do
+          it 'defaults to no reason given' do
+            guard = Guards::Guard.new({}, :only)
+
+            expect(guard.message).to eq('Test guarded; no reason given')
+          end
+
+          it 'accepts integer' do |example|
+            guards = WebDriver::Support::Guards.new(example, bug_tracker: 'http://example.com/bugs')
+            guard = Guards::Guard.new({reason: 1}, :only, guards)
+
+            expect(guard.message).to eq('Test guarded; Bug Filed: http://example.com/bugs/1')
+          end
+
+          it 'accepts String' do
+            guard = Guards::Guard.new({reason: 'because'}, :only)
+
+            expect(guard.message).to eq('Test guarded; because')
+          end
+
+          it 'accepts Symbol of known message' do
+            guard = Guards::Guard.new({reason: :unknown}, :only)
+
+            expect(guard.message).to eq('Test guarded; TODO: Investigate why this is failing and file a bug report')
+          end
+
+          it 'accepts Symbol of new message' do |example|
+            guards = WebDriver::Support::Guards.new(example)
+            guards.add_message(:foo, 'all due to foo')
+            guard = Guards::Guard.new({reason: :foo}, :only, guards)
+
+            expect(guard.message).to eq('Test guarded; all due to foo')
+          end
+
+          it 'has special message for exclude' do
+            guard = Guards::Guard.new({reason: 'because'}, :exclude)
+
+            expect(guard.message).to eq('Test not guarded because it breaks test run; because')
+          end
+
+          it 'has special message for exclusive' do
+            guard = Guards::Guard.new({reason: 'because'}, :exclusive)
+
+            expect(guard.message).to eq('Test does not apply to this configuration; because')
+          end
+        end
+      end
+
+    end # Support
+  end # WebDriver
+end # Selenium


### PR DESCRIPTION
The idea is to make guards more extensible so they can be used by 3rd party dependency libraries (e.g. Watir, webdrivers, etc), or pulled into a separate gem entirely.

I started by creating a subclass of `Guard` and then having `Guards` accept the class as a parameter, but it seemed like separating the conditions from the guard attribute might be a better way to go, and then you get more visibility into exactly what is getting set in the before hook. I'm sure there are other ways to do this, but this seemed like a reasonable approach.

Existing specs are all passing, but there's more functionality here that I should probably add more specs for, so let me know what you think about this approach in general, @p0deje.