### PR TITLE
[java] fix typo in macOS Monterrey to Monterey

### DIFF
--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -203,7 +203,7 @@ public enum Platform {
     }
   },
 
-  MONTERREY("monterrey", "os x 12.0", "macos 12.0") {
+  MONTEREY("monterey", "os x 12.0", "macos 12.0") {
     @Override
     public Platform family() {
       return MAC;


### PR DESCRIPTION
### Description

macOS 12 should be Monterey instead of Monterrey (A city of Mexico https://en.wikipedia.org/wiki/Monterrey ?). 
https://en.wikipedia.org/wiki/MacOS_Monterey :)

### Motivation and Context

It seems typo.
Is it enough to fix the typo in this file...?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
