### PR TITLE
[rb] fix bugs and allow saving print page

### DIFF
--- a/rb/lib/selenium/webdriver/common/driver_extensions/prints_page.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/prints_page.rb
@@ -21,8 +21,35 @@ module Selenium
   module WebDriver
     module DriverExtensions
       module PrintsPage
+        #
+        # Save a page as a PDF to the given path
+        #
+        # @example Save Printed Page
+        #   driver.save_print_page('../printed_page.pdf')
+        #
+        # @param [String] path to where the pdf should be saved
+        #
+        # @api public
+        #
+
+        def save_print_page(path, **options)
+          File.open(path, 'wb') do |file|
+            content = Base64.decode64 print_page(options)
+            file << content
+          end
+        end
+
+        #
+        # Return a Base64 encoded Print Page as a string
+        #
+        # @see https://w3c.github.io/webdriver/#print-page
+        #
+        # @api public
+        #
+
         def print_page(**options)
-          options[:page_ranges] &&= Array(options[:page_ranges])
+          options[:pageRanges] = Array(options.delete(:page_ranges)) || []
+          options[:shrinkToFit] = options.delete(:shrink_to_fit) { true }
 
           @bridge.print_page(options)
         end

--- a/rb/lib/selenium/webdriver/remote/driver.rb
+++ b/rb/lib/selenium/webdriver/remote/driver.rb
@@ -44,12 +44,6 @@ module Selenium
           super
         end
 
-        def print_page(**options)
-          options[:page_ranges] &&= Array(options[:page_ranges])
-
-          @bridge.print_page(options)
-        end
-
         private
 
         def devtools_address

--- a/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
@@ -53,7 +53,7 @@ module Selenium
           end
         end
 
-        describe '#print_options' do
+        describe 'PrintsPage' do
           let(:magic_number) { 'JVBER' }
           let(:options) { Chrome::Options.new(args: ['--headless']) }
 
@@ -64,19 +64,27 @@ module Selenium
             end
           end
 
-          it 'should print with orientation' do
-            create_driver!(capabilities: options) do |driver|
-              driver.navigate.to url_for('printPage.html')
-              expect(driver.print_page(orientation: 'landscape')).to include(magic_number)
-            end
-          end
-
           it 'should print with valid params' do
             create_driver!(capabilities: options) do |driver|
               driver.navigate.to url_for('printPage.html')
               expect(driver.print_page(orientation: 'landscape',
                                        page_ranges: ['1-2'],
                                        page: {width: 30})).to include(magic_number)
+            end
+          end
+
+          it 'should save pdf' do
+            create_driver!(capabilities: options) do |driver|
+              driver.navigate.to url_for('printPage.html')
+
+              path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.pdf"
+
+              driver.save_print_page path
+
+              expect(File.exist?(path)).to be true
+              expect(File.size(path)).to be_positive
+            ensure
+              File.delete(path) if File.exist?(path)
             end
           end
         end


### PR DESCRIPTION
Fixes #9298 

This implementation assumes each parameter will be a snake_case `Symbol`. According to the spec there are only two valid parameters that are multiple words, so this converts each to a camelCase `Symbol`. We can do something more robust here if we don't feel like this is good enough.

I pulled the method from `Remote::Driver` because `Driver` superclass is now extending `Extensions` for the applicable browser, so it is no longer necessary.

Also, I'm not sure why we weren't matching what we do in `TakesScreenshot` module, so I added a `#save_print_page` method while I was here.

Also, our specs are a little frustrating because they don't (can't?) test whether the parameters work as intended. 

@f4z4on does this seem like a workable solution?