### PR TITLE
[grid] Add trace headers to SessionRequest for distributed Grid tracing

### DIFF
--- a/java/server/src/org/openqa/selenium/grid/data/TraceSessionRequest.java
+++ b/java/server/src/org/openqa/selenium/grid/data/TraceSessionRequest.java
@@ -1,0 +1,27 @@
+package org.openqa.selenium.grid.data;
+
+import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.tracing.HttpTracing;
+import org.openqa.selenium.remote.tracing.TraceContext;
+import org.openqa.selenium.remote.tracing.Tracer;
+
+import static org.openqa.selenium.remote.http.HttpMethod.GET;
+
+public class TraceSessionRequest {
+
+  private TraceSessionRequest() {
+    // Utility methods
+  }
+
+  public static TraceContext extract(Tracer tracer, SessionRequest sessionRequest) {
+    Require.nonNull("Tracer", tracer);
+    Require.nonNull("Session request", sessionRequest);
+
+    return tracer.getPropagator()
+      .extractContext(
+        tracer.getCurrentContext(),
+        sessionRequest,
+        SessionRequest::getTraceHeader);
+  }
+}

--- a/java/server/src/org/openqa/selenium/grid/data/TraceSessionRequest.java
+++ b/java/server/src/org/openqa/selenium/grid/data/TraceSessionRequest.java
@@ -1,12 +1,8 @@
 package org.openqa.selenium.grid.data;
 
 import org.openqa.selenium.internal.Require;
-import org.openqa.selenium.remote.http.HttpRequest;
-import org.openqa.selenium.remote.tracing.HttpTracing;
 import org.openqa.selenium.remote.tracing.TraceContext;
 import org.openqa.selenium.remote.tracing.Tracer;
-
-import static org.openqa.selenium.remote.http.HttpMethod.GET;
 
 public class TraceSessionRequest {
 

--- a/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -66,7 +66,6 @@ import org.openqa.selenium.remote.tracing.EventAttribute;
 import org.openqa.selenium.remote.tracing.EventAttributeValue;
 import org.openqa.selenium.remote.tracing.Span;
 import org.openqa.selenium.remote.tracing.Status;
-import org.openqa.selenium.remote.tracing.TraceContext;
 import org.openqa.selenium.remote.tracing.Tracer;
 import org.openqa.selenium.status.HasReadyState;
 

--- a/java/server/src/org/openqa/selenium/grid/sessionqueue/NewSessionQueue.java
+++ b/java/server/src/org/openqa/selenium/grid/sessionqueue/NewSessionQueue.java
@@ -26,8 +26,6 @@ import org.openqa.selenium.grid.security.RequiresSecretFilter;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.internal.Either;
 import org.openqa.selenium.internal.Require;
-import org.openqa.selenium.remote.NewSessionPayload;
-import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.Routable;
@@ -35,16 +33,12 @@ import org.openqa.selenium.remote.http.Route;
 import org.openqa.selenium.remote.tracing.Tracer;
 import org.openqa.selenium.status.HasReadyState;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.openqa.selenium.remote.http.Route.combine;
 import static org.openqa.selenium.remote.http.Route.delete;

--- a/java/server/src/org/openqa/selenium/grid/sessionqueue/NewSessionQueue.java
+++ b/java/server/src/org/openqa/selenium/grid/sessionqueue/NewSessionQueue.java
@@ -65,18 +65,12 @@ public abstract class NewSessionQueue implements HasReadyState, Routable {
     routes = combine(
       post("/session")
         .to(() -> req -> {
-          try (Reader reader = Contents.reader(req);
-               NewSessionPayload payload = NewSessionPayload.create(reader)) {
-            SessionRequest sessionRequest = new SessionRequest(
-              new RequestId(UUID.randomUUID()),
-              Instant.now(),
-              payload.getDownstreamDialects(),
-              payload.stream().collect(Collectors.toSet()),
-              payload.getMetadata());
-            return addToQueue(sessionRequest);
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
+          SessionRequest sessionRequest = new SessionRequest(
+            new RequestId(UUID.randomUUID()),
+            req,
+            Instant.now()
+          );
+          return addToQueue(sessionRequest);
         }),
       post("/se/grid/newsessionqueue/session")
         .to(() -> new AddToSessionQueue(tracer, this))

--- a/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -1098,6 +1098,7 @@ public class DistributorTest {
               new ImmutableCapabilities("browserName", "not cheese"),
             // But there is for this, so we expect this to be created.
               new ImmutableCapabilities("browserName", "cheese")),
+      Map.of(),
       Map.of());
 
     Either<SessionNotCreatedException, CreateSessionResponse> result = local.newSession(sessionRequest);
@@ -1123,6 +1124,7 @@ public class DistributorTest {
               new ImmutableCapabilities("browserName", "not cheese"),
             // But there is for this, so we expect this to be created.
               new ImmutableCapabilities("browserName", "cheese")),
+      Map.of(),
       Map.of());
 
     Either<SessionNotCreatedException, CreateSessionResponse> result = local.newSession(sessionRequest);
@@ -1138,6 +1140,7 @@ public class DistributorTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(allCaps),
+      Map.of(),
       Map.of());
   }
 

