### PR TITLE
[dotnet] Use vendor-specific method names for additional Chromium options.

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeOptions.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeOptions.cs
@@ -79,5 +79,25 @@ namespace OpenQA.Selenium.Chrome
         {
             get { return string.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.VendorPrefix, ChromeOptionsCapabilityName); }
         }
+
+        /// <summary>
+        /// Provides a means to add additional capabilities not yet added as type safe options
+        /// for the Chrome driver.
+        /// </summary>
+        /// <param name="optionName">The name of the capability to add.</param>
+        /// <param name="optionValue">The value of the capability to add.</param>
+        /// <exception cref="ArgumentException">
+        /// thrown when attempting to add a capability for which there is already a type safe option, or
+        /// when <paramref name="optionName"/> is <see langword="null"/> or the empty string.
+        /// </exception>
+        /// <remarks>Calling <see cref="AddAdditionalChromeOption(string, object)"/>
+        /// where <paramref name="optionName"/> has already been added will overwrite the
+        /// existing value with the new value in <paramref name="optionValue"/>.
+        /// Calling this method adds capabilities to the Chrome-specific options object passed to
+        /// webdriver executable (property name 'goog:chromeOptions').</remarks>
+        public void AddAdditionalChromeOption(string optionName, object optionValue)
+        {
+            this.AddAdditionalChromiumOption(optionName, optionValue);
+        }
     }
 }

--- a/dotnet/src/webdriver/Chromium/ChromiumOptions.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumOptions.cs
@@ -495,12 +495,12 @@ namespace OpenQA.Selenium.Chromium
         /// thrown when attempting to add a capability for which there is already a type safe option, or
         /// when <paramref name="optionName"/> is <see langword="null"/> or the empty string.
         /// </exception>
-        /// <remarks>Calling <see cref="AddAdditionalChromeOption(string, object)"/>
+        /// <remarks>Calling <see cref="AddAdditionalChromiumOption(string, object)"/>
         /// where <paramref name="optionName"/> has already been added will overwrite the
         /// existing value with the new value in <paramref name="optionValue"/>.
-        /// Calling this method adds capabilities to the Chrome-specific options object passed to
-        /// webdriver executable (property name 'goog:chromeOptions').</remarks>
-        public void AddAdditionalChromeOption(string optionName, object optionValue)
+        /// Calling this method adds capabilities to the Chromium-specific options object passed to
+        /// webdriver executable (e.g. property name 'goog:chromeOptions').</remarks>
+        protected void AddAdditionalChromiumOption(string optionName, object optionValue)
         {
             this.ValidateCapabilityName(optionName);
             this.additionalChromeOptions[optionName] = optionValue;
@@ -554,7 +554,7 @@ namespace OpenQA.Selenium.Chromium
             }
             else
             {
-                this.AddAdditionalChromeOption(capabilityName, capabilityValue);
+                this.AddAdditionalChromiumOption(capabilityName, capabilityValue);
             }
         }
 

--- a/dotnet/src/webdriver/Edge/EdgeOptions.cs
+++ b/dotnet/src/webdriver/Edge/EdgeOptions.cs
@@ -82,5 +82,25 @@ namespace OpenQA.Selenium.Edge
             get { return this.BrowserName == WebViewBrowserNameValue; }
             set { this.BrowserName = value ? WebViewBrowserNameValue : DefaultBrowserNameValue; }
         }
+
+        /// <summary>
+        /// Provides a means to add additional capabilities not yet added as type safe options
+        /// for the Edge driver.
+        /// </summary>
+        /// <param name="optionName">The name of the capability to add.</param>
+        /// <param name="optionValue">The value of the capability to add.</param>
+        /// <exception cref="ArgumentException">
+        /// thrown when attempting to add a capability for which there is already a type safe option, or
+        /// when <paramref name="optionName"/> is <see langword="null"/> or the empty string.
+        /// </exception>
+        /// <remarks>Calling <see cref="AddAdditionalEdgeOption(string, object)"/>
+        /// where <paramref name="optionName"/> has already been added will overwrite the
+        /// existing value with the new value in <paramref name="optionValue"/>.
+        /// Calling this method adds capabilities to the Edge-specific options object passed to
+        /// webdriver executable (property name 'ms:edgeOptions').</remarks>
+        public void AddAdditionalEdgeOption(string optionName, object optionValue)
+        {
+            this.AddAdditionalChromiumOption(optionName, optionValue);
+        }
     }
 }


### PR DESCRIPTION
### Description
Renames `ChromiumOptions.AddAdditionalChromeOption` to the more vendor-neutral `ChromiumOptions.AddAdditionalChromiumOption`. Make this method protected and add vendor-specific versions of this method to the derived classes `ChromeOptions` and `EdgeOptions`.

### Motivation and Context
This avoids potential confusion with customers using `EdgeOptions` having to use the Chrome-branded `AddAdditionalChromeOption` for capabilities that may in fact be Edge-specific (e.g. webview2 or device portal options). The existing `AddAdditionalChromeOption` is preserved on `ChromeOptions` to avoid breaking ChromeOptions users that call this method.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
