### PR TITLE
[rb] Fix WebSockets in DevTools

### DIFF
--- a/rb/lib/selenium/devtools.rb
+++ b/rb/lib/selenium/devtools.rb
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'websocket'
+
 module Selenium
   module DevTools
     class << self


### PR DESCRIPTION
### Description

[This commit](https://github.com/SeleniumHQ/selenium/commit/e89eb141aec829af773c7226f8b1c20627146609#diff-9a9f51fd500d2166ddc3552382da74e9afbbc2d7c36afeb6628a7a9c04f79952) removed the line that I've re-added. I'm not sure why. But:

### Motivation and Context
Without that line, at least using JRuby, I get:

```
NameError:
       uninitialized constant Selenium::WebDriver::DevTools::WebSocket
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/devtools.rb:179:in `ws'
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/devtools.rb:173:in `socket'
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/devtools.rb:95:in `process_handshake'
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/devtools.rb:40:in `initialize'
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb:36:in `devtools'
     # ./features/build/.gems/gems/selenium-webdriver-4.1.0/lib/selenium/webdriver/common/driver_extensions/has_network_interception.rb:64:in `intercept'
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

P.S. This breakage happened after I updated `selenium-devtools` from `0.98.0` to `0.99.0` (which included this change).