### PR TITLE
EdgeDriver, Set UseChromium option as true by default.

### DIFF
--- a/dotnet/src/webdriver/Edge/EdgeOptions.cs
+++ b/dotnet/src/webdriver/Edge/EdgeOptions.cs
@@ -76,6 +76,7 @@ namespace OpenQA.Selenium.Edge
             this.AddKnownCapabilityName(UseInPrivateBrowsingCapability, "UseInPrivateBrowsing property");
             this.AddKnownCapabilityName(StartPageCapability, "StartPage property");
             this.AddKnownCapabilityName(ExtensionPathsCapability, "AddExtensionPaths method");
+            this.UseChromium = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Set the UseChromium property as true by default as Edge Legacy is [no longer supported](https://support.microsoft.com/en-us/microsoft-edge/what-is-microsoft-edge-legacy-3e779e55-4c55-08e6-ecc8-2333768c0fb0).
