### PR TITLE
[dotnet] Add additional RelativeSelectors

### DIFF
--- a/common/src/web/relative_locators.html
+++ b/common/src/web/relative_locators.html
@@ -14,9 +14,9 @@
 </head>
 <body>
 <h1>Relative Locator Tests</h1>
-<p id="above">This text is above.
-<p id="mid">This is a paragraph of text in the middle.
-<p id="below">This text is below.
+<p class="identify" id="above">This text is above.
+<p class="identify" id="mid">This is a paragraph of text in the middle.
+<p class="identify" id="below">This text is below.
 
 
 <table>
@@ -34,6 +34,24 @@
     <td id="seventh">7</td>
     <td id="eighth">8</td>
     <td id="ninth">9</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+   <td>
+	<a id="highestLink" href="#">One</a>
+   </td>
+  </tr>
+  <tr>
+   <td>
+   	<a id="middleLink" name="secondLink" href="#">Two</a>
+   </td>
+  </tr>
+  <tr> 
+   <td>
+   	<a id="lowestLink" href="#">Three</a>
+   </td>
   </tr>
 </table>
 

--- a/dotnet/src/webdriver/RelativeBy.cs
+++ b/dotnet/src/webdriver/RelativeBy.cs
@@ -81,6 +81,111 @@ namespace OpenQA.Selenium
         }
 
         /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified class name.
+        /// </summary>
+        /// <param name="className">The class name of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithClassName(string className)
+        {
+            if (string.IsNullOrEmpty(className))
+            {
+                throw new ArgumentException("Class name must not be null or the empty string", "className");
+            }
+
+            return new RelativeBy(By.ClassName(className));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified id.
+        /// </summary>
+        /// <param name="id">The id of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithId(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("Id must not be null or the empty string", "id");
+            }
+
+            return new RelativeBy(By.Id(id));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Name must not be null or the empty string", "name");
+            }
+
+            return new RelativeBy(By.Name(name));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified link text.
+        /// </summary>
+        /// <param name="linkText">The link text of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithLinkText(string linkText)
+        {
+            if (string.IsNullOrEmpty(linkText))
+            {
+                throw new ArgumentException("Link text must not be null or the empty string", "linkText");
+            }
+
+            return new RelativeBy(By.LinkText(linkText));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified partial link text.
+        /// </summary>
+        /// <param name="linkText">The link text of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithPartialLinkText(string linkText)
+        {
+            if (string.IsNullOrEmpty(linkText))
+            {
+                throw new ArgumentException("Link text must not be null or the empty string", "linkText");
+            }
+
+            return new RelativeBy(By.PartialLinkText(linkText));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified CSS selector.
+        /// </summary>
+        /// <param name="cssSelector">The link text of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithCssSelector(string cssSelector)
+        {
+            if (string.IsNullOrEmpty(cssSelector))
+            {
+                throw new ArgumentException("CSS selector must not be null or the empty string", "cssSelector");
+            }
+
+            return new RelativeBy(By.CssSelector(cssSelector));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RelativeBy"/> for finding elements with the specified XPath.
+        /// </summary>
+        /// <param name="xPath">The XPath of the element to find.</param>
+        /// <returns>A <see cref="RelativeBy"/> object to be used in finding the elements.</returns>
+        public static RelativeBy WithXPath(string xPath)
+        {
+            if (string.IsNullOrEmpty(xPath))
+            {
+                throw new ArgumentException("XPath must not be null or the empty string", "xPath");
+            }
+
+            return new RelativeBy(By.XPath(xPath));
+        }
+
+        /// <summary>
         /// Finds the first element matching the criteria.
         /// </summary>
         /// <param name="context">An <see cref="ISearchContext"/> object to use to search for the elements.</param>

--- a/dotnet/test/common/RelativeLocatorTest.cs
+++ b/dotnet/test/common/RelativeLocatorTest.cs
@@ -10,6 +10,94 @@ namespace OpenQA.Selenium
     public class RelativeLocatorTest : DriverTestFixture
     {
         [Test]
+        public void WithId()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("center"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithId("eighth").Below(highest));
+
+            var id = foundBelow.GetAttribute("id");
+            Assert.That(id == "eighth");
+        }
+
+        [Test]
+        public void WithCssSelector()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("center"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithCssSelector("#eighth").Below(highest));
+
+            var id = foundBelow.GetAttribute("id");
+            Assert.That(id == "eighth");
+        }
+
+        [Test]
+        public void WithXPath()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("center"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithXPath("//td").Below(highest).RightOf(By.Id("seventh")));
+
+            var id = foundBelow.GetAttribute("id");
+            Assert.AreEqual("eighth", id);
+        }
+
+        [Test]
+        public void WithName()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("highestLink"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithName("secondLink").Below(highest));
+
+            var id = foundBelow.GetAttribute("id");
+            Assert.That(id == "middleLink");
+        }
+
+        [Test]
+        public void WithLinkText()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("highestLink"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithLinkText("Two").Below(highest));
+
+            Assert.That(foundBelow.Displayed);
+        }
+
+        [Test]
+        public void WithPartialLinkText()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("highestLink"));
+            IWebElement foundBelow = driver.FindElement(RelativeBy.WithPartialLinkText("Thre").Below(highest));
+
+            Assert.That(foundBelow.Displayed);
+        }
+
+        [Test]
+        public void ShouldBeAbleToFindElementsBelowAnother()
+        {
+            driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));
+
+            IWebElement highest = driver.FindElement(By.Id("above"));
+
+            ReadOnlyCollection<IWebElement> elements = driver.FindElements(RelativeBy.WithClassName("identify").Below(highest));
+            List<string> elementIds = new List<string>();
+            foreach (IWebElement element in elements)
+            {
+                string id = element.GetAttribute("id");
+                elementIds.Add(id);
+            }
+
+            Assert.That(elementIds, Is.EquivalentTo(new List<string>() { "below", "mid" }));
+        }
+
+        [Test]
         public void ShouldBeAbleToFindElementsAboveAnother()
         {
             driver.Url = (EnvironmentManager.Instance.UrlBuilder.WhereIs("relative_locators.html"));


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Expands the number of RelativeSelectors that can be created. 

Additions to RelativeBy:
- WithClassName
- WithId
- WithName
- WithXPath
- WithCssSelector
- WithLinkText
- WithPartialLinkText

@jimevans mentioned the need for this while answering a question of mine.

### Motivation and Context
Currently in the dotnet bindings the RelativeSelector can only be created through WithTagName, but support for all other selectors needs to be implemented.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
