### PR TITLE
[java] Include JMX monitoring feature in the Grid local distributor

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/local/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/distributor/local/BUILD.bazel
@@ -29,6 +29,7 @@ java_library(
         "//java/src/org/openqa/selenium/grid/sessionqueue/remote",
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/remote",
+        "//java/src/org/openqa/selenium/grid/jmx",
         artifact("com.google.guava:guava"),
         artifact("dev.failsafe:failsafe"),
     ],

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -677,10 +677,18 @@ public class LocalDistributor extends Distributor implements Closeable {
   }
 
   @VisibleForTesting
-  @ManagedAttribute(name = "NodeCount")
-  public long getNodeCount() {
+  @ManagedAttribute(name = "NodeUpCount")
+  public long getUpNodeCount() {
     return model.getSnapshot().stream()
       .filter(nodeStatus -> nodeStatus.getAvailability().equals(UP))
+      .count();
+  }
+
+  @VisibleForTesting
+  @ManagedAttribute(name = "NodeDownCount")
+  public long getDownNodeCount() {
+    return model.getSnapshot().stream()
+      .filter(nodeStatus -> !nodeStatus.getAvailability().equals(UP))
       .count();
   }
 

--- a/java/test/org/openqa/selenium/grid/router/JmxTest.java
+++ b/java/test/org/openqa/selenium/grid/router/JmxTest.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.grid.router;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.junit.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
@@ -27,23 +26,23 @@ import org.openqa.selenium.events.local.GuavaEventBus;
 import org.openqa.selenium.grid.config.MapConfig;
 import org.openqa.selenium.grid.data.DefaultSlotMatcher;
 import org.openqa.selenium.grid.data.Session;
+import org.openqa.selenium.grid.distributor.Distributor;
+import org.openqa.selenium.grid.distributor.local.LocalDistributor;
+import org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector;
 import org.openqa.selenium.grid.jmx.JMXHelper;
 import org.openqa.selenium.grid.node.local.LocalNode;
 import org.openqa.selenium.grid.security.Secret;
 import org.openqa.selenium.grid.server.BaseServerOptions;
+import org.openqa.selenium.grid.sessionmap.local.LocalSessionMap;
 import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.config.NewSessionQueueOptions;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
+import org.openqa.selenium.grid.testing.PassthroughHttpClient;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.tracing.DefaultTestTracer;
 import org.openqa.selenium.remote.tracing.Tracer;
-
-import java.lang.management.ManagementFactory;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.time.Duration;
-import java.time.Instant;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -55,11 +54,19 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public class JmxTest {
+
+  private static final Logger LOG = Logger.getLogger(LocalNode.class.getName());
 
   private final Capabilities CAPS = new ImmutableCapabilities("browserName", "cheese");
   private final MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
@@ -221,6 +228,56 @@ public class JmxTest {
     } catch (AttributeNotFoundException e) {
       fail("Could not find the registered MBean's attribute");
     }
+  }
+
+  @Test
+  public void shouldBeAbleToMonitorHub() throws Exception {
+    ObjectName name = new ObjectName("org.seleniumhq.grid:type=Distributor,name=LocalDistributor");
+
+    new JMXHelper().unregister(name);
+
+    Tracer tracer = DefaultTestTracer.createTracer();
+    EventBus bus = new GuavaEventBus();
+    Secret secret = new Secret("cheese");
+    URI nodeUri = new URI("https://example.com:1234");
+
+    LocalNode localNode = LocalNode.builder(tracer, bus, nodeUri, nodeUri, secret)
+      .add(CAPS, new TestSessionFactory((id, caps) -> new Session(
+        id,
+        nodeUri,
+        new ImmutableCapabilities(),
+        caps,
+        Instant.now()))).build();
+
+    NewSessionQueue sessionQueue = new LocalNewSessionQueue(
+      tracer,
+      new DefaultSlotMatcher(),
+      Duration.ofSeconds(2),
+      Duration.ofSeconds(2),
+      secret);
+
+    Distributor distributor = new LocalDistributor(
+      tracer,
+      bus,
+      new PassthroughHttpClient.Factory(localNode),
+      new LocalSessionMap(tracer, bus),
+      sessionQueue,
+      new DefaultSlotSelector(),
+      secret,
+      Duration.ofMinutes(5),
+      false,
+      Duration.ofSeconds(5));
+
+    distributor.add(localNode);
+
+    MBeanInfo info = beanServer.getMBeanInfo(name);
+    assertThat(info).isNotNull();
+
+    String nodeCount = (String) beanServer.getAttribute(name, "NodeCount");
+
+    LOG.log(Debug.getDebugLogLevel(), "Node count=" + nodeCount);
+
+    assertThat(Integer.parseInt(nodeCount)).isEqualTo(1);
   }
 }
 

--- a/java/test/org/openqa/selenium/grid/router/JmxTest.java
+++ b/java/test/org/openqa/selenium/grid/router/JmxTest.java
@@ -273,11 +273,13 @@ public class JmxTest {
     MBeanInfo info = beanServer.getMBeanInfo(name);
     assertThat(info).isNotNull();
 
-    String nodeCount = (String) beanServer.getAttribute(name, "NodeCount");
+    String nodeUpCount = (String) beanServer.getAttribute(name, "NodeUpCount");
+    LOG.info("Node up count=" + nodeUpCount);
+    assertThat(Integer.parseInt(nodeUpCount)).isEqualTo(1);
 
-    LOG.log(Debug.getDebugLogLevel(), "Node count=" + nodeCount);
-
-    assertThat(Integer.parseInt(nodeCount)).isEqualTo(1);
+    String nodeDownCount = (String) beanServer.getAttribute(name, "NodeDownCount");
+    LOG.info("Node down count=" + nodeDownCount);
+    assertThat(Integer.parseInt(nodeDownCount)).isZero();
   }
 }
 

--- a/java/test/org/openqa/selenium/grid/router/JmxTest.java
+++ b/java/test/org/openqa/selenium/grid/router/JmxTest.java
@@ -39,7 +39,6 @@ import org.openqa.selenium.grid.sessionqueue.config.NewSessionQueueOptions;
 import org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue;
 import org.openqa.selenium.grid.testing.PassthroughHttpClient;
 import org.openqa.selenium.grid.testing.TestSessionFactory;
-import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.tracing.DefaultTestTracer;
 import org.openqa.selenium.remote.tracing.Tracer;
@@ -280,6 +279,15 @@ public class JmxTest {
     String nodeDownCount = (String) beanServer.getAttribute(name, "NodeDownCount");
     LOG.info("Node down count=" + nodeDownCount);
     assertThat(Integer.parseInt(nodeDownCount)).isZero();
+
+    String activeSlots = (String) beanServer.getAttribute(name, "ActiveSlots");
+    LOG.info("Active slots count=" + activeSlots);
+    assertThat(Integer.parseInt(activeSlots)).isZero();
+
+    String idleSlots = (String) beanServer.getAttribute(name, "IdleSlots");
+    LOG.info("Idle slots count=" + idleSlots);
+    assertThat(Integer.parseInt(idleSlots)).isEqualTo(1);
   }
+
 }
 


### PR DESCRIPTION
<!-- 
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.
-->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR implements issue #9794. It exposes metrics through JMX in the local distributor, namely:

- Number of up nodes
- Number of down nodes
- Number of active slots
- Number of idle slots

Regarding the session elapsed time (requested in the original feature proposal issue), that info should be available using GraphQL.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Grid 4 already implements JMX monitoring on the nodes. This PR allows to gather also other metrics in the local distributor.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
