### PR TITLE
Implement browser specific functionality 

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeDriver.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriver.cs
@@ -139,6 +139,11 @@ namespace OpenQA.Selenium.Chrome
             : base(service, options, commandTimeout)
         {
             this.AddCustomChromeCommand(ExecuteCdp, HttpCommandInfo.PostCommand, "/session/{sessionId}/goog/cdp/execute");
+            this.AddCustomChromeCommand(GetCastSinksCommand, HttpCommandInfo.GetCommand, "/session/{sessionId}/goog/cast/get_sinks");
+            this.AddCustomChromeCommand(SelectCastSinkCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/goog/cast/set_sink_to_use");
+            this.AddCustomChromeCommand(StartCastTabMirroringCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/goog/cast/start_tab_mirroring");
+            this.AddCustomChromeCommand(GetCastIssueMessageCommand, HttpCommandInfo.GetCommand, "/session/{sessionId}/goog/cast/get_issue_message");
+            this.AddCustomChromeCommand(StopCastingCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/goog/cast/stop_casting");
         }
 
     }

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -50,6 +50,7 @@ namespace OpenQA.Selenium.Chromium
         private const string SendChromeCommand = "sendChromeCommand";
         private const string SendChromeCommandWithResult = "sendChromeCommandWithResult";
         private const string LaunchAppCommand = "launchAppCommand";
+        private const string SetPermissionCommand = "setPermission";
 
         private readonly string optionsCapabilityName;
         private DevToolsSession devToolsSession;
@@ -83,6 +84,7 @@ namespace OpenQA.Selenium.Chromium
             this.AddCustomChromeCommand(SendChromeCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/send_command");
             this.AddCustomChromeCommand(SendChromeCommandWithResult, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/send_command_and_get_result");
             this.AddCustomChromeCommand(LaunchAppCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/launch_app");
+            this.AddCustomChromeCommand(SetPermissionCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/permissions");
         }
 
         /// <summary>
@@ -149,6 +151,31 @@ namespace OpenQA.Selenium.Chromium
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters["id"] = id;
             this.Execute(LaunchAppCommand, parameters);
+        }
+
+        /// <summary>
+        /// Set supported permission on browser.
+        /// </summary>
+        /// <param name="permissionName">Name of item to set the permission on.</param>
+        /// <param name="permissionValue">Value to set the permission to.</param>
+        public void SetPermission(string permissionName, string permissionValue)
+        {
+            if (permissionName == null)
+            {
+                throw new ArgumentNullException("permissionName", "name must not be null");
+            }
+
+            if (permissionValue == null)
+            {
+                throw new ArgumentNullException("permissionValue", "value must not be null");
+            }
+
+            Dictionary<string, object> nameParameter = new Dictionary<string, object>();
+            nameParameter["name"] = permissionName;
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["descriptor"] = nameParameter;
+            parameters["state"] = permissionValue;
+            this.Execute(SetPermissionCommand, parameters);
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -49,6 +49,7 @@ namespace OpenQA.Selenium.Chromium
         private const string DeleteNetworkConditionsCommand = "deleteNetworkConditions";
         private const string SendChromeCommand = "sendChromeCommand";
         private const string SendChromeCommandWithResult = "sendChromeCommandWithResult";
+        private const string LaunchAppCommand = "launchAppCommand";
 
         private readonly string optionsCapabilityName;
         private DevToolsSession devToolsSession;
@@ -81,6 +82,7 @@ namespace OpenQA.Selenium.Chromium
             this.AddCustomChromeCommand(DeleteNetworkConditionsCommand, HttpCommandInfo.DeleteCommand, "/session/{sessionId}/chromium/network_conditions");
             this.AddCustomChromeCommand(SendChromeCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/send_command");
             this.AddCustomChromeCommand(SendChromeCommandWithResult, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/send_command_and_get_result");
+            this.AddCustomChromeCommand(LaunchAppCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/chromium/launch_app");
         }
 
         /// <summary>
@@ -131,6 +133,22 @@ namespace OpenQA.Selenium.Chromium
                 parameters["network_conditions"] = value.ToDictionary();
                 this.Execute(SetNetworkConditionsCommand, parameters);
             }
+        }
+
+        /// <summary>
+        /// Launches a Chromium based application.
+        /// </summary>
+        /// <param name="id">ID of the chromium app to launch.</param>
+        public void LaunchApp(string id)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException("id", "id must not be null");
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["id"] = id;
+            this.Execute(LaunchAppCommand, parameters);
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -38,12 +38,17 @@ namespace OpenQA.Selenium.Chromium
         /// </summary>
         public static readonly bool AcceptUntrustedCertificates = true;
 
+        protected const string ExecuteCdp = "executeCdpCommand";
+        protected const string GetCastSinksCommand = "getCastSinks";
+        protected const string SelectCastSinkCommand = "selectCastSink";
+        protected const string StartCastTabMirroringCommand = "startCastTabMirroring";
+        protected const string GetCastIssueMessageCommand = "getCastIssueMessage";
+        protected const string StopCastingCommand = "stopCasting";
         private const string GetNetworkConditionsCommand = "getNetworkConditions";
         private const string SetNetworkConditionsCommand = "setNetworkConditions";
         private const string DeleteNetworkConditionsCommand = "deleteNetworkConditions";
         private const string SendChromeCommand = "sendChromeCommand";
         private const string SendChromeCommandWithResult = "sendChromeCommandWithResult";
-        protected const string ExecuteCdp = "executeCdpCommand";
 
         private readonly string optionsCapabilityName;
         private DevToolsSession devToolsSession;
@@ -232,6 +237,74 @@ namespace OpenQA.Selenium.Chromium
                 this.devToolsSession.Dispose();
                 this.devToolsSession = null;
             }
+        }
+
+        /// <summary>
+        /// Returns the list of cast sinks (Cast devices) available to the Chrome media router.
+        /// </summary>
+        /// <returns>An object representing the list of available sinks.</returns>
+        public object GetCastSinks()
+        {
+            Response response = this.Execute(GetCastSinksCommand, null);
+            return response.Value;
+        }
+
+        /// <summary>
+        /// Selects a cast sink (Cast device) as the recipient of media router intents (connect or play).
+        /// </summary>
+        /// <param name="deviceName">Name of the target sink (device).</param>
+        public void SelectCastSink(string deviceName)
+        {
+            if (deviceName == null)
+            {
+                throw new ArgumentNullException("deviceName", "deviceName must not be null");
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["sinkName"] = deviceName;
+            this.Execute(SelectCastSinkCommand, parameters);
+        }
+
+        /// <summary>
+        /// Initiates tab mirroring for the current browser tab on the specified device.
+        /// </summary>
+        /// <param name="deviceName">Name of the target sink (device).</param>
+        public void StartTabMirroring(string deviceName)
+        {
+            if (deviceName == null)
+            {
+                throw new ArgumentNullException("deviceName", "deviceName must not be null");
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["sinkName"] = deviceName;
+            this.Execute(StartCastTabMirroringCommand, parameters);
+        }
+
+        /// <summary>
+        /// Returns the error message if there is any issue in a Cast session.
+        /// </summary>
+        /// <returns>An error message.</returns>
+        public String GetCastIssueMessage()
+        {
+            Response response = this.Execute(GetCastIssueMessageCommand, null);
+            return (string)response.Value;
+        }
+
+        /// <summary>
+        /// Stops casting from media router to the specified device, if connected.
+        /// </summary>
+        /// <param name="deviceName">Name of the target sink (device).</param>
+        public void StopCasting(string deviceName)
+        {
+            if (deviceName == null)
+            {
+                throw new ArgumentNullException("deviceName", "deviceName must not be null");
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["sinkName"] = deviceName;
+            this.Execute(StopCastingCommand, parameters);
         }
 
         protected override void Dispose(bool disposing)

--- a/dotnet/src/webdriver/Edge/EdgeDriver.cs
+++ b/dotnet/src/webdriver/Edge/EdgeDriver.cs
@@ -107,6 +107,11 @@ namespace OpenQA.Selenium.Edge
             : base(service, options, commandTimeout)
         {
             this.AddCustomChromeCommand(ExecuteCdp, HttpCommandInfo.PostCommand, "/session/{sessionId}/ms/cdp/execute");
+            this.AddCustomChromeCommand(GetCastSinksCommand, HttpCommandInfo.GetCommand, "/session/{sessionId}/ms/cast/get_sinks");
+            this.AddCustomChromeCommand(SelectCastSinkCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/ms/cast/set_sink_to_use");
+            this.AddCustomChromeCommand(StartCastTabMirroringCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/ms/cast/start_tab_mirroring");
+            this.AddCustomChromeCommand(GetCastIssueMessageCommand, HttpCommandInfo.GetCommand, "/session/{sessionId}/ms/cast/get_issue_message");
+            this.AddCustomChromeCommand(StopCastingCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/ms/cast/stop_casting");
         }
     }
 }

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -62,6 +62,7 @@ namespace OpenQA.Selenium.Safari
     /// </example>
     public class SafariDriver : WebDriver
     {
+        private const string AttachDebuggerCommand = "attachDebugger";
         private const string GetPermissionsCommand = "getPermissions";
         private const string SetPermissionsCommand = "setPermissions";
 
@@ -144,8 +145,21 @@ namespace OpenQA.Selenium.Safari
         public SafariDriver(SafariDriverService service, SafariOptions options, TimeSpan commandTimeout)
             : base(new DriverServiceCommandExecutor(service, commandTimeout), ConvertOptionsToCapabilities(options))
         {
+            this.AddCustomSafariCommand(AttachDebuggerCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/apple/attach_debugger");
             this.AddCustomSafariCommand(GetPermissionsCommand, HttpCommandInfo.GetCommand, "/session/{sessionId}/apple/permissions");
             this.AddCustomSafariCommand(SetPermissionsCommand, HttpCommandInfo.PostCommand, "/session/{sessionId}/apple/permissions");
+        }
+
+        /// <summary>
+        /// This opens Safari's Web Inspector.
+        /// If driver subsequently executes script of "debugger;"
+        /// the execution will pause, no additional commands will be processed, and the code will time out.
+        /// </summary>
+        public void AttachDebugger()
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["attachDebugger"] = null;
+            this.Execute(AttachDebuggerCommand, parameters);
         }
 
         /// <summary>


### PR DESCRIPTION
Mostly double checking names are good (I'm matching Java on method names), and also need to know if I should be casting to String for message, and if (and/or how) I should cast to an Array or List for the `GetCastSinks` response. Fwiw, Java does: `(List<Map<String, String>>)`

Edit:
Went ahead and added all of the additional commands to bring it in parity with other languages.