### PR TITLE
[py] Fix return type hint in get_screenshot_as_png

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1341,7 +1341,7 @@ class WebDriver(BaseWebDriver):
         """
         return self.get_screenshot_as_file(filename)
 
-    def get_screenshot_as_png(self) -> str:
+    def get_screenshot_as_png(self) -> bytes:
         """
         Gets the screenshot of the current window as a binary data.
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Change return type hint of `get_screenshot_as_png` from `str` to `bytes`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`get_screenshot_as_png` returns a `bytes` object but the return type hint
is set to `str`. This causes IDEs to throw warning when using this function
with `io.BytesIO` (or any other function that expects bytes object)

Example Warning:
`Expected type 'bytes', got 'str' instead`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
