### PR TITLE
[java] Allow linting only on the default test

### DIFF
--- a/java/private/selenium_test.bzl
+++ b/java/private/selenium_test.bzl
@@ -84,7 +84,8 @@ def selenium_test(name, test_class, size = "medium", browsers = BROWSERS.keys(),
             test_class = test_class,
             size = size,
             jvm_flags = BROWSERS[browser]["jvm_flags"] + jvm_flags,
-            tags = BROWSERS[browser]["tags"] + tags,
+            # Only allow linting on the default test
+            tags = BROWSERS[browser]["tags"] + tags + ([] if test == name else ["no-lint"]),
             data = BROWSERS[browser]["data"] + data,
             **stripped_args
         )


### PR DESCRIPTION
### Description
After migrating Selenium tests to JUnit 5, the rule `java_junit5_test` delegates to `contrib_rules_jvm`’s `java_test`, and that adds lint tests for every target. We want to add one set of lint tests, since the rest are going to be identical. Therefore, we tag all but one test with `no-lint`.

### Motivation and Context
Improve the performance of spotbug tests (linting) after the migration to Selenium Java tests to JUnit 5 (issue #10196).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
