### PR TITLE
[dotnet] mark deprecated chromedriver commands as obsolete and implem…

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeDriver.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriver.cs
@@ -138,6 +138,7 @@ namespace OpenQA.Selenium.Chrome
         public ChromeDriver(ChromeDriverService service, ChromeOptions options, TimeSpan commandTimeout)
             : base(service, options, commandTimeout)
         {
+            this.AddCustomChromeCommand(ExecuteCdp, HttpCommandInfo.PostCommand, "/session/{sessionId}/goog/cdp/execute");
         }
 
     }

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -43,6 +43,7 @@ namespace OpenQA.Selenium.Chromium
         private const string DeleteNetworkConditionsCommand = "deleteNetworkConditions";
         private const string SendChromeCommand = "sendChromeCommand";
         private const string SendChromeCommandWithResult = "sendChromeCommandWithResult";
+        protected const string ExecuteCdp = "executeCdpCommand";
 
         private readonly string optionsCapabilityName;
         private DevToolsSession devToolsSession;
@@ -128,11 +129,12 @@ namespace OpenQA.Selenium.Chromium
         }
 
         /// <summary>
-        /// Executes a custom Chrome command.
+        /// Executes a custom Chrome Dev Tools Protocol Command.
         /// </summary>
         /// <param name="commandName">Name of the command to execute.</param>
         /// <param name="commandParameters">Parameters of the command to execute.</param>
-        public void ExecuteChromeCommand(string commandName, Dictionary<string, object> commandParameters)
+        /// <returns>An object representing the result of the command, if applicable.</returns>
+        public object ExecuteCdpCommand(string commandName, Dictionary<string, object> commandParameters)
         {
             if (commandName == null)
             {
@@ -142,7 +144,19 @@ namespace OpenQA.Selenium.Chromium
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters["cmd"] = commandName;
             parameters["params"] = commandParameters;
-            this.Execute(SendChromeCommand, parameters);
+            Response response = this.Execute(ExecuteCdp, parameters);
+            return response.Value;
+        }
+
+        /// <summary>
+        /// Executes a custom Chrome command.
+        /// </summary>
+        /// <param name="commandName">Name of the command to execute.</param>
+        /// <param name="commandParameters">Parameters of the command to execute.</param>
+        [Obsolete("ExecuteChromeCommand is deprecated in favor of ExecuteCdp.")]
+        public void ExecuteChromeCommand(string commandName, Dictionary<string, object> commandParameters)
+        {
+            ExecuteCdpCommand(commandName, commandParameters);
         }
 
         /// <summary>
@@ -151,18 +165,10 @@ namespace OpenQA.Selenium.Chromium
         /// <param name="commandName">Name of the command to execute.</param>
         /// <param name="commandParameters">Parameters of the command to execute.</param>
         /// <returns>An object representing the result of the command.</returns>
+        [Obsolete("ExecuteChromeCommandWithResult is deprecated in favor of ExecuteCdp.")]
         public object ExecuteChromeCommandWithResult(string commandName, Dictionary<string, object> commandParameters)
         {
-            if (commandName == null)
-            {
-                throw new ArgumentNullException("commandName", "commandName must not be null");
-            }
-
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters["cmd"] = commandName;
-            parameters["params"] = commandParameters;
-            Response response = this.Execute(SendChromeCommandWithResult, parameters);
-            return response.Value;
+            return ExecuteCdpCommand(commandName, commandParameters);
         }
 
         /// <summary>
@@ -248,7 +254,7 @@ namespace OpenQA.Selenium.Chromium
             return options.ToCapabilities();
         }
 
-        private void AddCustomChromeCommand(string commandName, string method, string resourcePath)
+        protected void AddCustomChromeCommand(string commandName, string method, string resourcePath)
         {
             HttpCommandInfo commandInfoToAdd = new HttpCommandInfo(method, resourcePath);
             this.CommandExecutor.TryAddCommand(commandName, commandInfoToAdd);

--- a/dotnet/src/webdriver/Edge/EdgeDriver.cs
+++ b/dotnet/src/webdriver/Edge/EdgeDriver.cs
@@ -106,6 +106,7 @@ namespace OpenQA.Selenium.Edge
         public EdgeDriver(EdgeDriverService service, EdgeOptions options, TimeSpan commandTimeout)
             : base(service, options, commandTimeout)
         {
+            this.AddCustomChromeCommand(ExecuteCdp, HttpCommandInfo.PostCommand, "/session/{sessionId}/ms/cdp/execute");
         }
     }
 }


### PR DESCRIPTION
The commands being used here are deprecated according to: https://bugs.chromium.org/p/chromedriver/issues/detail?id=2307

I have a basic template of a test I'm using for other languages, but I'm not sure how to write/run tests in .NET. 

There are a dozen custom browser commands I'd like to add once I make sure I'm doing everything correctly, so please let me know if I'm violating conventions, etc.