### PR TITLE
Remove require of websocket in selenium-devtools gem

### DIFF
--- a/rb/lib/selenium/devtools.rb
+++ b/rb/lib/selenium/devtools.rb
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'websocket'
-
 module Selenium
   module DevTools
     class << self

--- a/rb/selenium-devtools.gemspec
+++ b/rb/selenium-devtools.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |s|
   ] + Dir['lib/selenium/devtools/**/*']
 
   s.require_paths = ["lib"]
+
+  s.add_runtime_dependency 'selenium-webdriver', '~> 4.2'
 end


### PR DESCRIPTION

### Description
In cd69898 the dependency of websocket was removed from selenium-devtools gem. When this gem is required it raises an error of: `cannot load such file -- websocket (LoadError)`

We experienced this error because we updated selenium-devtools and hadn't updated selenium-webdriver. We found the problem was resolved by updating selenium-webdriver as that has a websocket dependency cd69898

### Motivation and Context

Resolve an error when requiring the selenium-devtools gem

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.