### PR TITLE
[py] overload log_path to accept kwargs for open

### DIFF
--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Tuple, Union
+from typing import List, Sequence, Union
 
 from selenium.webdriver.common import (service, utils)
 
@@ -28,7 +28,7 @@ class Service(service.Service):
 
     def __init__(self, executable_path: str = DEFAULT_EXECUTABLE_PATH,
                  port: int = 0, service_args: List[str] = None,
-                 log_path: Union[str, Tuple[str, str]] = "geckodriver.log", env: dict = None):
+                 log_path: Union[str, Sequence[str, str]] = "geckodriver.log", env: dict = None):
         """Creates a new instance of the GeckoDriver remote service proxy.
 
         GeckoDriver provides a HTTP interface speaking the W3C WebDriver
@@ -47,8 +47,11 @@ class Service(service.Service):
             in the services' environment.
         """
 
-        log_path, log_path_mode = (log_path[0], log_path[1]) if isinstance(log_path,Tuple) else (log_path, "a+")
-        log_file = open(log_path, log_path_mode, encoding='utf-8') if log_path else None
+        log_file = None
+        if log_path is not None:
+            open_args = (log_path, "a+", encoding='utf-8') if isinstance(log_path, str) else log_path
+            log_file = open(*open_args)
+
 
         super().__init__(executable_path, port=port, log_file=log_file, env=env)
         self.service_args = service_args or []

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List
+from typing import List, Tuple
 
 from selenium.webdriver.common import (service, utils)
 
@@ -28,7 +28,7 @@ class Service(service.Service):
 
     def __init__(self, executable_path: str = DEFAULT_EXECUTABLE_PATH,
                  port: int = 0, service_args: List[str] = None,
-                 log_path: str = "geckodriver.log", env: dict = None):
+                 log_path: Union[str, Tuple[str, str]] = "geckodriver.log", env: dict = None):
         """Creates a new instance of the GeckoDriver remote service proxy.
 
         GeckoDriver provides a HTTP interface speaking the W3C WebDriver
@@ -41,12 +41,14 @@ class Service(service.Service):
         :param service_args: Optional list of arguments to pass to the
             GeckoDriver binary.
         :param log_path: Optional path for the GeckoDriver to log to.
-            Defaults to _geckodriver.log_ in the current working directory.
+            Can also be called with (path_name, mode).
+            Defaults to _geckodriver.log_ in the current working directory and _a+_ respectively.
         :param env: Optional dictionary of output variables to expose
             in the services' environment.
-
         """
-        log_file = open(log_path, "a+", encoding='utf-8') if log_path else None
+
+        log_path, log_path_mode = (log_path[0], log_path[1]) if isinstance(log_path,Tuple) else (log_path, "a+")
+        log_file = open(log_path, log_path_mode, encoding='utf-8') if log_path else None
 
         super().__init__(executable_path, port=port, log_file=log_file, env=env)
         self.service_args = service_args or []

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from selenium.webdriver.common import (service, utils)
 

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Sequence, Union
+from typing import Any, List, Sequence, Union
 
 from selenium.webdriver.common import (service, utils)
 
@@ -28,7 +28,7 @@ class Service(service.Service):
 
     def __init__(self, executable_path: str = DEFAULT_EXECUTABLE_PATH,
                  port: int = 0, service_args: List[str] = None,
-                 log_path: Union[str, Sequence[str, str]] = "geckodriver.log", env: dict = None):
+                 log_path: Union[str, Sequence[Any], None] = "geckodriver.log", env: dict = None):
         """Creates a new instance of the GeckoDriver remote service proxy.
 
         GeckoDriver provides a HTTP interface speaking the W3C WebDriver
@@ -41,8 +41,9 @@ class Service(service.Service):
         :param service_args: Optional list of arguments to pass to the
             GeckoDriver binary.
         :param log_path: Optional path for the GeckoDriver to log to.
-            Can also be called with (path_name, mode).
+            Can also be called with a sequence of parameters which will be passed to open unmodified.
             Defaults to _geckodriver.log_ in the current working directory and _a+_ respectively.
+            Pass _None_ to disable logging
         :param env: Optional dictionary of output variables to expose
             in the services' environment.
         """

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -50,7 +50,7 @@ class Service(service.Service):
 
         log_file = None
         if log_path is not None:
