### PR TITLE
[java] fix screen rotate error

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteRotatable.java
+++ b/java/src/org/openqa/selenium/remote/RemoteRotatable.java
@@ -51,7 +51,7 @@ class RemoteRotatable implements Rotatable {
 
   @Override
   public void rotate(DeviceRotation rotation) {
-    executeMethod.execute(DriverCommand.SET_SCREEN_ORIENTATION, rotation.parameters());
+    executeMethod.execute(DriverCommand.SET_SCREEN_ROTATION, rotation.parameters());
   }
 
   @Override


### PR DESCRIPTION
### Description
 The implemetion of rotate command may be wrong in java client, SET_SCREEN_ORIENTATION has beeing used twice, but SET_SCREEN_ROTATION has never been used.
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
