### PR TITLE
Updated Session map command to work with selenium 4.1.2

### DIFF
--- a/java/src/org/openqa/selenium/grid/commands/sessionmaps.txt
+++ b/java/src/org/openqa/selenium/grid/commands/sessionmaps.txt
@@ -11,7 +11,7 @@ following types of data store.
 SESSIONS_IMPLEMENTATION=org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap \
 SESSIONS_SCHEME=redis \
 java -jar selenium.jar \
-  --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-session-map-redis:4.0.0-alpha-6) \
+  --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-session-map-redis:4.1.2) \
   sessions --sessions-host "<redis_host>" --sessions-port <redis_port>
 ```
 
@@ -39,7 +39,7 @@ CREATE TABLE sessions_map(
     session_start varchar(256)
  );
  ```
- 
+
 Here the size of each column is an arbitrary number. Ensure the datatype and limit matches the selected database. Also, the limit for varchar type should be able to accommodate the
 capabilities json stored in "session_caps" and stereotype json stored in "session_stereotype".
 
@@ -49,7 +49,7 @@ To start the `JdbcBackedSessionMap`:
 SESSIONS_IMPLEMENTATION=org.openqa.selenium.grid.sessionmap.jdbc.JdbcBackedSessionMap \
 SESSIONS_SCHEME=jdbc \
 java -jar selenium.jar
-  --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-session-map-jdbc:4.0.0-alpha-6 org.postgresql:postgresql:42.2.14.jre7) \
+  --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-session-map-jdbc:4.1.2 org.postgresql:postgresql:42.2.14.jre7) \
   sessions \
   --jdbc-user "<jdbc_user>" --jdbc-password "<jdbc_password>" \
   --jdbc-url "<jdbc_url>"


### PR DESCRIPTION
### Description
Updating the version of selenium from 4.0.0-alpha-6 to 4.1.2 in command to make Session Map (# RedisBackedSessionMap and # JdbcBackedSessionMap) work with the latest version.

### Motivation and Context
Keeping the session map up to date with the latest stable version of selenium.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->