### PR TITLE
[java] Restore Closure Java classes required for JavaScript build

### DIFF
--- a/java/test/org/openqa/selenium/javascript/BUILD.bazel
+++ b/java/test/org/openqa/selenium/javascript/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//java:defs.bzl", "java_library")
+
+java_library(
+    name = "javascript",
+    testonly = 1,
+    srcs = glob(["*.java"]),
+    visibility = ["//javascript:__subpackages__"],
+    deps = [
+        "//java/src/org/openqa/selenium:core",
+        "//java/test/org/openqa/selenium/build",
+        "//java/test/org/openqa/selenium/environment",
+        "//java/test/org/openqa/selenium/testing:test-base",
+        "//java/test/org/openqa/selenium/testing/drivers",
+        artifact("com.google.guava:guava"),
+        artifact("junit:junit"),
+        artifact("org.assertj:assertj-core"),
+    ],
+)

--- a/java/test/org/openqa/selenium/javascript/ClosureTestStatement.java
+++ b/java/test/org/openqa/selenium/javascript/ClosureTestStatement.java
@@ -1,0 +1,122 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.javascript;
+
+import static org.junit.Assert.fail;
+import static org.openqa.selenium.testing.TestUtilities.isOnTravis;
+
+import com.google.common.base.Stopwatch;
+
+import org.junit.runners.model.Statement;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+public class ClosureTestStatement extends Statement {
+
+  private static final Logger LOG = Logger.getLogger(ClosureTestStatement.class.getName());
+
+  private final Supplier<WebDriver> driverSupplier;
+  private final String testPath;
+  private final Function<String, URL> filePathToUrlFn;
+  private final long timeoutSeconds;
+
+  public ClosureTestStatement(
+      Supplier<WebDriver> driverSupplier,
+      String testPath,
+      Function<String, URL> filePathToUrlFn,
+      long timeoutSeconds) {
+    this.driverSupplier = driverSupplier;
+    this.testPath = testPath;
+    this.filePathToUrlFn = filePathToUrlFn;
+    this.timeoutSeconds = Math.max(0, timeoutSeconds);
+  }
+
+  @Override
+  public void evaluate() throws Throwable {
+    URL testUrl = filePathToUrlFn.apply(testPath);
+    LOG.info("Running: " + testUrl);
+
+    Stopwatch stopwatch = Stopwatch.createStarted();
+
+    WebDriver driver = driverSupplier.get();
+
+    if (!isOnTravis()) {
+      // Attempt to make the window as big as possible.
+      try {
+        driver.manage().window().maximize();
+      } catch (RuntimeException ignored) {
+        // We tried.
+      }
+    }
+
+    JavascriptExecutor executor = (JavascriptExecutor) driver;
+    // Avoid Safari JS leak between tests.
+    executor.executeScript("if (window && window.top) window.top.G_testRunner = null");
+
+    try {
+      driver.get(testUrl.toString());
+    } catch (WebDriverException e) {
+      fail("Test failed to load: " + e.getMessage());
+    }
+
+    while (!getBoolean(executor, Query.IS_FINISHED)) {
+      long elapsedTime = stopwatch.elapsed(TimeUnit.SECONDS);
+      if (timeoutSeconds > 0 && elapsedTime > timeoutSeconds) {
+        throw new JavaScriptAssertionError("Tests timed out after " + elapsedTime + " s. \nCaptured Errors: " +
+                                           ((JavascriptExecutor) driver).executeScript("return window.errors;")
+                                           + "\nPageSource: " + driver.getPageSource() + "\nScreenshot: " +
+                                           ((TakesScreenshot)driver).getScreenshotAs(OutputType.BASE64));
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+    }
+
+    if (!getBoolean(executor, Query.IS_SUCCESS)) {
+      String report = getString(executor, Query.GET_REPORT);
+      throw new JavaScriptAssertionError(report);
+    }
+  }
+
+  private boolean getBoolean(JavascriptExecutor executor, Query query) {
+    return (Boolean) executor.executeScript(query.script);
+  }
+
+  private String getString(JavascriptExecutor executor, Query query) {
+    return (String) executor.executeScript(query.script);
+  }
+
+  private enum Query {
+    IS_FINISHED("return !!tr && tr.isFinished();"),
+    IS_SUCCESS("return !!tr && tr.isSuccess();"),
+    GET_REPORT("return tr.getReport(true);");
+
+    private final String script;
+
+    Query(String script) {
+      this.script = "var tr = window.top.G_testRunner;" + script;
+    }
+  }
+}

--- a/java/test/org/openqa/selenium/javascript/ClosureTestSuite.java
+++ b/java/test/org/openqa/selenium/javascript/ClosureTestSuite.java
@@ -1,0 +1,34 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.javascript;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+
+@RunWith(JavaScriptTestSuite.class)
+public class ClosureTestSuite {
+
+  @BeforeClass
+  public static void checkShouldRun() {
+    assumeThat(Boolean.getBoolean("selenium.skiptest")).isFalse();
+  }
+
+}

--- a/java/test/org/openqa/selenium/javascript/JavaScriptAssertionError.java
+++ b/java/test/org/openqa/selenium/javascript/JavaScriptAssertionError.java
@@ -1,0 +1,35 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.javascript;
+
+class JavaScriptAssertionError extends AssertionError {
+
+  public JavaScriptAssertionError(String message) {
+    super(message);
+  }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;  // No java stack traces.
+  }
+
+  @Override
+  public void setStackTrace(StackTraceElement[] stackTraceElements) {
+    // No java stack traces.
+  }
+}

