### PR TITLE
[grid] Consider max-session value while selecting the slot and identifying Node capacity

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/NodeStatus.java
+++ b/java/src/org/openqa/selenium/grid/data/NodeStatus.java
@@ -141,8 +141,8 @@ public class NodeStatus {
 
   // Check if the Node's max session limit is not exceeded and has a free slot that supports the capability.
   public boolean hasCapacity(Capabilities caps) {
-    return slots.stream().filter(slot -> slot.getSession() != null).count() < maxSessionCount
-           && slots.stream().anyMatch(slot -> slot.getSession() == null && slot.isSupporting(caps));
+    return slots.stream().filter(slot -> slot.getSession() != null).count() < maxSessionCount &&
+           slots.stream().anyMatch(slot -> slot.getSession() == null && slot.isSupporting(caps));
   }
 
   public int getMaxSessionCount() {

--- a/java/src/org/openqa/selenium/grid/data/NodeStatus.java
+++ b/java/src/org/openqa/selenium/grid/data/NodeStatus.java
@@ -139,9 +139,10 @@ public class NodeStatus {
     return slots.stream().anyMatch(slot -> slot.getSession() == null);
   }
 
+  // Check if the Node's max session limit is not exceeded and has a free slot that supports the capability.
   public boolean hasCapacity(Capabilities caps) {
-    return slots.stream()
-      .anyMatch(slot -> slot.getSession() == null && slot.isSupporting(caps));
+    return slots.stream().filter(slot -> slot.getSession() != null).count() < maxSessionCount
+           && slots.stream().anyMatch(slot -> slot.getSession() == null && slot.isSupporting(caps));
   }
 
   public int getMaxSessionCount() {

--- a/java/test/org/openqa/selenium/grid/distributor/selector/DefaultSlotSelectorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/selector/DefaultSlotSelectorTest.java
@@ -132,6 +132,36 @@ public class DefaultSlotSelectorTest {
   }
 
   @Test
+  public void theNodeWhichHasExceededMaxSessionsIsNotSelected() {
+    Capabilities chrome = new ImmutableCapabilities("browserName", "chrome");
+
+    NodeStatus lightLoad =
+      createNode(ImmutableList.of(chrome), 12, 2);
+    NodeStatus mediumLoad =
+      createNode(ImmutableList.of(chrome), 12, 5);
+    NodeStatus maximumLoad =
+      createNode(ImmutableList.of(chrome), 12, 12);
+
+    Set<SlotId> ids = selector.selectSlot(chrome, ImmutableSet.of(maximumLoad, mediumLoad, lightLoad));
+    SlotId expected = ids.iterator().next();
+
+    // The slot should belong to the Node with light load
+    assertThat(lightLoad.getSlots().stream())
+      .anyMatch(slot -> expected.equals(slot.getId()));
+
+    // The node whose current number of sessions is greater than or equal to the max sessions is not included
+    // Hence, the node with the maximum load is skipped
+    ImmutableSet<NodeId> nodeIds = ids.stream()
+      .map(SlotId::getOwningNodeId)
+      .distinct()
+      .collect(toImmutableSet());
+    assertThat(nodeIds)
+      .containsSequence(
+        lightLoad.getNodeId(),
+        mediumLoad.getNodeId());
+  }
+
+  @Test
   public void nodesAreOrderedByNumberOfSupportedBrowsersAndLoad() {
     Capabilities chrome = new ImmutableCapabilities("browserName", "chrome");
     Capabilities firefox = new ImmutableCapabilities("browserName", "firefox");
@@ -161,6 +191,7 @@ public class DefaultSlotSelectorTest {
       .anyMatch(slot -> expected.equals(slot.getId()));
 
     // Nodes are ordered by the diversity of supported browsers, then by load
+    // The node whose current number of sessions is greater than or equal to the max sessions is not included
     ImmutableSet<NodeId> nodeIds = ids.stream()
       .map(SlotId::getOwningNodeId)
       .distinct()
@@ -169,7 +200,6 @@ public class DefaultSlotSelectorTest {
       .containsSequence(
         highLoadAndOneBrowser.getNodeId(),
         mediumLoadAndTwoBrowsers.getNodeId(),
-        mediumLoadAndOtherTwoBrowsers.getNodeId(),
         lightLoadAndThreeBrowsers.getNodeId());
   }
 

--- a/java/test/org/openqa/selenium/grid/distributor/selector/DefaultSlotSelectorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/selector/DefaultSlotSelectorTest.java
@@ -155,6 +155,7 @@ public class DefaultSlotSelectorTest {
       .map(SlotId::getOwningNodeId)
       .distinct()
       .collect(toImmutableSet());
+    assertThat(nodeIds).doesNotContain(maximumLoad.getNodeId());
     assertThat(nodeIds)
       .containsSequence(
         lightLoad.getNodeId(),


### PR DESCRIPTION


<!-- NOTE
Please be aware that the Selenium Grid 3.x is being deprecated in favour of the
upcoming version 4.x. We won't be receiving any PRs related to the Grid 3.x code. Thanks!
-->

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Consider max-session value while selecting the slot and identifying Node capacity

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Node allows configuring max-session value. In the current implementation, to ensure Grid is not underutilized, multiple threads are used to reserve a slot and create the session. As a result, multiple sessions are created simultaneously which often exceeds the max-session value and disregards it. To avoid overloading the machine, it is crucial that the max-session value is considered. The changes fix this by checking for that the current number of sessions do not exceed the max-session value during slot selection.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
