### PR TITLE
[py]: exclude `*venv` directories from `flake8`

### DIFF
--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .tox,docs/source/conf.py
+exclude = .tox,docs/source/conf.py,*venv
 ignore = E501
 
 [tool:pytest]


### PR DESCRIPTION
Invoking `tox` is a requirement currently and not something that bazel does; this means people need to typically make a virtualenv and install `tox` in it to do this task; installing `tox` globally is also possible but not -advised (but that won't encounter the problem this fixes if so).

Common python practice would be:

`python3.7 -m venv .venv` || `python3.7 -m venv venv` ( in the case of using 3.7 like selenium encourages)

This excludes `*venv` so that `tox -e flake8` does not take a long time to complete and flag up 200+ false positives by scanning files inside the virtual env.