### PR TITLE
[py]: Deprecate `opera` webdriver & options in prep for removal in `4.3`

### DIFF
--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -25,7 +25,7 @@ from .ie.options import Options as IeOptions  # noqa
 from .edge.webdriver import WebDriver as Edge  # noqa
 from .edge.webdriver import WebDriver as ChromiumEdge  # noqa
 from .edge.options import Options as EdgeOptions  # noqa
-from .opera.webdriver import WebDriver as Opera  # noqa  # Todo: gh-10379 (Remove for 4.3)
+from .opera.webdriver import WebDriver as Opera  # noqa
 from .safari.webdriver import WebDriver as Safari  # noqa
 from .webkitgtk.webdriver import WebDriver as WebKitGTK  # noqa
 from .webkitgtk.options import Options as WebKitGTKOptions  # noqa

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -25,7 +25,7 @@ from .ie.options import Options as IeOptions  # noqa
 from .edge.webdriver import WebDriver as Edge  # noqa
 from .edge.webdriver import WebDriver as ChromiumEdge  # noqa
 from .edge.options import Options as EdgeOptions  # noqa
-from .opera.webdriver import WebDriver as Opera  # noqa
+from .opera.webdriver import WebDriver as Opera  # noqa  # Todo: gh-10379 (Remove for 4.3)
 from .safari.webdriver import WebDriver as Safari  # noqa
 from .webkitgtk.webdriver import WebDriver as WebKitGTK  # noqa
 from .webkitgtk.options import Options as WebKitGTKOptions  # noqa

--- a/py/selenium/webdriver/opera/options.py
+++ b/py/selenium/webdriver/opera/options.py
@@ -20,7 +20,6 @@ from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
-# Todo: gh-10379 (Remove for 4.3)
 class Options(ChromeOptions):
     KEY = "operaOptions"
 

--- a/py/selenium/webdriver/opera/options.py
+++ b/py/selenium/webdriver/opera/options.py
@@ -24,7 +24,9 @@ class Options(ChromeOptions):
     KEY = "operaOptions"
 
     def __init__(self):
-        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3", DeprecationWarning, stacklevel=2)
+        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3; "
+                      f"see: https://www.selenium.dev/documentation/webdriver/getting_started/open_browser/#opera",
+                      DeprecationWarning, stacklevel=2)
         super().__init__()
         self._android_package_name = ''
         self._android_device_socket = ''

--- a/py/selenium/webdriver/opera/options.py
+++ b/py/selenium/webdriver/opera/options.py
@@ -14,16 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
+# Todo: gh-10379 (Remove for 4.3)
 class Options(ChromeOptions):
     KEY = "operaOptions"
 
     def __init__(self):
-        ChromeOptions.__init__(self)
+        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3", DeprecationWarning, stacklevel=2)
+        super().__init__()
         self._android_package_name = ''
         self._android_device_socket = ''
         self._android_command_line_file = ''
@@ -105,5 +108,5 @@ class Options(ChromeOptions):
 class AndroidOptions(Options):
 
     def __init__(self):
-        Options.__init__(self)
+        super().__init__()
         self.android_package_name = 'com.opera.browser'

--- a/py/selenium/webdriver/opera/webdriver.py
+++ b/py/selenium/webdriver/opera/webdriver.py
@@ -14,10 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
+
 from selenium.webdriver.chrome.webdriver import WebDriver as ChromiumDriver
 from .options import Options
 
 
+# Todo: gh-10379 (Remove for 4.3)
 class OperaDriver(ChromiumDriver):
     """Controls the new OperaDriver and allows you
     to drive the Opera browser based on Chromium."""
@@ -42,6 +45,7 @@ class OperaDriver(ChromiumDriver):
          - service_log_path - Where to log information from the driver.
            capabilities only, such as "proxy" or "loggingPref".
         """
+        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3", DeprecationWarning, stacklevel=2)
         executable_path = (executable_path if executable_path else "operadriver")
         ChromiumDriver.__init__(self,
                                 executable_path=executable_path,

--- a/py/selenium/webdriver/opera/webdriver.py
+++ b/py/selenium/webdriver/opera/webdriver.py
@@ -44,7 +44,9 @@ class OperaDriver(ChromiumDriver):
          - service_log_path - Where to log information from the driver.
            capabilities only, such as "proxy" or "loggingPref".
         """
