### PR TITLE
Update submit function

### DIFF
--- a/common/src/web/formPage.html
+++ b/common/src/web/formPage.html
@@ -106,7 +106,7 @@ There should be a form here:
 
     <p id="cheeseLiker">I like cheese</p>
     <input type="submit" value="Click!"/>
-    
+
     <input type="radio" id="lone_disabled_selected_radio" name="not_a_snack" value="cumberland" checked="checked" disabled="disabled" />Cumberland sausage
 </form>
 
@@ -150,7 +150,7 @@ There should be a form here:
     <input type="text" value="name" name="x"/>
   </div>
   <input type="submit" />
-</form>  
+</form>
 
 <!-- Form with disabled form elements -->
 <form method="get" action="xhtmlTest.html">
@@ -170,6 +170,15 @@ There should be a form here:
     <label for="checkbox-with-label" id="label-for-checkbox-with-label">Label</label><input type="checkbox" id="checkbox-with-label" />
   </p>
 </form>
+
+<form method="get" action="resultPage.html" name="submit_id">
+  <input type="submit" id="submit" value="Submit a Submit ID Button"/>
+</form>
+
+<form method="get" action="resultPage.html" name="submit_name">
+  <input type="submit" name="submit" value="Submit a Submit ID Button"/>
+</form>
+
 <input id="vsearchGadget" name="SearchableText" type="text" size="18" value="" title="Hvad søger du?" accesskey="4" class="inputLabel" />
 </body>
 </html>

--- a/dotnet/src/webdriver/WebElement.cs
+++ b/dotnet/src/webdriver/WebElement.cs
@@ -633,11 +633,17 @@ namespace OpenQA.Selenium
             }
             else
             {
-                IWebElement form = this.FindElement(By.XPath("./ancestor-or-self::form"));
-                this.driver.ExecuteScript(
-                    "var e = arguments[0].ownerDocument.createEvent('Event');" +
-                    "e.initEvent('submit', true, true);" +
-                    "if (arguments[0].dispatchEvent(e)) { arguments[0].submit(); }", form);
+                String script = "var form = arguments[0];\n" +
+                                "while (form.nodeName != \"FORM\" && form.parentNode) {\n" +
+                                "  form = form.parentNode;\n" +
+                                "}\n" +
+                                "if (!form) { throw Error('Unable to find containing form element'); }\n" +
+                                "if (!form.ownerDocument) { throw Error('Unable to find owning document'); }\n" +
+                                "var e = form.ownerDocument.createEvent('Event');\n" +
+                                "e.initEvent('submit', true, true);\n" +
+                                "if (form.dispatchEvent(e)) { HTMLFormElement.prototype.submit.call(form) }\n";
+
+                this.driver.ExecuteScript(script, this);
             }
         }
 

--- a/dotnet/test/common/FormHandlingTests.cs
+++ b/dotnet/test/common/FormHandlingTests.cs
@@ -60,10 +60,28 @@ namespace OpenQA.Selenium
         }
 
         [Test]
-        public void ShouldNotBeAbleToSubmitAFormThatDoesNotExist()
+        public void ShouldSubmitAFormWithIdSubmit()
         {
             driver.Url = formsPage;
-            Assert.That(() => driver.FindElement(By.Name("SearchableText")).Submit(), Throws.InstanceOf<NoSuchElementException>());
+            driver.FindElement(By.Id("submit")).Submit();
+            WaitFor(TitleToBe("We Arrive Here"), "Browser title is not 'We Arrive Here'");
+            Assert.AreEqual(driver.Title, "We Arrive Here");
+        }
+
+        [Test]
+        public void ShouldSubmitAFormWithNameSubmit()
+        {
+            driver.Url = formsPage;
+            driver.FindElement(By.Name("submit")).Submit();
+            WaitFor(TitleToBe("We Arrive Here"), "Browser title is not 'We Arrive Here'");
+            Assert.AreEqual(driver.Title, "We Arrive Here");
+        }
+
+        [Test]
+        public void ShouldNotBeAbleToSubmitAnInputOutsideAForm()
+        {
+            driver.Url = formsPage;
+            Assert.That(() => driver.FindElement(By.Name("SearchableText")).Submit(), Throws.InstanceOf<WebDriverException>());
         }
 
         [Test]

