### PR TITLE
[py] send Base64 encoded addon to driver instead of path String

### DIFF
--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -14,8 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from base64 import b64decode
+import base64
 from shutil import rmtree
 import warnings
 from contextlib import contextmanager
@@ -247,7 +246,11 @@ class WebDriver(RemoteWebDriver):
 
                 driver.install_addon('/path/to/firebug.xpi')
         """
-        payload = {"path": path}
+        file_ = open(path, 'rb')
+        addon = (base64.b64encode(file_.read()).decode('UTF-8'))
+        file_.close()
+
+        payload = {"addon": addon}
         if temporary:
             payload["temporary"] = temporary
         return self.execute("INSTALL_ADDON", payload)["value"]
@@ -317,7 +320,7 @@ class WebDriver(RemoteWebDriver):
 
                 driver.get_full_page_screenshot_as_png()
         """
-        return b64decode(self.get_full_page_screenshot_as_base64().encode('ascii'))
+        return base64.b64decode(self.get_full_page_screenshot_as_base64().encode('ascii'))
 
     def get_full_page_screenshot_as_base64(self) -> str:
         """

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -246,9 +246,8 @@ class WebDriver(RemoteWebDriver):
 
                 driver.install_addon('/path/to/firebug.xpi')
         """
-        file_ = open(path, 'rb')
-        addon = (base64.b64encode(file_.read()).decode('UTF-8'))
-        file_.close()
+        with open(path, 'rb') as file:
+            addon = (base64.b64encode(file.read()).decode('UTF-8'))
 
         payload = {"addon": addon}
         if temporary:

--- a/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
+++ b/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
@@ -1,0 +1,36 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from pathlib import Path
+
+from selenium.common.exceptions import WebDriverException
+
+
+def test_install_addon(driver, pages):
+    extension = os.path.join(Path(__file__).absolute().parents[5], 'third_party/firebug/favourite_colour-1.1-an+fx.xpi')
+    id = driver.install_addon(extension)
+    assert id == 'favourite-colour-examples@mozilla.org'
+
+
+def test_uninstall_addon(driver, pages):
+    extension = os.path.join(Path(__file__).absolute().parents[5], 'third_party/firebug/favourite_colour-1.1-an+fx.xpi')
+    id = driver.install_addon(extension)
+    try:
+        driver.uninstall_addon(id)
+    except WebDriverException as exc:
+        assert False, exc


### PR DESCRIPTION
Uses `addon` parameter instead of `path` parameter for installing Firefox AddOn

reference:
https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/CHANGES.md#l878

This matches current Ruby & .NET behavior.

This change will also make it easier to use in a remote driver when we get that functionality mixed in.

@AutomatedTester please let me know if my Python is correct here; like there might be a better way to do a relative file reference?