### PR TITLE
Add methods to options classes for w3c compliant capabilities

### DIFF
--- a/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
+++ b/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
@@ -17,18 +17,6 @@
 
 package org.openqa.selenium.remote;
 
-import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
-import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
-import static org.openqa.selenium.remote.CapabilityType.IMPLICIT_TIMEOUT;
-import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
-import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_TIMEOUT;
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
-import static org.openqa.selenium.remote.CapabilityType.PROXY;
-import static org.openqa.selenium.remote.CapabilityType.SCRIPT_TIMEOUT;
-import static org.openqa.selenium.remote.CapabilityType.STRICT_FILE_INTERACTABILITY;
-import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
-import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
-
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.PageLoadStrategy;
 import org.openqa.selenium.Proxy;
@@ -36,17 +24,25 @@ import org.openqa.selenium.UnexpectedAlertBehaviour;
 import org.openqa.selenium.internal.Require;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
+import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
+import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
+import static org.openqa.selenium.remote.CapabilityType.PROXY;
+import static org.openqa.selenium.remote.CapabilityType.STRICT_FILE_INTERACTABILITY;
+import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
+import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
+
 public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> extends MutableCapabilities {
+  private Map<String, Long> timeouts = new HashMap<>();
+
   public DO setBrowserVersion(String browserVersion) {
     setCapability(
       BROWSER_VERSION,
@@ -61,19 +57,21 @@ public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> ex
     return (DO) this;
   }
 
-  public DO setTimeouts(Map<String, Duration> timeouts) {
-    HashMap<String, Long> convertedTimeouts = new HashMap<>();
-    List<String> validTimeouts = new ArrayList<>(Arrays.asList(IMPLICIT_TIMEOUT, PAGE_LOAD_TIMEOUT, SCRIPT_TIMEOUT));
+  public DO setImplicitWaitTimeout(Duration timeout) {
+    this.timeouts.put("implicit", timeout.toMillis());
+    setCapability(TIMEOUTS, this.timeouts);
+    return (DO) this;
+  }
 
-    Require.nonNull("Timeouts", timeouts).forEach((k, v) -> {
-      if (validTimeouts.contains(k)) {
-        convertedTimeouts.put(k, v.toMillis());
-      } else {
-        throw new IllegalArgumentException(k + " is not one of the valid timeout values: " + validTimeouts);
-      }
-    });
+  public DO setPageLoadTimeout(Duration timeout) {
+    this.timeouts.put("pageLoad", timeout.toMillis());
+    setCapability(TIMEOUTS, this.timeouts);
+    return (DO) this;
+  }
 
-    setCapability(TIMEOUTS, convertedTimeouts);
+  public DO setScriptTimeout(Duration timeout) {
+    this.timeouts.put("script", timeout.toMillis());
+    setCapability(TIMEOUTS, this.timeouts);
     return (DO) this;
   }
 

--- a/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
+++ b/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
@@ -18,10 +18,15 @@
 package org.openqa.selenium.remote;
 
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
+import static org.openqa.selenium.remote.CapabilityType.IMPLICIT_TIMEOUT;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
+import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_TIMEOUT;
+import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 import static org.openqa.selenium.remote.CapabilityType.PROXY;
+import static org.openqa.selenium.remote.CapabilityType.SCRIPT_TIMEOUT;
 import static org.openqa.selenium.remote.CapabilityType.STRICT_FILE_INTERACTABILITY;
-import static org.openqa.selenium.remote.CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR;
+import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
 
 import org.openqa.selenium.MutableCapabilities;
@@ -30,13 +35,47 @@ import org.openqa.selenium.Proxy;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
 import org.openqa.selenium.internal.Require;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
 public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> extends MutableCapabilities {
+  public DO setBrowserVersion(String browserVersion) {
+    setCapability(
+      BROWSER_VERSION,
+      Require.nonNull("Browser version", browserVersion));
+    return (DO) this;
+  }
+
+  public DO setPlatformName(String platformName) {
+    setCapability(
+      PLATFORM_NAME,
+      Require.nonNull("Platform Name", platformName));
+    return (DO) this;
+  }
+
+  public DO setTimeouts(Map<String, Duration> timeouts) {
+    HashMap<String, Long> convertedTimeouts = new HashMap<>();
+    List<String> validTimeouts = new ArrayList<>(Arrays.asList(IMPLICIT_TIMEOUT, PAGE_LOAD_TIMEOUT, SCRIPT_TIMEOUT));
+
+    Require.nonNull("Timeouts", timeouts).forEach((k, v) -> {
+      if (validTimeouts.contains(k)) {
+        convertedTimeouts.put(k, v.toMillis());
+      } else {
+        throw new IllegalArgumentException(k + " is not one of the valid timeout values: " + validTimeouts);
+      }
+    });
+
+    setCapability(TIMEOUTS, convertedTimeouts);
+    return (DO) this;
+  }
 
   public DO setPageLoadStrategy(PageLoadStrategy strategy) {
     setCapability(

--- a/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
+++ b/java/src/org/openqa/selenium/remote/AbstractDriverOptions.java
@@ -41,8 +41,6 @@ import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;
 
 public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> extends MutableCapabilities {
-  private Map<String, Long> timeouts = new HashMap<>();
-
   public DO setBrowserVersion(String browserVersion) {
     setCapability(
       BROWSER_VERSION,
@@ -58,20 +56,26 @@ public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> ex
   }
 
   public DO setImplicitWaitTimeout(Duration timeout) {
-    this.timeouts.put("implicit", timeout.toMillis());
-    setCapability(TIMEOUTS, this.timeouts);
+    Map<String, Number> timeouts = getTimeouts();
+    timeouts.put("implicit", timeout.toMillis());
+
+    setCapability(TIMEOUTS, Collections.unmodifiableMap(timeouts));
     return (DO) this;
   }
 
   public DO setPageLoadTimeout(Duration timeout) {
-    this.timeouts.put("pageLoad", timeout.toMillis());
-    setCapability(TIMEOUTS, this.timeouts);
+    Map<String, Number> timeouts = getTimeouts();
+    timeouts.put("pageLoad", timeout.toMillis());
+
+    setCapability(TIMEOUTS, Collections.unmodifiableMap(timeouts));
     return (DO) this;
   }
 
   public DO setScriptTimeout(Duration timeout) {
-    this.timeouts.put("script", timeout.toMillis());
-    setCapability(TIMEOUTS, this.timeouts);
+    Map<String, Number> timeouts = getTimeouts();
+    timeouts.put("script", timeout.toMillis());
+
+    setCapability(TIMEOUTS, Collections.unmodifiableMap(timeouts));
     return (DO) this;
   }
 
@@ -130,5 +134,16 @@ public abstract class AbstractDriverOptions<DO extends AbstractDriverOptions> ex
     Map<String, Object> toReturn = new TreeMap<>(super.asMap());
     getExtraCapabilityNames().forEach(name -> toReturn.put(name, getCapability(name)));
     return Collections.unmodifiableMap(toReturn);
+  }
+
+  private Map<String, Number> getTimeouts() {
+    Map<String, Number> newTimeouts = new HashMap<>();
+    Object raw = getCapability(TIMEOUTS);
+    ((Map<?, ?>) raw).forEach((key, value) -> {
+      if (key instanceof String && value instanceof Number) {
+        newTimeouts.put((String) key, (Number) value);
+      }
+    });
+      return newTimeouts;
   }
 }

--- a/java/src/org/openqa/selenium/remote/CapabilityType.java
+++ b/java/src/org/openqa/selenium/remote/CapabilityType.java
@@ -47,6 +47,10 @@ public interface CapabilityType {
   String HAS_TOUCHSCREEN = "hasTouchScreen";
   String OVERLAPPING_CHECK_DISABLED = "overlappingCheckDisabled";
   String STRICT_FILE_INTERACTABILITY = "strictFileInteractability";
+  String TIMEOUTS = "timeouts";
+  String IMPLICIT_TIMEOUT = "implicit";
+  String PAGE_LOAD_TIMEOUT = "pageLoad";
+  String SCRIPT_TIMEOUT = "script";
 
   String LOGGING_PREFS = "loggingPrefs";
 

--- a/java/src/org/openqa/selenium/remote/CapabilityType.java
+++ b/java/src/org/openqa/selenium/remote/CapabilityType.java
@@ -48,9 +48,6 @@ public interface CapabilityType {
   String OVERLAPPING_CHECK_DISABLED = "overlappingCheckDisabled";
   String STRICT_FILE_INTERACTABILITY = "strictFileInteractability";
   String TIMEOUTS = "timeouts";
-  String IMPLICIT_TIMEOUT = "implicit";
-  String PAGE_LOAD_TIMEOUT = "pageLoad";
-  String SCRIPT_TIMEOUT = "script";
 
   String LOGGING_PREFS = "loggingPrefs";
 

--- a/java/test/org/openqa/selenium/chrome/BUILD.bazel
+++ b/java/test/org/openqa/selenium/chrome/BUILD.bazel
@@ -22,4 +22,8 @@ java_selenium_test_suite(
         artifact("org.assertj:assertj-core"),
         artifact("org.mockito:mockito-core"),
     ],
+    javacopts = [
+            "--release",
+            "11",
+        ],
 )

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -41,9 +41,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.openqa.selenium.chrome.ChromeDriverLogLevel.OFF;
 import static org.openqa.selenium.chrome.ChromeDriverLogLevel.SEVERE;
-import static org.openqa.selenium.remote.CapabilityType.IMPLICIT_TIMEOUT;
-import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_TIMEOUT;
-import static org.openqa.selenium.remote.CapabilityType.SCRIPT_TIMEOUT;
 
 @Category(UnitTests.class)
 public class ChromeOptionsTest {
@@ -76,18 +73,15 @@ public class ChromeOptionsTest {
   @Test
   public void canAddW3CCompliantOptions() {
     ChromeOptions chromeOptions = new ChromeOptions();
-    chromeOptions.setBrowserVersion("99");
-    chromeOptions.setPlatformName("9 3/4");
-    chromeOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
-    chromeOptions.setAcceptInsecureCerts(true);
-    chromeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
-    chromeOptions.setStrictFileInteractability(true);
-
-    Map<String, Duration> timeouts = new HashMap<>();
-    timeouts.put(IMPLICIT_TIMEOUT, Duration.ofSeconds(1));
-    timeouts.put(PAGE_LOAD_TIMEOUT, Duration.ofSeconds(2));
-    timeouts.put(SCRIPT_TIMEOUT, Duration.ofSeconds(3));
-    chromeOptions.setTimeouts(timeouts);
+    chromeOptions.setBrowserVersion("99")
+      .setPlatformName("9 3/4")
+      .setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE)
+      .setAcceptInsecureCerts(true)
+      .setPageLoadStrategy(PageLoadStrategy.EAGER)
+      .setStrictFileInteractability(true)
+      .setImplicitWaitTimeout(Duration.ofSeconds(1))
+      .setPageLoadTimeout(Duration.ofSeconds(2))
+      .setScriptTimeout(Duration.ofSeconds(3));
 
     Map<String, Object> mappedOptions = chromeOptions.asMap();
     assertThat(mappedOptions.get("browserName")).isEqualTo("chrome");
@@ -98,35 +92,29 @@ public class ChromeOptionsTest {
     assertThat(mappedOptions.get("pageLoadStrategy").toString()).isEqualTo("eager");
     assertThat(mappedOptions.get("strictFileInteractability")).isEqualTo(true);
 
-    Map<String, Long> convertedTimeouts = new HashMap<>();
-    convertedTimeouts.put("implicit", 1000L);
-    convertedTimeouts.put("pageLoad", 2000L);
-    convertedTimeouts.put("script", 3000L);
+    Map<String, Long> expectedTimeouts = new HashMap<>();
+    expectedTimeouts.put("implicit", 1000L);
+    expectedTimeouts.put("pageLoad", 2000L);
+    expectedTimeouts.put("script", 3000L);
 
-    assertThat(mappedOptions.get("timeouts")).isEqualTo(convertedTimeouts);
+    assertThat(expectedTimeouts).isEqualTo(mappedOptions.get("timeouts"));
   }
 
   @Test
-  public void canAddOneTimeout() {
+  public void canAddSequentialTimeouts() {
     ChromeOptions chromeOptions = new ChromeOptions();
-    Map<String, Duration> timeouts = new HashMap<>();
-    timeouts.put("implicit", Duration.ofSeconds(1));
+    chromeOptions.setImplicitWaitTimeout(Duration.ofSeconds(1));
 
-    Map<String, Long> convertedTimeouts = new HashMap<>();
-    convertedTimeouts.put("implicit", 1000L);
-
-    chromeOptions.setTimeouts(timeouts);
     Map<String, Object> mappedOptions = chromeOptions.asMap();
-    assertThat(mappedOptions.get("timeouts")).isEqualTo(convertedTimeouts);
-  }
+    Map<String, Long> expectedTimeouts = new HashMap<>();
 
-  @Test(expected = IllegalArgumentException.class)
-  public void canNotAddInvalidTimeout() {
-    ChromeOptions chromeOptions = new ChromeOptions();
-    Map<String, Duration> timeouts = new HashMap<>();
-    timeouts.put("foo", Duration.ofSeconds(1));
+    expectedTimeouts.put("implicit", 1000L);
+    assertThat(expectedTimeouts).isEqualTo(mappedOptions.get("timeouts"));
 
-    chromeOptions.setTimeouts(timeouts);
+    chromeOptions.setPageLoadTimeout(Duration.ofSeconds(2));
+    expectedTimeouts.put("pageLoad", 2000L);
+    Map<String, Object> mappedOptions2 = chromeOptions.asMap();
+    assertThat(expectedTimeouts).isEqualTo(mappedOptions2.get("timeouts"));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.openqa.selenium.chrome.ChromeDriverLogLevel.OFF;
 import static org.openqa.selenium.chrome.ChromeDriverLogLevel.SEVERE;
+import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 
 @Category(UnitTests.class)
 public class ChromeOptionsTest {
@@ -115,6 +116,19 @@ public class ChromeOptionsTest {
     expectedTimeouts.put("pageLoad", 2000L);
     Map<String, Object> mappedOptions2 = chromeOptions.asMap();
     assertThat(expectedTimeouts).isEqualTo(mappedOptions2.get("timeouts"));
+  }
+
+  @Test
+  public void mixAddingTimeoutsCapsAndSetter() {
+    ChromeOptions chromeOptions = new ChromeOptions();
+    chromeOptions.setCapability(TIMEOUTS, Map.of("implicit", 1000));
+    chromeOptions.setPageLoadTimeout(Duration.ofSeconds(2));
+
+    Map<String, Number> expectedTimeouts = new HashMap<>();
+    expectedTimeouts.put("implicit", 1000);
+    expectedTimeouts.put("pageLoad", 2000L);
+
+    assertThat(chromeOptions.asMap().get("timeouts")).isEqualTo(expectedTimeouts);
   }
 
   @Test


### PR DESCRIPTION
### Description

Adds methods and tests for:
* `setBrowserVersion()`
* `setPlatformName()`
* ~`setTimeouts()`~
edit:
* `setImplicitWaitTimeout()`
* `setPageLoadTimeout()`
* `setScriptTimeout()`

Timeouts has user-facing `Duration` that gets converted to millis when adding it to capabilities. 

### Motivation and Context

It makes sense to have specific methods for known capabilities, and this is backwards compatible.
