### PR TITLE
[java] Improving exception when server returns 504 (WIP)

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
@@ -20,8 +20,8 @@ package org.openqa.selenium.remote.codec.w3c;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
+import static java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 import static org.openqa.selenium.json.Json.OBJECT_TYPE;
 import static org.openqa.selenium.remote.http.Contents.string;
@@ -89,6 +89,9 @@ public class W3CHttpResponseCodec extends AbstractHttpResponseCodec {
       log.fine("Processing an error");
       if (HTTP_BAD_METHOD == encodedResponse.getStatus()) {
         response.setStatus(ErrorCodes.UNKNOWN_COMMAND);
+        response.setValue(content);
+      } else if (HTTP_GATEWAY_TIMEOUT == encodedResponse.getStatus()) {
+        response.setStatus(ErrorCodes.UNHANDLED_ERROR);
         response.setValue(content);
       } else {
         Map<String, Object> obj = json.toType(content, MAP_TYPE);


### PR DESCRIPTION

### Description
Here I'm adding one extra condition to `W3CHttpResponseCodec#decode` in order to specifically handle 504 Gateway Time-out server errors.

This fix is very similar to the fix that was applied in 6a9c546 (see #7792).

### Motivation and Context

While running a test on a Selenium Grid (v3.141.59), I got the following pretty **unfriendly** exception upon a `WebElement#click` call:

```
org.openqa.selenium.json.JsonException: Unable to determine type from: <. Last 1 characters read: <
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'Albertos-iMac.local', ip: '192.168.1.130', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.15.7', java.version: '1.8.0_281'
Driver info: driver.version: RemoteWebDriver
    at org.openqa.selenium.json.JsonInput.peek(JsonInput.java:122)
    at org.openqa.selenium.json.JsonTypeCoercer.lambda$null$6(JsonTypeCoercer.java:140)
    at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:126)
    at org.openqa.selenium.json.Json.toType(Json.java:69)
    at org.openqa.selenium.json.Json.toType(Json.java:55)
    at org.openqa.selenium.json.Json.toType(Json.java:50)
    at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:87)
    at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
    at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
    at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
    at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:285)
    at org.openqa.selenium.remote.RemoteWebElement.click(RemoteWebElement.java:84)
[..]
```

Only by debugging the test and stepping through the calls, I was able to find that the server was actually returning a plain text response:

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```
<img width="2157" alt="Screenshot 2021-03-25 at 19 39 07" src="https://user-images.githubusercontent.com/2717169/113492466-cc377c80-94d7-11eb-946a-dbdba4ec83e9.png">

It shouldn't be required from the end user to do this.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (note: I only ran _small_ tests)


PS: I was wondering if it makes sense to extend this special handling logic to **any** 4XX/5XX errors, instead of only to 405 and 504.
I mean, I would expect the server to return a Json only when the HTTP status is 200.

I did some research and I found that `AbstractHttpResponseCodec` (the superclass of `W3CHttpResponseCodec`) is already doing what I was thinking:

https://github.com/SeleniumHQ/selenium/blob/fcfbc6ba2582d67704f62a728f82fbb09e447ee9/java/client/src/org/openqa/selenium/remote/codec/AbstractHttpResponseCodec.java#L105

On the other hand, I also see that in W3CHttpResponseCodec there's a line which expects to get a JSON together with a 500 error  😕 
https://github.com/SeleniumHQ/selenium/blob/fcfbc6ba2582d67704f62a728f82fbb09e447ee9/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java#L117

@shs96c can you maybe spread some light? Tagging you as the author of `W3CHttpResponseCodec`

Thanks!