### PR TITLE
[grid] Update eventbus poll timeout

### DIFF
--- a/java/server/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
@@ -241,6 +241,7 @@ class UnboundZmqEventBus implements EventBus {
     } catch (Throwable e) {
       // if the exception escapes, then we never get scheduled again
       LOG.log(Level.WARNING, e, () -> "Caught and swallowed exception: " + e.getMessage());
+      e.printStackTrace();
     }
   }
 

--- a/java/server/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
@@ -199,7 +199,7 @@ class UnboundZmqEventBus implements EventBus {
 
   private void pollForIncomingEvents(ZMQ.Poller poller, Secret secret, AtomicBoolean pollingStarted) {
     try {
-      int count = poller.poll(0);
+      int count = poller.poll(50);
 
       pollingStarted.lazySet(true);
 

--- a/java/server/test/org/openqa/selenium/events/BUILD.bazel
+++ b/java/server/test/org/openqa/selenium/events/BUILD.bazel
@@ -2,8 +2,8 @@ load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//java:defs.bzl", "java_test_suite")
 
 java_test_suite(
-    name = "medium-tests",
-    size = "medium",
+    name = "large-tests",
+    size = "large",
     srcs = glob(["*.java"]),
     deps = [
         "//java/client/src/org/openqa/selenium:core",

--- a/java/server/test/org/openqa/selenium/events/EventBusTest.java
+++ b/java/server/test/org/openqa/selenium/events/EventBusTest.java
@@ -59,12 +59,12 @@ public class EventBusTest {
             "tcp://*:" + PortProber.findFreePort(),
             true,
             secret),
-//        () -> ZeroMqEventBus.create(
-//            new ZContext(),
-//            "tcp://localhost:" + PortProber.findFreePort(),
-//            "tcp://localhost:" + PortProber.findFreePort(),
-//            true,
-//            secret),
+        () -> ZeroMqEventBus.create(
+            new ZContext(),
+            "tcp://localhost:" + PortProber.findFreePort(),
+            "tcp://localhost:" + PortProber.findFreePort(),
+            true,
+            secret),
         GuavaEventBus::new);
   }
 

--- a/java/server/test/org/openqa/selenium/events/EventBusTest.java
+++ b/java/server/test/org/openqa/selenium/events/EventBusTest.java
@@ -59,12 +59,12 @@ public class EventBusTest {
             "tcp://*:" + PortProber.findFreePort(),
             true,
             secret),
-        () -> ZeroMqEventBus.create(
-            new ZContext(),
-            "tcp://localhost:" + PortProber.findFreePort(),
-            "tcp://localhost:" + PortProber.findFreePort(),
-            true,
-            secret),
+//        () -> ZeroMqEventBus.create(
+//            new ZContext(),
+//            "tcp://localhost:" + PortProber.findFreePort(),
+//            "tcp://localhost:" + PortProber.findFreePort(),
+//            true,
+//            secret),
         GuavaEventBus::new);
   }
 

--- a/java/server/test/org/openqa/selenium/events/EventBusTest.java
+++ b/java/server/test/org/openqa/selenium/events/EventBusTest.java
@@ -83,7 +83,7 @@ public class EventBusTest {
     bus.close();
   }
 
-  @Test(timeout = 4000)
+  @Test(timeout = 10000)
   public void shouldBeAbleToPublishToAKnownTopic() throws InterruptedException {
     EventName cheese = new EventName("cheese");
     Event event = new Event(cheese, null);
@@ -91,7 +91,7 @@ public class EventBusTest {
     CountDownLatch latch = new CountDownLatch(1);
     bus.addListener(new EventListener<>(cheese, Object.class, obj -> latch.countDown()));
     bus.fire(event);
-    latch.await(1, SECONDS);
+    latch.await(5, SECONDS);
 
     assertThat(latch.getCount()).isEqualTo(0);
   }
@@ -120,7 +120,7 @@ public class EventBusTest {
         executor.submit(() -> bus.fire(new Event(name, "")));
       }
 
-      assertThat(count.await(20, SECONDS)).describedAs(count.toString()).isTrue();
+      assertThat(count.await(60, SECONDS)).describedAs(count.toString()).isTrue();
     } finally {
       executor.shutdownNow();
     }


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixing event bus flaky tests to avoid ClosedSelectorException and CancelledKeyException. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Increasing the Eventbus poll timeout to ensure all messages are read as they come on the listener end.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
