### PR TITLE
[java] use FileDetector to install Firefox addons

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/RemoteExecuteMethod.java
@@ -17,11 +17,13 @@
 
 package org.openqa.selenium.remote;
 
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.internal.Require;
 
 import java.util.Map;
 
-public class RemoteExecuteMethod implements ExecuteMethod {
+public class RemoteExecuteMethod implements ExecuteMethod, WrapsDriver {
   private final RemoteWebDriver driver;
 
   public RemoteExecuteMethod(RemoteWebDriver driver) {
@@ -39,5 +41,9 @@ public class RemoteExecuteMethod implements ExecuteMethod {
     }
 
     return response.getValue();
+  }
+
+  @Override public WebDriver getWrappedDriver() {
+    return this.driver;
   }
 }

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DriverCommand;
+import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.UnreachableBrowserException;
@@ -503,8 +504,12 @@ public class FirefoxDriverTest extends JUnit4TestBase {
   public void canAddRemoveExtensions() {
     Path extension = InProject.locate("third_party/firebug/favourite_colour-1.1-an+fx.xpi");
 
-    ((HasExtensions) driver).installExtension(extension);
-    ((HasExtensions) driver).uninstallExtension("favourite-colour-examples@mozilla.org");
+    if (driver.getClass().equals(RemoteWebDriver.class)) {
+      ((RemoteWebDriver) driver).setFileDetector(new LocalFileDetector());
+    }
+
+    String id = ((HasExtensions) driver).installExtension(extension);
+    ((HasExtensions) driver).uninstallExtension(id);
   }
 
   @Test


### PR DESCRIPTION
I don't see an ideal way to do this.

The whole point is to be able to do this with the Augmenter, which means the interfaces which don't know about RemoteWebDriver methods, and I don't want to put the driver instance as a parameter for the method in the interface. 

~This is the best I came up with.:~

~The implementation is mostly copied from `RemoteWebElement#upload` but again, I don't see an easy way to put this logic where both of them can access it.~

Edit:
I changed this so it tries the string as provided first, and if that doesn't work, it determines if the file exists locally, and if so uploads it and retries. 

Not sure it's ideal either, but it won't break anything, and won't keep us from doing something better later.