### PR TITLE
[py]: fix `flake8` issues in `trunk`

### DIFF
--- a/py/selenium/webdriver/common/action_chains.py
+++ b/py/selenium/webdriver/common/action_chains.py
@@ -321,7 +321,7 @@ class ActionChains:
         self.send_keys(*keys_to_send)
         return self
 
-    def scroll(self, x: int, y: int, delta_x: int, delta_y: int, duration: int = 0, origin= "viewport"):
+    def scroll(self, x: int, y: int, delta_x: int, delta_y: int, duration: int = 0, origin="viewport"):
         """
         Sends wheel scroll information to the browser to be processed.
 


### PR DESCRIPTION
`trunk` is currently broken with py builds due to `flake8` violations.  (I much prefer to have `pre-commit` catching these before they are committed locally rather than finding out later on the remote)