### PR TITLE
[grid] Fix build due to SessionRequests renaming

### DIFF
--- a/java/server/src/org/openqa/selenium/grid/commands/Hub.java
+++ b/java/server/src/org/openqa/selenium/grid/commands/Hub.java
@@ -44,7 +44,7 @@ import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.config.SessionRequestOptions;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.web.CombinedHandler;
 import org.openqa.selenium.grid.web.GridUiRoute;
@@ -144,7 +144,7 @@ public class Hub extends TemplateGridServerCommand {
       networkOptions.getHttpClientFactory(tracer));
 
     SessionRequestOptions sessionRequestOptions = new SessionRequestOptions(config);
-    SessionRequests sessionRequests = new LocalSessionRequests(
+    SessionRequests sessionRequests = new SessionRequests(
       tracer,
       bus,
       sessionRequestOptions.getSessionRequestRetryInterval(),

--- a/java/server/src/org/openqa/selenium/grid/commands/Standalone.java
+++ b/java/server/src/org/openqa/selenium/grid/commands/Standalone.java
@@ -45,7 +45,6 @@ import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.config.SessionRequestOptions;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.web.CombinedHandler;
 import org.openqa.selenium.grid.web.GridUiRoute;
@@ -141,7 +140,7 @@ public class Standalone extends TemplateGridServerCommand {
     combinedHandler.addHandler(sessions);
 
     SessionRequestOptions sessionRequestOptions = new SessionRequestOptions(config);
-    SessionRequests sessionRequests = new LocalSessionRequests(
+    SessionRequests sessionRequests = new SessionRequests(
       tracer,
       bus,
       sessionRequestOptions.getSessionRequestRetryInterval(),

--- a/java/server/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
+++ b/java/server/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
@@ -70,7 +70,7 @@ public class LocalNewSessionQueue extends NewSessionQueue {
     EventBus bus = new EventBusOptions(config).getEventBus();
     Duration retryInterval = new SessionRequestOptions(config).getSessionRequestRetryInterval();
     Duration requestTimeout = new SessionRequestOptions(config).getSessionRequestTimeout();
-    SessionRequests sessionRequests = new LocalSessionRequests(
+    SessionRequests sessionRequests = new SessionRequests(
       tracer,
       bus,
       retryInterval,

--- a/java/server/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
@@ -46,7 +46,7 @@ import org.openqa.selenium.grid.node.Node;
 import org.openqa.selenium.grid.node.local.LocalNode;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.grid.web.CombinedHandler;
@@ -106,7 +106,7 @@ public class AddingNodesTest {
       HttpClient.Factory.createDefault());
 
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localNewSessionQueue = new LocalSessionRequests(
+    SessionRequests localNewSessionQueue = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -50,7 +50,7 @@ import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.SessionRequest;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.EitherAssert;
 import org.openqa.selenium.grid.testing.PassthroughHttpClient;
@@ -124,7 +124,7 @@ public class DistributorTest {
     tracer = DefaultTestTracer.createTracer();
     bus = new GuavaEventBus();
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localNewSessionQueue = new LocalSessionRequests(
+    SessionRequests localNewSessionQueue = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -156,7 +156,7 @@ public class DistributorTest {
   public void shouldStartHeartBeatOnNodeRegistration() {
     EventBus bus = new GuavaEventBus();
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localNewSessionQueue = new LocalSessionRequests(
+    SessionRequests localNewSessionQueue = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -207,7 +207,7 @@ public class DistributorTest {
   @Test
   public void shouldBeAbleToAddANodeAndCreateASession() {
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -248,7 +248,7 @@ public class DistributorTest {
   @Test
   public void creatingASessionAddsItToTheSessionMap() {
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -291,7 +291,7 @@ public class DistributorTest {
   @Test
   public void shouldBeAbleToRemoveANode() throws MalformedURLException {
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -332,7 +332,7 @@ public class DistributorTest {
   @Test
   public void testDrainingNodeDoesNotAcceptNewSessions() {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -368,7 +368,7 @@ public class DistributorTest {
   @Test
   public void testDrainedNodeShutsDownOnceEmpty() throws InterruptedException {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -414,7 +414,7 @@ public class DistributorTest {
   @Test
   public void drainedNodeDoesNotShutDownIfNotEmpty() throws InterruptedException {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -460,7 +460,7 @@ public class DistributorTest {
   @Test
   public void drainedNodeShutsDownAfterSessionsFinish() throws InterruptedException {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -535,7 +535,7 @@ public class DistributorTest {
     // * reverse insertion order
     // * sorted with most heavily used first
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -582,7 +582,7 @@ public class DistributorTest {
   @Test
   public void shouldUseLastSessionCreatedTimeAsTieBreaker() {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -661,7 +661,7 @@ public class DistributorTest {
     CombinedHandler handler = new CombinedHandler();
 
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -717,7 +717,7 @@ public class DistributorTest {
   @Test
   public void shouldNotScheduleAJobIfAllSlotsAreBeingUsed() {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -757,7 +757,7 @@ public class DistributorTest {
   @Test
   public void shouldReleaseSlotOnceSessionEnds() {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -816,7 +816,7 @@ public class DistributorTest {
     CombinedHandler handler = new CombinedHandler();
 
     LocalSessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -852,7 +852,7 @@ public class DistributorTest {
   @Test
   public void attemptingToStartASessionWhichFailsMarksAsTheSlotAsAvailable() {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -894,7 +894,7 @@ public class DistributorTest {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     handler.addHandler(sessions);
     AtomicReference<Availability> isUp = new AtomicReference<>(DOWN);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -969,7 +969,7 @@ public class DistributorTest {
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     handler.addHandler(sessions);
 
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/distributor/local/GridModelTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/local/GridModelTest.java
@@ -24,7 +24,7 @@ import org.openqa.selenium.grid.distributor.Distributor;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.remote.tracing.DefaultTestTracer;
@@ -39,7 +39,7 @@ public class GridModelTest {
   private final HttpClient.Factory clientFactory = HttpClient.Factory.createDefault();
   private final SessionMap sessions = new LocalSessionMap(tracer, events);
   private final Secret secret = new Secret("cheese");
-  LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+  SessionRequests localSessionRequests = new SessionRequests(
     tracer,
     events,
     Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
@@ -36,8 +36,8 @@ import org.openqa.selenium.grid.node.local.LocalNode;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.SessionRequest;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.internal.Either;
 import org.openqa.selenium.remote.HttpSessionId;
@@ -95,7 +95,7 @@ public class LocalDistributorTest {
 
   @Test
   public void testAddNodeToDistributor() {
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -129,7 +129,7 @@ public class LocalDistributorTest {
   @Test
   public void testShouldNotAddNodeWithWrongSecret() {
     Secret secret = new Secret("my_secret");
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -157,7 +157,7 @@ public class LocalDistributorTest {
 
   @Test
   public void testRemoveNodeFromDistributor() {
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -191,7 +191,7 @@ public class LocalDistributorTest {
 
   @Test
   public void testAddSameNodeTwice() {
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -220,7 +220,7 @@ public class LocalDistributorTest {
 
   @Test
   public void shouldBeAbleToAddMultipleSessionsConcurrently() throws Exception {
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -300,7 +300,7 @@ public class LocalDistributorTest {
 
   @Test
   public void testDrainNodeFromDistributor() {
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),
@@ -341,7 +341,7 @@ public class LocalDistributorTest {
   public void testDrainNodeFromNode() {
     assertThat(localNode.isDraining()).isFalse();
 
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
+++ b/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
@@ -55,7 +55,7 @@ import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.SessionRequest;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.internal.Either;
@@ -92,7 +92,7 @@ public class GraphqlHandlerTest {
   private EventBus events;
   private ImmutableCapabilities caps;
   private ImmutableCapabilities stereotype;
-  private LocalSessionRequests localNewSessionQueue;
+  private SessionRequests localNewSessionQueue;
   private SessionRequest sessionRequest;
 
   public GraphqlHandlerTest() throws URISyntaxException {
@@ -113,7 +113,7 @@ public class GraphqlHandlerTest {
       Set.of(OSS, W3C),
       Set.of(caps));
 
-    localNewSessionQueue = new LocalSessionRequests(
+    localNewSessionQueue = new SessionRequests(
       tracer,
       events,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/router/JmxTest.java
+++ b/java/server/test/org/openqa/selenium/grid/router/JmxTest.java
@@ -30,7 +30,7 @@ import org.openqa.selenium.grid.node.local.LocalNode;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.server.BaseServerOptions;
 import org.openqa.selenium.grid.sessionqueue.config.SessionRequestOptions;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.tracing.DefaultTestTracer;
@@ -193,7 +193,7 @@ public class JmxTest {
       Tracer tracer = DefaultTestTracer.createTracer();
       EventBus bus = new GuavaEventBus();
 
-      LocalSessionRequests localNewSessionQueue = new LocalSessionRequests(
+      SessionRequests localNewSessionQueue = new SessionRequests(
         tracer,
         bus,
         Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/router/NewSessionCreationTest.java
+++ b/java/server/test/org/openqa/selenium/grid/router/NewSessionCreationTest.java
@@ -41,7 +41,7 @@ import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.grid.web.CombinedHandler;
@@ -92,7 +92,7 @@ public class NewSessionCreationTest {
   @Test
   public void ensureJsCannotCreateANewSession() throws URISyntaxException {
     SessionMap sessions = new LocalSessionMap(tracer, events);
-    LocalSessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       events,
       Duration.ofSeconds(2),
@@ -168,7 +168,7 @@ public class NewSessionCreationTest {
 
     SessionMap sessions = new LocalSessionMap(tracer, events);
     handler.addHandler(sessions);
-    SessionRequests sessionRequests = new LocalSessionRequests(
+    SessionRequests sessionRequests = new SessionRequests(
       tracer,
       events,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/router/RouterTest.java
+++ b/java/server/test/org/openqa/selenium/grid/router/RouterTest.java
@@ -34,7 +34,7 @@ import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.PassthroughHttpClient;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
@@ -85,7 +85,7 @@ public class RouterTest {
 
     registrationSecret = new Secret("stinking bishop");
 
-    LocalSessionRequests localNewSessionQueue = new LocalSessionRequests(
+    SessionRequests localNewSessionQueue = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(2),

--- a/java/server/test/org/openqa/selenium/grid/router/SessionQueueGridTest.java
+++ b/java/server/test/org/openqa/selenium/grid/router/SessionQueueGridTest.java
@@ -64,7 +64,7 @@ import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
+import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
 import org.openqa.selenium.grid.web.CombinedHandler;
@@ -98,7 +98,7 @@ public class SessionQueueGridTest {
 
     SessionMap sessions = new LocalSessionMap(tracer, bus);
     handler.addHandler(sessions);
-    SessionRequests localSessionRequests = new LocalSessionRequests(
+    SessionRequests localSessionRequests = new SessionRequests(
       tracer,
       bus,
       Duration.ofSeconds(5),

--- a/java/server/test/org/openqa/selenium/grid/sessionqueue/NewSessionQueueTest.java
+++ b/java/server/test/org/openqa/selenium/grid/sessionqueue/NewSessionQueueTest.java
@@ -33,7 +33,6 @@ import org.openqa.selenium.grid.data.NewSessionResponseEvent;
 import org.openqa.selenium.grid.data.RequestId;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.grid.security.Secret;
-import org.openqa.selenium.grid.sessionqueue.local.LocalSessionRequests;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.local.SessionRequests;
 import org.openqa.selenium.grid.sessionqueue.remote.RemoteNewSessionQueue;
@@ -94,7 +93,7 @@ public class NewSessionQueueTest {
     caps = new ImmutableCapabilities("browserName", "chrome");
     bus = new GuavaEventBus();
 
-    sessionQueue = new LocalSessionRequests(
+    sessionQueue = new SessionRequests(
         tracer,
         bus,
         Duration.ofSeconds(1),
@@ -428,7 +427,7 @@ public class NewSessionQueueTest {
   @Test(timeout = 15000)
   public void shouldBeAbleToTimeoutARequestOnRemove() {
     Tracer tracer = DefaultTestTracer.createTracer();
-    LocalSessionRequests sessionQueue = new LocalSessionRequests(
+    SessionRequests sessionQueue = new SessionRequests(
         tracer,
         bus,
         Duration.ofSeconds(4),

--- a/java/server/test/org/openqa/selenium/grid/sessionqueue/local/SessionRequestsTest.java
+++ b/java/server/test/org/openqa/selenium/grid/sessionqueue/local/SessionRequestsTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.openqa.selenium.remote.Dialect.W3C;
 
-public class LocalSessionRequestsTest {
+public class SessionRequestsTest {
 
   private EventBus bus;
   private SessionRequests sessionQueue;
@@ -58,7 +58,7 @@ public class LocalSessionRequestsTest {
     Tracer tracer = DefaultTestTracer.createTracer();
     expectedCaps = new ImmutableCapabilities("browserName", "chrome");
     bus = new GuavaEventBus();
-    sessionQueue = new LocalSessionRequests(
+    sessionQueue = new SessionRequests(
         tracer,
         bus,
         Duration.ofSeconds(30),
@@ -202,7 +202,7 @@ public class LocalSessionRequestsTest {
 
   @Test(timeout = 15000)
   public void shouldBeAbleToRemoveRequestsOnTimeout() throws InterruptedException {
-    SessionRequests localSessionQueue = new LocalSessionRequests(
+    SessionRequests localSessionQueue = new SessionRequests(
       DefaultTestTracer.createTracer(),
       bus,
       Duration.ofSeconds(30),


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fix build due to SessionRequests renaming

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The java build was breaking due since it was unable to find LocalSessionRequests. The LocalSessionRequests class contents were merged into SessionRequests class. The changes rename the LocalSessionRequests to SessionRequests all necessary source files and test files.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
