### PR TITLE
Rb extension capabilities

### DIFF
--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -90,7 +90,8 @@ module Selenium
       # @param [Boolean, String, Integer] value Value of the option
       #
 
-      def add_option(name, value)
+      def add_option(name, value = nil)
+        @options[name.keys.first] = name.values.first if value.nil? && name.is_a?(Hash)
         @options[name] = value
       end
 

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -123,10 +123,14 @@ module Selenium
 
       private
 
+      def w3c?(key)
+        W3C_OPTIONS.include?(key) || key.to_s.include?(':')
+      end
+
       def process_w3c_options(options)
-        w3c_options = options.select { |key, _val| W3C_OPTIONS.include?(key) }
+        w3c_options = options.select { |key, _val| w3c?(key) }
         w3c_options[:unhandled_prompt_behavior] &&= w3c_options[:unhandled_prompt_behavior]&.to_s&.tr('_', ' ')
-        options.delete_if { |key, _val| W3C_OPTIONS.include?(key) }
+        options.delete_if { |key, _val| w3c?(key) }
         w3c_options
       end
 
@@ -173,6 +177,8 @@ module Selenium
       def camel_case(str)
         str.gsub(/_([a-z])/) { Regexp.last_match(1).upcase }
       end
-    end # Options
+    end
+
+    # Options
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/safari/options.rb
+++ b/rb/lib/selenium/webdriver/safari/options.rb
@@ -28,8 +28,9 @@ module Selenium
                         automatic_profiling: 'safari:automaticProfiling'}.freeze
         BROWSER = 'safari'
 
-        def add_option(name, value)
-          raise ArgumentError, 'Safari does not support options that are not namespaced' unless name.to_s.include?(':')
+        def add_option(name, value = nil)
+          key = name.is_a?(Hash) ? name.keys.first : name
+          raise ArgumentError, 'Safari does not support options that are not namespaced' unless key.to_s.include?(':')
 
           super
         end

--- a/rb/lib/selenium/webdriver/safari/options.rb
+++ b/rb/lib/selenium/webdriver/safari/options.rb
@@ -28,6 +28,12 @@ module Selenium
                         automatic_profiling: 'safari:automaticProfiling'}.freeze
         BROWSER = 'safari'
 
+        def add_option(name, value)
+          raise ArgumentError, 'Safari does not support options that are not namespaced' unless name.to_s.include?(':')
+
+          super
+        end
+
       end # Options
     end # Safari
   end # WebDriver

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -212,9 +212,12 @@ module Selenium
             expect(options.as_json).to eq("browserName" => "chrome", "goog:chromeOptions" => {})
           end
 
-          it 'returns added option' do
+          it 'returns added options' do
             options.add_option(:foo, 'bar')
-            expect(options.as_json).to eq("browserName" => "chrome", "goog:chromeOptions" => {"foo" => "bar"})
+            options.add_option('foo:bar', {foo: 'bar'})
+            expect(options.as_json).to eq("browserName" => "chrome",
+                                          "foo:bar" => {"foo" => "bar"},
+                                          "goog:chromeOptions" => {"foo" => "bar"})
           end
 
           it 'converts profile' do
@@ -260,7 +263,8 @@ module Selenium
                                exclude_switches: %w[foobar barfoo],
                                minidump_path: 'linux/only',
                                perf_logging_prefs: {'enable_network': true},
-                               window_types: %w[normal devtools])
+                               window_types: %w[normal devtools],
+                               'custom:options': {foo: 'bar'})
 
             key = 'goog:chromeOptions'
             expect(opts.as_json).to eq('browserName' => 'chrome',
@@ -274,6 +278,7 @@ module Selenium
                                                       'pageLoad' => 400000,
                                                       'implicit' => 1},
                                        'setWindowRect' => false,
+                                       'custom:options' => {'foo' => 'bar'},
                                        key => {'args' => %w[foo bar],
                                                'prefs' => {'foo' => 'bar',
                                                            'key_that_should_not_be_camelcased' => 'baz',

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -177,8 +177,13 @@ module Selenium
         end
 
         describe '#add_option' do
-          it 'adds an option' do
+          it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
+          end
+
+          it 'adds an option with Hash' do
+            options.add_option(foo: 'bar')
             expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
           end
         end

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -133,8 +133,13 @@ module Selenium
         end
 
         describe '#add_option' do
-          it 'adds an option' do
+          it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
+          end
+
+          it 'adds an option with Hash' do
+            options.add_option(foo: 'bar')
             expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
           end
         end

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -168,9 +168,12 @@ module Selenium
             expect(options.as_json).to eq("browserName" => "MicrosoftEdge", "ms:edgeOptions" => {})
           end
 
-          it 'returns added option' do
+          it 'returns added options' do
             options.add_option(:foo, 'bar')
-            expect(options.as_json).to eq("browserName" => "MicrosoftEdge", "ms:edgeOptions" => {"foo" => "bar"})
+            options.add_option('foo:bar', {foo: 'bar'})
+            expect(options.as_json).to eq("browserName" => "MicrosoftEdge",
+                                          "foo:bar" => {"foo" => "bar"},
+                                          "ms:edgeOptions" => {"foo" => "bar"})
           end
 
           it 'returns a JSON hash' do
@@ -202,7 +205,8 @@ module Selenium
                                exclude_switches: %w[foobar barfoo],
                                minidump_path: 'linux/only',
                                perf_logging_prefs: {'enable_network': true},
-                               window_types: %w[normal devtools])
+                               window_types: %w[normal devtools],
+                               'custom:options': {foo: 'bar'})
 
             key = 'ms:edgeOptions'
             expect(opts.as_json).to eq('browserName' => 'MicrosoftEdge',
@@ -216,6 +220,7 @@ module Selenium
                                                       'pageLoad' => 400000,
                                                       'implicit' => 1},
                                        'setWindowRect' => false,
