### PR TITLE
add support for CONNECT method to tunnel TLS

### DIFF
--- a/javascript/node/selenium-webdriver/http/index.js
+++ b/javascript/node/selenium-webdriver/http/index.js
@@ -25,7 +25,7 @@
 const http = require('http')
 const https = require('https')
 const url = require('url')
-const tls = require('tls');
+const tls = require('tls')
 
 const httpLib = require('../lib/http')
 
@@ -92,11 +92,11 @@ class HttpClient {
     /**
      * @private {?RequestOptions}
      */
-    this.proxyOptions_ = opt_proxy ? getRequestOptions(opt_proxy) : null;
+    this.proxyOptions_ = opt_proxy ? getRequestOptions(opt_proxy) : null
     /**
      * Allow skipping certificate validation for test cases.
      */
-    this.doCertificateCheck = true;
+    this.doCertificateCheck = true
   }
 
   /** @override */
@@ -213,11 +213,11 @@ function sendRequest(options, onOk, onError, opt_data, opt_proxy, opt_retries) {
         request.end()
       }
     } else {
-      options.headers['Host'] = targetHost;
-      options.path = absoluteUri;
-      options.host = proxy.host;
-      options.hostname = proxy.hostname;
-      options.port = proxy.port;
+      options.headers['Host'] = targetHost
+      options.path = absoluteUri
+      options.host = proxy.host
+      options.hostname = proxy.hostname
+      options.port = proxy.port
 
       // Update the protocol to avoid EPROTO errors when the webdriver proxy
       // uses a different protocol from the remote selenium server.

--- a/javascript/node/selenium-webdriver/lib/test/httpserver.js
+++ b/javascript/node/selenium-webdriver/lib/test/httpserver.js
@@ -42,7 +42,7 @@ let Server = function (requestHandler) {
   })
 
   this.setConnectHandler = function(handler) {
-    return server.on('connect', handler);
+    return server.on('connect', handler)
   }
 
   /** @typedef {{port: number, address: string, family: string}} */

--- a/javascript/node/selenium-webdriver/lib/test/httpserver.js
+++ b/javascript/node/selenium-webdriver/lib/test/httpserver.js
@@ -41,6 +41,10 @@ let Server = function (requestHandler) {
     stream.setTimeout(4000)
   })
 
+  this.setConnectHandler = function(handler) {
+    return server.on('connect', handler);
+  }
+
   /** @typedef {{port: number, address: string, family: string}} */
   let Host // eslint-disable-line
 

--- a/javascript/node/selenium-webdriver/test/http/http_test.js
+++ b/javascript/node/selenium-webdriver/test/http/http_test.js
@@ -100,7 +100,7 @@ describe('HttpClient', function () {
 
   server.setConnectHandler(function(req, sock, head) {
     if (req.method == 'CONNECT' && req.url == "another.server.com") {
-      sock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      sock.write('HTTP/1.1 200 Connection Established\r\n\r\n')
       const keyData = fs.readFileSync("test/http/server-key.pem")
       const certData = fs.readFileSync("test/http/server-cert.pem")
       const tlsConfig = {


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
The current implementation of proxy support in the HTTP library is broken when connecting to HTTPS servers. This patch adds support for the "CONNECT" method to tunnel TLS.

See here for details: https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_method

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
