### PR TITLE
Update IE Options Classes to match currently supported IE Driver Capabilities

### DIFF
--- a/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
@@ -89,6 +89,9 @@ namespace OpenQA.Selenium.IE
         private const string ForceShellWindowsApiCapability = "ie.forceShellWindowsApi";
         private const string FileUploadDialogTimeoutCapability = "ie.fileUploadDialogTimeout";
         private const string EnableFullPageScreenshotCapability = "ie.enableFullPageScreenshot";
+        private const string EdgeExecutablePathCapability = "ie.edgepath";
+        private const string LegacyFileUploadDialogHandlingCapability = "ie.useLegacyFileUploadDialogHandling";
+        private const string AttachToEdgeChromeCapability = "ie.edgechromium";
 
         private bool ignoreProtectedModeSettings;
         private bool ignoreZoomLevel;
@@ -100,10 +103,13 @@ namespace OpenQA.Selenium.IE
         private bool usePerProcessProxy;
         private bool ensureCleanSession;
         private bool enableFullPageScreenshot = true;
+        private bool legacyFileUploadDialogHandling;
+        private bool attachToEdgeChrome;
         private TimeSpan browserAttachTimeout = TimeSpan.MinValue;
         private TimeSpan fileUploadDialogTimeout = TimeSpan.MinValue;
         private string initialBrowserUrl = string.Empty;
         private string browserCommandLineArguments = string.Empty;
+        private string edgeExecutablePathCapability = string.Empty;
         private InternetExplorerElementScrollBehavior elementScrollBehavior = InternetExplorerElementScrollBehavior.Default;
         private Dictionary<string, object> additionalInternetExplorerOptions = new Dictionary<string, object>();
 
@@ -131,6 +137,9 @@ namespace OpenQA.Selenium.IE
             this.AddKnownCapabilityName(EnsureCleanSessionCapability, "EnsureCleanSession property");
             this.AddKnownCapabilityName(FileUploadDialogTimeoutCapability, "FileUploadDialogTimeout property");
             this.AddKnownCapabilityName(EnableFullPageScreenshotCapability, "EnableFullPageScreenshot property");
+            this.AddKnownCapabilityName(LegacyFileUploadDialogHanldingCapability, "LegacyFileUploadDialogHanlding property");
+            this.AddKnownCapabilityName(AttachToEdgeChromeCapability, "AttachToEdgeChrome property");
+            this.AddKnownCapabilityName(EdgeExecutablePathCapability, "EdgeExecutablePath property");
         }
 
         /// <summary>
