### PR TITLE
[py] Normalized finding by class (not via CSS selector)

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -848,7 +848,7 @@ class WebDriver(BaseWebDriver):
             value = '[id="%s"]' % value
         elif by == By.CLASS_NAME:
             by = By.CSS_SELECTOR
-            value = ".%s" % value
+            value = '[class="%s"]' % value
         elif by == By.NAME:
             by = By.CSS_SELECTOR
             value = '[name="%s"]' % value


### PR DESCRIPTION
### Description
⠀Good day!
⠀I use Selenium in several of my projects and I often encounter classes consisting of several words separated by spaces. When I do a search on such classes I get nothing, because now the class search is done through the CSS selector. So I applied the proposed commit to my local libraries and it works logically and as it should work.

### Motivation and Context
⠀When developer want to find an element by class name, which can be several words separated by spaces, he want find it by class name, not CSS selector. If he want find element by CSS selector he'll just do it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
