### PR TITLE
Require "uri" in Selenium::Webdriver container module

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -23,6 +23,7 @@ require 'fileutils'
 require 'date'
 require 'json'
 require 'set'
+require 'uri'
 
 require 'selenium/webdriver/atoms'
 require 'selenium/webdriver/common'


### PR DESCRIPTION
### Description
This PR adds one line to `rb/lib/selenium/webdriver.rb`:

```ruby
require 'uri'
```

Fixes #9825

### Motivation and Context

`URI` was gemified in Ruby 2.7 https://github.com/ruby/uri/commit/a4a1d4c8094663585a5e8d9e08b52164cbadf267 and therefore must be manually required to use. I opened issue https://github.com/SeleniumHQ/selenium/issues/9825 illustrating the problem I was running into.

NB: I was not sure how to add tests for this, as this was a bugfix that made the library work correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
