### PR TITLE
New implementation of one shot nodes

### DIFF
--- a/java/src/org/openqa/selenium/grid/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/BUILD.bazel
@@ -15,7 +15,6 @@ genrule(
     executable = True,
     visibility = [
         "//:__pkg__",
-        "//deploys/docker:__pkg__",
     ],
 )
 

--- a/java/src/org/openqa/selenium/grid/commands/Hub.java
+++ b/java/src/org/openqa/selenium/grid/commands/Hub.java
@@ -163,6 +163,7 @@ public class Hub extends TemplateGridServerCommand {
       distributorOptions.getSlotSelector(),
       secret,
       distributorOptions.getHealthCheckInterval(),
+      distributorOptions.oneShotNodes(),
       distributorOptions.shouldRejectUnsupportedCaps(),
       newSessionRequestOptions.getSessionRequestRetryInterval());
     handler.addHandler(distributor);

--- a/java/src/org/openqa/selenium/grid/commands/Standalone.java
+++ b/java/src/org/openqa/selenium/grid/commands/Standalone.java
@@ -161,6 +161,7 @@ public class Standalone extends TemplateGridServerCommand {
       distributorOptions.getSlotSelector(),
       registrationSecret,
       distributorOptions.getHealthCheckInterval(),
+      distributorOptions.oneShotNodes(),
       distributorOptions.shouldRejectUnsupportedCaps(),
       newSessionRequestOptions.getSessionRequestRetryInterval());
     combinedHandler.addHandler(distributor);

--- a/java/src/org/openqa/selenium/grid/distributor/config/DistributorFlags.java
+++ b/java/src/org/openqa/selenium/grid/distributor/config/DistributorFlags.java
@@ -32,6 +32,7 @@ import static org.openqa.selenium.grid.config.StandardGridRoles.DISTRIBUTOR_ROLE
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_DISTRIBUTOR_IMPLEMENTATION;
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_GRID_MODEL_IMPLEMENTATION;
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_HEALTHCHECK_INTERVAL;
+import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_ONE_SHOT_NODES;
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_REJECT_UNSUPPORTED_CAPS;
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_SLOT_MATCHER;
 import static org.openqa.selenium.grid.distributor.config.DistributorOptions.DEFAULT_SLOT_SELECTOR_IMPLEMENTATION;
@@ -90,6 +91,13 @@ public class DistributorFlags implements HasRoles {
       "This ensures the server can ping all the Nodes successfully.")
   @ConfigValue(section = DISTRIBUTOR_SECTION, name = "healthcheck-interval", example = "60")
   public int healthcheckInterval =  DEFAULT_HEALTHCHECK_INTERVAL;
+
+  @Parameter(
+    names = {"--one-shot-nodes"},
+    description = "Make the distributor drain a node after the first session has been started on it. This useful " +
+      "in certain deployment scenarios, especially to Kubernetes clusters.")
+  @ConfigValue(section = DISTRIBUTOR_SECTION, name = "one-shot-nodes", example = "true")
+  public boolean oneShotNodes = DEFAULT_ONE_SHOT_NODES;
 
   @Parameter(description = "Allow the Distributor to reject a request immediately if the Grid does not support the requested capability." +
     "Rejecting requests immediately is suitable for Grid set up that does not spin up Nodes on demand.",

--- a/java/src/org/openqa/selenium/grid/distributor/config/DistributorOptions.java
+++ b/java/src/org/openqa/selenium/grid/distributor/config/DistributorOptions.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 public class DistributorOptions {
 
   public static final int DEFAULT_HEALTHCHECK_INTERVAL = 120;
+  public static final boolean DEFAULT_ONE_SHOT_NODES = false;
   public static final String DISTRIBUTOR_SECTION = "distributor";
   static final String DEFAULT_DISTRIBUTOR_IMPLEMENTATION =
     "org.openqa.selenium.grid.distributor.local.LocalDistributor";
@@ -117,6 +118,11 @@ public class DistributorOptions {
       "slot-selector",
       SlotSelector.class,
       DEFAULT_SLOT_SELECTOR_IMPLEMENTATION);
+  }
+
+  public boolean oneShotNodes() {
+    return config.getBool(DISTRIBUTOR_SECTION,
+      "one-shot-nodes").orElse(DEFAULT_ONE_SHOT_NODES);
   }
 
   public boolean shouldRejectUnsupportedCaps() {

--- a/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
@@ -139,6 +139,7 @@ public class AddingNodesTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     distributor = new RemoteDistributor(tracer, new PassthroughHttpClient.Factory(local), externalUrl, registrationSecret);
@@ -170,6 +171,7 @@ public class AddingNodesTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -203,6 +205,7 @@ public class AddingNodesTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -247,6 +250,7 @@ public class AddingNodesTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     distributor = new RemoteDistributor(tracer, new PassthroughHttpClient.Factory(local), externalUrl, registrationSecret);
@@ -282,6 +286,7 @@ public class AddingNodesTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 

--- a/java/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -164,6 +164,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     Either<SessionNotCreatedException, CreateSessionResponse> result = local.newSession(createRequest(caps));
     assertThatEither(result).isLeft();
@@ -227,6 +228,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     distributor.add(node);
     waitToHaveCapacity(distributor);
@@ -268,6 +270,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     distributor.add(node);
@@ -312,6 +315,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     Distributor distributor = new RemoteDistributor(
       tracer,
@@ -352,6 +356,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     distributor.add(node);
     distributor.drain(node.getId());
@@ -359,6 +364,44 @@ public class DistributorTest {
     assertTrue(node.isDraining());
 
     Either<SessionNotCreatedException, CreateSessionResponse> result = distributor.newSession(createRequest(caps));
+    assertThatEither(result).isLeft();
+  }
+
+    @Test
+  public void testOneShotNodeDoesNotAcceptNewSessions() {
+    SessionMap sessions = new LocalSessionMap(tracer, bus);
+    NewSessionQueue queue = new LocalNewSessionQueue(
+      tracer,
+      bus,
+      new DefaultSlotMatcher(),
+      Duration.ofSeconds(2),
+      Duration.ofSeconds(2),
+      registrationSecret);
+    LocalNode node = LocalNode.builder(tracer, bus, routableUri, routableUri, registrationSecret)
+      .add(
+        caps,
+        new TestSessionFactory((id, c) -> new Session(id, nodeUri, stereotype, c, Instant.now())))
+      .build();
+
+    Distributor distributor = new LocalDistributor(
+      tracer,
+      bus,
+      new PassthroughHttpClient.Factory(node),
+      sessions,
+      queue,
+      new DefaultSlotSelector(),
+      registrationSecret,
+      Duration.ofMinutes(5),
+      true,
+      false,
+      Duration.ofSeconds(5));
+    distributor.add(node);
+    Either<SessionNotCreatedException, CreateSessionResponse> result = distributor.newSession(createRequest(caps));
+    assertThatEither(result).isRight();
+
+    assertTrue(node.isDraining());
+
+    result = distributor.newSession(createRequest(caps));
     assertThatEither(result).isLeft();
   }
 
@@ -390,6 +433,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     distributor.add(node);
@@ -436,6 +480,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     distributor.add(node);
@@ -486,6 +531,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     distributor.add(node);
     waitToHaveCapacity(distributor);
@@ -528,6 +574,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -574,6 +621,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5))
       .add(heavy)
       .add(medium)
@@ -617,6 +665,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5))
       .add(leastRecent);
