### PR TITLE
[java] Fix FluentWait's sample usage wrt durations

### DIFF
--- a/java/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -49,8 +49,8 @@ import java.util.function.Supplier;
  *   // Waiting 30 seconds for an element to be present on the page, checking
  *   // for its presence once every 5 seconds.
  *   Wait&lt;WebDriver&gt; wait = new FluentWait&lt;WebDriver&gt;(driver)
- *       .withTimeout(30, SECONDS)
- *       .pollingEvery(5, SECONDS)
+ *       .withTimeout(Duration.ofSeconds(30L))
+ *       .pollingEvery(Duration.ofSeconds(5L))
  *       .ignoring(NoSuchElementException.class);
  *
  *   WebElement foo = wait.until(new Function&lt;WebDriver, WebElement&gt;() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes the sample usage of the `FluentWait` class which currently does not compile.

### Motivation and Context
Commit 502301edeb4c4caf27aad125e8e75da3f22691f1 removed some deprecated methods which used the deprecated `TimeUnit` class and kept only the overloaded methods that use Java's `java.time.Duration` class.

However, it missed fixing the sample usage at the beginning of the javadoc that still referred to these methods.
This patch fixes the issue and replaces the method calls in the sample usage with the newer methods that accept a `Duration` argument.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. - N/A - documentation change only
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


Fixes #10207