### PR TITLE
RemoteWebDriverBuilder for local drivers

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -18,12 +18,14 @@
 package org.openqa.selenium.chrome;
 
 import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chromium.ChromiumDriver;
 import org.openqa.selenium.chromium.ChromiumDriverCommandExecutor;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.util.Map;
@@ -104,6 +106,11 @@ public class ChromeDriver extends ChromiumDriver {
     super(new ChromeDriverCommandExecutor(service), capabilities, ChromeOptions.CAPABILITY);
     casting = new AddHasCasting().getImplementation(getCapabilities(), getExecuteMethod());
     cdp = new AddHasCdp().getImplementation(getCapabilities(), getExecuteMethod());
+  }
+
+  @Beta
+  public static RemoteWebDriverBuilder builder() {
+    return RemoteWebDriver.builder().oneOf(new ChromeOptions());
   }
 
   private static class ChromeDriverCommandExecutor extends ChromiumDriverCommandExecutor {

--- a/java/src/org/openqa/selenium/edge/EdgeDriver.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriver.java
@@ -17,12 +17,15 @@
 package org.openqa.selenium.edge;
 
 import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chromium.ChromiumDriver;
 import org.openqa.selenium.chromium.ChromiumDriverCommandExecutor;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.CommandInfo;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.util.Map;
@@ -54,6 +57,11 @@ public class EdgeDriver extends ChromiumDriver {
   @Deprecated
   public EdgeDriver(Capabilities capabilities) {
     this(new EdgeDriverService.Builder().build(), new EdgeOptions().merge(capabilities));
+  }
+
+  @Beta
+  public static RemoteWebDriverBuilder builder() {
+    return RemoteWebDriver.builder().oneOf(new EdgeOptions());
   }
 
   private static class EdgeDriverCommandExecutor extends ChromiumDriverCommandExecutor {

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.firefox;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.MutableCapabilities;
@@ -42,6 +43,7 @@ import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.html5.RemoteWebStorage;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.HttpClient;
@@ -135,6 +137,11 @@ public class FirefoxDriver extends RemoteWebDriver
     public static final String BINARY = "firefox_binary";
     public static final String PROFILE = "firefox_profile";
     public static final String MARIONETTE = "marionette";
+  }
+
+  @Beta
+  public static RemoteWebDriverBuilder builder() {
+    return RemoteWebDriver.builder().oneOf(new FirefoxOptions());
   }
 
   private static class FirefoxDriverCommandExecutor extends DriverCommandExecutor {

--- a/java/src/org/openqa/selenium/ie/InternetExplorerDriver.java
+++ b/java/src/org/openqa/selenium/ie/InternetExplorerDriver.java
@@ -17,12 +17,14 @@
 
 package org.openqa.selenium.ie;
 
+import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.service.DriverCommandExecutor;
 
 import java.io.File;
@@ -191,6 +193,11 @@ public class InternetExplorerDriver extends RemoteWebDriver {
     throw new WebDriverException(
         "Setting the file detector only works on remote webdriver instances obtained " +
         "via RemoteWebDriver");
+  }
+
+  @Beta
+  public static RemoteWebDriverBuilder builder() {
+    return RemoteWebDriver.builder().oneOf(new InternetExplorerOptions());
   }
 
   protected void assertOnWindows() {

--- a/java/src/org/openqa/selenium/safari/SafariDriver.java
+++ b/java/src/org/openqa/selenium/safari/SafariDriver.java
@@ -18,12 +18,14 @@
 package org.openqa.selenium.safari;
 
 import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.service.DriverCommandExecutor;
 import org.openqa.selenium.remote.service.DriverService;
 
@@ -125,5 +127,10 @@ public class SafariDriver extends RemoteWebDriver implements HasPermissions, Has
     throw new WebDriverException(
         "Setting the file detector only works on remote webdriver instances obtained " +
         "via RemoteWebDriver");
+  }
+
+  @Beta
+  public static RemoteWebDriverBuilder builder() {
+    return RemoteWebDriver.builder().oneOf(new SafariOptions());
   }
 }

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
@@ -26,6 +26,8 @@ import org.openqa.selenium.chromium.HasCasting;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.chromium.HasNetworkConditions;
 import org.openqa.selenium.chromium.HasPermissions;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JUnit4TestBase;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
@@ -57,6 +60,16 @@ public class ChromeDriverFunctionalTest extends JUnit4TestBase {
     assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
 
     driver.quit();
+  }
+
+  @Test
+  public void builderWithClientConfigthrowsException() {
+    ClientConfig clientConfig = ClientConfig.defaultConfig().readTimeout(Duration.ofMinutes(1));
+    RemoteWebDriverBuilder builder = ChromeDriver.builder().config(clientConfig);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(builder::build)
+      .withMessage("ClientConfig instances do not work for Local Drivers");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
@@ -17,10 +17,6 @@
 
 package org.openqa.selenium.chrome;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assumptions.assumeThat;
-
 import org.junit.Test;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -38,10 +34,30 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 public class ChromeDriverFunctionalTest extends JUnit4TestBase {
 
   private final String CLIPBOARD_READ = "clipboard-read";
   private final String CLIPBOARD_WRITE = "clipboard-write";
+
+  @Test
+  public void builderGeneratesDefaultChromeOptions() {
+    WebDriver driver = ChromeDriver.builder().build();
+    driver.quit();
+  }
+
+  @Test
+  public void builderOverridesDefaultChromeOptions() {
+    ChromeOptions options = new ChromeOptions();
+    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    WebDriver driver = ChromeDriver.builder().oneOf(options).build();
+    assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
+
+    driver.quit();
+  }
 
   @Test
   public void canSetPermission() {

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -43,6 +43,22 @@ public class EdgeDriverFunctionalTest extends JUnit4TestBase {
   private final String CLIPBOARD_WRITE = "clipboard-write";
 
   @Test
+  public void builderGeneratesDefaultChromeOptions() {
+    WebDriver driver = EdgeDriver.builder().build();
+    driver.quit();
+  }
+
+  @Test
+  public void builderOverridesDefaultChromeOptions() {
+    EdgeOptions options = new EdgeOptions();
+    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    WebDriver driver = EdgeDriver.builder().oneOf(options).build();
+    assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
+
+    driver.quit();
+  }
+
+  @Test
   public void canSetPermission() {
     HasPermissions permissions = (HasPermissions) driver;
 

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -26,6 +26,8 @@ import org.openqa.selenium.chromium.HasCasting;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.chromium.HasNetworkConditions;
 import org.openqa.selenium.chromium.HasPermissions;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.testing.JUnit4TestBase;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
 
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
@@ -56,6 +59,16 @@ public class EdgeDriverFunctionalTest extends JUnit4TestBase {
     assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
 
     driver.quit();
+  }
+
+  @Test
+  public void builderWithClientConfigthrowsException() {
+    ClientConfig clientConfig = ClientConfig.defaultConfig().readTimeout(Duration.ofMinutes(1));
+    RemoteWebDriverBuilder builder = EdgeDriver.builder().config(clientConfig);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(builder::build)
+      .withMessage("ClientConfig instances do not work for Local Drivers");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -39,8 +39,10 @@ import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.UnreachableBrowserException;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.testing.Ignore;
@@ -60,6 +62,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 import static org.mockito.Mockito.atLeastOnce;
@@ -110,6 +113,16 @@ public class FirefoxDriverTest extends JUnit4TestBase {
     assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
 
     driver.quit();
+  }
+
+  @Test
+  public void builderWithClientConfigthrowsException() {
+    ClientConfig clientConfig = ClientConfig.defaultConfig().readTimeout(Duration.ofMinutes(1));
+    RemoteWebDriverBuilder builder = FirefoxDriver.builder().config(clientConfig);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(builder::build)
+      .withMessage("ClientConfig instances do not work for Local Drivers");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -97,6 +97,22 @@ public class FirefoxDriverTest extends JUnit4TestBase {
   }
 
   @Test
+  public void builderGeneratesDefaultChromeOptions() {
+    WebDriver driver = FirefoxDriver.builder().build();
+    driver.quit();
+  }
+
+  @Test
+  public void builderOverridesDefaultChromeOptions() {
+    FirefoxOptions options = new FirefoxOptions();
+    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    WebDriver driver = FirefoxDriver.builder().oneOf(options).build();
+    assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
+
+    driver.quit();
+  }
+
+  @Test
   public void canStartDriverWithNoParameters() {
     localDriver = new WebDriverBuilder().get();
     assertThat(((HasCapabilities) localDriver).getCapabilities().getBrowserName()).isEqualTo("firefox");

--- a/java/test/org/openqa/selenium/ie/InternetExplorerDriverTest.java
+++ b/java/test/org/openqa/selenium/ie/InternetExplorerDriverTest.java
@@ -24,6 +24,8 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.testing.JUnit4TestBase;
 import org.openqa.selenium.testing.NoDriverAfterTest;
 import org.openqa.selenium.testing.NoDriverBeforeTest;
@@ -33,6 +35,7 @@ import java.awt.*;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.openqa.selenium.ie.InternetExplorerDriver.ENABLE_PERSISTENT_HOVERING;
 
 public class InternetExplorerDriverTest extends JUnit4TestBase {
@@ -51,6 +54,16 @@ public class InternetExplorerDriverTest extends JUnit4TestBase {
     assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
 
     driver.quit();
+  }
+
+  @Test
+  public void builderWithClientConfigthrowsException() {
+    ClientConfig clientConfig = ClientConfig.defaultConfig().readTimeout(Duration.ofMinutes(1));
+    RemoteWebDriverBuilder builder = InternetExplorerDriver.builder().config(clientConfig);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(builder::build)
+      .withMessage("ClientConfig instances do not work for Local Drivers");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/ie/InternetExplorerDriverTest.java
+++ b/java/test/org/openqa/selenium/ie/InternetExplorerDriverTest.java
@@ -30,11 +30,28 @@ import org.openqa.selenium.testing.NoDriverBeforeTest;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
 
 import java.awt.*;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openqa.selenium.ie.InternetExplorerDriver.ENABLE_PERSISTENT_HOVERING;
 
 public class InternetExplorerDriverTest extends JUnit4TestBase {
+
+  @Test
+  public void builderGeneratesDefaultChromeOptions() {
+    WebDriver driver = InternetExplorerDriver.builder().build();
+    driver.quit();
+  }
+
+  @Test
+  public void builderOverridesDefaultChromeOptions() {
+    InternetExplorerOptions options = new InternetExplorerOptions();
+    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    WebDriver driver = InternetExplorerDriver.builder().oneOf(options).build();
+    assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
+
+    driver.quit();
+  }
 
   @Test
   @NoDriverBeforeTest

--- a/java/test/org/openqa/selenium/safari/SafariDriverTest.java
+++ b/java/test/org/openqa/selenium/safari/SafariDriverTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
@@ -51,6 +52,22 @@ public class SafariDriverTest extends JUnit4TestBase {
     if (service != null) {
       service.stop();
     }
+  }
+
+  @Test
+  public void builderGeneratesDefaultChromeOptions() {
+    WebDriver driver = SafariDriver.builder().build();
+    driver.quit();
+  }
+
+  @Test
+  public void builderOverridesDefaultChromeOptions() {
+    SafariOptions options = new SafariOptions();
+    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    WebDriver driver = SafariDriver.builder().oneOf(options).build();
+    assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
+
+    driver.quit();
   }
 
   @Test

--- a/java/test/org/openqa/selenium/safari/SafariDriverTest.java
+++ b/java/test/org/openqa/selenium/safari/SafariDriverTest.java
@@ -21,6 +21,8 @@ import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.net.PortProber;
+import org.openqa.selenium.remote.RemoteWebDriverBuilder;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.testing.JUnit4TestBase;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
 
@@ -31,6 +33,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assume.assumeTrue;
 
 public class SafariDriverTest extends JUnit4TestBase {
@@ -68,6 +71,16 @@ public class SafariDriverTest extends JUnit4TestBase {
     assertThat(driver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ofMillis(1));
 
     driver.quit();
+  }
+
+  @Test
+  public void builderWithClientConfigthrowsException() {
+    ClientConfig clientConfig = ClientConfig.defaultConfig().readTimeout(Duration.ofMinutes(1));
+    RemoteWebDriverBuilder builder = SafariDriver.builder().config(clientConfig);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(builder::build)
+      .withMessage("ClientConfig instances do not work for Local Drivers");
   }
 
   @Test


### PR DESCRIPTION
So, this would fix #10064 but in a slightly hacky way. Since we can't create a null config, and we can't determine if a driver is local until `build()` is called, this creates a config with a zero readTimeout. Since no one should be passing in a config with a zero read timeout, anything they pass in will override the one that the local driver class put there, and will throw an error in `build()`.

It also seemed weird to have to do this:
```
ChromeDriver.builder().oneOf(new ChromeOptions()).build();
```

So now this will do the expected thing:
```
ChromeDriver.builder().build();
```