--- a/java/test/org/openqa/selenium/javascript/JavaScriptTestSuite.java
+++ b/java/test/org/openqa/selenium/javascript/JavaScriptTestSuite.java
@@ -1,0 +1,190 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.javascript;
+
+import static java.util.stream.Collectors.toList;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.environment.GlobalTestEnvironment;
+import org.openqa.selenium.environment.InProcessTestEnvironment;
+import org.openqa.selenium.environment.TestEnvironment;
+import org.openqa.selenium.environment.webserver.AppServer;
+import org.openqa.selenium.build.InProject;
+import org.openqa.selenium.testing.drivers.WebDriverBuilder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * JUnit4 test runner for Closure-based JavaScript tests.
+ */
+public class JavaScriptTestSuite extends ParentRunner<Runner> {
+
+  private final List<Runner> children;
+  private final Supplier<WebDriver> driverSupplier;
+
+  public JavaScriptTestSuite(Class<?> testClass) throws InitializationError, IOException {
+    super(testClass);
+
+    long timeout = Math.max(0, Long.getLong("js.test.timeout", 0));
+
+    driverSupplier = new DriverSupplier();
+
+    children = createChildren(driverSupplier, timeout);
+  }
+
+  private static boolean isBazel() {
+    return InProject.findRunfilesRoot() != null;
+  }
+
+  private static List<Runner> createChildren(
+      final Supplier<WebDriver> driverSupplier, final long timeout) throws IOException {
+    final Path baseDir = InProject.findProjectRoot();
+    final Function<String, URL> pathToUrlFn = s -> {
+      AppServer appServer = GlobalTestEnvironment.get().getAppServer();
+      try {
+        String url = "/" + s;
+        if (isBazel() && !url.startsWith("/common/generated/")) {
+          url = "/filez/selenium" + url;
+        }
+        return new URL(appServer.whereIs(url));
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    List<Path> tests = TestFileLocator.findTestFiles();
+    return tests.stream()
+        .map(file -> {
+          final String path = TestFileLocator.getTestFilePath(baseDir, file);
+          Description description = Description.createSuiteDescription(
+              path.replaceAll(".html$", ""));
+
+          Statement testStatement = new ClosureTestStatement(
+              driverSupplier, path, pathToUrlFn, timeout);
+          return new StatementRunner(testStatement, description);
+        })
+        .collect(toList());
+  }
+
+  @Override
+  protected List<Runner> getChildren() {
+    return children;
+  }
+
+  @Override
+  protected Description describeChild(Runner child) {
+    return child.getDescription();
+  }
+
+  @Override
+  protected void runChild(Runner child, RunNotifier notifier) {
+    child.run(notifier);
+  }
+
+  @Override
+  protected Statement classBlock(RunNotifier notifier) {
+    final Statement suite = super.classBlock(notifier);
+
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        TestEnvironment testEnvironment = null;
+        try {
+          testEnvironment = GlobalTestEnvironment.getOrCreate(InProcessTestEnvironment::new);
+          suite.evaluate();
+        } finally {
+          if (testEnvironment != null) {
+            testEnvironment.stop();
+          }
+          if (driverSupplier instanceof Closeable) {
+            ((Closeable) driverSupplier).close();
+          }
+        }
+      }
+    };
+  }
+
+  private static class StatementRunner extends Runner {
+
+    private final Description description;
+    private final Statement testStatement;
+
+    private StatementRunner(Statement testStatement, Description description) {
+      this.testStatement = testStatement;
+      this.description = description;
+    }
+
+    @Override
+    public Description getDescription() {
+      return description;
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+      notifier.fireTestStarted(description);
+      try {
+        testStatement.evaluate();
+      } catch (Throwable throwable) {
+        Failure failure = new Failure(description, throwable);
+        notifier.fireTestFailure(failure);
+      } finally {
+        notifier.fireTestFinished(description);
+      }
+    }
+  }
+
+  private static class DriverSupplier implements Supplier<WebDriver>, Closeable {
+
+    private volatile WebDriver driver;
+
+    @Override
+    public WebDriver get() {
+      if (driver != null) {
+        return driver;
+      }
+
+      synchronized (this) {
+        if (driver == null) {
+          driver = new WebDriverBuilder().get();
+        }
+      }
+
+      return driver;
+    }
+
+    public void close() {
+      if (driver != null) {
+        driver.quit();
+      }
+    }
+  }
+}

