### PR TITLE
Update doc for ignored_exceptions of WebDriverWait()

### DIFF
--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -32,7 +32,7 @@ class WebDriverWait(object):
             - timeout - Number of seconds before timing out
             - poll_frequency - sleep interval between calls
               By default, it is 0.5 second.
-            - ignored_exceptions - iterable structure of exception classes ignored during calls.
+            - ignored_exceptions - iterable structure of exception classes ignored during calls. N.B. `selenium.common.exceptions.TimeoutException` is not ignored for `until(self, method, message='')` and `until_not(self, method, message='')` 
               By default, it contains NoSuchElementException only.
 
            Example::


### PR DESCRIPTION
If we set 
`WebDriverWait(driver, timeout, poll_frequency=0.5, ignored_exceptions=[TimeoutException])`
It won't ignore the `TimeoutException` because[ the source code](https://github.com/SeleniumHQ/selenium/blob/64447d4b03f6986337d1ca8d8b6476653570bcc1/py/selenium/webdriver/support/wait.py#L87) shows  it still raise the exception 