### PR TITLE
correctly checks the driver supports DevTools

### DIFF
--- a/dotnet/src/webdriver/JavaScriptEngine.cs
+++ b/dotnet/src/webdriver/JavaScriptEngine.cs
@@ -54,7 +54,7 @@ namespace OpenQA.Selenium
             this.session = new Lazy<DevToolsSession>(() =>
             {
                 IDevTools devToolsDriver = driver as IDevTools;
-                if (session == null)
+                if (devToolsDriver == null)
                 {
                     throw new WebDriverException("Driver must implement IDevTools to use these features");
                 }


### PR DESCRIPTION
When using a driver like EventFiringWebDriver as a parameter for
JavaScriptEngine and trying to use StartEventMonitoring the constructor
will throw a NullReferenceException. This is caused by casting the
driver to IDevTools using "as" which will return null if the casting
failed, and incorrectly checking the field "session" instead
of "devToolsDriver" for null value.

fixes #10776

### Description
This commit will correctly check in the JavascriptEngine constructor that the driver passed as a parameter supports DevTools

### Motivation and Context
Previously the JavascriptEngine constructor checked the field session was not null, instead of the field devToolsDriver which would cause a NullReferenceException when using an incompatible driver like the EventFiringWebDriver. Now it correctly check the field devToolsDriver and, if the casting of the driver to IDevTools returns null, the JavascriptEngine constructor will correctly throw a WebDriverException with the message "Driver must implement IDevTools to use these features"

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
