### PR TITLE
[IE] Check process ID when searching for Edge window handle

### DIFF
--- a/cpp/iedriver/BrowserFactory.cpp
+++ b/cpp/iedriver/BrowserFactory.cpp
@@ -1087,6 +1087,14 @@ BOOL CALLBACK BrowserFactory::FindEdgeWindow(HWND hwnd, LPARAM arg) {
   // continue if it is not "Chrome_WidgetWin_1"
   if (strcmp(ANDIE_FRAME_WINDOW_CLASS, name) != 0) return TRUE;
 
+  // continue if window does not belong to the target process
+  DWORD process_id = NULL;
+  ::GetWindowThreadProcessId(hwnd, &process_id);
+  ProcessWindowInfo* process_window_info = reinterpret_cast<ProcessWindowInfo*>(arg);
+  if (process_window_info->dwProcessId != process_id) {
+    return TRUE;
+  }
+
   return EnumChildWindows(hwnd, FindEdgeChildWindowForProcess, arg);
 }
 


### PR DESCRIPTION
### Description
Submitting the bug fix first shared by: https://github.com/HiroyukiSakoh/selenium/commit/44af88bad326f4ba7d3037b5d3e25bd21bfb91f2

This update IEDriver's FindEdgeWindow method to skip Edge windows that do not belong to the expected Edge process.

### Motivation and Context
This is a fix for an issue that users are encountering when attempting to run two instances of Edge in IE Mode in parallel:
- https://github.com/SeleniumHQ/selenium/issues/10339
- https://github.com/MicrosoftEdge/EdgeWebDriver/issues/11

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
