### PR TITLE
[java] Fix the retry request filter's max duration value to allow retries

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/RetryRequest.java
+++ b/java/src/org/openqa/selenium/remote/http/RetryRequest.java
@@ -42,7 +42,7 @@ public class RetryRequest implements Filter {
       .handleIf(failure -> failure.getCause() instanceof ConnectException)
       .withBackoff(1, 4, ChronoUnit.SECONDS)
       .withMaxRetries(3)
-      .withMaxDuration(Duration.ofSeconds(10))
+      .withMaxDuration(Duration.ofMinutes(1))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Connection failure #{0}. Retrying.",
@@ -54,7 +54,7 @@ public class RetryRequest implements Filter {
       .handle(TimeoutException.class)
       .withBackoff(1, 4, ChronoUnit.SECONDS)
       .withMaxRetries(3)
-      .withMaxDuration(Duration.ofSeconds(10))
+      .withMaxDuration(Duration.ofMinutes(10))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Read timeout #{0}. Retrying.",
@@ -68,7 +68,7 @@ public class RetryRequest implements Filter {
       .handleResultIf(response -> response.getStatus() == HTTP_UNAVAILABLE)
       .withBackoff(1, 2, ChronoUnit.SECONDS)
       .withMaxRetries(2)
-      .withMaxDuration(Duration.ofSeconds(3))
+      .withMaxDuration(Duration.ofMinutes(2))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Failure due to server error #{0}. Retrying.",

--- a/java/src/org/openqa/selenium/remote/http/RetryRequest.java
+++ b/java/src/org/openqa/selenium/remote/http/RetryRequest.java
@@ -42,7 +42,6 @@ public class RetryRequest implements Filter {
       .handleIf(failure -> failure.getCause() instanceof ConnectException)
       .withBackoff(1, 4, ChronoUnit.SECONDS)
       .withMaxRetries(3)
-      .withMaxDuration(Duration.ofMinutes(1))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Connection failure #{0}. Retrying.",
@@ -54,7 +53,6 @@ public class RetryRequest implements Filter {
       .handle(TimeoutException.class)
       .withBackoff(1, 4, ChronoUnit.SECONDS)
       .withMaxRetries(3)
-      .withMaxDuration(Duration.ofMinutes(10))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Read timeout #{0}. Retrying.",
@@ -68,7 +66,6 @@ public class RetryRequest implements Filter {
       .handleResultIf(response -> response.getStatus() == HTTP_UNAVAILABLE)
       .withBackoff(1, 2, ChronoUnit.SECONDS)
       .withMaxRetries(2)
-      .withMaxDuration(Duration.ofMinutes(2))
       .onRetry(e -> LOG.log(
         getDebugLogLevel(),
         "Failure due to server error #{0}. Retrying.",


### PR DESCRIPTION


**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Primarily related to https://github.com/SeleniumHQ/selenium/issues/9528

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Misunderstood the max-duration option (https://github.com/failsafe-lib/failsafe/pull/244/files) and hence it was not configured correctly to allow retries. This was an issue if the request timeout exception was thrown. The changes fix it by adding appropriate max duration values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