--- a/java/test/org/openqa/selenium/javascript/TestFileLocator.java
+++ b/java/test/org/openqa/selenium/javascript/TestFileLocator.java
@@ -1,0 +1,110 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.javascript;
+
+import static java.lang.System.getProperty;
+import static java.util.Collections.emptySet;
+
+import com.google.common.base.Splitter;
+
+import org.openqa.selenium.build.InProject;
+import org.openqa.selenium.internal.Require;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+/**
+ * Builder for test suites that run JavaScript tests.
+ */
+class TestFileLocator {
+
+  private static final String TEST_DIRECTORY_PROPERTY = "js.test.dir";
+  private static final String TEST_EXCLUDES_PROPERTY = "js.test.excludes";
+
+  public static List<Path> findTestFiles() throws IOException {
+    Path directory = getTestDirectory();
+    Set<Path> excludedFiles = getExcludedFiles(directory);
+    return findTestFiles(directory, excludedFiles);
+  }
+
+  private static List<Path> findTestFiles(Path directory, Set<Path> excludedFiles)
+    throws IOException {
+    return Files.find(
+      directory,
+      Integer.MAX_VALUE,
+      (path, basicFileAttributes) -> {
+        String name = path.getFileName().toString();
+        return name.endsWith("_test.html");
+        // TODO: revive support for _test.js files.
+//        Path sibling = path.resolveSibling(name.replace(".js", ".html"));
+//        return name.endsWith("_test.html")
+//               || (name.endsWith("_test.js") && !Files.exists(sibling));
+      })
+      .filter(path -> !excludedFiles.contains(path))
+      .collect(Collectors.toList());
+  }
+
+  private static Path getTestDirectory() {
+    String testDirName = Require.state("Test directory", getProperty(TEST_DIRECTORY_PROPERTY)).nonNull(
+                                 "You must specify the test directory with the %s system property",
+                                 TEST_DIRECTORY_PROPERTY);
+    
+    Path runfiles = InProject.findRunfilesRoot();
+    Path testDir;
+    if (runfiles != null) {
+      // Running with bazel.
+      testDir = runfiles.resolve("selenium").resolve(testDirName);
+    } else {
+      // Legacy.
+      testDir = InProject.locate(testDirName);
+    }
+
+    Require.state("Test directory", testDir.toFile()).isDirectory();
+
+    return testDir;
+  }
+
+  private static Set<Path> getExcludedFiles(final Path testDirectory) {
+    String excludedFiles = getProperty(TEST_EXCLUDES_PROPERTY);
+    if (excludedFiles == null) {
+      return emptySet();
+    }
+
+    Iterable<String> splitExcludes = Splitter.on(',').omitEmptyStrings().split(excludedFiles);
+
+    return StreamSupport.stream(splitExcludes.spliterator(), false)
+        .map(testDirectory::resolve).collect(Collectors.toSet());
+  }
+
+  public static String getTestFilePath(Path baseDir, Path testFile) {
+    String path = testFile.toAbsolutePath().toString()
+        .replace(baseDir.toAbsolutePath().toString() + File.separator, "")
+        .replace(File.separator, "/");
+    if (path.endsWith(".js")) {
+      path = "common/generated/" + path;
+    }
+    return path;
+  }
+}


### PR DESCRIPTION
### Description
PR #10778 deleted by mistake a Java package required by the JavaScript build, and as a result, the JavaScript build started to fail. This PR restores these files.

### Motivation and Context
Migration of Java tests to JUnit 5 (issue #10196).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
