### PR TITLE
[rb] - Improving Wait class error handling

### DIFF
--- a/rb/CHANGES
+++ b/rb/CHANGES
@@ -1,3 +1,9 @@
+trunk (TBD)
+=========================
+
+Ruby:
+  * Fix Wait class tripping up during poll when a StaleElementReference would occur (#10659)
+
 4.1.0 (2021-11-22)
 =========================
 

--- a/rb/lib/selenium/webdriver/common/wait.rb
+++ b/rb/lib/selenium/webdriver/common/wait.rb
@@ -22,7 +22,7 @@ module Selenium
     class Wait
       DEFAULT_TIMEOUT  = 5
       DEFAULT_INTERVAL = 0.2
-      DEFAULT_ERRORS_TO_IGNORE = [Error::NoSuchElementError, Error::StaleElementReferenceError]
+      DEFAULT_ERRORS_TO_IGNORE = [Error::NoSuchElementError, Error::StaleElementReferenceError].freeze
 
       #
       # Create a new Wait instance

--- a/rb/lib/selenium/webdriver/common/wait.rb
+++ b/rb/lib/selenium/webdriver/common/wait.rb
@@ -38,7 +38,7 @@ module Selenium
         @timeout  = opts.fetch(:timeout, DEFAULT_TIMEOUT)
         @interval = opts.fetch(:interval, DEFAULT_INTERVAL)
         @message  = opts[:message]
-        @ignored  = Array(opts[:ignore]) || DEFAULT_ERRORS_TO_IGNORE
+        @ignored  = Array(opts[:ignore] || DEFAULT_ERRORS_TO_IGNORE)
       end
 
       #

--- a/rb/lib/selenium/webdriver/common/wait.rb
+++ b/rb/lib/selenium/webdriver/common/wait.rb
@@ -22,6 +22,7 @@ module Selenium
     class Wait
       DEFAULT_TIMEOUT  = 5
       DEFAULT_INTERVAL = 0.2
+      DEFAULT_ERRORS_TO_IGNORE = [Error::NoSuchElementError, Error::StaleElementReferenceError]
 
       #
       # Create a new Wait instance
@@ -37,7 +38,7 @@ module Selenium
         @timeout  = opts.fetch(:timeout, DEFAULT_TIMEOUT)
         @interval = opts.fetch(:interval, DEFAULT_INTERVAL)
         @message  = opts[:message]
-        @ignored  = Array(opts[:ignore] || Error::NoSuchElementError)
+        @ignored  = Array(opts[:ignore]) || DEFAULT_ERRORS_TO_IGNORE
       end
 
       #

--- a/rb/spec/unit/selenium/webdriver/wait_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/wait_spec.rb
@@ -51,8 +51,30 @@ module Selenium
         expect(wait.until(&block)).to be true
       end
 
+      it 'should silently capture StaleElementReferenceErrors' do
+        called = false
+        block = lambda do
+          if called
+            true
+          else
+            called = true
+            raise Error::StaleElementReferenceError
+          end
+        end
+
+        expect(wait.until(&block)).to be true
+      end
+
       it 'will use the message from any NoSuchElementError raised while waiting' do
         block = -> { raise Error::NoSuchElementError, 'foo' }
+
+        expect {
+          wait(timeout: 0.5).until(&block)
+        }.to raise_error(Error::TimeoutError, /foo/)
+      end
+
+      it 'will use the message from any StaleElementReferenceError raised while waiting' do
+        block = -> { raise Error::StaleElementReferenceError, 'foo' }
 
         expect {
           wait(timeout: 0.5).until(&block)


### PR DESCRIPTION
### Description
When re-polling during the `Wait#until` method. Ensure we don't trip up if the element is missing **OR** if the element is stale, as both are equally likely

### Motivation and Context
During the upgrade from capybara 3.35 to 3.37.1 this error starts showing a **lot** more. It is likely that as we are moving faster in better rubies, we are likely to hit that split second where the web element could be missing OR it could be in the process of appearing / changing and therefore register as stale.

I've classified this as a bugfix. As ideally missing element and stale element should live hand in hand.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
