### PR TITLE
add deleteNetworkConditions for chromium

### DIFF
--- a/javascript/node/selenium-webdriver/chromium.js
+++ b/javascript/node/selenium-webdriver/chromium.js
@@ -92,6 +92,7 @@ const Command = {
   LAUNCH_APP: 'launchApp',
   GET_NETWORK_CONDITIONS: 'getNetworkConditions',
   SET_NETWORK_CONDITIONS: 'setNetworkConditions',
+  DELETE_NETWORK_CONDITIONS: 'deleteNetworkConditions',
   SEND_DEVTOOLS_COMMAND: 'sendDevToolsCommand',
   SEND_AND_GET_DEVTOOLS_COMMAND: 'sendAndGetDevToolsCommand',
   SET_PERMISSION: 'setPermission',
@@ -135,6 +136,11 @@ function configureExecutor(executor, vendorPrefix) {
   executor.defineCommand(
     Command.SET_NETWORK_CONDITIONS,
     'POST',
+    '/session/:sessionId/chromium/network_conditions'
+  )
+  executor.defineCommand(
+    Command.DELETE_NETWORK_CONDITIONS,
+    'DELETE',
     '/session/:sessionId/chromium/network_conditions'
   )
   executor.defineCommand(
@@ -704,6 +710,15 @@ class Driver extends webdriver.WebDriver {
    */
   getNetworkConditions() {
     return this.execute(new command.Command(Command.GET_NETWORK_CONDITIONS))
+  }
+
+  /**
+   * Schedules a command to delete Chromium network emulation settings.
+   * @return {!Promise} A promise that will be resolved when network
+   *     emulation settings have been deleted.
+   */
+  deleteNetworkConditions() {
+    return this.execute(new command.Command(Command.DELETE_NETWORK_CONDITIONS))
   }
 
   /**

--- a/javascript/node/selenium-webdriver/test/chrome/options_test.js
+++ b/javascript/node/selenium-webdriver/test/chrome/options_test.js
@@ -156,6 +156,24 @@ test.suite(
         assert.strictEqual(userAgent, 'foo;bar')
       })
 
+      it('can start chromium with network conditions set', async function () {
+        driver = await env.builder().build()
+        await driver.get(test.Pages.ajaxyPage)
+        await driver.setNetworkConditions({
+          offline: true,
+          latency: 0,
+          download_throughput: 0,
+          upload_throughput: 0,
+        })
+        assert.deepStrictEqual(await driver.getNetworkConditions(), {
+          download_throughput: 0,
+          latency: 0,
+          offline: true,
+          upload_throughput: 0,
+        })
+        await driver.deleteNetworkConditions()
+      })
+
       it('can install an extension from path', async function () {
         let options = new chrome.Options().addExtensions(WEBEXTENSION_CRX)
 


### PR DESCRIPTION
This implements the functionality to delete previously set network conditions
in Chromium.

Fixes #10322

### Description

Adds the `deleteNetworkConditions` public method to the Chromium Driver.

### Motivation and Context

The method was missing for Javascript.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