-            open_args = {"file": log_path, "mode":"a+", "encoding":"utf-8"} if isinstance(log_path, str) else {"mode":"a+", "encoding":"utf-8"} | log_path
+            open_args = {"file": log_path, "mode":"a+", "encoding":"utf-8"} if isinstance(log_path, str) else {"file": "geckodriver.log", "mode":"a+", "encoding":"utf-8"} | log_path
             log_file = open(**open_args)
 
 

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, List, Sequence, Union
+from typing import Any, List, Mapping, Union
 
 from selenium.webdriver.common import (service, utils)
 
@@ -28,7 +28,7 @@ class Service(service.Service):
 
     def __init__(self, executable_path: str = DEFAULT_EXECUTABLE_PATH,
                  port: int = 0, service_args: List[str] = None,
-                 log_path: Union[str, Sequence[Any], None] = "geckodriver.log", env: dict = None):
+                 log_path: Union[str, Mapping[str,Any], None] = "geckodriver.log", env: dict = None):
         """Creates a new instance of the GeckoDriver remote service proxy.
 
         GeckoDriver provides a HTTP interface speaking the W3C WebDriver
@@ -41,8 +41,8 @@ class Service(service.Service):
         :param service_args: Optional list of arguments to pass to the
             GeckoDriver binary.
         :param log_path: Optional path for the GeckoDriver to log to.
-            Can also be called with a sequence of parameters which will be passed to open unmodified.
-            Defaults to _geckodriver.log_ in the current working directory and _a+_ respectively.
+            Can also be called with a mapping of parameters which will be expanded as kwargs to open.
+            Defaults to _geckodriver.log_ in the current working directory as file, _a+_ as mode and _utf-8_ as encoding.
             Pass _None_ to disable logging
         :param env: Optional dictionary of output variables to expose
             in the services' environment.
@@ -50,8 +50,8 @@ class Service(service.Service):
 
         log_file = None
         if log_path is not None:
-            open_args = (log_path, "a+", encoding='utf-8') if isinstance(log_path, str) else log_path
-            log_file = open(*open_args)
+            open_args = {"file": log_path, "mode":"a+", "encoding":"utf-8"} if isinstance(log_path, str) else log_path
+            log_file = open(**open_args)
 
 
         super().__init__(executable_path, port=port, log_file=log_file, env=env)

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -50,7 +50,7 @@ class Service(service.Service):
 
         log_file = None
         if log_path is not None:
-            open_args = {"file": log_path, "mode":"a+", "encoding":"utf-8"} if isinstance(log_path, str) else log_path
+            open_args = {"file": log_path, "mode":"a+", "encoding":"utf-8"} if isinstance(log_path, str) else {"mode":"a+", "encoding":"utf-8"} | log_path
             log_file = open(**open_args)
 
 

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from selenium.webdriver import Firefox
+from selenium.webdriver.firefox import Service
 
 
 def test_launch_and_close_browser(driver):
@@ -32,10 +33,17 @@ def test_we_can_launch_multiple_firefox_instances(capabilities):
 
 
 def test_launch_firefox_with_none_service_log_path(capabilities):
-    driver = Firefox(capabilities=capabilities, service_log_path=None)
+    service = Service(log_path=None)
+    driver = Firefox(capabilities=capabilities, service=service)
     driver.quit()
 
 
 def test_launch_firefox_with_empty_string_service_log_path(capabilities):
-    driver = Firefox(capabilities=capabilities, service_log_path="")
+    service = Service(log_path="")
+    driver = Firefox(capabilities=capabilities, service=service)
+    driver.quit()
+
+def test_launch_firefox_with_empty_string_service_log_path(capabilities):
+    service = Service(log_path=("geckodriver.log", "w"))
+    driver = Firefox(capabilities=capabilities, service=service)
     driver.quit()

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -43,6 +43,7 @@ def test_launch_firefox_with_service_log_path(log_path):
     else:
         assert driver.service.log_file.name == log_path["file"]
         assert driver.service.log_file.mode == log_path["mode"]
+        assert driver.service.log_file.encoding == log_path["encoding"] if "encoding" in log_path else "utf-8"
 
 
 def test_launch_firefox_with_service_default_log_path():

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -31,7 +31,7 @@ def test_we_can_launch_multiple_firefox_instances(capabilities):
     Firefox(capabilities=capabilities)
 
 
-@pytest.mark.parametrize('log_path', [None, "different_file.log", ("my_custom_pipe", "w"), ["windows.log", "a+", "-1", "cp1253"]])
+@pytest.mark.parametrize('log_path', [None, "different_file.log", ("my_custom_pipe", "w"), ["windows.log", "a+", -1, "cp1253"]])
 def test_launch_firefox_with_service_log_path(log_path):
     service = Service(log_path=log_path)
     driver = Firefox(service=service)

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -23,7 +23,6 @@ import pytest
 def test_launch_and_close_browser(driver):
     assert 'browserName' in driver.capabilities
 
-
 def test_we_can_launch_multiple_firefox_instances(capabilities):
     driver1 = Firefox(capabilities=capabilities)
     driver2 = Firefox(capabilities=capabilities)
@@ -32,9 +31,22 @@ def test_we_can_launch_multiple_firefox_instances(capabilities):
     driver2.quit()
     driver3.quit()
 
-
-@pytest.mark.parametrize('log_path', [None, "", ("geckodriver.log", "w")])
+@pytest.mark.parametrize('log_path', [None, "different_file.log", ("my_custom_pipe", "w"), ["windows.log", "a+", "-1", "cp1253"]])
 def test_launch_firefox_with_service_log_path(log_path):
     service = Service(log_path=log_path)
     driver = Firefox(capabilities=capabilities, service=service)
-    driver.quit()
+    if log_path is None:
+        assert driver.service.log_file is None
+    elif isinstance(log_path, str) :
+        assert driver.service.log_file.name == log_path
+        assert driver.service.log_file.mode == "a+"
+    else:
+        assert driver.service.log_file.name == log_path[0]
+        assert driver.service.log_file.mode == log_path[1]
+
+
+def test_launch_firefox_with_service_default_log_path():
+    service = Service()
+    driver = Firefox(capabilities=capabilities, service=service)
+    assert driver.service.log_file.mode == "a+"
+    assert driver.service.log_file.name == "geckodriver.log"

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -18,6 +18,7 @@
 from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.service import Service
 
+import pytest
 
 def test_launch_and_close_browser(driver):
     assert 'browserName' in driver.capabilities

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -31,7 +31,7 @@ def test_we_can_launch_multiple_firefox_instances(capabilities):
     Firefox(capabilities=capabilities)
 
 
-@pytest.mark.parametrize('log_path', [None, "different_file.log", ("my_custom_pipe", "w"), ["windows.log", "a+", -1, "cp1253"]])
+@pytest.mark.parametrize('log_path', [None, "different_file.log", {"file":"my_custom_pipe", "mode":"w"}, {"file":"windows.log", "mode":"a+", "encoding":"cp1253"}])
 def test_launch_firefox_with_service_log_path(log_path):
     service = Service(log_path=log_path)
     driver = Firefox(service=service)
@@ -41,8 +41,8 @@ def test_launch_firefox_with_service_log_path(log_path):
         assert driver.service.log_file.name == log_path
         assert driver.service.log_file.mode == "a+"
     else:
-        assert driver.service.log_file.name == log_path[0]
-        assert driver.service.log_file.mode == log_path[1]
+        assert driver.service.log_file.name == log_path["file"]
+        assert driver.service.log_file.mode == log_path["mode"]
 
 
 def test_launch_firefox_with_service_default_log_path():

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from selenium.webdriver import Firefox
-from selenium.webdriver.firefox import Service
+from selenium.webdriver.firefox.service import Service
 
 
 def test_launch_and_close_browser(driver):
@@ -32,18 +32,8 @@ def test_we_can_launch_multiple_firefox_instances(capabilities):
     driver3.quit()
 
 
-def test_launch_firefox_with_none_service_log_path(capabilities):
-    service = Service(log_path=None)
-    driver = Firefox(capabilities=capabilities, service=service)
-    driver.quit()
-
-
-def test_launch_firefox_with_empty_string_service_log_path(capabilities):
-    service = Service(log_path="")
-    driver = Firefox(capabilities=capabilities, service=service)
-    driver.quit()
-
-def test_launch_firefox_with_empty_string_service_log_path(capabilities):
-    service = Service(log_path=("geckodriver.log", "w"))
+@pytest.mark.parametrize('log_path', [None, "", ("geckodriver.log", "w")])
+def test_launch_firefox_with_service_log_path(log_path):
+    service = Service(log_path=log_path)
     driver = Firefox(capabilities=capabilities, service=service)
     driver.quit()

--- a/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
+++ b/py/test/selenium/webdriver/marionette/mn_launcher_tests.py
@@ -20,24 +20,24 @@ from selenium.webdriver.firefox.service import Service
 
 import pytest
 
+
 def test_launch_and_close_browser(driver):
     assert 'browserName' in driver.capabilities
 
+
 def test_we_can_launch_multiple_firefox_instances(capabilities):
-    driver1 = Firefox(capabilities=capabilities)
-    driver2 = Firefox(capabilities=capabilities)
-    driver3 = Firefox(capabilities=capabilities)
-    driver1.quit()
-    driver2.quit()
-    driver3.quit()
+    Firefox(capabilities=capabilities)
+    Firefox(capabilities=capabilities)
+    Firefox(capabilities=capabilities)
+
 
 @pytest.mark.parametrize('log_path', [None, "different_file.log", ("my_custom_pipe", "w"), ["windows.log", "a+", "-1", "cp1253"]])
 def test_launch_firefox_with_service_log_path(log_path):
     service = Service(log_path=log_path)
-    driver = Firefox(capabilities=capabilities, service=service)
+    driver = Firefox(service=service)
     if log_path is None:
         assert driver.service.log_file is None
-    elif isinstance(log_path, str) :
+    elif isinstance(log_path, str):
         assert driver.service.log_file.name == log_path
         assert driver.service.log_file.mode == "a+"
     else:
@@ -47,6 +47,6 @@ def test_launch_firefox_with_service_log_path(log_path):
 
 def test_launch_firefox_with_service_default_log_path():
     service = Service()
-    driver = Firefox(capabilities=capabilities, service=service)
+    driver = Firefox(service=service)
     assert driver.service.log_file.mode == "a+"
     assert driver.service.log_file.name == "geckodriver.log"


### PR DESCRIPTION
### Description

This change allows users to exactly specify how they want
to open their log file while falling back to the defaults for arguments that weren't specified.

### Motivation and Context

In [OpenWPM](https://github.com/openwpm/OpenWPM) we run multiple Firefox instances in parallel.
To integrate their output with our logging infrastructure we want them to write their logs into pipes, which we then read on the other side, enrich it with metadata and log it ourselves.

This feature is relevant to anyone who wants to interleave their own code's log lines with Selenium's or the browser's.

Fixes #10703

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.
