### PR TITLE
allow Augmenter implementations to specify additional commands

### DIFF
--- a/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
+++ b/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
@@ -21,12 +21,15 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.AugmenterProvider;
+import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.ExecuteMethod;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import static java.util.Collections.singletonMap;
+import static org.openqa.selenium.firefox.FirefoxDriver.EXTRA_COMMANDS;
 import static org.openqa.selenium.remote.BrowserType.FIREFOX;
 
 @AutoService(AugmenterProvider.class)
@@ -57,5 +60,10 @@ public class AddHasExtensions implements AugmenterProvider<HasExtensions> {
         executeMethod.execute(FirefoxDriver.ExtraCommands.UNINSTALL_EXTENSION, singletonMap("id", extensionId));
       }
     };
+  }
+
+  @Override
+  public Map<String, CommandInfo> getAdditionalCommands() {
+    return EXTRA_COMMANDS;
   }
 }

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -146,7 +146,7 @@ public class FirefoxDriver extends RemoteWebDriver
     static String FULL_PAGE_SCREENSHOT = "fullPageScreenshot";
   }
 
-  private static final ImmutableMap<String, CommandInfo> EXTRA_COMMANDS = ImmutableMap.of(
+  static final ImmutableMap<String, CommandInfo> EXTRA_COMMANDS = ImmutableMap.of(
       ExtraCommands.INSTALL_EXTENSION,
       new CommandInfo("/session/:sessionId/moz/addon/install", HttpMethod.POST),
       ExtraCommands.UNINSTALL_EXTENSION,

--- a/java/src/org/openqa/selenium/remote/Augmenter.java
+++ b/java/src/org/openqa/selenium/remote/Augmenter.java
@@ -114,6 +114,15 @@ public class Augmenter {
   public <X> Augmenter addDriverAugmentation(
     String capabilityName,
     Class<X> implementThis,
+    BiFunction<Capabilities, ExecuteMethod, X> usingThis) {
+    Map<String, CommandInfo> addingCommands = new HashMap<>();
+
+    return this.addDriverAugmentation(capabilityName, implementThis, usingThis, addingCommands);
+  }
+
+  public <X> Augmenter addDriverAugmentation(
+    String capabilityName,
+    Class<X> implementThis,
     BiFunction<Capabilities, ExecuteMethod, X> usingThis,
     Map<String, CommandInfo> addingCommands) {
     Require.nonNull("Capability name", capabilityName);
@@ -121,6 +130,15 @@ public class Augmenter {
     Require.nonNull("Concrete implementation", usingThis, "of %s", implementThis);
 
     return addDriverAugmentation(check(capabilityName), implementThis, usingThis, addingCommands);
+  }
+
+  public <X> Augmenter addDriverAugmentation(
+    Predicate<Capabilities> whenThisMatches,
+    Class<X> implementThis,
+    BiFunction<Capabilities, ExecuteMethod, X> usingThis) {
+    Map<String, CommandInfo> addingCommands = new HashMap<>();
+
+    return this.addDriverAugmentation(whenThisMatches, implementThis, usingThis, addingCommands);
   }
 
   public <X> Augmenter addDriverAugmentation(

--- a/java/src/org/openqa/selenium/remote/AugmenterProvider.java
+++ b/java/src/org/openqa/selenium/remote/AugmenterProvider.java
@@ -19,6 +19,8 @@ package org.openqa.selenium.remote;
 
 import org.openqa.selenium.Capabilities;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 /**
@@ -43,4 +45,8 @@ public interface AugmenterProvider<X> {
    * @return An interface implementation
    */
   X getImplementation(Capabilities capabilities, ExecuteMethod executeMethod);
+
+  default Map<String, CommandInfo> getAdditionalCommands() {
+    return new HashMap<>();
+  }
 }

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -28,14 +28,15 @@ import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.ParallelTestRunner;
 import org.openqa.selenium.ParallelTestRunner.Worker;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.build.InProject;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -51,6 +52,7 @@ import org.openqa.selenium.testing.drivers.WebDriverBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -528,8 +530,11 @@ public class FirefoxDriverTest extends JUnit4TestBase {
       .build();
 
     try {
-      assertThat(driver).isInstanceOf(HasExtensions.class);
-      fail(driver.getClass().getName());
+      String MOOLTIPASS_PATH = "third_party/firebug/mooltipass-1.1.87.xpi";
+      Path extension = InProject.locate(MOOLTIPASS_PATH);
+      ((HasExtensions) driver).installExtension(extension);
+    } catch (UnsupportedCommandException e) {
+      fail("Expected HasExtensions to support installExtension()");
     } finally {
       driver.quit();
     }


### PR DESCRIPTION
The problem with existing implementation is that while you can cast to the interface, you don't have access to the commands that are needed to actually execute the associated methods.

This code creates an additional method `getAdditionalCommands()` on the `AugmenterProvider` interface. There is a default of an empty Map, so implementing it is optional.

`Augmentation` class has this method added to the constructor, which meant updating a bunch of things in the class. This is probably not backwards compatible, I'm not sure the right way to address that.

Essentially I need Augmenter class to provide a public method `getMatchingAdditionalCommands()`.

`RemoteWebDriverBuilder` can now call this method after augmenting the driver, and set `additionalCommands` field.

The tricky/messy bit is that I hacked into the middle of the `baseExecutor` lambda to `defineCommand` on each of the commands in the `additionalCommands` field.

There has to be a better way to do this, but it works, ~and my only real concern is backwards compatibility for the Augmentation class constructor~. (edit: fixed this!)