### PR TITLE
[ruby] fix: setting w3c: false throws error

### DIFF
--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -49,6 +49,7 @@ module Selenium
         #
 
         def create_session(capabilities)
+          check_chrome_w3c_false(capabilities)
           response = execute(:new_session, {}, prepare_capabilities_payload(capabilities))
 
           @session_id = response['sessionId']
@@ -665,6 +666,27 @@ module Selenium
           string = "\\#{UNICODE_CODE_POINT + Integer(string[0])} #{string[1..]}" if string[0]&.match?(/[[:digit:]]/)
 
           string
+        end
+
+        #
+        # Checks if w3c key is set to false and raises error for the same.
+        #
+        def check_chrome_w3c_false(capabilities)
+          return unless capabilities['browserName'] == 'chrome' && capabilities.key?('goog:chromeOptions')
+
+          capability = capabilities['goog:chromeOptions']
+          w3c = true
+
+          if capability.instance_of?(Hash)
+            raw_w3c = capability['w3c']
+            w3c = raw_w3c.nil? || raw_w3c
+          end
+
+          return if w3c
+
+          raise Error::WebDriverError, "Setting 'w3c: false' inside 'goog:chromeOptions' is not "\
+                                       "allowed. \nPlease update to W3C Syntax: https://www"\
+                                       ".selenium.dev/blog/2022/legacy-protocol-support/"
         end
       end # Bridge
     end # Remote

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -684,8 +684,8 @@ module Selenium
 
           return if w3c
 
-          raise Error::WebDriverError, "Setting 'w3c: false' inside 'goog:chromeOptions' is not "\
-                                       "allowed. \nPlease update to W3C Syntax: https://www"\
+          raise Error::WebDriverError, "Setting 'w3c: false' is not allowed.\n"\
+                                       "Please update to W3C Syntax: https://www"\
                                        ".selenium.dev/blog/2022/legacy-protocol-support/"
         end
       end # Bridge

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -40,12 +40,8 @@ module Selenium
       end
 
       it 'should raise error when w3c is false', exclusive: {browser: %i[chrome]} do
-        capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-          'goog:chromeOptions': {
-            w3c: false
-          }
-        )
-        expect { create_driver!(capabilities: capabilities) }.to raise_error(Error::WebDriverError)
+        options = Selenium::WebDriver::Chrome::Options.new(w3c: false)
+        expect { Selenium::WebDriver.for :chrome, capabilities: options }.to raise_error(Error::WebDriverError)
       end
 
       it 'should get driver status' do

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -39,6 +39,15 @@ module Selenium
         end
       end
 
+      it 'should raise error when w3c is false', exclusive: {browser: %i[chrome]} do
+        capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+          'goog:chromeOptions': {
+            w3c: false
+          }
+        )
+        expect { create_driver!(capabilities: capabilities) }.to raise_error(Error::WebDriverError)
+      end
+
       it 'should get driver status' do
         status = driver.status
         expect(status).to include('ready', 'message')


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
`w3c: false` does not work in ruby binding. Setting this key as false will throw an error. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/SeleniumHQ/selenium/issues/10448#issuecomment-1149870933


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
