### PR TITLE
[py] fix type hints for selenium.webdriver.remote.file_detector

### DIFF
--- a/py/selenium/types.py
+++ b/py/selenium/types.py
@@ -1,0 +1,23 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Selenium type definitions."""
+
+from typing import Union
+
+
+AnyKey = Union[str, int, float]

--- a/py/selenium/webdriver/common/utils.py
+++ b/py/selenium/webdriver/common/utils.py
@@ -22,9 +22,9 @@ The Utils methods.
 from typing import Iterable, List, Optional, Union
 
 import socket
+from selenium.types import AnyKey
 from selenium.webdriver.common.keys import Keys
 
-AnyKey = Union[str, int, float]
 
 _is_connectable_exceptions = (socket.error, ConnectionResetError)
 

--- a/py/selenium/webdriver/remote/file_detector.py
+++ b/py/selenium/webdriver/remote/file_detector.py
@@ -18,8 +18,8 @@
 from abc import ABCMeta, abstractmethod
 import os
 from typing import Optional
+from selenium.types import AnyKey
 from selenium.webdriver.common.utils import keys_to_typing
-# from selenium.types import AnyKey
 
 
 class FileDetector(metaclass=ABCMeta):
@@ -29,7 +29,7 @@ class FileDetector(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def is_local_file(self, *keys) -> Optional[str]:
+    def is_local_file(self, *keys: AnyKey) -> Optional[str]:
         return None
 
 
@@ -38,7 +38,7 @@ class UselessFileDetector(FileDetector):
     A file detector that never finds anything.
     """
 
-    def is_local_file(self, *keys) -> Optional[str]:
+    def is_local_file(self, *keys: AnyKey) -> Optional[str]:
         return None
 
 
@@ -47,7 +47,7 @@ class LocalFileDetector(FileDetector):
     Detects files on the local disk.
     """
 
-    def is_local_file(self, *keys) -> Optional[str]:
+    def is_local_file(self, *keys: AnyKey) -> Optional[str]:
         file_path = ''.join(keys_to_typing(keys))
 
         if not file_path:


### PR DESCRIPTION
### Description
This PR introduces a module `selenium.types` that contains types reused throughout the codebase. Unfortunately, I forgot to include that in #9606, which caused tests breakage.

### Motivation and Context
The type of the input valid to be typed in a `WebElement` (`Union[str, float, int]`) is required for typing in several modules, so the proposal to avoid duplication is to move it to a common module `selenium.types` used to declare custom types. This approach is often used in large libraries, for example in `tensorflow`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.