### PR TITLE
[dotnet] implement scroll action

### DIFF
--- a/dotnet/src/webdriver/Interactions/WheelInputDevice.cs
+++ b/dotnet/src/webdriver/Interactions/WheelInputDevice.cs
@@ -19,9 +19,6 @@
 using OpenQA.Selenium.Internal;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Interactions
 {
@@ -75,7 +72,7 @@ namespace OpenQA.Selenium.Interactions
         /// <param name="deltaX">The distance along the X axis to scroll using the wheel.</param>
         /// <param name="deltaY">The distance along the Y axis to scroll using the wheel.</param>
         /// <param name="duration">The duration of the scroll action.</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="Interaction"/> representing the wheel scroll.</returns>
         public Interaction CreateWheelScroll(int deltaX, int deltaY, TimeSpan duration)
         {
             return new WheelScrollInteraction(this, null, CoordinateOrigin.Viewport, 0, 0, deltaX, deltaY, duration);
@@ -90,7 +87,7 @@ namespace OpenQA.Selenium.Interactions
         /// <param name="deltaX">The distance along the X axis to scroll using the wheel.</param>
         /// <param name="deltaY">The distance along the Y axis to scroll using the wheel.</param>
         /// <param name="duration">The duration of the scroll action.</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="Interaction"/> representing the wheel scroll.</returns>
         public Interaction CreateWheelScroll(IWebElement target, int xOffset, int yOffset, int deltaX, int deltaY, TimeSpan duration)
         {
             return new WheelScrollInteraction(this, target, CoordinateOrigin.Element, xOffset, yOffset, deltaX, deltaY, duration);
@@ -105,10 +102,28 @@ namespace OpenQA.Selenium.Interactions
         /// <param name="deltaX">The distance along the X axis to scroll using the wheel.</param>
         /// <param name="deltaY">The distance along the Y axis to scroll using the wheel.</param>
         /// <param name="duration">The duration of the scroll action.</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="Interaction"/> representing the wheel scroll.</returns>
         public Interaction CreateWheelScroll(CoordinateOrigin origin, int xOffset, int yOffset, int deltaX, int deltaY, TimeSpan duration)
         {
             return new WheelScrollInteraction(this, null, origin, xOffset, yOffset, deltaX, deltaY, duration);
+        }
+
+        public class ScrollOrigin
+        {
+            private IWebElement element;
+            private bool viewport;
+
+            public IWebElement Element
+            {
+                get { return this.element; }
+                set { this.element = value; }
+            }
+
+            public bool Viewport
+            {
+                get { return this.viewport; }
+                set { this.viewport = value; }
+            }
         }
 
         private class WheelScrollInteraction : Interaction

--- a/dotnet/test/common/DriverTestFixture.cs
+++ b/dotnet/test/common/DriverTestFixture.cs
@@ -81,6 +81,8 @@ namespace OpenQA.Selenium
         public string authenticationPage = EnvironmentManager.Instance.UrlBuilder.WhereIs("basicAuth");
         public string html5Page = EnvironmentManager.Instance.UrlBuilder.WhereIs("html5Page.html");
         public string shadowRootPage = EnvironmentManager.Instance.UrlBuilder.WhereIs("shadowRootPage.html");
+        public string scrollFrameOutOfViewport = EnvironmentManager.Instance.UrlBuilder.WhereIs("scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html");
+        public string scrollFrameInViewport = EnvironmentManager.Instance.UrlBuilder.WhereIs("scrolling_tests/frame_with_nested_scrolling_frame.html");
 
         protected IWebDriver driver;
 

--- a/dotnet/test/common/Interactions/BasicWheelInterfaceTest.cs
+++ b/dotnet/test/common/Interactions/BasicWheelInterfaceTest.cs
@@ -1,0 +1,146 @@
+using System;
+using NUnit.Framework;
+
+namespace OpenQA.Selenium.Interactions
+{
+    [TestFixture]
+    public class BasicWheelInterfaceTest : DriverTestFixture
+    {
+        [SetUp]
+        public void SetupTest()
+        {
+            IActionExecutor actionExecutor = driver as IActionExecutor;
+            if (actionExecutor != null)
+            {
+                actionExecutor.ResetInputState();
+            }
+            driver.SwitchTo().DefaultContent();
+            ((IJavaScriptExecutor)driver).ExecuteScript("window.scrollTo(0, 0)");
+        }
+
+        [Test]
+        public void ShouldAllowScrollingToAnElement()
+        {
+            driver.Url = scrollFrameOutOfViewport;
+            IWebElement iframe = driver.FindElement(By.TagName("iframe"));
+
+            Assert.IsFalse(IsInViewport(iframe));
+
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Element = iframe
+            };
+
+            new Actions(driver).Scroll(0, 0, 0, 0, scrollOrigin).Build().Perform();
+
+            Assert.IsTrue(IsInViewport(iframe));
+        }
+
+        [Test]
+        public void ShouldScrollFromElementByGivenAmount()
+        {
+            driver.Url = scrollFrameOutOfViewport;
+            IWebElement iframe = driver.FindElement(By.TagName("iframe"));
+            WheelInputDevice.ScrollOrigin scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Element = iframe
+            };
+
+            new Actions(driver).Scroll(0, 0, 0, 200, scrollOrigin).Build().Perform();
+
+            driver.SwitchTo().Frame(iframe);
+            IWebElement checkbox = driver.FindElement(By.Name("scroll_checkbox"));
+            Assert.IsTrue(IsInViewport(checkbox));
+        }
+
+        [Test]
+        public void ShouldAllowScrollingFromElementByGivenAmountWithOffset()
+        {
+            driver.Url = scrollFrameOutOfViewport;
+            IWebElement footer = driver.FindElement(By.TagName("footer"));
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Element = footer
+            };
+
+            new Actions(driver).Scroll(0, -50, 0, 200, scrollOrigin).Build().Perform();
+
+            IWebElement iframe = driver.FindElement(By.TagName("iframe"));
+            driver.SwitchTo().Frame(iframe);
+            IWebElement checkbox = driver.FindElement(By.Name("scroll_checkbox"));
+            Assert.IsTrue(IsInViewport(checkbox));
+        }
+
+        [Test]
+        public void ShouldNotAllowScrollingWhenElementOriginOutOfViewport()
+        {
+            driver.Url = scrollFrameOutOfViewport;
+            IWebElement footer = driver.FindElement(By.TagName("footer"));
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Element = footer
+            };
+
+            Assert.That(() => new Actions(driver).Scroll(0, 50, 0, 0, scrollOrigin).Build().Perform(),
+                Throws.InstanceOf<MoveTargetOutOfBoundsException>());
+        }
+
+        [Test]
+        public void ShouldAllowScrollingFromViewportByGivenAmount()
+        {
+            driver.Url = scrollFrameOutOfViewport;
+            IWebElement footer = driver.FindElement(By.TagName("footer"));
+            int deltaY = footer.Location.Y;
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Viewport = true
+            };
+
+            new Actions(driver).Scroll(0, 0, 0, deltaY, scrollOrigin).Build().Perform();
+
+            Assert.IsTrue(IsInViewport(footer));
+        }
+
+        [Test]
+        public void ShouldAllowScrollingFromViewportByGivenAmountFromOrigin()
+        {
+            driver.Url = scrollFrameInViewport;
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Viewport = true
+            };
+
+            new Actions(driver).Scroll(10, 10, 0, 200, scrollOrigin).Build().Perform();
+
+            IWebElement iframe = driver.FindElement(By.TagName("iframe"));
+            driver.SwitchTo().Frame(iframe);
+            IWebElement checkbox = driver.FindElement(By.Name("scroll_checkbox"));
+            Assert.IsTrue(IsInViewport(checkbox));
+        }
+
+        [Test]
+        public void ShouldNotAllowScrollingWhenOriginOffsetIsOutOfViewport()
+        {
+            driver.Url = scrollFrameInViewport;
+            var scrollOrigin = new WheelInputDevice.ScrollOrigin
+            {
+                Viewport = true
+            };
+
+            Assert.That(() => new Actions(driver).Scroll(-10, -10, 0, 200, scrollOrigin).Build().Perform(),
+                Throws.InstanceOf<MoveTargetOutOfBoundsException>());
+        }
+
+        private bool IsInViewport(IWebElement element)
+        {
+            String script =
+                "for(var e=arguments[0],f=e.offsetTop,t=e.offsetLeft,o=e.offsetWidth,n=e.offsetHeight;\n"
+                + "e.offsetParent;)f+=(e=e.offsetParent).offsetTop,t+=e.offsetLeft;\n"
+                + "return f<window.pageYOffset+window.innerHeight&&t<window.pageXOffset+window.innerWidth&&f+n>\n"
+                + "window.pageYOffset&&t+o>window.pageXOffset";
+            IJavaScriptExecutor javascriptDriver = this.driver as IJavaScriptExecutor;
+
+            return (bool)javascriptDriver.ExecuteScript(script, element);
+        }
+    }
+}


### PR DESCRIPTION
.NET implemented multiple `WheelScrollInteraction` interactions for `WheelInputDevice`, but this single `Scroll()` method matches what we're doing for other languages at this point, with the same tests.
