### PR TITLE
[js] Add a check for Grid CDP endpoint

### DIFF
--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -1229,6 +1229,14 @@ class WebDriver {
     if (target && cdpTargets.indexOf(target.toLowerCase()) === -1) {
       throw new error.InvalidArgumentError('invalid target value')
     }
+
+    if (debuggerAddress.match(/\/se\/cdp/)) {
+      if (debuggerAddress.match("ws:\/\/", "http:\/\/")) {
+        return debuggerAddress.replace("ws:\/\/", "http:\/\/") 
+      }
+      return debuggerAddress
+    }
+
     const path = '/json/version'
     let request = new http.Request('GET', path)
     let client = new http.HttpClient('http://' + debuggerAddress)

--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -1234,7 +1234,12 @@ class WebDriver {
       if (debuggerAddress.match("ws:\/\/", "http:\/\/")) {
         return debuggerAddress.replace("ws:\/\/", "http:\/\/") 
       }
+      else if (debuggerAddress.match("wss:\/\/", "https:\/\/")) {
+        return debuggerAddress.replace("wss:\/\/", "https:\/\/") 
+      }
+      else {
       return debuggerAddress
+      }
     }
 
     const path = '/json/version'


### PR DESCRIPTION
<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add a check for Grid CDP endpoint and accordingly return the URL for websocket connection. Fixes #9779.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a remote web driver is built and a create CDP connection request is made, it just waits for an indefinite period of time. This happens because the client tries to send a request to the endpoint of this format "http://ws://session/{session-id}/se/cdp" to the Grid server. Since the Grid does not recognize this, the client does not receive any response. This is fixed by checking if the endpoint received from "se:cdp" capability is a Grid CDP endpoint and accordingly it is handled. The client then uses this endpoint to make a websocket connection with the Grid. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