--- a/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
@@ -263,6 +263,7 @@ public class LocalDistributorTest {
             Instant.now(),
             Set.of(W3C),
             Set.of(new ImmutableCapabilities("browserName", "cheese")),
+            Map.of(),
             Map.of());
 
     List<Callable<SessionId>> callables = new ArrayList<>();

--- a/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
+++ b/java/server/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
@@ -113,6 +113,7 @@ public class GraphqlHandlerTest {
       Instant.now(),
       Set.of(OSS, W3C),
       Set.of(caps),
+      Map.of(),
       Map.of());
 
     queue = new LocalNewSessionQueue(
@@ -182,6 +183,7 @@ public class GraphqlHandlerTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(caps),
+      Map.of(),
       Map.of());
 
     continueOnceAddedToQueue(request);
@@ -203,6 +205,7 @@ public class GraphqlHandlerTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(caps),
+      Map.of(),
       Map.of());
 
     continueOnceAddedToQueue(request);

--- a/java/server/test/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueueTest.java
+++ b/java/server/test/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueueTest.java
@@ -125,6 +125,7 @@ public class LocalNewSessionQueueTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(CAPS),
+      Map.of(),
       Map.of());
   }
 
@@ -383,6 +384,7 @@ public class LocalNewSessionQueueTest {
         Instant.now(),
         Set.of(W3C),
         Set.of(CAPS),
+        Map.of(),
         Map.of());
 
       return queue.addToQueue(sessionRequest);
@@ -416,6 +418,7 @@ public class LocalNewSessionQueueTest {
       LONG_AGO,
       Set.of(W3C),
       Set.of(CAPS),
+      Map.of(),
       Map.of());
 
     AtomicInteger count = new AtomicInteger();
@@ -446,6 +449,7 @@ public class LocalNewSessionQueueTest {
       LONG_AGO,
       Set.of(W3C),
       Set.of(CAPS),
+      Map.of(),
       Map.of());
     localQueue.injectIntoQueue(sessionRequest);
 
@@ -465,6 +469,7 @@ public class LocalNewSessionQueueTest {
         Instant.now(),
         Set.of(W3C),
         Set.of(CAPS),
+        Map.of(),
         Map.of());
       return queue.addToQueue(sessionRequest);
     };
@@ -499,6 +504,7 @@ public class LocalNewSessionQueueTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(new ImmutableCapabilities("browserName", "cheese", "se:kind", "smoked")),
+      Map.of(),
       Map.of());
     localQueue.injectIntoQueue(expected);
 
@@ -507,6 +513,7 @@ public class LocalNewSessionQueueTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(new ImmutableCapabilities("browserName", "peas", "se:kind", "mushy")),
+      Map.of(),
       Map.of()));
 
     Optional<SessionRequest> returned = queue.getNextAvailable(
@@ -525,6 +532,7 @@ public class LocalNewSessionQueueTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(new ImmutableCapabilities("browserName", "peas", "se:kind", "mushy")),
+      Map.of(),
       Map.of()));
 
     SessionRequest expected = new SessionRequest(
@@ -532,6 +540,7 @@ public class LocalNewSessionQueueTest {
       Instant.now(),
       Set.of(W3C),
       Set.of(new ImmutableCapabilities("browserName", "cheese", "se:kind", "smoked")),
+      Map.of(),
       Map.of());
     localQueue.injectIntoQueue(expected);
 


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add trace headers to SessionRequest for distributed Grid tracing

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When run in Hub-Node or fully distributed Grid mode, the trace for a new session request was incomplete between New Session Queue and Distributor. The changes fix that by ensuring the trace context is propagated correctly between services. This is done by adding tracer headers and using them to recreate the trace context to create the span.

Thank you @shs96c for providing the right direction via https://github.com/shs96c/selenium/tree/queue-tracing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
