### PR TITLE
Lazy initialisation of the singleton default client factory instance

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/HttpCommandExecutor.java
+++ b/java/client/src/org/openqa/selenium/remote/HttpCommandExecutor.java
@@ -45,8 +45,6 @@ import static org.openqa.selenium.remote.HttpSessionId.getSessionId;
 
 public class HttpCommandExecutor implements CommandExecutor, NeedsLocalLogs {
 
-  private static final HttpClient.Factory defaultClientFactory = HttpClient.Factory.createDefault();
-
   private final URL remoteServer;
   private final HttpClient client;
   private final HttpClient.Factory httpClientFactory;
@@ -56,14 +54,22 @@ public class HttpCommandExecutor implements CommandExecutor, NeedsLocalLogs {
 
   private LocalLogs logs = LocalLogs.getNullLogger();
 
+  private static class DefaultClientFactoryHolder {
+    static HttpClient.Factory defaultClientFactory = HttpClient.Factory.createDefault();
+  }
+
+  public static HttpClient.Factory getDefaultClientFactory() {
+    return DefaultClientFactoryHolder.defaultClientFactory;
+  }
+
   public HttpCommandExecutor(URL addressOfRemoteServer) {
     this(emptyMap(), Require.nonNull("Server URL", addressOfRemoteServer));
   }
 
   public HttpCommandExecutor(ClientConfig config) {
     this(emptyMap(),
-         Require.nonNull("HTTP client configuration", config),
-         defaultClientFactory);
+      Require.nonNull("HTTP client configuration", config),
+      getDefaultClientFactory());
   }
 
   /**
@@ -78,8 +84,8 @@ public class HttpCommandExecutor implements CommandExecutor, NeedsLocalLogs {
     URL addressOfRemoteServer)
   {
     this(Require.nonNull("Additional commands", additionalCommands),
-         Require.nonNull("Server URL", addressOfRemoteServer),
-         defaultClientFactory);
+      Require.nonNull("Server URL", addressOfRemoteServer),
+      getDefaultClientFactory());
   }
 
   public HttpCommandExecutor(


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes #9232 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The single global instance of the default http client factory is lazily initialized as needed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
