### PR TITLE
[py] build(setup.py): Add `project_urls` for PyPI

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -35,7 +35,7 @@ setup_args = {
     'project_urls': {
         'Bug Tracker': 'https://github.com/SeleniumHQ/selenium/issues',
         'Changes': 'https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES',
-        'Documentation': 'https://seleniumhq.github.io/selenium/docs/api/py/api.html',
+        'Documentation': 'https://www.selenium.dev/documentation/overview/',
         'Source Code': 'https://github.com/SeleniumHQ/selenium/tree/trunk/py',
     },
     'python_requires': '~=3.7',

--- a/py/setup.py
+++ b/py/setup.py
@@ -32,6 +32,12 @@ setup_args = {
     'description': 'Python bindings for Selenium',
     'long_description': open(join(abspath(dirname(__file__)), "README.rst")).read(),
     'url': 'https://github.com/SeleniumHQ/selenium/',
+    'project_urls': {
+        'Bug Tracker': 'https://github.com/SeleniumHQ/selenium/issues',
+        'Changes': 'https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES',
+        'Documentation': 'https://seleniumhq.github.io/selenium/docs/api/py/api.html',
+        'Source Code': 'https://github.com/SeleniumHQ/selenium/tree/trunk/py',
+    },
     'python_requires': '~=3.7',
     'classifiers': ['Development Status :: 5 - Production/Stable',
                     'Intended Audience :: Developers',


### PR DESCRIPTION
### Description

Show Project URLs to [Selenium's PyPI page](https://pypi.org/project/selenium/) via [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to _setup.py_

![image](https://user-images.githubusercontent.com/26336/179226514-48d45405-744b-4f7d-b569-227e14a16fc2.png)

### Motivation and Context

It takes a few clicks to get around to the docs and source code.  This makes it possible launch all of them via PyPI. 

It also is helpful to anyone else that ingests the metadata from setup.py / PyPI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