@@ -280,6 +289,33 @@ namespace OpenQA.Selenium.IE
         {
             get { return this.ensureCleanSession; }
             set { this.ensureCleanSession = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the legacy handling for file upload dialogs.
+        /// </summary>
+        public bool LegacyFileUploadDialogHanlding
+        {
+            get { return this.legacyFileUploadDialogHandling; }
+            set { this.legacyFileUploadDialogHandling = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to attach to Edge Chrome browser.
+        /// </summary>
+        public bool AttachToEdgeChrome
+        {
+            get { return this.attachToEdgeChrome; }
+            set { this.attachToEdgeChrome = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the path to the Edge Browser Executable.
+        /// </summary>
+        public string EdgeExecutablePath
+        {
+            get { return this.edgeExecutablePath; }
+            set { this.edgeExecutablePath = value; }
         }
 
         /// <summary>
@@ -445,6 +481,21 @@ namespace OpenQA.Selenium.IE
             if (!this.enableFullPageScreenshot)
             {
                 internetExplorerOptionsDictionary[EnableFullPageScreenshotCapability] = false;
+            }
+
+            if (this.legacyFileUploadDialogHandling)
+            {
+                internetExplorerOptionsDictionary[LegacyFileUploadDialogHandling] = true;
+            }
+
+            if (this.attachToEdgeChrome)
+            {
+                internetExplorerOptionsDictionary[AttachToEdgeChrome] = true;
+            }
+
+            if (!string.IsNullOrEmpty(this.edgeExecutablePathCapability))
+            {
+                internetExplorerOptionsDictionary[EdgeExecutablePathCapability] = this.edgeExecutablePathCapability;
             }
 
             foreach (KeyValuePair<string, object> pair in this.additionalInternetExplorerOptions)

--- a/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
+++ b/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
@@ -63,7 +63,9 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
   private static final String FULL_PAGE_SCREENSHOT = "ie.enableFullPageScreenshot";
   private static final String UPLOAD_DIALOG_TIMEOUT = "ie.fileUploadDialogTimeout";
   private static final String FORCE_WINDOW_SHELL_API = "ie.forceShellWindowsApi";
-  private static final String VALIDATE_COOKIE_DOCUMENT_TYPE = "ie.validateCookieDocumentType";
+  private static final String LEGACY_FILE_UPLOAD_DIALOG_HANDLING = "ie.useLegacyFileUploadDialogHandling";
+  private static final String ATTACH_TO_EDGE_CHROME = "ie.edgechromium";
+  private static final String EDGE_EXECUTABLE_PATH = "ie.edgepath";
 
   private static final List<String> CAPABILITY_NAMES = Arrays.asList(
     BROWSER_ATTACH_TIMEOUT,
@@ -80,8 +82,11 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
     INTRODUCE_FLAKINESS_BY_IGNORING_SECURITY_DOMAINS,
     REQUIRE_WINDOW_FOCUS,
     UPLOAD_DIALOG_TIMEOUT,
-    VALIDATE_COOKIE_DOCUMENT_TYPE,
-    NATIVE_EVENTS);
+    NATIVE_EVENTS,
+    LEGACY_FILE_UPLOAD_DIALOG_HANDLING,
+    ATTACH_TO_EDGE_CHROME,
+    EDGE_EXECUTABLE_PATH);
+
 
   private final Map<String, Object> ieOptions = new HashMap<>();
 
@@ -211,6 +216,18 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
 
   public InternetExplorerOptions takeFullPageScreenshot() {
     return amend(FULL_PAGE_SCREENSHOT, true);
+  }
+
+  public InternetExplorerOptions useLegacyUploadDialog() {
+    return amend(LEGACY_FILE_UPLOAD_DIALOG_HANDLING, true);
+  }
+
+  public InternetExplorerOptions attachToEdgeChrome() {
+    return amend(ATTACH_TO_EDGE_CHROME, true);
+  }
+
+  public InternetExplorerOptions withEdgeExecutablePath(String path) {
+    return amend(EDGE_EXECUTABLE_PATH, path);
   }
 
   private InternetExplorerOptions amend(String optionName, Object value) {

--- a/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
+++ b/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
@@ -49,7 +49,6 @@ public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> ex
     setCapability(
         UNHANDLED_PROMPT_BEHAVIOUR,
         Require.nonNull("Unhandled prompt behavior", behaviour));
-    setCapability(UNEXPECTED_ALERT_BEHAVIOUR, behaviour);
     return (DO) this;
   }
 

--- a/py/selenium/webdriver/ie/options.py
+++ b/py/selenium/webdriver/ie/options.py
@@ -44,7 +44,9 @@ class Options(ArgOptions):
     PERSISTENT_HOVER = 'enablePersistentHover'
     REQUIRE_WINDOW_FOCUS = 'requireWindowFocus'
     USE_PER_PROCESS_PROXY = 'ie.usePerProcessProxy'
-    VALIDATE_COOKIE_DOCUMENT_TYPE = 'ie.validateCookieDocumentType'
+    USE_LEGACY_FILE_UPLOAD_DIALOG_HANDLING = 'ie.useLegacyFileUploadDialogHandling'
+    ATTACH_TO_EDGE_CHROME = 'ie.edgechromium'
+    EDGE_EXECUTABLE_PATH = 'ie.edgepath'
 
     def __init__(self):
         super(Options, self).__init__()
@@ -289,20 +291,52 @@ class Options(ArgOptions):
         self._options[self.USE_PER_PROCESS_PROXY] = value
 
     @property
-    def validate_cookie_document_type(self) -> bool:
-        """:Returns: The options Validate Cookie Document Type value """
-        return self._options.get(self.VALIDATE_COOKIE_DOCUMENT_TYPE)
+    def use_legacy_file_upload_dialog_handling(self) -> bool:
+        """:Returns: The options Use Legacy File Upload Dialog Handling value """
+        return self._options.get(self.USE_LEGACY_FILE_UPLOAD_DIALOG_HANDLING)
 
-    @validate_cookie_document_type.setter
-    def validate_cookie_document_type(self, value: bool):
+    @use_legacy_file_upload_dialog_handling.setter
+    def use_legacy_file_upload_dialog_handling(self, value: bool):
         """
-        Sets the options Validate Cookie Document Type value
+        Sets the options Use Legacy File Upload Dialog Handling value
 
         :Args:
          - value: boolean value
 
         """
-        self._options[self.VALIDATE_COOKIE_DOCUMENT_TYPE] = value
+        self._options[self.USE_LEGACY_FILE_UPLOAD_DIALOG_HANDLING] = value
+
+    @property
+    def attach_to_edge_chrome(self) -> bool:
+        """:Returns: The options Attach to Edge Chrome value """
+        return self._options.get(self.ATTACH_TO_EDGE_CHROME)
+
+    @attach_to_edge_chrome.setter
+    def attach_to_edge_chrome(self, value: bool):
+        """
+        Sets the options Attach to Edge Chrome value
+
+        :Args:
+         - value: boolean value
+
+        """
+        self._options[self.ATTACH_TO_EDGE_CHROME] = value
+
+    @property
+    def edge_executable_path(self) -> str:
+        """:Returns: The options Edge Executable Path value """
+        return self._options.get(self.EDGE_EXECUTABLE_PATH)
+
+    @edge_executable_path.setter
+    def edge_executable_path(self, value: str):
+        """
+        Sets the options Initial Browser Url value
+
+        :Args:
+         - value: Path string
+
+        """
+        self._options[self.EDGE_EXECUTABLE_PATH] = value
 
     @property
     def additional_options(self) -> dict:

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -39,7 +39,9 @@ module Selenium
           persistent_hover: 'enablePersistentHover',
           require_window_focus: 'requireWindowFocus',
           use_per_process_proxy: 'ie.usePerProcessProxy',
-          validate_cookie_document_type: 'ie.validateCookieDocumentType'
+          use_legacy_file_upload_dialog_handling: 'ie.useLegacyFileUploadDialogHandling',
+          attach_to_edge_chrome: 'ie.edgechromium',
+          edge_executable_path: 'ie.edgepath'
         }.freeze
         BROWSER = 'internet explorer'
 

--- a/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
@@ -54,7 +54,9 @@ module Selenium
                                persistent_hover: true,
                                require_window_focus: true,
                                use_per_process_proxy: true,
-                               validate_cookie_document_type: true,
+                               use_legacy_file_upload_dialog_handling: true,
+                               attach_to_edge_chrome: true,
+                               edge_executable_path: '/path/to/edge',
                                'custom:options': {foo: 'bar'})
 
             expect(opts.args.to_a).to eq(%w[foo bar])
@@ -72,7 +74,9 @@ module Selenium
             expect(opts.persistent_hover).to eq(true)
             expect(opts.require_window_focus).to eq(true)
             expect(opts.use_per_process_proxy).to eq(true)
-            expect(opts.validate_cookie_document_type).to eq(true)
+            expect(opts.use_legacy_file_upload_dialog_handling).to eq(true)
+            expect(opts.attach_to_edge_chrome).to eq(true)
+            expect(opts.edge_executable_path).to eq('/path/to/edge')
             expect(opts.browser_name).to eq('internet explorer')
             expect(opts.browser_version).to eq('11')
             expect(opts.platform_name).to eq('win10')
@@ -142,7 +146,9 @@ module Selenium
                                persistent_hover: true,
                                require_window_focus: true,
                                use_per_process_proxy: true,
-                               validate_cookie_document_type: true)
+                               use_legacy_file_upload_dialog_handling: true,
+                               attach_to_edge_chrome: true,
+                               edge_executable_path: '/path/to/edge')
 
             key = 'se:ieOptions'
             expect(opts.as_json).to eq('browserName' => 'internet explorer',
@@ -171,7 +177,9 @@ module Selenium
                                                'enablePersistentHover' => true,
                                                'requireWindowFocus' => true,
                                                'ie.usePerProcessProxy' => true,
-                                               'ie.validateCookieDocumentType' => true})
+                                               'ie.useLegacyFileUploadDialogHandling' => true,
+                                               'ie.edgechromium' => true,
+                                               'ie.edgepath' => '/path/to/edge'})
           end
         end
       end # Options


### PR DESCRIPTION
This addresses #9699 

I think I did this correctly for each language, please verify.

(Oh, and I wanted to double check I'm not screwing up backward compatibility with a JWP capability I deleted in Java)

Thanks!