### PR TITLE
update docs for PointerActions#move_to

### DIFF
--- a/rb/lib/selenium/webdriver/common/interactions/pointer_actions.rb
+++ b/rb/lib/selenium/webdriver/common/interactions/pointer_actions.rb
@@ -68,9 +68,8 @@ module Selenium
       end
 
       #
-      # Moves the pointer to the middle of the given element.
-      # its location is calculated using getBoundingClientRect.
-      # Then the pointer is moved to optional offset coordinates from the element.
+      # Moves the pointer to the in-view center point of the given element.
+      # Then the pointer is moved to optional offset coordinates.
       #
       # The element is not scrolled into view.
       # MoveTargetOutOfBoundsError will be raised if element with offset is outside the viewport
@@ -88,10 +87,10 @@ module Selenium
       #   driver.action.move_to(el, 100, 100).perform
       #
       # @param [Selenium::WebDriver::Element] element to move to.
-      # @param [Integer] right_by Optional offset from the top-left corner. A negative value means
-      #   coordinates to the left of the element.
-      # @param [Integer] down_by Optional offset from the top-left corner. A negative value means
-      #   coordinates above the element.
+      # @param [Integer] right_by Optional offset from the in-view center of the
+      #   element. A negative value means coordinates to the left of the center.
+      # @param [Integer] down_by Optional offset from the in-view center of the
+      #   element. A negative value means coordinates to the top of the center.
       # @param [Symbol || String] device optional name of the PointerInput device to move.
       # @return [ActionBuilder] A self reference.
       #


### PR DESCRIPTION
`move_to` has been changed to start from the center of the element rather than the top-left corner.

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.