### PR TITLE
[dotnet] allow RemoteWebDriver to access Selenium logs

### DIFF
--- a/dotnet/src/webdriver/Logs.cs
+++ b/dotnet/src/webdriver/Logs.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -27,7 +28,6 @@ namespace OpenQA.Selenium
     public class Logs : ILogs
     {
         private WebDriver driver;
-        private bool isLogSupported = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteLogs"/> class.
@@ -36,7 +36,6 @@ namespace OpenQA.Selenium
         public Logs(WebDriver driver)
         {
             this.driver = driver;
-            this.isLogSupported = (this.driver as ISupportsLogs) != null;
         }
 
         /// <summary>
@@ -47,7 +46,7 @@ namespace OpenQA.Selenium
             get
             {
                 List<string> availableLogTypes = new List<string>();
-                if (this.isLogSupported)
+                try
                 {
                     Response commandResponse = this.driver.InternalExecute(DriverCommand.GetAvailableLogTypes, null);
                     object[] responseValue = commandResponse.Value as object[];
@@ -58,6 +57,10 @@ namespace OpenQA.Selenium
                             availableLogTypes.Add(logKind.ToString());
                         }
                     }
+                }
+                catch (NotImplementedException)
+                {
+                    // Swallow for backwards compatibility
                 }
 
                 return availableLogTypes.AsReadOnly();
@@ -73,7 +76,7 @@ namespace OpenQA.Selenium
         public ReadOnlyCollection<LogEntry> GetLog(string logKind)
         {
             List<LogEntry> entries = new List<LogEntry>();
-            if (this.isLogSupported)
+            try
             {
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 parameters.Add("type", logKind);
@@ -91,6 +94,10 @@ namespace OpenQA.Selenium
                         }
                     }
                 }
+            }
+            catch (NotImplementedException)
+            {
+                // Swallow for backwards compatibility
             }
 
             return entries.AsReadOnly();


### PR DESCRIPTION
There are 3 options I can see for quickly fixing #8229, none of them are ideal.

1. Require users to subclass RemoteWebDriver and add implementation for `ISupportsLog` which I *think should "just work" (at least it did in my quick test of it).
```cs
public class RemoteChromeDriver : RemoteWebDriver, ISupportsLogs
```
2. This PR, which would allow a user to do this:
```cs
var customCommandDriver = driver as ICustomDriverCommandExecutor;
customCommandDriver.RegisterCustomDriverCommands(ChromeDriver.CustomCommandDefinitions);

ReadOnlyCollection<string> logTypes = driver.Manage().Logs.AvailableLogTypes;
driver.Url = "https://selenium.dev/selenium/web/errors.html";
driver.FindElement(By.CssSelector("input")).Click();
ReadOnlyCollection<LogEntry> results = driver.Manage().Logs.GetLog("browser");
```
3. Can remove some of the uglier parts of this PR and put more onus on user:
```cs
IReadOnlyDictionary<string, CommandInfo> logCommands = new Dictionary<string, CommandInfo>
{
    {
        DriverCommand.GetAvailableLogTypes,
        new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/se/log/types")
    },
    {
        DriverCommand.GetLog,
        new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log")
    }
};

var customCommandDriver = driver as ICustomDriverCommandExecutor;
customCommandDriver.RegisterCustomDriverCommands(logCommands);

ReadOnlyCollection<string> logTypes = driver.Manage().Logs.AvailableLogTypes;
driver.Url = "https://selenium.dev/selenium/web/errors.html";
driver.FindElement(By.CssSelector("input")).Click();
ReadOnlyCollection<LogEntry> results = driver.Manage().Logs.GetLog("browser");
```

The existing code allows driver classes for drivers that haven't implemented the logging endpoints, to call the log methods, but it won't actually send the commands. No error that the method isn't actually doing anything.

This PR would always send the command but will swallow the not-implemented exception if the driver commands were not added. So same end result, but slightly less efficient, but if a user is calling for something that never returns anything anyway, maybe that doesn't matter from an implementation standpoint.

Any feedback from anyone would be great on this, thanks.