### PR TITLE
[JS] Updated jsdoc for move action

### DIFF
--- a/javascript/node/selenium-webdriver/lib/input.js
+++ b/javascript/node/selenium-webdriver/lib/input.js
@@ -857,9 +857,9 @@ class Actions {
   /**
    * Inserts an action for moving the mouse `x` and `y` pixels relative to the
    * specified `origin`. The `origin` may be defined as the mouse's
-   * {@linkplain ./input.Origin.POINTER current position}, the
+   * {@linkplain ./input.Origin.POINTER current position}, the top-left corner of the
    * {@linkplain ./input.Origin.VIEWPORT viewport}, or the center of a specific
-   * {@linkplain ./webdriver.WebElement WebElement}.
+   * {@linkplain ./webdriver.WebElement WebElement}. Default is top left corner of the view-port if origin is not specified
    *
    * You may adjust how long the remote end should take, in milliseconds, to
    * perform the move using the `duration` parameter (defaults to 100 ms).


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

This PR improves the selenium JS documentation regarding move action. The current documentation doesnt give clear indication on what is the default behavior if no origin is specified and when view port is specified as origin. Users might mistaken that for view port also the default behavior is to move to center of the view port (same like webelement) but the implementation is like moving to top-left corner for all other origins other than webelement.

<!--- Describe your changes in detail -->

### Motivation and Context

To improve clarity on move action

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
