### PR TITLE
Py commands

### DIFF
--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -25,6 +25,7 @@ class ChromiumRemoteConnection(RemoteConnection):
         self._commands["launchApp"] = ('POST', '/session/$sessionId/chromium/launch_app')
         self._commands["setNetworkConditions"] = ('POST', '/session/$sessionId/chromium/network_conditions')
         self._commands["getNetworkConditions"] = ('GET', '/session/$sessionId/chromium/network_conditions')
+        self._commands["deleteNetworkConditions"] = ('DELETE', '/session/$sessionId/chromium/network_conditions')
         self._commands['executeCdpCommand'] = ('POST', '/session/$sessionId/{}/cdp/execute'.format(vendor_prefix))
         self._commands['getSinks'] = ('GET', '/session/$sessionId/{}/cast/get_sinks'.format(vendor_prefix))
         self._commands['getIssueMessage'] = ('GET', '/session/$sessionId/{}/cast/get_issue_message'.format(vendor_prefix))

--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -23,6 +23,7 @@ class ChromiumRemoteConnection(RemoteConnection):
         RemoteConnection.__init__(self, remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
         self.browser_name = browser_name
         self._commands["launchApp"] = ('POST', '/session/$sessionId/chromium/launch_app')
+        self._commands["setPermissions"] = ('POST', '/session/$sessionId/permissions')
         self._commands["setNetworkConditions"] = ('POST', '/session/$sessionId/chromium/network_conditions')
         self._commands["getNetworkConditions"] = ('GET', '/session/$sessionId/chromium/network_conditions')
         self._commands["deleteNetworkConditions"] = ('DELETE', '/session/$sessionId/chromium/network_conditions')

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -145,6 +145,20 @@ class ChromiumDriver(RemoteWebDriver):
         """
         self.execute("deleteNetworkConditions")
 
+    def set_permissions(self, name: str, value: str) -> NoReturn:
+        """
+        Sets Applicable Permission.
+
+        :Args:
+         - name: The item to set the permission on.
+         - value: The value to set on the item
+
+        :Usage:
+            ::
+                driver.set_permissions('clipboard-read', 'denied')
+        """
+        self.execute("setPermissions", {'descriptor': {'name': name}, 'state': value})
+
     def execute_cdp_cmd(self, cmd: str, cmd_args: dict):
         """
         Execute Chrome Devtools Protocol command and get returned result

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -139,6 +139,12 @@ class ChromiumDriver(RemoteWebDriver):
             'network_conditions': network_conditions
         })
 
+    def delete_network_conditions(self) -> NoReturn:
+        """
+        Resets Chromium network emulation settings.
+        """
+        self.execute("deleteNetworkConditions")
+
     def execute_cdp_cmd(self, cmd: str, cmd_args: dict):
         """
         Execute Chrome Devtools Protocol command and get returned result

--- a/py/test/selenium/webdriver/chrome/chrome_network_emulation_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_network_emulation_tests.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver import Chrome
 
 
@@ -29,3 +31,6 @@ def test_network_conditions_emulation():
     assert conditions['latency'] == 56
     assert conditions['download_throughput'] == 789
     assert conditions['upload_throughput'] == 789
+    driver.delete_network_conditions()
+    with pytest.raises(WebDriverException):
+        driver.get_network_conditions()


### PR DESCRIPTION
I have a checklist of all of the browser specific commands to add to each of the bindings; Python had most of them implemented already, so these were all I needed to add to make it the first one to have everything. @AutomatedTester let me know if I did the deprecation correctly.