-        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3", DeprecationWarning, stacklevel=2)
+        warnings.warn(f"{self.__class__} is deprecated and will be removed in 4.3; "
+                      f"see: https://www.selenium.dev/documentation/webdriver/getting_started/open_browser/#opera",
+                      DeprecationWarning, stacklevel=2)
         executable_path = (executable_path if executable_path else "operadriver")
         ChromiumDriver.__init__(self,
                                 executable_path=executable_path,

--- a/py/selenium/webdriver/opera/webdriver.py
+++ b/py/selenium/webdriver/opera/webdriver.py
@@ -20,7 +20,6 @@ from selenium.webdriver.chrome.webdriver import WebDriver as ChromiumDriver
 from .options import Options
 
 
-# Todo: gh-10379 (Remove for 4.3)
 class OperaDriver(ChromiumDriver):
     """Controls the new OperaDriver and allows you
     to drive the Opera browser based on Chromium."""

--- a/py/setup.py
+++ b/py/setup.py
@@ -61,7 +61,7 @@ setup_args = {
                  'selenium.webdriver.firefox',
                  'selenium.webdriver.ie',
                  'selenium.webdriver.edge',
-                 'selenium.webdriver.opera',
+                 'selenium.webdriver.opera',  # Todo: gh-10379 (Remove for 4.3)
                  'selenium.webdriver.remote',
                  'selenium.webdriver.support', ],
     'include_package_data': True,

--- a/py/setup.py
+++ b/py/setup.py
@@ -61,7 +61,7 @@ setup_args = {
                  'selenium.webdriver.firefox',
                  'selenium.webdriver.ie',
                  'selenium.webdriver.edge',
-                 'selenium.webdriver.opera',  # Todo: gh-10379 (Remove for 4.3)
+                 'selenium.webdriver.opera',
                  'selenium.webdriver.remote',
                  'selenium.webdriver.support', ],
     'include_package_data': True,

--- a/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
+++ b/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
@@ -92,5 +92,6 @@ def test_is_a_baseoptions(options):
 def test_opera_options_is_deprecated(options):
     with pytest.warns(DeprecationWarning) as captured:
         Options()
-    expected = "<class 'selenium.webdriver.opera.options.Options'> is deprecated and will be removed in 4.3"
+    expected = "<class 'selenium.webdriver.opera.options.Options'> is deprecated and will be removed in 4.3; " \
+               "see: https://www.selenium.dev/documentation/webdriver/getting_started/open_browser/#opera"
     assert captured[0].message.args[0] == expected

--- a/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
+++ b/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
@@ -20,9 +20,6 @@ import pytest
 from selenium.webdriver.opera.options import Options
 
 
-# Todo: gh-10379 (Remove for 4.3)
-
-
 @pytest.fixture
 def options():
     return Options()

--- a/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
+++ b/py/test/unit/selenium/webdriver/opera/opera_options_tests.py
@@ -20,6 +20,9 @@ import pytest
 from selenium.webdriver.opera.options import Options
 
 
+# Todo: gh-10379 (Remove for 4.3)
+
+
 @pytest.fixture
 def options():
     return Options()
@@ -87,3 +90,10 @@ def test_starts_with_default_capabilities(options):
 def test_is_a_baseoptions(options):
     from selenium.webdriver.common.options import BaseOptions
     assert isinstance(options, BaseOptions)
+
+
+def test_opera_options_is_deprecated(options):
+    with pytest.warns(DeprecationWarning) as captured:
+        Options()
+    expected = "<class 'selenium.webdriver.opera.options.Options'> is deprecated and will be removed in 4.3"
+    assert captured[0].message.args[0] == expected


### PR DESCRIPTION
Deprecate opera driver `Options` and `WebDriver` subclass usage.  I have added appropriate 'rip out' todo's so grepping for `# Todo: gh-10379 (Remove for 4.3)` will yield everything that needs removed after 4.2 is cut; and we can properly remove it for `4.3` .  There isn't actually any `opera` webdriver based tests outside of basic unit/options ones so I didn't invest the time into that here as i'll be removing it in a few days again.

relates to #10379 