### PR TITLE
Fix Javadoc code block formatting

### DIFF
--- a/java/src/org/openqa/selenium/By.java
+++ b/java/src/org/openqa/selenium/By.java
@@ -31,14 +31,14 @@ import java.util.Objects;
  * though it is expected that all subclasses rely on the basic finding mechanisms provided
  * through static methods of this class:
  *
- * <code>
+ * <pre><code>
  * public WebElement findElement(WebDriver driver) {
  *     WebElement element = driver.findElement(By.id(getSelector()));
  *     if (element == null)
  *       element = driver.findElement(By.name(getSelector());
  *     return element;
  * }
- * </code>
+ * </code></pre>
  */
 public abstract class By {
   /**

--- a/java/src/org/openqa/selenium/devtools/NetworkInterceptor.java
+++ b/java/src/org/openqa/selenium/devtools/NetworkInterceptor.java
@@ -50,7 +50,7 @@ import static org.openqa.selenium.remote.http.Contents.utf8String;
  *   try (NetworkInterceptor interceptor = new NetworkInterceptor(driver, route)) {
  *     // Your code here.
  *   }
- * </pre></code>
+ * </code></pre>
  * <p>
  * It is also possible to intercept and modify responses that the browser will
  * receive. Do this by calling {@link #NetworkInterceptor(WebDriver, Filter)}.

--- a/java/src/org/openqa/selenium/devtools/NetworkInterceptor.java
+++ b/java/src/org/openqa/selenium/devtools/NetworkInterceptor.java
@@ -43,14 +43,14 @@ import static org.openqa.selenium.remote.http.Contents.utf8String;
  * <p>
  * Example usage:
  * <p>
- * <code>
+ * <pre><code>
  *   Route route = Route.matching(req -&gt; GET == req.getMethod() &amp;&amp; req.getUri().endsWith("/example"))
  *     .to(() -&gt; req -&gt; new HttpResponse().setContent(Contents.utf8String("Hello, World!")));
  *
  *   try (NetworkInterceptor interceptor = new NetworkInterceptor(driver, route)) {
  *     // Your code here.
  *   }
- * </code>
+ * </pre></code>
  * <p>
  * It is also possible to intercept and modify responses that the browser will
  * receive. Do this by calling {@link #NetworkInterceptor(WebDriver, Filter)}.

--- a/java/src/org/openqa/selenium/opera/OperaOptions.java
+++ b/java/src/org/openqa/selenium/opera/OperaOptions.java
@@ -110,7 +110,7 @@ public class OperaOptions extends AbstractDriverOptions<OperaOptions> {
 
   /**
    * Adds additional command line arguments to be used when starting Opera.
-   * For example:
+   * <p>For example:
    * <pre><code>
    *   options.setArguments(
    *       "load-extension=/path/to/unpacked_extension",

--- a/java/src/org/openqa/selenium/remote/http/Filter.java
+++ b/java/src/org/openqa/selenium/remote/http/Filter.java
@@ -27,16 +27,16 @@ import java.util.function.Function;
  * {@link HttpRequest}s or outgoing {@link HttpResponse}s using the well-known "Filter" pattern.
  * This is very similar to the Servlet spec's {@link javax.servlet.Filter}, but takes advantage of
  * lambdas:
- * <pre>{@code
- * Filter filter = next -> {
- *   return req -> {
+ * <pre><code>
+ * Filter filter = next -&gt; {
+ *   return req -&gt; {
  *     req.addHeader("cheese", "brie");
  *     HttpResponse res = next.apply(req);
  *     res.addHeader("vegetable", "peas");
  *     return res;
  *   };
  * }
- * }</pre>
+ * </code></pre>
  *
  *<p>Because each filter returns an {@link HttpHandler}, it's easy to do processing before, or after
  * each request, as well as short-circuit things if necessary.

--- a/java/src/org/openqa/selenium/support/PageFactory.java
+++ b/java/src/org/openqa/selenium/support/PageFactory.java
@@ -39,15 +39,15 @@ public class PageFactory {
    * List&lt;WebElement&gt; fields that have been declared, assuming that the field
    * name is also the HTML element's "id" or "name". This means that for the class:
    *
-   * <code> public class Page { private WebElement submit; } </code>
+   * <pre><code> public class Page { private WebElement submit; } </code></pre>
    *
    * there will be an element that can be located using the xpath expression "//*[@id='submit']" or
    * "//*[@name='submit']"
-   *
+   * <p>
    * By default, the element or the list is looked up each and every time a method is called upon
    * it. To change this behaviour, simply annotate the field with the {@link CacheLookup}. To change
    * how the element is located, use the {@link FindBy} annotation.
-   *
+   * <p>
    * This method will attempt to instantiate the class given to it, preferably using a constructor
    * which takes a WebDriver instance as its only argument or falling back on a no-arg constructor.
    * An exception will be thrown if the class cannot be instantiated.

--- a/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
+++ b/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
@@ -98,45 +98,45 @@ import java.util.stream.Collectors;
  * One of the most widely used decorator examples is a logging decorator.
  * In this case we want to add the same piece of logging code before and after
  * each invoked method:
- * <pre>{@code
+ * <pre><code>
  *   public class LoggingDecorator extends WebDriverDecorator {
  *     final Logger logger = LoggerFactory.getLogger(Thread.currentThread().getName());
  *
- *     @Override
- *     public void beforeCall(Decorated<?> target, Method method, Object[] args) {
+ *     &#x40;Override
+ *     public void beforeCall(Decorated&lt;?&gt; target, Method method, Object[] args) {
  *       logger.debug("before {}.{}({})", target, method, args);
  *     }
- *     @Override
- *     public void afterCall(Decorated<?> target, Method method, Object[] args, Object res) {
- *       logger.debug("after {}.{}({}) => {}", target, method, args, res);
+ *     &#x40;Override
+ *     public void afterCall(Decorated&lt;?&gt; target, Method method, Object[] args, Object res) {
+ *       logger.debug("after {}.{}({}) =&gt; {}", target, method, args, res);
  *     }
  *   }
- * }</pre>
+ * </code></pre>
  * For the second example let's implement a decorator that implicitly waits
  * for an element to be visible before any click or sendKeys method call.
- * <pre>{@code
+ * <pre><code>
  *   public class ImplicitlyWaitingDecorator extends WebDriverDecorator {
  *     private WebDriverWait wait;
  *
- *     @Override
- *     public Decorated<WebDriver> createDecorated(WebDriver driver) {
+ *     &#x40;Override
+ *     public Decorated&lt;WebDriver&gt; createDecorated(WebDriver driver) {
  *       wait = new WebDriverWait(driver, Duration.ofSeconds(10));
  *       return super.createDecorated(driver);
  *     }
- *     @Override
- *     public Decorated<WebElement> createDecorated(WebElement original) {
- *       return new DefaultDecorated<>(original, this) {
- *         @Override
+ *     &#x40;Override
+ *     public Decorated&lt;WebElement&gt; createDecorated(WebElement original) {
+ *       return new DefaultDecorated&lt;&gt;(original, this) {
+ *         &#x40;Override
  *         public void beforeCall(Method method, Object[] args) {
  *           String methodName = method.getName();
  *           if ("click".equals(methodName) || "sendKeys".equals(methodName)) {
- *             wait.until(d -> getOriginal().isDisplayed());
+ *             wait.until(d -&gt; getOriginal().isDisplayed());
  *           }
  *         }
  *       };
  *     }
  *   }
- * }</pre>
+ * </code></pre>
  * This class is not a pure decorator, it allows to not only add new behavior
  * but also replace "normal" behavior of a WebDriver or derived objects.
  * <p>
@@ -144,12 +144,12 @@ import java.util.stream.Collectors;
  * ones (yes, this allows to interact with invisible elements, it's a bad
  * practice in general but sometimes it's inevitable). This behavior change
  * can be achieved with the following "decorator":
- * <pre>{@code
+ * <pre><code>
  *   public class JavaScriptPoweredDecorator extends WebDriverDecorator {
- *     @Override
- *     public Decorated<WebElement> createDecorated(WebElement original) {
- *       return new DefaultDecorated<>(original, this) {
- *         @Override
+ *     &#x40;Override
+ *     public Decorated&lt;WebElement&gt; createDecorated(WebElement original) {
+ *       return new DefaultDecorated&lt;&gt;(original, this) {
+ *         &#x40;Override
  *         public Object call(Method method, Object[] args) throws Throwable {
  *           String methodName = method.getName();
  *           if ("click".equals(methodName)) {
@@ -163,16 +163,16 @@ import java.util.stream.Collectors;
  *       };
  *     }
  *   }
- * }</pre>
+ * </code></pre>
  * It is possible to apply multiple decorators to compose behaviors added
  * by each of them. For example, if you want to log method calls and
  * implicitly wait for elements visibility you can use two decorators:
- * <pre>{@code
+ * <pre><code>
  *   WebDriver original = new FirefoxDriver();
  *   WebDriver decorated =
  *     new ImplicitlyWaitingDecorator().decorate(
  *       new LoggingDecorator().decorate(original));
- * }</pre>
+ * </code></pre>
  */
 @Beta
 public class WebDriverDecorator {

--- a/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
+++ b/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
@@ -46,21 +46,21 @@ import java.util.stream.Collectors;
  * Here is a general usage pattern:
  * <ol>
  *   <li>implement a subclass of WebDriverDecorator that adds something to WebDriver behavior:<br>
- *     <code>
- *       public class MyWebDriverDecorator extends WebDriverDecorator { ... }
- *     </code><br>
+ *     <pre><code>
+ * public class MyWebDriverDecorator extends WebDriverDecorator { ... }
+ *     </code></pre>
  *     (see below for details)</li>
  *   <li>use a decorator instance to decorate a WebDriver object:<br>
- *     <code>
- *       WebDriver original = new FirefoxDriver();
- *       WebDriver decorated = new MyWebDriverDecorator().decorate(original);
- *     </code></li>
+ *     <pre><code>
+ * WebDriver original = new FirefoxDriver();
+ * WebDriver decorated = new MyWebDriverDecorator().decorate(original);
+ *     </code></pre></li>
  *   <li>use the decorated WebDriver instead of the original one:<br>
- *    <code>
- *      decorated.get("http://example.com/");
- *      ...
- *      decorated.quit();
- *    </code>
+ *    <pre><code>
+ * decorated.get("http://example.com/");
+ * ...
+ * decorated.quit();
+ *    </code></pre>
  *   </li>
  * </ol>
  * By subclassing WebDriverDecorator you can define what code should be executed
@@ -98,7 +98,7 @@ import java.util.stream.Collectors;
  * One of the most widely used decorator examples is a logging decorator.
  * In this case we want to add the same piece of logging code before and after
  * each invoked method:
- * <code>
+ * <pre>{@code
  *   public class LoggingDecorator extends WebDriverDecorator {
  *     final Logger logger = LoggerFactory.getLogger(Thread.currentThread().getName());
  *
@@ -111,10 +111,10 @@ import java.util.stream.Collectors;
  *       logger.debug("after {}.{}({}) => {}", target, method, args, res);
  *     }
  *   }
- * </code>
+ * }</pre>
  * For the second example let's implement a decorator that implicitly waits
  * for an element to be visible before any click or sendKeys method call.
- * <code>
+ * <pre>{@code
  *   public class ImplicitlyWaitingDecorator extends WebDriverDecorator {
  *     private WebDriverWait wait;
  *
@@ -136,7 +136,7 @@ import java.util.stream.Collectors;
  *       };
  *     }
  *   }
- * </code>
+ * }</pre>
  * This class is not a pure decorator, it allows to not only add new behavior
  * but also replace "normal" behavior of a WebDriver or derived objects.
  * <p>
