### PR TITLE
[java] implement separate Origin class for WheelInput

### DIFF
--- a/java/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/src/org/openqa/selenium/interactions/Actions.java
@@ -271,7 +271,7 @@ public class Actions {
     return moveInTicks(target, 0, 0).tick(getActivePointer().createPointerUp(LEFT.asArg()));
   }
 
-  public Actions scroll( int x, int y, int deltaX, int deltaY, Origin origin) {
+  public Actions scroll( int x, int y, int deltaX, int deltaY, WheelInput.Origin origin) {
     return tick(getActiveWheel().createScroll(x, y, deltaX, deltaY, Duration.ofMillis(250), origin));
   }
 

--- a/java/src/org/openqa/selenium/interactions/WheelInput.java
+++ b/java/src/org/openqa/selenium/interactions/WheelInput.java
@@ -25,7 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.openqa.selenium.interactions.PointerInput.Origin;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.internal.Require;
 
 /**
@@ -89,8 +90,6 @@ public class WheelInput implements InputSource, Encodable {
       this.deltaY = deltaY;
       this.duration = nonNegative(duration);
       this.origin = Require.nonNull("Origin of scroll", origin);
-      Require.precondition(!origin.asArg().equals("pointer"),
-                           "Wheel input only accepts viewport or element origin." );
     }
 
     @Override
@@ -106,6 +105,30 @@ public class WheelInput implements InputSource, Encodable {
       toReturn.put("origin", origin.asArg());
 
       return toReturn;
+    }
+  }
+
+  public static final class Origin {
+    private final Object originObject;
+
+    public Object asArg() {
+      Object arg = originObject;
+      while (arg instanceof WrapsElement) {
+        arg = ((WrapsElement) arg).getWrappedElement();
+      }
+      return arg;
+    }
+
+    private Origin(Object originObject) {
+      this.originObject = originObject;
+    }
+
+    public static WheelInput.Origin viewport() {
+      return new WheelInput.Origin("viewport");
+    }
+
+    public static WheelInput.Origin fromElement(WebElement element) {
+      return new WheelInput.Origin(Require.nonNull("Element", element));
     }
   }
 }

--- a/java/test/org/openqa/selenium/interactions/DefaultWheelTest.java
+++ b/java/test/org/openqa/selenium/interactions/DefaultWheelTest.java
@@ -50,7 +50,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       0,
       0,
       0,
-      PointerInput.Origin.fromElement(iframe)).perform();
+      WheelInput.Origin.fromElement(iframe)).perform();
 
     assertTrue(inViewport(iframe));
   }
@@ -65,7 +65,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       0,
       0,
       200,
-      PointerInput.Origin.fromElement(iframe)).perform();
+      WheelInput.Origin.fromElement(iframe)).perform();
 
     driver.switchTo().frame(iframe);
 
@@ -83,7 +83,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       -50,
       0,
       200,
-      PointerInput.Origin.fromElement(footer)).perform();
+      WheelInput.Origin.fromElement(footer)).perform();
 
     driver.switchTo().frame(driver.findElement(By.tagName("iframe")));
 
@@ -101,7 +101,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       50,
       0,
       200,
-      PointerInput.Origin.fromElement(footer)).perform();
+      WheelInput.Origin.fromElement(footer)).perform();
   }
 
   @Test
@@ -116,7 +116,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       0,
       0,
       y,
-      PointerInput.Origin.viewport()).perform();
+      WheelInput.Origin.viewport()).perform();
 
     assertTrue(inViewport(footer));
   }
@@ -132,7 +132,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       10,
       0,
       200,
-      PointerInput.Origin.viewport()).perform();
+      WheelInput.Origin.viewport()).perform();
 
     driver.switchTo().frame(iframe);
 
@@ -149,7 +149,7 @@ public class DefaultWheelTest extends JUnit4TestBase {
       -10,
       0,
       200,
-      PointerInput.Origin.viewport()).perform();
+      WheelInput.Origin.viewport()).perform();
   }
 
   private boolean inViewport(WebElement element) {

--- a/java/test/org/openqa/selenium/interactions/WheelInputTest.java
+++ b/java/test/org/openqa/selenium/interactions/WheelInputTest.java
@@ -50,7 +50,7 @@ public class WheelInputTest {
       0,
       0,
       Duration.ofMillis(100),
-      Origin.fromElement(element));
+      WheelInput.Origin.fromElement(element));
     Sequence sequence = new Sequence(wheelInput, 0).addAction(scroll);
 
     String rawJson = new Json().toJson(sequence);
@@ -84,7 +84,7 @@ public class WheelInputTest {
       30,
       60,
       Duration.ofSeconds(1),
-      Origin.viewport());
+      WheelInput.Origin.viewport());
 
     Map<String, Object> encodedResult = interaction.encode();
     assertThat(encodedResult)
@@ -110,7 +110,7 @@ public class WheelInputTest {
       30,
       60,
       Duration.ofSeconds(1),
-      Origin.fromElement(innerElement));
+      WheelInput.Origin.fromElement(innerElement));
 
     Map<String, Object> encodedResult = interaction.encode();
     assertThat(encodedResult)
@@ -121,20 +121,6 @@ public class WheelInputTest {
       .containsEntry("deltaY", 60)
       .containsEntry("duration", 1000L)
       .containsEntry("origin", innerElement);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldNotAllowPointerOrigin() {
-
-    WheelInput wheelInput = new WheelInput("test-wheel");
-    WheelInput.ScrollInteraction interaction = new WheelInput.ScrollInteraction(
-      wheelInput,
-      25,
-      50,
-      30,
-      60,
-      Duration.ofSeconds(1),
-      Origin.pointer());
   }
 
   private static class ActionSequenceJson {


### PR DESCRIPTION
This is what I was talking about in the TLC meeting. I'd rather have a separate implementation than use one from another (tangential but still unrelated) class that has an unsupported method that we have to treat differently.

(I also have an idea for how I'd like to build on this class in a way that requires it to be independent).