### PR TITLE
Added possibility to reduce stacktrace from WebDriverWait 

### DIFF
--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -60,7 +60,7 @@ class WebDriverWait(object):
         return '<{0.__module__}.{0.__name__} (session="{1}")>'.format(
             type(self), self._driver.session_id)
 
-    def until(self, method, message=''):
+    def until(self, method, message='', capture_stacktrace=True):
         """Calls the method provided with the driver as an argument until the \
         return value does not evaluate to ``False``.
 
@@ -82,7 +82,8 @@ class WebDriverWait(object):
                 raise e
             except self._ignored_exceptions as exc:
                 screen = getattr(exc, 'screen', None)
-                stacktrace = getattr(exc, 'stacktrace', None)
+                if capture_stacktrace:
+                    stacktrace = getattr(exc, 'stacktrace', None)
             time.sleep(self._poll)
             if time.time() > end_time:
                 break

--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -66,6 +66,7 @@ class WebDriverWait(object):
 
         :param method: callable(WebDriver)
         :param message: optional message for :exc:`TimeoutException`
+        :param capture_stacktrace: adds stack trace into exception output
         :returns: the result of the last call to `method`
         :raises: :exc:`selenium.common.exceptions.TimeoutException` if timeout occurs
         """


### PR DESCRIPTION
https://github.com/SeleniumHQ/selenium/issues/10195

### Motivation and Context
I wanna have possibility to reduce stacktrace output from WebDriverWait.until due to long output (see picture).
![image](https://user-images.githubusercontent.com/36446855/147663426-bde1055d-95f0-47c0-9aa8-9a49959e0410.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
