### PR TITLE
[rb] bugfix: Loading type of driver can fail if previously loaded files are not present

### DIFF
--- a/rb/lib/selenium/webdriver/chrome.rb
+++ b/rb/lib/selenium/webdriver/chrome.rb
@@ -19,6 +19,8 @@
 
 require 'net/http'
 
+require 'selenium/webdriver/common/platform'
+
 module Selenium
   module WebDriver
     module Chrome

--- a/rb/lib/selenium/webdriver/edge.rb
+++ b/rb/lib/selenium/webdriver/edge.rb
@@ -19,6 +19,8 @@
 
 require 'net/http'
 
+require 'selenium/webdriver/common/platform'
+
 module Selenium
   module WebDriver
     module Edge

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -21,6 +21,8 @@ require 'timeout'
 require 'socket'
 require 'rexml/document'
 
+require 'selenium/webdriver/common/platform'
+
 module Selenium
   module WebDriver
     module Firefox

--- a/rb/lib/selenium/webdriver/safari.rb
+++ b/rb/lib/selenium/webdriver/safari.rb
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'selenium/webdriver/common/platform'
+
 module Selenium
   module WebDriver
     module Safari


### PR DESCRIPTION
Fix issue where requiring a type of webdriver file would autoload all required files except the platform module. This then causes a failure when checking paths
