### PR TITLE
[py] Implement `/status` in the python bindings

### DIFF
--- a/py/selenium/webdriver/remote/command.py
+++ b/py/selenium/webdriver/remote/command.py
@@ -86,6 +86,7 @@ class Command:
     FULLSCREEN_WINDOW = "fullscreenWindow"
     MINIMIZE_WINDOW = "minimizeWindow"
     PRINT_PAGE = 'printPage'
+    W3C_STATUS = "status"
 
     # Alerts
     W3C_DISMISS_ALERT = "w3cDismissAlert"

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -309,6 +309,8 @@ class RemoteConnection:
                 ('POST', '/session/$sessionId/window/minimize'),
             Command.PRINT_PAGE:
                 ('POST', '/session/$sessionId/print'),
+            Command.W3C_STATUS:
+                ('GET', '/status'),
             Command.ADD_VIRTUAL_AUTHENTICATOR:
                 ('POST', '/session/$sessionId/webauthn/authenticator'),
             Command.REMOVE_VIRTUAL_AUTHENTICATOR:
@@ -337,8 +339,9 @@ class RemoteConnection:
          - params - A dictionary of named parameters to send with the command as
            its JSON payload.
         """
-        command_info = self._commands[command]
-        assert command_info is not None, 'Unrecognised command %s' % command
+        command_info = self._commands.get(command)
+        if command_info is None:
+            raise ValueError(f"Command: {command} is not a valid webdriver command.")
         path = string.Template(command_info[1]).substitute(params)
         if isinstance(params, dict) and 'sessionId' in params:
             del params['sessionId']

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -291,7 +291,7 @@ class WebDriver(BaseWebDriver):
         create new sessions.  If the status `ready` is True, it does not guarantee that attempts
         to create a new session would be successful.
         """
-        return self.execute(Command.W3C_STATUS).get("value")
+        return self.execute(Command.W3C_STATUS)["value"]
 
     @contextmanager
     def file_detector_context(self, file_detector_class, *args, **kwargs):

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -284,6 +284,19 @@ class WebDriver(BaseWebDriver):
     def __exit__(self, *args):
         self.quit()
 
+    @property
+    def status(self) -> Dict:
+        """
+        Retrieve status information about whether a remote end is in a state in which it can
+        create new sessions.  If the status `ready` is True, it does not guarantee that attempts
+        to create a new session would be successful.
+        """
+        response = self.execute(Command.W3C_STATUS).get("value")
+        if response is None:
+            # Todo: Should this raise? should it return something instead?
+            raise ValueError(f"Unable to retrieve /status information for the driver.")
+        return response
+
     @contextmanager
     def file_detector_context(self, file_detector_class, *args, **kwargs):
         """

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -291,11 +291,7 @@ class WebDriver(BaseWebDriver):
         create new sessions.  If the status `ready` is True, it does not guarantee that attempts
         to create a new session would be successful.
         """
-        response = self.execute(Command.W3C_STATUS).get("value")
-        if response is None:
-            # Todo: Should this raise? should it return something instead?
-            raise ValueError(f"Unable to retrieve /status information for the driver.")
-        return response
+        return self.execute(Command.W3C_STATUS).get("value")
 
     @contextmanager
     def file_detector_context(self, file_detector_class, *args, **kwargs):

--- a/py/test/selenium/webdriver/common/status_tests.py
+++ b/py/test/selenium/webdriver/common/status_tests.py
@@ -1,0 +1,5 @@
+
+# Todo: Actual tests
+
+def test_can_retrieve_webdriver_status(driver, pages):
+    assert all(key in driver.status for key in ("ready", "message"))


### PR DESCRIPTION
A draft implementation of calling out to the w3c `/status` endpoint.

Todo:
 - Error handling
 - More test(s)
