### PR TITLE
Allow commands to be loaded via the ServiceLoader

### DIFF
--- a/java/src/org/openqa/selenium/remote/AdditionalHttpCommands.java
+++ b/java/src/org/openqa/selenium/remote/AdditionalHttpCommands.java
@@ -1,0 +1,33 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote;
+
+import java.util.Map;
+
+/**
+ * Used to allow a {@link CommandExecutor} using HTTP to find additional
+ * commands that should be supported. Implementations of this interface
+ * are found using the {@link java.util.ServiceLoader}
+ */
+@FunctionalInterface
+public interface AdditionalHttpCommands {
+  /**
+   * @return Additional commands to add to the {@link CommandExecutor}.
+   */
+  Map<String, CommandInfo> getAdditionalCommands();
+}

--- a/java/src/org/openqa/selenium/remote/CommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/CommandCodec.java
@@ -28,6 +28,11 @@ import org.openqa.selenium.remote.http.HttpMethod;
 public interface CommandCodec<T> {
 
   /**
+   * @return Whether this {@link CommandCodec} supports the given command name.
+   */
+  boolean isSupported(String commandName);
+
+  /**
    * Encodes a command.
    *
    * @param command the command to encode.

--- a/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
@@ -237,6 +237,12 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
   }
 
   @Override
+  public boolean isSupported(String commandName) {
+    Require.nonNull("Command name", commandName);
+    return nameToSpec.containsKey(commandName) || aliases.containsKey(commandName);
+  }
+
+  @Override
   public HttpRequest encode(Command command) {
     String name = aliases.getOrDefault(command.getName(), command.getName());
     CommandSpec spec = nameToSpec.get(name);


### PR DESCRIPTION
### Description

When adding commands via the Augmenter, it is sometimes helpful to
provide an actual command too. This change allows drivers to specify
new commands and add them as necessary.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