@@ -703,6 +752,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofSeconds(1),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
     distributor.add(alwaysDown);
@@ -753,7 +803,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
-      false,
+      false, false,
       Duration.ofSeconds(5));
 
     distributor.add(node);
@@ -794,6 +844,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     distributor.add(node);
@@ -851,6 +902,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
 
@@ -891,6 +943,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     distributor.add(node);
@@ -937,6 +990,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofSeconds(1),
+      false,
       false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
@@ -1003,6 +1057,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofSeconds(1),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
     distributor.add(node);
@@ -1062,6 +1117,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -1177,6 +1233,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     local.add(node);
@@ -1210,6 +1267,7 @@ public class DistributorTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     local.add(node);
@@ -1237,6 +1295,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -1280,6 +1339,7 @@ public class DistributorTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
     local.add(brokenNode);

--- a/java/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
+++ b/java/test/org/openqa/selenium/grid/graphql/GraphqlHandlerTest.java
@@ -137,6 +137,7 @@ public class GraphqlHandlerTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
   }
 
@@ -306,6 +307,7 @@ public class GraphqlHandlerTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     distributor.add(node);
@@ -352,6 +354,7 @@ public class GraphqlHandlerTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -420,6 +423,7 @@ public class GraphqlHandlerTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     distributor.add(node);
@@ -484,6 +488,7 @@ public class GraphqlHandlerTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 
@@ -555,6 +560,7 @@ public class GraphqlHandlerTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       false,
       Duration.ofSeconds(5));
 

--- a/java/test/org/openqa/selenium/grid/router/NewSessionCreationTest.java
+++ b/java/test/org/openqa/selenium/grid/router/NewSessionCreationTest.java
@@ -113,6 +113,7 @@ public class NewSessionCreationTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
 
     Routable router = new Router(tracer, clientFactory, sessions, queue, distributor)
@@ -213,6 +214,7 @@ public class NewSessionCreationTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
 
@@ -280,6 +282,7 @@ public class NewSessionCreationTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofMinutes(5),
+      false,
       true,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);

--- a/java/test/org/openqa/selenium/grid/router/RouterTest.java
+++ b/java/test/org/openqa/selenium/grid/router/RouterTest.java
@@ -118,6 +118,7 @@ public class RouterTest {
       registrationSecret,
       Duration.ofSeconds(1),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
 

--- a/java/test/org/openqa/selenium/grid/router/SessionCleanUpTest.java
+++ b/java/test/org/openqa/selenium/grid/router/SessionCleanUpTest.java
@@ -159,6 +159,7 @@ public class SessionCleanUpTest {
       registrationSecret,
       Duration.ofSeconds(1),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
 
@@ -278,6 +279,7 @@ public class SessionCleanUpTest {
       new DefaultSlotSelector(),
       registrationSecret,
       Duration.ofSeconds(1),
+      false,
       false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);

--- a/java/test/org/openqa/selenium/grid/router/SessionQueueGridTest.java
+++ b/java/test/org/openqa/selenium/grid/router/SessionQueueGridTest.java
@@ -140,6 +140,7 @@ public class SessionQueueGridTest {
       registrationSecret,
       Duration.ofMinutes(5),
       false,
+      false,
       Duration.ofSeconds(5));
     handler.addHandler(distributor);
 


### PR DESCRIPTION
### Description

Adding a config to the distributor to automatically drain a node after it has gotten it's first
session.

The existing one shot node functionality (OneShotNode) has not been maintained. This is
understandable as it's repeating instead of reusing the functionality of LocalNode but isn't used by
many.

After this PR is accepted I intend to make a follow up PR cleaning away OneShotNode.

### Motivation and Context

As the old OneShotNode this is mainly meant to be used when deploying to Kubernetes. See the discussion in #9845.

This PR kind of fixes #docker-selenium/1514, though the configuration would be different now.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
