### PR TITLE
[java] Fix getScreenshotAs: avoid unnecessary conversions

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -358,8 +358,7 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor, HasInputD
       String base64EncodedPng = (String) result;
       return outputType.convertFromBase64Png(base64EncodedPng);
     } else if (result instanceof byte[]) {
-      String base64EncodedPng = new String((byte[]) result, UTF_8);
-      return outputType.convertFromBase64Png(base64EncodedPng);
+      return outputType.convertFromPngBytes((byte[]) result);
     } else {
       throw new RuntimeException(String.format("Unexpected result for %s command: %s",
           DriverCommand.SCREENSHOT,

--- a/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -88,7 +88,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.openqa.selenium.remote.CapabilityType.LOGGING_PREFS;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM;

--- a/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
@@ -43,8 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 public class RemoteWebElement implements WebElement, WrapsDriver, TakesScreenshot, Locatable {
 
   private String foundBy;

--- a/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java
@@ -376,8 +376,7 @@ public class RemoteWebElement implements WebElement, WrapsDriver, TakesScreensho
       String base64EncodedPng = (String) result;
       return outputType.convertFromBase64Png(base64EncodedPng);
     } else if (result instanceof byte[]) {
-      String base64EncodedPng = new String((byte[]) result, UTF_8);
-      return outputType.convertFromBase64Png(base64EncodedPng);
+      return outputType.convertFromPngBytes((byte[]) result);
     } else {
       throw new RuntimeException(String.format(
         "Unexpected result for %s command: %s",


### PR DESCRIPTION

### Description
I've noticed that the getScreenshotAs methods were not leveraging `OutputType#convertFromPngBytes`; instead, they were all using `OutputType#convertFromBase64Png`, **even when the raw bytes was what we got from the Server**.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
