### PR TITLE
[java] Avoid using ServiceLoader while creating FirefoxDriver instance

### DIFF
--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -55,8 +55,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.stream.StreamSupport;
 
 /**
  * An implementation of the {#link WebDriver} interface that drives Firefox.
@@ -103,8 +101,9 @@ public class FirefoxDriver extends RemoteWebDriver
         Require.nonNull("Driver service", service),
         new FirefoxOptions(desiredCapabilities));
   }
+
   public FirefoxDriver(FirefoxOptions options) {
-    this(toExecutor(options), options);
+    this(new FirefoxDriverCommandExecutor(GeckoDriverService.createDefaultService()), options);
   }
 
   public FirefoxDriver(FirefoxDriverService service) {
@@ -139,18 +138,6 @@ public class FirefoxDriver extends RemoteWebDriver
   @Beta
   public static RemoteWebDriverBuilder builder() {
     return RemoteWebDriver.builder().oneOf(new FirefoxOptions());
-  }
-
-  private static FirefoxDriverCommandExecutor toExecutor(FirefoxOptions options) {
-    Require.nonNull("Options to construct executor from", options);
-
-    FirefoxDriverService.Builder<?, ?> builder =
-      StreamSupport.stream(ServiceLoader.load(DriverService.Builder.class).spliterator(), false)
-        .filter(b -> b instanceof FirefoxDriverService.Builder)
-        .map(FirefoxDriverService.Builder.class::cast)
-        .findFirst().orElseThrow(WebDriverException::new);
-
-    return new FirefoxDriverCommandExecutor(builder.withOptions(options).build());
   }
 
   /**


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes https://github.com/SeleniumHQ/selenium/issues/10010 and https://github.com/SeleniumHQ/selenium/issues/10301.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/SeleniumHQ/selenium/commit/017f2c7f62963353ecc2fd662027676f193b9935 introduced the use of ServiceLoader in creating the FirefoxDriver instance. This was to support the legacy system and XpiDriverService. However, legacy support was long deprecated by Selenium and now it is removed via https://github.com/SeleniumHQ/selenium/commit/d4dba1c07a1d8601f80b9e71be7853317ab0d49d, https://github.com/SeleniumHQ/selenium/commit/12c8c2752b3ec8dcc05175e85b7ccf5c363dcefe, and https://github.com/SeleniumHQ/selenium/commit/5fc8b53b579d08753b0f89cc6307c5a1bc0e539e. ServiceLoader introduced a problem while packaging jars as the `META-INF/services/org.openqa.selenium.remote.service.DriverService$Builder` files would overwrite each other and FirefoxDriver would not be detected while creating the FirefoxDriver instance. Removing the dependency of using ServiceLoader while creating the instance fixes this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
