### PR TITLE
[py] Port to new style classes

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -186,7 +186,7 @@ def pytest_exception_interact(node, call, report):
 
 @pytest.fixture
 def pages(driver, webserver):
-    class Pages(object):
+    class Pages:
         def url(self, name):
             return webserver.where_is(name)
 

--- a/py/selenium/webdriver/common/action_chains.py
+++ b/py/selenium/webdriver/common/action_chains.py
@@ -23,7 +23,7 @@ from .utils import keys_to_typing
 from .actions.action_builder import ActionBuilder
 
 
-class ActionChains(object):
+class ActionChains:
     """
     ActionChains are a way to automate low level interactions such as
     mouse movements, mouse button actions, key press, and context menu interactions.

--- a/py/selenium/webdriver/common/actions/action_builder.py
+++ b/py/selenium/webdriver/common/actions/action_builder.py
@@ -26,7 +26,7 @@ from .wheel_input import WheelInput
 from .wheel_actions import WheelActions
 
 
-class ActionBuilder(object):
+class ActionBuilder:
     def __init__(self, driver, mouse=None, wheel=None, keyboard=None, duration=250) -> None:
         if not mouse:
             mouse = PointerInput(interaction.POINTER_MOUSE, "mouse")

--- a/py/selenium/webdriver/common/actions/input_device.py
+++ b/py/selenium/webdriver/common/actions/input_device.py
@@ -18,7 +18,7 @@
 import uuid
 
 
-class InputDevice(object):
+class InputDevice:
     """
         Describes the input device being used for the action.
     """

--- a/py/selenium/webdriver/common/actions/interaction.py
+++ b/py/selenium/webdriver/common/actions/interaction.py
@@ -29,7 +29,7 @@ POINTER_PEN = "pen"
 POINTER_KINDS = set([POINTER_MOUSE, POINTER_TOUCH, POINTER_PEN])
 
 
-class Interaction(object):
+class Interaction:
 
     PAUSE = "pause"
 

--- a/py/selenium/webdriver/common/actions/mouse_button.py
+++ b/py/selenium/webdriver/common/actions/mouse_button.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-class MouseButton(object):
+class MouseButton:
 
     LEFT = 0
     MIDDLE = 1

--- a/py/selenium/webdriver/common/alert.py
+++ b/py/selenium/webdriver/common/alert.py
@@ -23,7 +23,7 @@ from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command
 
 
-class Alert(object):
+class Alert:
     """
     Allows to work with alerts.
 

--- a/py/selenium/webdriver/common/by.py
+++ b/py/selenium/webdriver/common/by.py
@@ -20,7 +20,7 @@ The By implementation.
 """
 
 
-class By(object):
+class By:
     """
     Set of supported locator strategies.
     """

--- a/py/selenium/webdriver/common/desired_capabilities.py
+++ b/py/selenium/webdriver/common/desired_capabilities.py
@@ -20,7 +20,7 @@ The Desired Capabilities implementation.
 """
 
 
-class DesiredCapabilities(object):
+class DesiredCapabilities:
     """
     Set of default supported desired capabilities.
 

--- a/py/selenium/webdriver/common/html5/application_cache.py
+++ b/py/selenium/webdriver/common/html5/application_cache.py
@@ -25,7 +25,7 @@ import warnings
 from selenium.webdriver.remote.command import Command
 
 
-class ApplicationCache(object):
+class ApplicationCache:
 
     UNCACHED = 0
     IDLE = 1

--- a/py/selenium/webdriver/common/keys.py
+++ b/py/selenium/webdriver/common/keys.py
@@ -20,7 +20,7 @@ The Keys implementation.
 """
 
 
-class Keys(object):
+class Keys:
     """
     Set of special keys codes.
     """

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -59,7 +59,7 @@ class ProxyType:
         raise Exception(f"No proxy type is found for {value}")
 
 
-class Proxy(object):
+class Proxy:
     """
     Proxy contains information about proxy type and necessary proxy settings.
     """

--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -29,7 +29,7 @@ from selenium.webdriver.common import utils
 _HAS_NATIVE_DEVNULL = True
 
 
-class Service(object):
+class Service:
 
     def __init__(self, executable, port=0, log_file=DEVNULL, env=None, start_error_message=""):
         self.path = executable

--- a/py/selenium/webdriver/common/timeouts.py
+++ b/py/selenium/webdriver/common/timeouts.py
@@ -36,7 +36,7 @@ else:
     JSONTimeouts = Dict[str, int]
 
 
