### PR TITLE
[grid] Delete existing sessions if the Node is restarted

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/NodeRestartedEvent.java
+++ b/java/src/org/openqa/selenium/grid/data/NodeRestartedEvent.java
@@ -1,0 +1,40 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+import org.openqa.selenium.events.Event;
+import org.openqa.selenium.events.EventListener;
+import org.openqa.selenium.events.EventName;
+import org.openqa.selenium.internal.Require;
+
+import java.util.function.Consumer;
+
+public class NodeRestartedEvent extends Event {
+
+  private static final EventName NODE_RESTARTED_EVENT = new EventName("node-restarted");
+
+  public NodeRestartedEvent(NodeStatus nodes) {
+    super(NODE_RESTARTED_EVENT, nodes);
+  }
+
+  public static EventListener<NodeStatus> listener(Consumer<NodeStatus> handler) {
+    Require.nonNull("Handler", handler);
+
+    return new EventListener<>(NODE_RESTARTED_EVENT, NodeStatus.class , handler);
+  }
+}

--- a/java/src/org/openqa/selenium/grid/distributor/GridModel.java
+++ b/java/src/org/openqa/selenium/grid/distributor/GridModel.java
@@ -24,6 +24,7 @@ import org.openqa.selenium.grid.data.Availability;
 import org.openqa.selenium.grid.data.NodeDrainStarted;
 import org.openqa.selenium.grid.data.NodeId;
 import org.openqa.selenium.grid.data.NodeRemovedEvent;
+import org.openqa.selenium.grid.data.NodeRestartedEvent;
 import org.openqa.selenium.grid.data.NodeStatus;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.grid.data.SessionClosedEvent;
@@ -102,6 +103,16 @@ public class GridModel {
           updateHealthCheckCount(refreshed.getNodeId(), refreshed.getAvailability());
 
           return;
+        }
+
+        // If the URI is the same but NodeId is different then the Node has restarted
+        if(!next.getNodeId().equals(node.getNodeId()) &&
+           next.getExternalUri().equals(node.getExternalUri())) {
+          LOG.info(String.format("Re-adding node with id %s and URI %s.", node.getNodeId(), node.getExternalUri()));
+
+          events.fire(new NodeRestartedEvent(node));
+          iterator.remove();
+          break;
         }
 
         // If the URI has changed, then assume this is a new node and fall

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.events.EventBus;
 import org.openqa.selenium.grid.config.Config;
 import org.openqa.selenium.grid.data.NodeRemovedEvent;
+import org.openqa.selenium.grid.data.NodeRestartedEvent;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.grid.data.SessionClosedEvent;
 import org.openqa.selenium.grid.log.LoggingOptions;
@@ -76,6 +77,9 @@ public class LocalSessionMap extends SessionMap {
       .filter(slot -> slot.getSession() != null)
       .map(slot -> slot.getSession().getId())
       .forEach(knownSessions::remove)));
+
+    bus.addListener(NodeRestartedEvent.listener(nodeStatus -> knownSessions.values()
+      .removeIf(value -> value.getUri().equals(nodeStatus.getExternalUri()))));
 
   }
 


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Delete existing sessions if the Node is restarted

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the Node is restarted, the Session Map might have some leftover sessions. In this case, they need to be deleted. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
