### PR TITLE
actually do not camel case fx prefs

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -175,7 +175,7 @@ module Selenium
         end
 
         def camelize?(key)
-          key != :prefs
+          key != "prefs"
         end
       end # Options
     end # Firefox

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -149,6 +149,14 @@ module Selenium
             options.add_preference(:foo, 'bar')
             expect(options.prefs[:foo]).to eq('bar')
           end
+
+          it 'does not camelize preferences' do
+            options.add_preference('intl.accepted_languages', 'en-US')
+
+            prefs    = options.as_json['moz:firefoxOptions']['prefs']
+            expected = { 'intl.accepted_languages' => 'en-US' }
+            expect(prefs).to eq(expected)
+          end
         end
 
         describe '#enable_android' do


### PR DESCRIPTION
### Description

firefox preferences must not be camelized. this was intended in eb2d0176 but failed simply due to a type mismatch.

### Motivation and Context

i wanted to set `intl.accepted_languages` but in a firefox instance it ended up as `intl.acceptedLanguages` and thus having no effect.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

all tests in the scope of my changes are passing. many others don't. i consider them being wip.

before this pr:

```
bundle exec rspec spec/unit/selenium/webdriver/firefox/options_spec.rb:153
Run options: include {:locations=>{"./spec/unit/selenium/webdriver/firefox/options_spec.rb"=>[153]}}
F

Failures:

  1) Selenium::WebDriver::Firefox::Options#add_preference does not camelize preferences
     Failure/Error: expect(prefs).to eq(expected)

       expected: {"intl.accepted_languages"=>"en-US"}
            got: {"intl.acceptedLanguages"=>"en-US"}

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -"intl.accepted_languages" => "en-US",
       +"intl.acceptedLanguages" => "en-US",

     # ./spec/unit/selenium/webdriver/firefox/options_spec.rb:158:in `block (3 levels) in <module:Firefox>'

Finished in 0.01195 seconds (files took 0.40692 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/unit/selenium/webdriver/firefox/options_spec.rb:153 # Selenium::WebDriver::Firefox::Options#add_preference does not camelize preferences
```

