### PR TITLE
fix return type hints for `screenshot_as_png`

### DIFF
--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -660,7 +660,7 @@ class WebElement(BaseWebElement):
         return self._execute(Command.ELEMENT_SCREENSHOT)['value']
 
     @property
-    def screenshot_as_png(self) -> str:
+    def screenshot_as_png(self) -> bytes:
         """
         Gets the screenshot of the current element as a binary data.
 


### PR DESCRIPTION
`b64decode` returns bytes..

closes #10623