--- a/java/src/org/openqa/selenium/remote/RemoteWebElement.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebElement.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
@@ -79,7 +80,12 @@ public class RemoteWebElement implements WebElement, Locatable, TakesScreenshot,
 
   @Override
   public void submit() {
-    execute(DriverCommand.SUBMIT_ELEMENT(id));
+    try {
+      execute(DriverCommand.SUBMIT_ELEMENT(id));
+    } catch (JavascriptException ex) {
+      String message = "To submit an element, it must be nested inside a form element";
+      throw new UnsupportedOperationException(message);
+    }
   }
 
   @Override

--- a/java/test/org/openqa/selenium/FormHandlingTest.java
+++ b/java/test/org/openqa/selenium/FormHandlingTest.java
@@ -83,7 +83,7 @@ public class FormHandlingTest extends JUnit4TestBase {
   public void testShouldNotBeAbleToSubmitAFormThatDoesNotExist() {
     driver.get(pages.formPage);
     WebElement element = driver.findElement(By.name("SearchableText"));
-    assertThatExceptionOfType(JavascriptException.class).isThrownBy(element::submit);
+    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(element::submit);
   }
 
   @Test
@@ -282,14 +282,10 @@ public class FormHandlingTest extends JUnit4TestBase {
 
   @Test
   public void canSubmitFormWithSubmitButtonIdEqualToSubmit() {
-    String blank = appServer.create(new Page().withTitle("Submitted Successfully!"));
-    driver.get(appServer.create(new Page().withBody(
-        String.format("<form action='%s'>", blank),
-        "  <input type='submit' id='submit' value='Submit'>",
-        "</form>")));
-
-    driver.findElement(By.id("submit")).submit();
-    wait.until(titleIs("Submitted Successfully!"));
+    driver.get(pages.formPage);
+    driver.findElement(By.id("submit")).click();
+    wait.until(titleIs("We Arrive Here"));
+    assertThat(driver.getTitle()).isEqualTo("We Arrive Here");
   }
 
   @Test

--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -2765,13 +2765,17 @@ class WebElement {
    *     when the form has been submitted.
    */
   submit() {
-    const form = this.findElement({ xpath: './ancestor-or-self::form' })
-    this.driver_.executeScript(
-      "var e = arguments[0].ownerDocument.createEvent('Event');" +
-        "e.initEvent('submit', true, true);" +
-        'if (arguments[0].dispatchEvent(e)) { arguments[0].submit() }',
-      form
-    )
+    const script = "var form = arguments[0];\n" +
+      "while (form.nodeName != \"FORM\" && form.parentNode) {\n" +
+      "  form = form.parentNode;\n" +
+      "}\n" +
+      "if (!form) { throw Error('Unable to find containing form element'); }\n" +
+      "if (!form.ownerDocument) { throw Error('Unable to find owning document'); }\n" +
+      "var e = form.ownerDocument.createEvent('Event');\n" +
+      "e.initEvent('submit', true, true);\n" +
+      "if (form.dispatchEvent(e)) { HTMLFormElement.prototype.submit.call(form) }\n";
+
+    this.driver_.executeScript(script, this);
   }
 
   /**

--- a/py/test/selenium/webdriver/common/form_handling_tests.py
+++ b/py/test/selenium/webdriver/common/form_handling_tests.py
@@ -41,28 +41,40 @@ def test_should_be_able_to_click_image_buttons(driver, pages):
     WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
 
-def test_should_be_able_to_submit_forms(driver, pages):
+def test_should_submit_input_in_form(driver, pages):
     pages.load("formPage.html")
     driver.find_element(By.NAME, "login").submit()
     WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
 
-def test_should_submit_aform_when_any_input_element_within_that_form_is_submitted(driver, pages):
+def test_should_submit_any_input_element_within_form(driver, pages):
     pages.load("formPage.html")
     driver.find_element(By.ID, "checky").submit()
     WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
 
-def test_should_submit_aform_when_any_element_within_that_form_is_submitted(driver, pages):
+def test_should_submit_any_element_within_form(driver, pages):
     pages.load("formPage.html")
     driver.find_element(By.XPATH, "//form/p").submit()
     WebDriverWait(driver, 5).until(EC.title_is("We Arrive Here"))
 
 
-def test_should_not_be_able_to_submit_aform_that_does_not_exist(driver, pages):
+def test_should_submit_element_with_id_submit(driver, pages):
     pages.load("formPage.html")
-    with pytest.raises(NoSuchElementException):
-        driver.find_element(By.NAME, "there is no spoon").submit()
+    driver.find_element(By.ID, "submit").submit()
+    WebDriverWait(driver, 5).until(EC.title_is("We Arrive Here"))
+
+
+def test_should_submit_element_with_name_submit(driver, pages):
+    pages.load("formPage.html")
+    driver.find_element(By.NAME, "submit").submit()
+    WebDriverWait(driver, 5).until(EC.title_is("We Arrive Here"))
+
+
+def test_should_not_submit_button_outside_form(driver, pages):
+    pages.load("formPage.html")
+    with pytest.raises(WebDriverException):
+        driver.find_element(By.NAME, "SearchableText").submit()
 
 
 def test_should_be_able_to_enter_text_into_atext_area_by_setting_its_value(driver, pages):

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -425,10 +425,19 @@ module Selenium
         end
 
         def submit_element(element)
-          form = find_element_by('xpath', "./ancestor-or-self::form", [:element, element])
-          execute_script("var e = arguments[0].ownerDocument.createEvent('Event');" \
-                         "e.initEvent('submit', true, true);" \
-                         'if (arguments[0].dispatchEvent(e)) { arguments[0].submit() }', form.as_json)
+          script = "var form = arguments[0];\n" \
+                   "while (form.nodeName != \"FORM\" && form.parentNode) {\n" \
+                   "  form = form.parentNode;\n" \
+                   "}\n" \
+                   "if (!form) { throw Error('Unable to find containing form element'); }\n" \
+                   "if (!form.ownerDocument) { throw Error('Unable to find owning document'); }\n" \
+                   "var e = form.ownerDocument.createEvent('Event');\n" \
+                   "e.initEvent('submit', true, true);\n" \
+                   "if (form.dispatchEvent(e)) { HTMLFormElement.prototype.submit.call(form) }\n"
+
+          execute_script(script, Element::ELEMENT_KEY => element)
+        rescue Error::JavascriptError
+          raise Error::UnsupportedOperationError, "To submit an element, it must be nested inside a form element"
         end
 
         #

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -40,11 +40,46 @@ module Selenium
         expect { driver.find_element(id: 'other_contents').click }.to raise_error(Error::ElementClickInterceptedError)
       end
 
-      it 'should submit' do
-        driver.navigate.to url_for('formPage.html')
-        wait_for_element(id: 'submitButton')
-        expect { driver.find_element(id: 'submitButton').submit }.not_to raise_error
-        reset_driver!
+      describe '#submit' do
+        it 'valid submit button' do
+          driver.navigate.to url_for('formPage.html')
+          driver.find_element(id: 'submitButton').submit
+
+          expect(driver.title).to eq('We Arrive Here')
+        end
+
+        it 'any input element in form' do
+          driver.navigate.to url_for('formPage.html')
+          driver.find_element(id: 'checky').submit
+
+          expect(driver.title).to eq('We Arrive Here')
+        end
+
+        it 'any element in form' do
+          driver.navigate.to url_for('formPage.html')
+          driver.find_element(id: 'form > p').submit
+
+          expect(driver.title).to eq('We Arrive Here')
+        end
+
+        it 'button with id submit' do
+          driver.navigate.to url_for('formPage.html')
+          driver.find_element(id: 'submit').submit
+
+          expect(driver.title).to eq('We Arrive Here')
+        end
+
+        it 'button with name submit' do
+          driver.navigate.to url_for('formPage.html')
+          driver.find_element(name: 'submit').submit
+
+          expect(driver.title).to eq('We Arrive Here')
+        end
+
+        it 'errors with button outside form' do
+          driver.navigate.to url_for('formPage.html')
+          expect { driver.find_element(name: 'SearchableText').submit }.to raise_error(Error::UnsupportedOperationError)
+        end
       end
 
       it 'should send string keys' do


### PR DESCRIPTION
There was a bug that Java fixed that the other languages didn't.
I also noticed that Java does everything in one wire call instead of two like the other languages, so I updated the other languages to match Java.

Also, when Submit method failed in Java, it's returning an unhelpful JavaScriptError.
When submit method failed in the other languages, it returned an unhelpful NoSuchElementError which is confusing since the user didn't think they were searching for anything, and the locator is confusing unless they understand the implementation.

This PR uses: `To submit an element, it must be nested inside a form element`

Ruby & Java both have an `UnsupportedOperation` error, the other languages I went with the generic error.

If anyone has preferences for a different message or different exception class for any of these, let me know.

@harsha509 yeah, I made sure the existing submit test passed, but I didn't add any of the other tests.
