### PR TITLE
[rb] Fix an example of `WebDriver::Options`

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -50,7 +50,7 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::Chrome::Options.new(args: ['start-maximized', 'user-data-dir=/tmp/temp_profile'])
-        #   driver = Selenium::WebDriver.for(:chrome, options: options)
+        #   driver = Selenium::WebDriver.for(:chrome, capabilities: options)
         #
         # @param [Profile] :profile An instance of a Chrome::Profile Class
         # @param [Array] :encoded_extensions List of extensions that do not need to be Base64 encoded

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -44,7 +44,7 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::Firefox::Options.new(args: ['--host=127.0.0.1'])
-        #   driver = Selenium::WebDriver.for :firefox, options: options
+        #   driver = Selenium::WebDriver.for :firefox, capabilities: options
         #
         # @param [Hash] opts the pre-defined options to create the Firefox::Options with
         # @option opts [String] :binary Path to the Firefox executable to use

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -52,12 +52,12 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::IE::Options.new(args: ['--host=127.0.0.1'])
-        #   driver = Selenium::WebDriver.for(:ie, options: options)
+        #   driver = Selenium::WebDriver.for(:ie, capabilities: options)
         #
         # @example
         #   options = Selenium::WebDriver::IE::Options.new
         #   options.element_scroll_behavior = Selenium::WebDriver::IE::Options::SCROLL_BOTTOM
-        #   driver = Selenium::WebDriver.for(:ie, options: options)
+        #   driver = Selenium::WebDriver.for(:ie, capabilities: options)
         #
         # @param [Hash] opts the pre-defined options
         # @option opts [Array<String>] args


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


### Description

`:options` as a parameter for driver initialization is deprecated now. So I changed to use `:capabilities`.

```ruby
options = Selenium::WebDriver::Chrome::Options.new(args: ['start-maximized', 'user-data-dir=/tmp/temp_profile'])
Selenium::WebDriver.for(:chrome, options: options)
# => WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