-class Timeouts(object):
+class Timeouts:
 
     def __init__(self, implicit_wait: float = 0, page_load: float = 0, script: float = 0) -> None:
         """

--- a/py/selenium/webdriver/common/window.py
+++ b/py/selenium/webdriver/common/window.py
@@ -20,7 +20,7 @@ The WindowTypes implementation.
 """
 
 
-class WindowTypes(object):
+class WindowTypes:
     """Set of supported window types."""
 
     TAB = u'tab'

--- a/py/selenium/webdriver/firefox/firefox_binary.py
+++ b/py/selenium/webdriver/firefox/firefox_binary.py
@@ -24,7 +24,7 @@ from selenium.webdriver.common import utils
 import time
 
 
-class FirefoxBinary(object):
+class FirefoxBinary:
 
     NO_FOCUS_LIBRARY_NAME = "x_ignore_nofocus.so"
 

--- a/py/selenium/webdriver/firefox/firefox_profile.py
+++ b/py/selenium/webdriver/firefox/firefox_profile.py
@@ -40,7 +40,7 @@ class AddonFormatError(Exception):
     """Exception for not well-formed add-on manifest files"""
 
 
-class FirefoxProfile(object):
+class FirefoxProfile:
     ANONYMOUS_PROFILE_NAME = "WEBDRIVER_ANONYMOUS_PROFILE"
     DEFAULT_PREFERENCES = None
 

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -22,7 +22,7 @@ from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from selenium.webdriver.common.options import ArgOptions
 
 
-class Log(object):
+class Log:
     def __init__(self):
         self.level = None
 

--- a/py/selenium/webdriver/remote/command.py
+++ b/py/selenium/webdriver/remote/command.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-class Command(object):
+class Command:
     """
     Defines constants for the standard WebDriver commands.
 

--- a/py/selenium/webdriver/remote/errorhandler.py
+++ b/py/selenium/webdriver/remote/errorhandler.py
@@ -52,7 +52,7 @@ _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
 
-class ErrorCode(object):
+class ErrorCode:
     """
     Error codes defined in the WebDriver wire protocol.
     """
@@ -98,7 +98,7 @@ class ErrorCode(object):
     METHOD_NOT_ALLOWED = [405, 'unsupported operation']
 
 
-class ErrorHandler(object):
+class ErrorHandler:
     """
     Handles errors returned by the WebDriver server.
     """

--- a/py/selenium/webdriver/remote/mobile.py
+++ b/py/selenium/webdriver/remote/mobile.py
@@ -18,9 +18,9 @@
 from .command import Command
 
 
-class Mobile(object):
+class Mobile:
 
-    class ConnectionType(object):
+    class ConnectionType:
 
         def __init__(self, mask):
             self.mask = mask

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -35,7 +35,7 @@ from . import utils
 LOGGER = logging.getLogger(__name__)
 
 
-class RemoteConnection(object):
+class RemoteConnection:
     """A connection with the Remote WebDriver server.
 
     Communicates with the server using the WebDriver wire protocol:

--- a/py/selenium/webdriver/safari/options.py
+++ b/py/selenium/webdriver/safari/options.py
@@ -18,7 +18,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.options import ArgOptions
 
 
-class Log(object):
+class Log:
     def __init__(self):
         self.level = None
 

--- a/py/selenium/webdriver/safari/permissions.py
+++ b/py/selenium/webdriver/safari/permissions.py
@@ -20,7 +20,7 @@ The Permission implementation.
 """
 
 
-class Permission(object):
+class Permission:
     """
     Set of supported permissions.
     """

--- a/py/selenium/webdriver/support/abstract_event_listener.py
+++ b/py/selenium/webdriver/support/abstract_event_listener.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-class AbstractEventListener(object):
+class AbstractEventListener:
     """
     Event listener must subclass and implement this fully or partially
     """

--- a/py/selenium/webdriver/support/color.py
+++ b/py/selenium/webdriver/support/color.py
@@ -44,7 +44,7 @@ HSL_PATTERN = r"^\s*hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)\s*$
 HSLA_PATTERN = r"^\s*hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*(0|1|0\.\d+)\s*\)\s*$"
 
 
-class Color(object):
+class Color:
     """
     Color conversion support class
 
@@ -63,7 +63,7 @@ class Color(object):
     def from_string(str_: str) -> "Color":
         import re
 
-        class Matcher(object):
+        class Matcher:
             match_obj: Optional[Match[str]]
 
             def __init__(self) -> None:

--- a/py/selenium/webdriver/support/event_firing_webdriver.py
+++ b/py/selenium/webdriver/support/event_firing_webdriver.py
@@ -38,7 +38,7 @@ def _wrap_elements(result, ef_driver):
         return result
 
 
