### PR TITLE
[grid] Propagate the error to the client when reserving a slot

### DIFF
--- a/java/server/src/org/openqa/selenium/grid/distributor/Distributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/Distributor.java
@@ -60,14 +60,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -192,7 +190,7 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
         return Either.left(exception);
       }
 
-      Optional<Supplier<CreateSessionResponse>> selected;
+      Either<SessionNotCreatedException, CreateSessionResponse> selected;
       CreateSessionRequest firstRequest = new CreateSessionRequest(
         payload.getDownstreamDialects(),
         iterator.next(),
@@ -226,16 +224,22 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
         // Find a Node that supports the capabilities present in the new session
         Set<SlotId> slotIds = slotSelector.selectSlot(firstRequest.getCapabilities(), model);
         if (!slotIds.isEmpty()) {
-          selected = Optional.of(reserve(slotIds.iterator().next(), firstRequest));
+          selected = reserve(slotIds.iterator().next(), firstRequest);
         } else {
-          selected = Optional.empty();
+          String errorMessage =
+            String.format(
+              "Unable to find provider for session: %s",
+              payload.stream().map(Capabilities::toString)
+                .collect(Collectors.joining(", ")));
+          SessionNotCreatedException exception = new RetrySessionRequestException(errorMessage);
+          selected = Either.left(exception);
         }
       } finally {
         writeLock.unlock();
       }
 
-      if (selected.isPresent()) {
-        CreateSessionResponse sessionResponse = selected.get().get();
+      if (selected.isRight()) {
+        CreateSessionResponse sessionResponse = selected.right();
 
         sessions.add(sessionResponse.getSession());
         SessionId sessionId = sessionResponse.getSession().getId();
@@ -254,13 +258,7 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
         return Either.right(sessionResponse);
 
       } else {
-        String errorMessage =
-            String.format(
-                "Unable to find provider for session: %s",
-                payload.stream().map(Capabilities::toString)
-                  .collect(Collectors.joining(", ")));
-        SessionNotCreatedException exception = new RetrySessionRequestException(errorMessage);
-        return Either.left(exception);
+        return selected;
       }
     } catch (SessionNotCreatedException e) {
       span.setAttribute(AttributeKey.ERROR.getKey(), true);
@@ -298,8 +296,8 @@ public abstract class Distributor implements HasReadyState, Predicate<HttpReques
 
   protected abstract Set<NodeStatus> getAvailableNodes();
 
-  protected abstract Supplier<CreateSessionResponse> reserve(SlotId slot,
-                                                             CreateSessionRequest request);
+  protected abstract Either<SessionNotCreatedException, CreateSessionResponse> reserve(SlotId slot,
+                                                                                       CreateSessionRequest request);
 
   @Override
   public boolean test(HttpRequest httpRequest) {

--- a/java/server/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.grid.distributor.remote;
 
+import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.grid.data.CreateSessionRequest;
 import org.openqa.selenium.grid.data.CreateSessionResponse;
 import org.openqa.selenium.grid.data.DistributorStatus;
@@ -29,6 +30,7 @@ import org.openqa.selenium.grid.security.AddSecretFilter;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.NullSessionMap;
 import org.openqa.selenium.grid.web.Values;
+import org.openqa.selenium.internal.Either;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.Filter;
 import org.openqa.selenium.remote.http.HttpClient;
@@ -40,7 +42,6 @@ import org.openqa.selenium.remote.tracing.Tracer;
 
 import java.net.URL;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import static org.openqa.selenium.remote.http.Contents.asJson;
@@ -129,7 +130,7 @@ public class RemoteDistributor extends Distributor {
   }
 
   @Override
-  protected Supplier<CreateSessionResponse> reserve(SlotId slot, CreateSessionRequest request) {
+  protected Either<SessionNotCreatedException, CreateSessionResponse> reserve(SlotId slot, CreateSessionRequest request) {
     throw new UnsupportedOperationException("reserve is not required for remote sessions");
   }
 }


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Propagate the error to the client when reserving a slot

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ideally, the exception received while creating a session with the driver should be bubbled up to the client. A part of the work would be to ensure DriverSessionFactory communicates the error details to the LocalNode which in turn reaches the Distributor (separate PR after this). Another part is to ensure the LocalDistributor passes on the error details to the client. 
The changes are related to the 2nd part.
When reserving a slot in the grid and creating a session, in case of error situations, the error is simply thrown instead of being passed back to the client. The changes fix that by using Either.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
