### PR TITLE
[java] Remove Edge USE_CHROMIUM flag

### DIFF
--- a/java/src/org/openqa/selenium/edge/EdgeDriverInfo.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverInfo.java
@@ -46,12 +46,9 @@ public class EdgeDriverInfo extends ChromiumDriverInfo {
 
   @Override
   public boolean isSupporting(Capabilities capabilities) {
-    return (EDGE.is(capabilities.getBrowserName())
-            || capabilities.getCapability("ms:edgeOptions") != null
-            || capabilities.getCapability("edgeOptions") != null)
-           &&
-           (capabilities.getCapability(EdgeOptions.USE_CHROMIUM) == null
-            || Objects.equals(capabilities.getCapability(EdgeOptions.USE_CHROMIUM), true));
+    return EDGE.is(capabilities.getBrowserName())
+           || capabilities.getCapability("ms:edgeOptions") != null
+           || capabilities.getCapability("edgeOptions") != null;
   }
 
   @Override

--- a/java/src/org/openqa/selenium/edge/EdgeDriverService.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverService.java
@@ -125,11 +125,6 @@ public class EdgeDriverService extends DriverService {
         score++;
       }
 
-      Object useChromium = capabilities.getCapability(EdgeOptions.USE_CHROMIUM);
-      if (Objects.equals(useChromium, false)) {
-        score--;
-      }
-
       if (capabilities.getCapability(EdgeOptions.CAPABILITY) != null) {
         score++;
       }

--- a/java/src/org/openqa/selenium/edge/EdgeOptions.java
+++ b/java/src/org/openqa/selenium/edge/EdgeOptions.java
@@ -44,13 +44,6 @@ import org.openqa.selenium.remote.CapabilityType;
 public class EdgeOptions extends ChromiumOptions<EdgeOptions> {
 
   /**
-   * Key used to indicate whether to use an Edge Chromium or Edge Legacy driver.
-   *
-   * @deprecated This will be removed as Chromium based Edge is the only supported one.
-   */
-  public static final String USE_CHROMIUM = "ms:edgeChromium";
-
-  /**
    * Key used to store a set of ChromeOptions in a {@link Capabilities}
    * object.
    */

--- a/java/test/org/openqa/selenium/edge/EdgeDriverInfoTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverInfoTest.java
@@ -47,22 +47,6 @@ public class EdgeDriverInfoTest {
   }
 
   @Test
-  public void isNotSupportingEdgeHtml() {
-    assertThat(new EdgeDriverInfo()).isNot(supporting(
-        new ImmutableCapabilities(
-          CapabilityType.BROWSER_NAME, EDGE.browserName(),
-          EdgeOptions.USE_CHROMIUM, false)));
-  }
-
-  @Test
-  public void isSupportingEdgeWithExplicitlySetChromiumFlag() {
-    assertThat(new EdgeDriverInfo()).is(supporting(
-        new ImmutableCapabilities(
-          CapabilityType.BROWSER_NAME, EDGE.browserName(),
-          EdgeOptions.USE_CHROMIUM, true)));
-  }
-
-  @Test
   public void isNotSupportingFirefox() {
     assertThat(new EdgeDriverInfo()).isNot(supporting(
         new ImmutableCapabilities(CapabilityType.BROWSER_NAME, FIREFOX.browserName())));
@@ -74,16 +58,6 @@ public class EdgeDriverInfoTest {
         new ImmutableCapabilities(EdgeOptions.CAPABILITY, Collections.emptyMap())));
     assertThat(new EdgeDriverInfo()).is(supporting(
         new ImmutableCapabilities("edgeOptions", Collections.emptyMap())));
-  }
-
-  @Test
-  public void canRejectEdgeHtmlByVendorSpecificCapability() {
-    assertThat(new EdgeDriverInfo()).isNot(supporting(
-        new ImmutableCapabilities(EdgeOptions.CAPABILITY, Collections.emptyMap(),
-                                  EdgeOptions.USE_CHROMIUM, false)));
-    assertThat(new EdgeDriverInfo()).isNot(supporting(
-        new ImmutableCapabilities("edgeOptions", Collections.emptyMap(),
-                                  EdgeOptions.USE_CHROMIUM, false)));
   }
 
   private Condition<EdgeDriverInfo> supporting(Capabilities capabilities) {


### PR DESCRIPTION
### Description
Removing the `ms:edgeChromium` a.k.a. `USE_CHROMIUM` flag from the Java bindings as this should no longer be used.

### Motivation and Context
The flag was originally introduced as a hint for middleware like Selenium Grid to let the client select either EdgeHTML or Chromium-based Edge. In #9166 the decision was made to remove EdgeHTML support from Selenium 4 and make Edge Chromium the default and only supported Edge version. Since there are no longer plans to support running both Edge implementations side-by-side, this flag can be removed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
