### PR TITLE
[py] extend typing options for get_property()

### DIFF
--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -24,6 +24,7 @@ import warnings
 import zipfile
 from abc import ABCMeta
 from io import BytesIO
+from typing import Optional
 
 from selenium.common.exceptions import WebDriverException, JavascriptException
 from selenium.webdriver.common.by import By
@@ -108,7 +109,7 @@ class WebElement(BaseWebElement):
         """Clears the text if it's a text entry element."""
         self._execute(Command.CLEAR_ELEMENT)
 
-    def get_property(self, name) -> str | bool | WebElement | dict:
+    def get_property(self, name) -> Optional[str | int | bool | WebElement | dict | list]:
         """
         Gets the given property of the element.
 


### PR DESCRIPTION
fixes #10624

Extend list of types which can be returned byt `get_property()` method.

### Description

Current typing options does not cover all possible types returned by get_property()

For example

* `clientHeight` property is returned as int
* `fooBar` property is returned as NoneType
* `childNodes` property is returned as list


### Motivation and Context

Linters (like mypy or PyCharm) complains about `get_property()` usage when we expect one of mentioned data type.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