-class EventFiringWebDriver(object):
+class EventFiringWebDriver:
     """
     A wrapper around an arbitrary WebDriver instance which supports firing events
     """
@@ -226,7 +226,7 @@ class EventFiringWebDriver(object):
             raise
 
 
-class EventFiringWebElement(object):
+class EventFiringWebElement:
     """"
     A wrapper around WebElement instance which supports firing events
     """

--- a/py/selenium/webdriver/support/relative_locator.py
+++ b/py/selenium/webdriver/support/relative_locator.py
@@ -55,7 +55,7 @@ def locate_with(by: By, using: str) -> "RelativeBy":
     return RelativeBy({by: using})
 
 
-class RelativeBy(object):
+class RelativeBy:
     """
         Gives the opportunity to find elements based on their relative location
         on the page from a root elelemt. It is recommended that you use the helper

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -19,7 +19,7 @@ from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException, UnexpectedTagNameException
 
 
-class Select(object):
+class Select:
 
     def __init__(self, webelement):
         """

--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -23,7 +23,7 @@ POLL_FREQUENCY = 0.5  # How long to sleep in between calls to the method
 IGNORED_EXCEPTIONS = (NoSuchElementException,)  # exceptions ignored during calls to the method
 
 
-class WebDriverWait(object):
+class WebDriverWait:
     def __init__(self, driver, timeout, poll_frequency=POLL_FREQUENCY, ignored_exceptions=None):
         """Constructor, takes a WebDriver instance and timeout in seconds.
 

--- a/py/test/selenium/webdriver/common/google_one_box.py
+++ b/py/test/selenium/webdriver/common/google_one_box.py
@@ -21,7 +21,7 @@ from results_page import ResultsPage
 from page_loader import require_loaded
 
 
-class GoogleOneBox(object):
+class GoogleOneBox:
     """This class models a page that has a google search bar."""
 
     def __init__(self, driver, url):

--- a/py/test/selenium/webdriver/common/results_page.py
+++ b/py/test/selenium/webdriver/common/results_page.py
@@ -19,7 +19,7 @@
 from selenium.webdriver.common.by import By
 
 
-class ResultsPage(object):
+class ResultsPage:
     """This class models a google search result page."""
 
     def __init__(self, driver):

--- a/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -77,7 +77,7 @@ def testShouldWaitUntilAtLeastOneVisibleElementsIsFoundWhenSearchingForMany(driv
     add_visible.click()
     add_hidden.click()
 
-    class wait_for_two_elements(object):
+    class wait_for_two_elements:
 
         def __init__(self, locator):
             self.locator = locator

--- a/py/test/selenium/webdriver/common/webserver.py
+++ b/py/test/selenium/webdriver/common/webserver.py
@@ -127,7 +127,7 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     pass
 
 
-class SimpleWebServer(object):
+class SimpleWebServer:
     """A very basic web server."""
 
     def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT):

--- a/py/test/selenium/webdriver/marionette/mn_options_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_options_tests.py
@@ -31,13 +31,13 @@ def driver_kwargs(driver_kwargs):
     return driver_kwargs
 
 
-class TestIntegration(object):
+class TestIntegration:
     def test_we_can_pass_options(self, driver, pages):
         pages.load("formPage.html")
         driver.find_element(By.ID, "cheese")
 
 
-class TestUnit(object):
+class TestUnit:
     def test_ctor(self):
         opts = Options()
         assert opts._binary is None

--- a/py/test/selenium/webdriver/safari/launcher_tests.py
+++ b/py/test/selenium/webdriver/safari/launcher_tests.py
@@ -33,7 +33,7 @@ def test_launch_with_invalid_executable_path_raises_exception(driver_class):
 
 
 @pytest.mark.skipif(not os.path.exists('/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver'), reason="Preview not installed")
-class TestTechnologyPreview(object):
+class TestTechnologyPreview:
 
     @pytest.fixture
     def driver_kwargs(self):

--- a/py/test/unit/selenium/webdriver/remote/subtyping_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/subtyping_tests.py
@@ -41,7 +41,7 @@ def test_web_element_not_subclassed():
 
 def test_webdriver_not_subclassed():
     """A registered subtype of WebDriver should work with isinstance checks."""
-    class MyWebDriver(object):
+    class MyWebDriver:
         def __init__(self, *args, **kwargs):
             super(MyWebDriver, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
[documentation](https://github.com/symonk/selenium/tree/trunk/py#supported-python-versions) states we only support `Python 3.7+`.  This is a small (but wide) PR to remove the unnecessary explicit inheritance on `object` which is more applicable to python 2, in favour of new style classes.