### PR TITLE
[Javascript] Add support for installing addon by remote path in Firefox

### DIFF
--- a/javascript/node/selenium-webdriver/firefox.js
+++ b/javascript/node/selenium-webdriver/firefox.js
@@ -632,22 +632,30 @@ class Driver extends webdriver.WebDriver {
    * ID that may later be used to {@linkplain #uninstallAddon uninstall} the
    * addon.
    *
+   * To install an unpacked extension, specify the path to the extension
+   * directory with temporary = true and remotePath = true.
    *
-   * @param {string} path Path on the local filesystem to the web extension to
-   *     install.
+   * @param {string} path Path on the local or remote filesystem to the web
+   * extension to install.
    * @param {boolean} temporary Flag indicating whether the extension should be
    *     installed temporarily - gets removed on restart
+   * @param {boolean} remotePath Flag indicating whether the path should be
+   *     resolved locally or on the remote sever. If true, the addon path must
+   *     be absolute.
    * @return {!Promise<string>} A promise that will resolve to an ID for the
    *     newly installed addon.
    * @see #uninstallAddon
    */
-  async installAddon(path, temporary = false) {
-    let buf = await io.read(path)
-    return this.execute(
-      new command.Command(ExtensionCommand.INSTALL_ADDON)
-        .setParameter('addon', buf.toString('base64'))
-        .setParameter('temporary', temporary)
-    )
+  async installAddon(path, temporary = false, remotePath = false) {
+    let cmd = new command.Command(ExtensionCommand.INSTALL_ADDON)
+      .setParameter('temporary', temporary)
+    if (remotePath) {
+      cmd = cmd.setParameter('path', path)
+    } else {
+      let buf = await io.read(path)
+      cmd = cmd.setParameter('addon', buf.toString('base64'))
+    }
+    return this.execute(cmd)
   }
 
   /**

--- a/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/inject.js
+++ b/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/inject.js
@@ -1,0 +1,6 @@
+((function(document) {
+  var div = document.createElement('div');
+  div.id = 'webextensions-selenium-example'
+  div.textContent = "Content injected by webextensions-selenium-example";
+  document.body.appendChild(div);
+})(document))

--- a/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/manifest.json
+++ b/javascript/node/selenium-webdriver/lib/test/data/firefox/webextension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 2,
+  "name": "webextensions-selenium-example",
+  "description": "Inject a div with id webextensions-selenium-example to verify that WebExtensions work in Firefox/Selenium" ,
+  "version": "0.1",
+  "content_scripts": [
+    {
+      "matches": ["https://*/*","http://*/*"],
+      "js": ["inject.js"]
+    }
+  ],
+  "applications": {
+   "gecko": {
+     "id": "webextensions-selenium-example@example.com"
+   }
+ }
+}

--- a/javascript/node/selenium-webdriver/test/firefox_test.js
+++ b/javascript/node/selenium-webdriver/test/firefox_test.js
@@ -34,6 +34,10 @@ const WEBEXTENSION_EXTENSION_ZIP = path.join(
   __dirname,
   '../lib/test/data/firefox/webextension.zip'
 )
+const WEBEXTENSION_EXTENSION_UNPACKED = path.join(
+  __dirname,
+  '../lib/test/data/firefox/webextension'
+)
 
 const WEBEXTENSION_EXTENSION_ID =
   'webextensions-selenium-example@example.com.xpi'
@@ -253,6 +257,24 @@ suite(
           'Content injected by webextensions-selenium-example'
         )
       }
+
+      it('unpacked addons can be installed and uninstalled at runtime', async function () {
+        driver = env.builder().build()
+
+        await driver.get(Pages.echoPage)
+        await verifyWebExtensionNotInstalled()
+
+        let id = await driver.installAddon(
+          WEBEXTENSION_EXTENSION_UNPACKED, true, true)
+        await driver.sleep(1000) // Give extension time to install
+
+        await driver.get(Pages.echoPage)
+        await verifyWebExtensionWasInstalled()
+
+        await driver.uninstallAddon(id)
+        await driver.get(Pages.echoPage)
+        await verifyWebExtensionNotInstalled()
+      })
     })
   },
   { browsers: [Browser.FIREFOX] }


### PR DESCRIPTION
### Description

Add a `remotePath` parameter to the firefox `Driver.installAddon()` method to allow specifying a path to the addon on the WebDriver server.

### Motivation and Context
Geckodriver allows two ways of specifying an addon to install at runtime:
* The addon contents may be specified with the `addon` parameter
* The path to the addon may be specified with the `path` parameter

Currently the Javascript code reads the specified path to a string and sends it using the `addon` parameter.  This requires the addon to be in a "packed" .xpi or .zip file format.

This change adds the capability to send the path to the remote server instead of the addon data. In this case, the path may be either a .xpi/.zip file or an unpacked directory.

See #8357

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