@@ -144,7 +144,7 @@ import java.util.stream.Collectors;
  * ones (yes, this allows to interact with invisible elements, it's a bad
  * practice in general but sometimes it's inevitable). This behavior change
  * can be achieved with the following "decorator":
- * <code>
+ * <pre>{@code
  *   public class JavaScriptPoweredDecorator extends WebDriverDecorator {
  *     @Override
  *     public Decorated<WebElement> createDecorated(WebElement original) {
@@ -163,16 +163,16 @@ import java.util.stream.Collectors;
  *       };
  *     }
  *   }
- * </code>
+ * }</pre>
  * It is possible to apply multiple decorators to compose behaviors added
  * by each of them. For example, if you want to log method calls and
  * implicitly wait for elements visibility you can use two decorators:
- * <code>
+ * <pre>{@code
  *   WebDriver original = new FirefoxDriver();
  *   WebDriver decorated =
  *     new ImplicitlyWaitingDecorator().decorate(
  *       new LoggingDecorator().decorate(original));
- * </code>
+ * }</pre>
  */
 @Beta
 public class WebDriverDecorator {

--- a/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
+++ b/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
@@ -47,14 +47,14 @@ import java.util.logging.Logger;
  * To use this decorator you have to prepare a listener, create a decorator using this listener,
  * decorate the original WebDriver instance with this decorator and use the new WebDriver
  * instance created by the decorator instead of the original one:
- * <pre>{@code
+ * <pre><code>
  *   WebDriver original = new FirefoxDriver();
  *   WebDriverListener listener = new MyListener();
  *   WebDriver decorated = new EventFiringDecorator(listener).decorate(original);
  *   decorated.get("http://example.com/");
  *   WebElement header = decorated.findElement(By.tagName("h1"));
  *   String headerText = header.getText();
- * }</pre>
+ * </code></pre>
  * <p>
  * The instance of WebDriver created by the decorator implements all the same interfaces as
  * the original driver.
@@ -67,56 +67,56 @@ import java.util.logging.Logger;
  * the target method to be watched. The listener methods for "before"-events receive the parameters
  * passed to the decorated method. The listener methods for "after"-events receive the parameters
  * passed to the decorated method as well as the result returned by this method.
- * <pre>{@code
+ * <pre><code>
  *   WebDriverListener listener = new WebDriverListener() {
- *     @Override
+ *     &#x40;Override
  *     public void beforeGet(WebDriver driver, String url) {
  *       logger.log("About to open a page %s", url);
  *     }
- *     @Override
+ *     &#x40;Override
  *     public void afterGetText(WebElement element, String result) {
  *       logger.log("Element %s has text '%s'", element, result);
  *     }
  *   };
- * }</pre>
+ * </code></pre>
  * <p>
  * To subscribe to a "generic" event a listener should implement a method with a name derived from
  * the class to be watched:
- * <pre>{@code
+ * <pre><code>
  *   WebDriverListener listener = new WebDriverListener() {
- *     @Override
+ *     &#x40;Override
  *     public void beforeAnyWebElementCall(WebElement element, Method method, Object[] args) {
  *       logger.log("About to call a method %s in element %s with parameters %s",
  *                  method, element, args);
  *     }
- *     @Override
+ *     &#x40;Override
  *     public void afterAnyWebElementCall(WebElement element, Method method, Object[] args, Object result) {
  *       logger.log("Method %s called in element %s with parameters %s returned %s",
  *                  method, element, args, result);
  *     }
  *   };
- * }</pre>
+ * </code></pre>
  * <p>
  * There are also listener methods for "super-generic" events:
- * <pre>{@code
+ * <pre><code>
  *   WebDriverListener listener = new WebDriverListener() {
- *     @Override
+ *     &#x40;Override
  *     public void beforeAnyCall(Object target, Method method, Object[] args) {
  *       logger.log("About to call a method %s in %s with parameters %s",
  *                  method, target, args);
  *     }
- *     @Override
+ *     &#x40;Override
  *     public void afterAnyCall(Object target, Method method, Object[] args, Object result) {
  *       logger.log("Method %s called in %s with parameters %s returned %s",
  *                  method, target, args, result);
  *     }
  *   };
- * }</pre>
+ * </code></pre>
  * <p>
  * A listener can subscribe to both "specific" and "generic" events at the same time. In this case
  * "before"-events are fired in order from the most generic to the most specific,
  * and "after"-events are fired in the opposite order, for example:
- * <pre>{@code
+ * <pre><code>
  *   beforeAnyCall
  *   beforeAnyWebDriverCall
  *   beforeGet
@@ -124,7 +124,7 @@ import java.util.logging.Logger;
  *   afterGet
  *   afterAnyWebDriverCall
  *   afterAnyCall
- * }</pre>
+ * </code></pre>
  * <p>
  * One of the most obvious use of this decorator is logging. But it can be used to modify behavior
  * of the original driver to some extent because listener methods are executed in the same thread
@@ -132,9 +132,9 @@ import java.util.logging.Logger;
  * <p>
  * For example, a listener can be used to slow down execution for demonstration purposes, just
  * make a listener that adds a pause before some operations:
- * <pre>{@code
+ * <pre><code>
  *   WebDriverListener listener = new WebDriverListener() {
- *     @Override
+ *     &#x40;Override
  *     public void beforeClick(WebElement element) {
  *       try {
  *         Thread.sleep(3000);
@@ -143,7 +143,7 @@ import java.util.logging.Logger;
  *       }
  *     }
  *   };
- * }</pre>
+ * </code></pre>
  * <p>
  * Just be careful to not block the current thread in a listener method!
  * <p>

--- a/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
+++ b/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
@@ -47,14 +47,14 @@ import java.util.logging.Logger;
  * To use this decorator you have to prepare a listener, create a decorator using this listener,
  * decorate the original WebDriver instance with this decorator and use the new WebDriver
  * instance created by the decorator instead of the original one:
- * <code>
+ * <pre>{@code
  *   WebDriver original = new FirefoxDriver();
  *   WebDriverListener listener = new MyListener();
  *   WebDriver decorated = new EventFiringDecorator(listener).decorate(original);
  *   decorated.get("http://example.com/");
  *   WebElement header = decorated.findElement(By.tagName("h1"));
  *   String headerText = header.getText();
- * </code>
+ * }</pre>
  * <p>
  * The instance of WebDriver created by the decorator implements all the same interfaces as
  * the original driver.
@@ -67,7 +67,7 @@ import java.util.logging.Logger;
  * the target method to be watched. The listener methods for "before"-events receive the parameters
  * passed to the decorated method. The listener methods for "after"-events receive the parameters
  * passed to the decorated method as well as the result returned by this method.
- * <code>
+ * <pre>{@code
  *   WebDriverListener listener = new WebDriverListener() {
  *     @Override
  *     public void beforeGet(WebDriver driver, String url) {
@@ -78,11 +78,11 @@ import java.util.logging.Logger;
  *       logger.log("Element %s has text '%s'", element, result);
  *     }
  *   };
- * </code>
+ * }</pre>
  * <p>
  * To subscribe to a "generic" event a listener should implement a method with a name derived from
  * the class to be watched:
- * <code>
+ * <pre>{@code
  *   WebDriverListener listener = new WebDriverListener() {
  *     @Override
  *     public void beforeAnyWebElementCall(WebElement element, Method method, Object[] args) {
@@ -95,10 +95,10 @@ import java.util.logging.Logger;
  *                  method, element, args, result);
  *     }
  *   };
- * </code>
+ * }</pre>
  * <p>
  * There are also listener methods for "super-generic" events:
- * <code>
+ * <pre>{@code
  *   WebDriverListener listener = new WebDriverListener() {
  *     @Override
  *     public void beforeAnyCall(Object target, Method method, Object[] args) {
@@ -111,12 +111,12 @@ import java.util.logging.Logger;
  *                  method, target, args, result);
  *     }
  *   };
- * </code>
+ * }</pre>
  * <p>
  * A listener can subscribe to both "specific" and "generic" events at the same time. In this case
  * "before"-events are fired in order from the most generic to the most specific,
  * and "after"-events are fired in the opposite order, for example:
- * <code>
+ * <pre>{@code
  *   beforeAnyCall
  *   beforeAnyWebDriverCall
  *   beforeGet
@@ -124,7 +124,7 @@ import java.util.logging.Logger;
  *   afterGet
  *   afterAnyWebDriverCall
  *   afterAnyCall
- * </code>
+ * }</pre>
  * <p>
  * One of the most obvious use of this decorator is logging. But it can be used to modify behavior
  * of the original driver to some extent because listener methods are executed in the same thread
@@ -132,7 +132,7 @@ import java.util.logging.Logger;
  * <p>
  * For example, a listener can be used to slow down execution for demonstration purposes, just
  * make a listener that adds a pause before some operations:
- * <code>
+ * <pre>{@code
  *   WebDriverListener listener = new WebDriverListener() {
  *     @Override
  *     public void beforeClick(WebElement element) {
@@ -143,7 +143,7 @@ import java.util.logging.Logger;
  *       }
  *     }
  *   };
- * </code>
+ * }</pre>
  * <p>
  * Just be careful to not block the current thread in a listener method!
  * <p>


### PR DESCRIPTION
### Description
Several classes use the `<code>` tag for for javadoc code blocks. This tag doesn't maintain formatting and should be combined with a `<pre>` tag (as is done in most classes). Additionally '<', '>', and '@' characters needs to be escaped in plain HTML javadoc.

### Motivation and Context
The unformatted code blocks result in badly formatted documentation and unescaped characters result broken or incomplete documentation. For instance, the doc for [WebDriverDecorator](https://www.javadoc.io/doc/org.seleniumhq.selenium/selenium-support/4.0.0/org/openqa/selenium/support/decorators/WebDriverDecorator.html) is cut short by [an unescaped '@'](https://github.com/SeleniumHQ/selenium/blob/702b3aae7385adf331d75cdeacd79720cf6b9c84/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java#L105).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
