### PR TITLE
[grid] Purge Nodes if health check fails consistently

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -290,6 +290,7 @@ public class LocalDistributor extends Distributor implements Closeable {
           getDebugLogLevel(),
           String.format("Health check result for %s was %s", node.getId(), result.getAvailability()));
         model.setAvailability(id, result.getAvailability());
+        model.updateHealthCheckCount(id, result.getAvailability());
       } finally {
         writeLock.unlock();
       }

--- a/java/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -90,6 +90,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -941,6 +942,117 @@ public class DistributorTest {
     assertThatEither(result).isRight();
   }
 
+  @Test
+  public void shouldRemoveNodeWhoseHealthCheckFailsConsistently() {
+    CombinedHandler handler = new CombinedHandler();
+
+    AtomicReference<Availability> availability = new AtomicReference<>(UP);
+
+    SessionMap sessions = new LocalSessionMap(tracer, bus);
+    handler.addHandler(sessions);
+    NewSessionQueue queue = new LocalNewSessionQueue(
+      tracer,
+      bus,
+      new DefaultSlotMatcher(),
+      Duration.ofSeconds(2),
+      Duration.ofSeconds(2),
+      registrationSecret);
+
+    URI uri = createUri();
+    Node node = LocalNode.builder(tracer, bus, uri, uri, registrationSecret)
+      .add(
+        caps,
+        new TestSessionFactory((id, caps) -> new Session(id, uri, stereotype, caps, Instant.now())))
+      .advanced()
+      .healthCheck(() -> new HealthCheck.Result(availability.get(), "TL;DR"))
+      .build();
+    handler.addHandler(node);
+
+    LocalDistributor distributor = new LocalDistributor(
+      tracer,
+      bus,
+      new PassthroughHttpClient.Factory(handler),
+      sessions,
+      queue,
+      new DefaultSlotSelector(),
+      registrationSecret,
+      Duration.ofSeconds(1),
+      false);
+    handler.addHandler(distributor);
+    distributor.add(node);
+
+    waitToHaveCapacity(distributor);
+
+    Either<SessionNotCreatedException, CreateSessionResponse> result =
+      distributor.newSession(createRequest(caps));
+    assertThatEither(result).isRight();
+
+    availability.set(DOWN);
+
+    waitTillNodesAreRemoved(distributor);
+
+    result =
+      distributor.newSession(createRequest(caps));
+    assertThatEither(result).isLeft();
+  }
+
+  @Test
+  public void shouldNotRemoveNodeWhoseHealthCheckPassesBeforeThreshold()
+    throws InterruptedException {
+    CombinedHandler handler = new CombinedHandler();
+
+    AtomicInteger count = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    SessionMap sessions = new LocalSessionMap(tracer, bus);
+    handler.addHandler(sessions);
+    NewSessionQueue queue = new LocalNewSessionQueue(
+      tracer,
+      bus,
+      new DefaultSlotMatcher(),
+      Duration.ofSeconds(2),
+      Duration.ofSeconds(2),
+      registrationSecret);
+
+    URI uri = createUri();
+    Node node = LocalNode.builder(tracer, bus, uri, uri, registrationSecret)
+      .add(
+        caps,
+        new TestSessionFactory((id, caps) -> new Session(id, uri, stereotype, caps, Instant.now())))
+      .advanced()
+      .healthCheck(() -> {
+        if (count.get() <= 4) {
+          count.incrementAndGet();
+          return new HealthCheck.Result(DOWN, "Down");
+        }
+        latch.countDown();
+        return new HealthCheck.Result(UP, "Up");
+      })
+      .build();
+    handler.addHandler(node);
+
+    LocalDistributor distributor = new LocalDistributor(
+      tracer,
+      bus,
+      new PassthroughHttpClient.Factory(handler),
+      sessions,
+      queue,
+      new DefaultSlotSelector(),
+      registrationSecret,
+      Duration.ofSeconds(1),
+      false);
+    handler.addHandler(distributor);
+    distributor.add(node);
+
+    latch.await(60, TimeUnit.SECONDS);
+
+    waitToHaveCapacity(distributor);
+
+    Either<SessionNotCreatedException, CreateSessionResponse> result =
+      distributor.newSession(createRequest(caps));
+    assertThatEither(result).isRight();
+  }
+
   private Set<Node> createNodeSet(CombinedHandler handler, Distributor distributor, int count, Capabilities...capabilities) {
     Set<Node> nodeSet = new HashSet<>();
     for (int i=0; i<count; i++) {
@@ -1253,7 +1365,7 @@ public class DistributorTest {
 
   private void waitTillNodesAreRemoved(Distributor distributor) {
     new FluentWait<>(distributor)
-      .withTimeout(Duration.ofSeconds(5))
+      .withTimeout(Duration.ofSeconds(60))
       .pollingEvery(Duration.ofMillis(100))
       .until(d -> {
         Set<NodeStatus> nodes = d.getStatus().getNodes();


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Purge Nodes if health check fails consistently

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the Node is purged if the heartbeat is not received for the threshold time interval (value is 4 times the heartbeat interval). If the health check fails, the Node is marked as "Down" but the next heartbeat can again change it to "Up". 
Heartbeat serves the purpose to ensure Node's liveliness. The health check serves the purpose to ensure Node's reachability from the Distributor.
So there might a situation where the health check is continuously failing but the heartbeat is alive, then the Node should be removed since it will not be reachable or might not be able to process new sessions.  The changes keep track of consecutive Node health check failures and purge the Nodes if it is beyond a threshold. The failed health check count is reset if the Node's healthcheck passes before hitting the threshold.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