+                                       'custom:options' => {'foo' => 'bar'},
                                        key => {'args' => %w[foo bar],
                                                'prefs' => {'foo' => 'bar',
                                                            'key_that_should_not_be_camelcased' => 'baz'},

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -143,9 +143,12 @@ module Selenium
             expect(options.as_json).to eq("browserName" => "firefox", "moz:firefoxOptions" => {})
           end
 
-          it 'returns added option' do
+          it 'returns added options' do
             options.add_option(:foo, 'bar')
-            expect(options.as_json).to eq("browserName" => "firefox", "moz:firefoxOptions" => {"foo" => "bar"})
+            options.add_option('foo:bar', {foo: 'bar'})
+            expect(options.as_json).to eq("browserName" => "firefox",
+                                          "foo:bar" => {"foo" => "bar"},
+                                          "moz:firefoxOptions" => {"foo" => "bar"})
           end
 
           it 'converts to a json hash' do
@@ -167,7 +170,8 @@ module Selenium
                                prefs: {foo: 'bar'},
                                foo: 'bar',
                                profile: profile,
-                               log_level: :debug)
+                               log_level: :debug,
+                               'custom:options': {foo: 'bar'})
 
             key = 'moz:firefoxOptions'
             expect(opts.as_json).to eq('browserName' => 'firefox',
@@ -181,6 +185,7 @@ module Selenium
                                                       'pageLoad' => 400000,
                                                       'implicit' => 1},
                                        'setWindowRect' => false,
+                                       'custom:options' => {'foo' => 'bar'},
                                        key => {'args' => %w[foo bar],
                                                'binary' => '/foo/bar',
                                                'prefs' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -125,8 +125,13 @@ module Selenium
         end
 
         describe '#add_option' do
-          it 'adds an option' do
+          it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
+          end
+
+          it 'adds an option with Hash' do
+            options.add_option(foo: 'bar')
             expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
           end
         end

--- a/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
@@ -102,9 +102,14 @@ module Selenium
         end
 
         describe '#add_option' do
-          it 'adds an option' do
+          it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')
-            expect(options.options[:foo]).to eq('bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
+          end
+
+          it 'adds an option with Hash' do
+            options.add_option(foo: 'bar')
+            expect(options.instance_variable_get('@options')[:foo]).to eq('bar')
           end
         end
 

--- a/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
@@ -114,9 +114,11 @@ module Selenium
                                           "se:ieOptions" => {"nativeEvents" => true})
           end
 
-          it 'returns added option' do
+          it 'returns added options' do
             options.add_option(:foo, 'bar')
+            options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq("browserName" => "internet explorer",
+                                          "foo:bar" => {"foo" => "bar"},
                                           "se:ieOptions" => {"nativeEvents" => true, "foo" => "bar"})
           end
 
@@ -148,7 +150,8 @@ module Selenium
                                use_per_process_proxy: true,
                                use_legacy_file_upload_dialog_handling: true,
                                attach_to_edge_chrome: true,
-                               edge_executable_path: '/path/to/edge')
+                               edge_executable_path: '/path/to/edge',
+                               'custom:options': {foo: 'bar'})
 
             key = 'se:ieOptions'
             expect(opts.as_json).to eq('browserName' => 'internet explorer',
@@ -162,6 +165,7 @@ module Selenium
                                                       'pageLoad' => 400000,
                                                       'implicit' => 1},
                                        'setWindowRect' => false,
+                                       'custom:options' => {'foo' => 'bar'},
                                        key => {'ie.browserCommandLineSwitches' => 'foo bar',
                                                'browserAttachTimeout' => 30000,
                                                'elementScrollBehavior' => 1,

--- a/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
@@ -58,14 +58,28 @@ module Selenium
           end
         end
 
+        describe '#add_option' do
+          it 'adds an option if name spaced' do
+            options.add_option('safari:foo', 'bar')
+            expect(options.instance_variable_get('@options')['safari:foo']).to eq('bar')
+          end
+
+          # Note that this only applies to the method, weird things can still happen
+          # if stuff is passed into the constructor
+          it 'raises exception if not name spaced' do
+            expect { options.add_option('foo', 'bar') }.to raise_exception(ArgumentError)
+          end
+        end
+
         describe '#as_json' do
           it 'returns empty options by default' do
             expect(options.as_json).to eq("browserName" => "safari")
           end
 
-          it 'returns added option' do
-            options.add_option(:foo, 'bar')
-            expect(options.as_json).to eq("browserName" => "safari", "foo" => "bar")
+          it 'returns added options' do
+            options.add_option('safari:foo', 'bar')
+            expect(options.as_json).to eq("browserName" => "safari",
+                                          "safari:foo" => "bar")
           end
 
           it 'returns JSON hash' do
@@ -80,7 +94,8 @@ module Selenium
                                           implicit: 1},
                                set_window_rect: false,
                                automatic_profiling: false,
