### PR TITLE
Issue #8550: SlowLoadableComponent ignores UnableToLoadMessage

### DIFF
--- a/dotnet/src/support/UI/SlowLoadableComponent{T}.cs
+++ b/dotnet/src/support/UI/SlowLoadableComponent{T}.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SlowLoadableComponent{T}.cs" company="WebDriver Committers">
+// <copyright file="SlowLoadableComponent{T}.cs" company="WebDriver Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
@@ -104,8 +104,12 @@ namespace OpenQA.Selenium.Support.UI
             }
             else
             {
-                string timeoutMessage = string.Format(CultureInfo.InvariantCulture, "Timed out after {0} seconds.", this.timeout.TotalSeconds);
-                throw new WebDriverTimeoutException(timeoutMessage);
+                if (string.IsNullOrEmpty(UnableToLoadMessage))
+                {
+                    UnableToLoadMessage = string.Format(CultureInfo.InvariantCulture, "Timed out after {0} seconds.", this.timeout.TotalSeconds);
+                }
+
+                throw new WebDriverTimeoutException(this.UnableToLoadMessage);
             }
         }
 


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
`SlowLoadableComponent` type ignores `UnableToLoadMessage` and instead defaults to message "Timed out after X seconds.". This PR checks if string `UnableToLoadMessage` is set and uses that string instead.

### Motivation and Context
The `SlowLoadableComponent` was not working as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
