### PR TITLE
Close DriverService and DriverCommandExecutor executor on quit

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/service/DriverCommandExecutor.java
+++ b/java/client/src/org/openqa/selenium/remote/service/DriverCommandExecutor.java
@@ -130,6 +130,8 @@ public class DriverCommandExecutor extends HttpCommandExecutor implements Closea
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new WebDriverException("Timed out waiting for driver server to stop.", e);
+      } finally {
+        executorService.shutdownNow();
       }
 
     } else {

--- a/java/client/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/client/src/org/openqa/selenium/remote/service/DriverService.java
@@ -286,6 +286,7 @@ public class DriverService implements Closeable {
     } finally {
       process = null;
       lock.unlock();
+      executorService.shutdownNow();
     }
 
     if (toThrow != null) {


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes #9666

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A dedicated thread pool is provided for DriverService's async calls. The thread pool was initially not closed after the session is quit. The changes fix that. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
