### PR TITLE
Update javadoc for getCssValue()

### DIFF
--- a/java/client/src/org/openqa/selenium/WebElement.java
+++ b/java/client/src/org/openqa/selenium/WebElement.java
@@ -306,9 +306,12 @@ public interface WebElement extends SearchContext, TakesScreenshot {
 
   /**
    * Get the value of a given CSS property.
-   * Color values should be returned as rgba strings, so,
-   * for example if the "background-color" property is set as "green" in the
-   * HTML source, the returned value will be "rgba(0, 255, 0, 1)".
+   * Color values could be returned as rgba or rgb strings.
+   * This depends on whether the browser omits the implicit opacity value or not.
+   *
+   * For example if the "background-color" property is set as "green" in the
+   * HTML source, the returned value could be "rgba(0, 255, 0, 1)" if implicit opacity value is
+   * preserved or "rgb(0, 255, 0)" if it is omitted.
    *
    * Note that shorthand CSS properties (e.g. background, font, border, border-top, margin,
    * margin-top, padding, padding-top, list-style, outline, pause, cue) are not returned,


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes #7697

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix Javadoc for getCssValue() while returning values for color values. Different browsers have different interpretations for returning the colour value either using rgb or rgba. Some browsers (Chrome for example) preserve the implicit opacity value 1, where Firefox omits it. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
