### PR TITLE
[py] remove non-w3c compliant parameters from default capabilities

### DIFF
--- a/py/selenium/webdriver/common/desired_capabilities.py
+++ b/py/selenium/webdriver/common/desired_capabilities.py
@@ -55,32 +55,24 @@ class DesiredCapabilities(object):
 
     INTERNETEXPLORER = {
         "browserName": "internet explorer",
-        "version": "",
-        "platform": "WINDOWS",
+        "platformName": "WINDOWS",
     }
 
     EDGE = {
         "browserName": "MicrosoftEdge",
-        "version": "",
-        "platform": "ANY"
     }
 
     CHROME = {
         "browserName": "chrome",
-        "version": "",
-        "platform": "ANY",
     }
 
     OPERA = {
         "browserName": "opera",
-        "version": "",
-        "platform": "ANY",
     }
 
     SAFARI = {
         "browserName": "safari",
-        "version": "",
-        "platform": "MAC",
+        "platformName": "MAC",
     }
 
     HTMLUNIT = {

--- a/py/test/unit/selenium/webdriver/remote/new_session_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/new_session_tests.py
@@ -87,8 +87,6 @@ def test_always_match_if_2_of_the_same_options():
             "alwaysMatch": {
                 "browserName": "chrome",
                 "pageLoadStrategy": "normal",
-                "platform": "ANY",
-                "version": ""
             },
             "firstMatch": [
                 {"goog:chromeOptions": {"args": ["foo"], "extensions": []}},
@@ -109,8 +107,6 @@ def test_first_match_when_2_different_option_types():
             "alwaysMatch": {"pageLoadStrategy": "normal"},
             "firstMatch": [
                 {"browserName": "chrome",
-                 "platform": "ANY",
-                 "version": "",
                  "goog:chromeOptions": {"extensions": [], "args": []}},
                 {"browserName": "firefox",
                  "acceptInsecureCerts": True,


### PR DESCRIPTION
I'm not sure this is the right fix for this. I'm trying to generate compliant capabilities with `ChromeOptions().to_capabilities()`, but it includes `version` and `platform` kyes. The right answer might be not to call this in the first place during the init? `self._caps = self.default_capabilities`

The Python tests appear to all be broken from [this commit](2ea9026477a051e62cc486eb18a61db3fc228934), so I'm not sure if there are tests that also need to be updated for this.