-                               automatic_inspection: true)
+                               automatic_inspection: true,
+                               'safari:foo': 'foo')
 
             expect(opts.as_json).to eq('browserName' => 'safari',
                                        'browserVersion' => '12',
@@ -94,7 +109,8 @@ module Selenium
                                                       'implicit' => 1},
                                        'setWindowRect' => false,
                                        'safari:automaticInspection' => true,
-                                       'safari:automaticProfiling' => false)
+                                       'safari:automaticProfiling' => false,
+                                       'safari:foo' => 'foo')
           end
         end
       end # Options

--- a/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
@@ -59,15 +59,26 @@ module Selenium
         end
 
         describe '#add_option' do
-          it 'adds an option if name spaced' do
-            options.add_option('safari:foo', 'bar')
-            expect(options.instance_variable_get('@options')['safari:foo']).to eq('bar')
+          context 'when namespaced' do
+            it 'adds an option with ordered pairs' do
+              options.add_option('safari:foo', 'bar')
+              expect(options.instance_variable_get('@options')['safari:foo']).to eq('bar')
+            end
+
+            it 'adds an option with Hash' do
+              options.add_option('safari:foo': 'bar')
+              expect(options.instance_variable_get('@options')[:'safari:foo']).to eq('bar')
+            end
           end
 
-          # Note that this only applies to the method, weird things can still happen
-          # if stuff is passed into the constructor
-          it 'raises exception if not name spaced' do
-            expect { options.add_option('foo', 'bar') }.to raise_exception(ArgumentError)
+          context 'when not namespaced' do
+            it 'raises exception with ordered pairs' do
+              expect { options.add_option('foo', 'bar') }.to raise_exception(ArgumentError)
+            end
+
+            it 'raises exception with Hash' do
+              expect { options.add_option(foo: 'bar') }.to raise_exception(ArgumentError)
+            end
           end
         end
 


### PR DESCRIPTION
I'm working on an update to the [Sauce Platform Configurator](https://saucelabs.com/platform/platform-configurator#/) for Selenium 4. All of the other languages are pretty straightforward with what they need to do, even if they do things a little differently:

#### Java
```java
ChromeOptions browserOptions = new ChromeOptions();
browserOptions.setCapability("platformName", "macOS 11.00");
browserOptions.setCapability("browserVersion", "latest");
MutableCapabilities sauceOptions = new MutableCapabilities();
browserOptions.setCapability("sauce:options", sauceOptions);
```

#### .NET
```c#
var browserOptions = new ChromeOptions();
browserOptions.PlatformName = "macOS 11.00";
browserOptions.BrowserVersion = "latest";
var sauceOptions = new Dictionary<string, object>();
browserOptions.AddAdditionalOption("sauce:options", sauceOptions, true);
```

#### Python
```python
from selenium.webdriver.chrome.options import Options as ChromeOptions

options = ChromeOptions()
options.set_capability('browserVersion', 'latest')
options.set_capability('platformName', 'macOS 11.00')
sauce_options = {}
options.set_capability('sauce:options', sauce_options)
```

#### Ruby

```ruby
options = Selenium::WebDriver::Options.chrome
options.browser_version = 'latest'
options.platform_name = 'macOS 11.00'
sauce_options = Selenium::WebDriver::Remote::Capabilities.new

capabilities = [options, sauce_options]
```

it works, but it's a little weird.

@jimevans did a nice thing in .NET where there is:
`AddAdditionalChromeOption` to get put inside `goog:chromeOptions` and `AddAdditionalOption` to get put at the top level of the capabilities.

But Ruby's `Options#add_option` currently will only put the value inside the vendor namepsaced capability (except for Safari since it doesn't have that, so everything is put at the top level).

This PR has `#add_option` checking if the value has a w3c compliant namespace, and if so it is put at the top level and if it doesn't, it is put inside the browser vendor's namespace. Thankfully the spec says this can't conflict:

> Other specifications may define additional WebDriver capabilities. Each defined capability must have a capability name which is a string not containing a ":" (colon) character

This PR also allows `#add_option` to be a `Hash` instead of just ordered pairs.

So both of these would now work as desired:
```ruby
options = Selenium::WebDriver::Options.chrome
options.browser_version = 'latest'
options.platform_name = 'macOS 11.00'
sauce_options = {}
options.add_option('sauce:options' => sauce_options)
```

```ruby
sauce_options ={}
options = Selenium::WebDriver::Options.chrome('sauce:options' => sauce_options)
options.browser_version = 'latest'
options.platform_name = 'macOS 11.00'
```