### PR TITLE
[java] Removing the 'ELEMENT' key when serialising RemoteWebElement to Json

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
@@ -391,7 +391,6 @@ public class RemoteWebElement implements WebElement, WrapsDriver, TakesScreensho
 
   public Map<String, Object> toJson() {
     return ImmutableMap.of(
-      Dialect.OSS.getEncodedElementKey(), getId(),
       Dialect.W3C.getEncodedElementKey(), getId());
   }
 }


### PR DESCRIPTION


<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes #6393 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The changes remove the legacy pointer 'ELEMENT' while serialising the RemoteWebElement to Json. This aligns with the Webdrive spec https://w3c.github.io/webdriver/#dfn-web-element-identifier 
"The JSON serialization of an element is a JSON Object where the web element identifier key is mapped to the element’s web element reference."  
"The web element identifier is the string constant "element-6066-11e4-a52e-4f735466cecf".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
