### PR TITLE
[py]: Enable co-operative multi inheritance with `super()` throughout

### DIFF
--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -20,7 +20,7 @@ from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 class ChromiumRemoteConnection(RemoteConnection):
     def __init__(self, remote_server_addr, vendor_prefix, browser_name, keep_alive=True, ignore_proxy=False):
-        RemoteConnection.__init__(self, remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
         self.browser_name = browser_name
         self._commands["launchApp"] = ('POST', '/session/$sessionId/chromium/launch_app')
         self._commands["setPermissions"] = ('POST', '/session/$sessionId/permissions')

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -42,7 +42,7 @@ class ChromiumService(service.Service):
         if not start_error_message:
             raise AttributeError("start_error_message should not be empty")
 
-        service.Service.__init__(self, executable_path, port=port, env=env, start_error_message=start_error_message)
+        super().__init__(executable_path, port=port, env=env, start_error_message=start_error_message)
 
     def command_line_args(self) -> List[str]:
         return ["--port=%d" % self.port] + self.service_args

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -89,8 +89,7 @@ class ChromiumDriver(RemoteWebDriver):
         self.service.start()
 
         try:
-            RemoteWebDriver.__init__(
-                self,
+            super().__init__(
                 command_executor=ChromiumRemoteConnection(
                     remote_server_addr=self.service.service_url,
                     browser_name=browser_name, vendor_prefix=vendor_prefix,
@@ -231,7 +230,7 @@ class ChromiumDriver(RemoteWebDriver):
         that is started when starting the ChromiumDriver
         """
         try:
-            RemoteWebDriver.quit(self)
+            super().quit()
         except Exception:
             # We don't care about the message because something probably has gone wrong
             pass

--- a/py/selenium/webdriver/firefox/extension_connection.py
+++ b/py/selenium/webdriver/firefox/extension_connection.py
@@ -51,7 +51,7 @@ class ExtensionConnection(RemoteConnection):
 
         self.binary.launch_browser(self.profile, timeout=timeout)
         _URL = "http://%s:%d/hub" % (HOST, PORT)
-        super().__init__(URL, keep_alive=True)
+        super().__init__(_URL, keep_alive=True)
 
     def quit(self, sessionId=None):
         self.execute(Command.QUIT, {'sessionId': sessionId})

--- a/py/selenium/webdriver/firefox/extension_connection.py
+++ b/py/selenium/webdriver/firefox/extension_connection.py
@@ -51,8 +51,7 @@ class ExtensionConnection(RemoteConnection):
 
         self.binary.launch_browser(self.profile, timeout=timeout)
         _URL = "http://%s:%d/hub" % (HOST, PORT)
-        RemoteConnection.__init__(
-            self, _URL, keep_alive=True)
+        super().__init__(URL, keep_alive=True)
 
     def quit(self, sessionId=None):
         self.execute(Command.QUIT, {'sessionId': sessionId})

--- a/py/selenium/webdriver/firefox/remote_connection.py
+++ b/py/selenium/webdriver/firefox/remote_connection.py
@@ -24,7 +24,7 @@ class FirefoxRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.FIREFOX['browserName']
 
     def __init__(self, remote_server_addr, keep_alive=True, ignore_proxy=False):
-        RemoteConnection.__init__(self, remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
 
         self._commands["GET_CONTEXT"] = ('GET', '/session/$sessionId/moz/context')
         self._commands["SET_CONTEXT"] = ("POST", "/session/$sessionId/moz/context")

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -48,8 +48,7 @@ class Service(service.Service):
         """
         log_file = open(log_path, "a+") if log_path else None
 
-        service.Service.__init__(
-            self, executable_path, port=port, log_file=log_file, env=env)
+        super().__init__(executable_path, port=port, log_file=log_file, env=env)
         self.service_args = service_args or []
 
         # Set a port for CDP

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -174,8 +174,7 @@ class WebDriver(RemoteWebDriver):
         executor = FirefoxRemoteConnection(
             remote_server_addr=self.service.service_url,
             ignore_proxy=options._ignore_local_proxy)
-        RemoteWebDriver.__init__(
-            self,
+        super().__init__(
             command_executor=executor,
             options=options,
             keep_alive=True)
@@ -185,7 +184,7 @@ class WebDriver(RemoteWebDriver):
     def quit(self) -> None:
         """Quits the driver and close every associated window."""
         try:
-            RemoteWebDriver.quit(self)
+            super().quit()
         except Exception:
             # We don't care about the message because something probably has gone wrong
             pass

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -50,7 +50,7 @@ class Service(service.Service):
         if log_file:
             self.service_args.append("--log-file=%s" % log_file)
 
-        service.Service.__init__(self, executable_path, port=port,
+        super().__init__(executable_path, port=port,
                                  start_error_message="Please download from https://www.selenium.dev/downloads/ and read up at https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver")
 
     def command_line_args(self) -> List[str]:

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -19,7 +19,6 @@ from typing import List
 
 from selenium.webdriver.common import service
 
-
 DEFAULT_EXECUTABLE_PATH = 'IEDriverServer.exe'
 
 
@@ -51,7 +50,7 @@ class Service(service.Service):
             self.service_args.append("--log-file=%s" % log_file)
 
         super().__init__(executable_path, port=port,
-                                 start_error_message="Please download from https://www.selenium.dev/downloads/ and read up at https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver")
+                         start_error_message="Please download from https://www.selenium.dev/downloads/ and read up at https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver")
 
     def command_line_args(self) -> List[str]:
         return ["--port=%d" % self.port] + self.service_args

--- a/py/selenium/webdriver/ie/webdriver.py
+++ b/py/selenium/webdriver/ie/webdriver.py
@@ -107,15 +107,14 @@ class WebDriver(RemoteWebDriver):
 
         self.iedriver.start()
 
-        RemoteWebDriver.__init__(
-            self,
+        super().__init__(
             command_executor=self.iedriver.service_url,
             options=options,
             keep_alive=keep_alive)
         self._is_remote = False
 
     def quit(self) -> None:
-        RemoteWebDriver.quit(self)
+        super().quit()
         self.iedriver.stop()
 
     def create_options(self) -> Options:

--- a/py/selenium/webdriver/safari/remote_connection.py
+++ b/py/selenium/webdriver/safari/remote_connection.py
@@ -24,8 +24,7 @@ class SafariRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.SAFARI['browserName']
 
     def __init__(self, remote_server_addr, keep_alive=True, ignore_proxy=False):
-        RemoteConnection.__init__(self, remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
-
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
         self._commands["GET_PERMISSIONS"] = ('GET', '/session/$sessionId/apple/permissions')
         self._commands["SET_PERMISSIONS"] = ('POST', '/session/$sessionId/apple/permissions')
         self._commands["ATTACH_DEBUGGER"] = ('POST', '/session/$sessionId/apple/attach_debugger')

--- a/py/selenium/webdriver/safari/service.py
+++ b/py/selenium/webdriver/safari/service.py
@@ -55,7 +55,7 @@ class Service(service.Service):
         log = PIPE
         if quiet:
             log = open(os.devnull, 'w')
-        service.Service.__init__(self, executable_path, port, log)
+        super().__init__(executable_path, port, log)
 
     def command_line_args(self):
         return ["-p", "%s" % self.port] + self.service_args

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -90,8 +90,7 @@ class WebDriver(RemoteWebDriver):
         executor = SafariRemoteConnection(remote_server_addr=self.service.service_url,
                                           keep_alive=keep_alive)
 
-        RemoteWebDriver.__init__(
-            self,
+        super().__init__(
             command_executor=executor,
             options=options,
             desired_capabilities=desired_capabilities)
@@ -104,7 +103,7 @@ class WebDriver(RemoteWebDriver):
         that is started when starting the SafariDriver
         """
         try:
-            RemoteWebDriver.quit(self)
+            super().quit()
         except http_client.BadStatusLine:
             pass
         finally:

--- a/py/selenium/webdriver/webkitgtk/service.py
+++ b/py/selenium/webdriver/webkitgtk/service.py
@@ -37,7 +37,7 @@ class Service(service.Service):
          - log_path : Path for the WebKitGTKDriver service to log to
         """
         log_file = open(log_path, "wb") if log_path else None
-        service.Service.__init__(self, executable_path, port, log_file)
+        super().__init__(executable_path, port, log_file)
 
     def command_line_args(self):
         return ["-p", "%d" % self.port]

--- a/py/selenium/webdriver/webkitgtk/webdriver.py
+++ b/py/selenium/webdriver/webkitgtk/webdriver.py
@@ -56,8 +56,7 @@ class WebDriver(RemoteWebDriver):
         self.service = Service(executable_path, port=port, log_path=service_log_path)
         self.service.start()
 
-        RemoteWebDriver.__init__(
-            self,
+        super().__init__(
             command_executor=self.service.service_url,
             desired_capabilities=desired_capabilities,
             keep_alive=keep_alive)
@@ -69,7 +68,7 @@ class WebDriver(RemoteWebDriver):
         that is started when starting the WebKitGTKDriver
         """
         try:
-            RemoteWebDriver.quit(self)
+            super().quit()
         except http_client.BadStatusLine:
             pass
         finally:

--- a/py/selenium/webdriver/wpewebkit/service.py
+++ b/py/selenium/webdriver/wpewebkit/service.py
@@ -37,7 +37,7 @@ class Service(service.Service):
          - log_path : Path for the WPEWebKitDriver service to log to
         """
         log_file = open(log_path, "wb") if log_path else None
-        service.Service.__init__(self, executable_path, port, log_file)
+        super().__init__(executable_path, port, log_file)
 
     def command_line_args(self):
         return ["-p", "%d" % self.port]

--- a/py/selenium/webdriver/wpewebkit/webdriver.py
+++ b/py/selenium/webdriver/wpewebkit/webdriver.py
@@ -52,8 +52,7 @@ class WebDriver(RemoteWebDriver):
         self.service = Service(executable_path, port=port, log_path=service_log_path)
         self.service.start()
 
-        RemoteWebDriver.__init__(
-            self,
+        super().__init__(
             command_executor=self.service.service_url,
             desired_capabilities=desired_capabilities)
         self._is_remote = False
@@ -64,7 +63,7 @@ class WebDriver(RemoteWebDriver):
         that is started when starting the WPEWebKitDriver
         """
         try:
-            RemoteWebDriver.quit(self)
+            super().quit()
         except http_client.BadStatusLine:
             pass
         finally:


### PR DESCRIPTION
I updated most of the code to be python3.7+ syntactically, a few outliers referencing their parent class explicitly by name. This patch addresses all cases of that throughout the code.  This will allow co-operative multi inheritance (leaving mro to python rather than strictly naming the class) should we/a user wish to benefit from it and make things syntactically tidier.

closes #10769