### PR TITLE
Add the debuggerAddress option to chromium.js

### DIFF
--- a/javascript/node/selenium-webdriver/chromium.js
+++ b/javascript/node/selenium-webdriver/chromium.js
@@ -276,6 +276,19 @@ class Options extends Capabilities {
   }
 
   /**
+   * Sets the address of a Chromium remote debugging server to connect to.
+   * Address should be of the form "{hostname|IP address}:port"
+   * (e.g. "localhost:9222").
+   *
+   * @param {string} address The address to connect to.
+   * @return {!Options} A self reference.
+   */
+  debuggerAddress(address) {
+    this.options_.debuggerAddress = address;
+    return this
+  }
+
+  /**
    * Configures the driver to start the browser in headless mode.
    *
    * > __NOTE:__ Resizing the browser window in headless mode is only supported


### PR DESCRIPTION
### Description
Adding a setter for Chromium's debuggerAddress capability. This is available in other language bindings but was missing from the JS bindings.

### Motivation and Context
Chromium-based drivers provide the `debuggerAddress` option to let the user attach to an already-running browser instance at the specified address instead of launching a new one. One example where this is useful is certain WebView2 (WV2) scenarios. Users may want to test the web portion of an app that embeds WV2, but need to launch the app outside WebDriver first and drill through some native UI in order to activate the WV2 they are trying to test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
