### PR TITLE
ability to set no_vnc_port

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
@@ -231,7 +231,8 @@ public class DriverServiceSessionFactory implements SessionFactory {
     String seVncEnabled = String.valueOf(requestedCaps.getCapability(seVncEnabledCap));
     boolean vncLocalAddressSet = requestedCaps.getCapabilityNames().contains("se:vncLocalAddress");
     if (Boolean.parseBoolean(seVncEnabled) && !vncLocalAddressSet) {
-      String vncLocalAddress = String.format("ws://%s:7900", getHost());
+      String noVncPort = System.getProperty("NO_VNC_PORT", "7900");
+      String vncLocalAddress = String.format("ws://%s:%s", getHost(), noVncPort);
       returnedCaps = new PersistentCapabilities(returnedCaps)
         .setCapability("se:vncLocalAddress", vncLocalAddress)
         .setCapability(seVncEnabledCap, true);

--- a/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
@@ -17,6 +17,10 @@
 
 package org.openqa.selenium.grid.node.config;
 
+import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
+import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES_EVENT;
+import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
+
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.PersistentCapabilities;
@@ -57,10 +61,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
-import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES_EVENT;
-import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
 
 public class DriverServiceSessionFactory implements SessionFactory {
 

--- a/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
@@ -17,10 +17,6 @@
 
 package org.openqa.selenium.grid.node.config;
 
-import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
-import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES_EVENT;
-import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
-
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.PersistentCapabilities;
@@ -61,6 +57,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
+import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES_EVENT;
+import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
 
 public class DriverServiceSessionFactory implements SessionFactory {
 
@@ -231,7 +231,10 @@ public class DriverServiceSessionFactory implements SessionFactory {
     String seVncEnabled = String.valueOf(requestedCaps.getCapability(seVncEnabledCap));
     boolean vncLocalAddressSet = requestedCaps.getCapabilityNames().contains("se:vncLocalAddress");
     if (Boolean.parseBoolean(seVncEnabled) && !vncLocalAddressSet) {
-      String noVncPort = System.getProperty("NO_VNC_PORT", "7900");
+      String noVncPort = System.getenv("NO_VNC_PORT");
+      if (noVncPort == null || noVncPort.isEmpty()) {
+        noVncPort = "7900";
+      }
       String vncLocalAddress = String.format("ws://%s:%s", getHost(), noVncPort);
       returnedCaps = new PersistentCapabilities(returnedCaps)
         .setCapability("se:vncLocalAddress", vncLocalAddress)


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


Ability to set NO_VNC_PORT

### Description
The vnc port is hardcoded to 7900. Allowing it to be set will enable live view for users who are not using the default port

### Motivation and Context
Live view does not work for me because I am unable to set separate external and internal ports

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

The change simply reads the system property of NO_VNC_PORT and uses the default 7900 if not set. ** @diemol, I could change this to use a command line option instead of an environment variable, but I am not all that familiar with the codebase and NO_VNC_PORT is a variable already used in docker-selenium. **
