### PR TITLE
[dotnet] Handle the case when http response content type might be null

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -282,7 +282,7 @@ namespace OpenQA.Selenium.Remote
                 {
                     HttpResponseInfo httpResponseInfo = new HttpResponseInfo();
                     httpResponseInfo.Body = await responseMessage.Content.ReadAsStringAsync();
-                    httpResponseInfo.ContentType = responseMessage.Content.Headers.ContentType.ToString();
+                    httpResponseInfo.ContentType = responseMessage.Content.Headers.ContentType?.ToString();
                     httpResponseInfo.StatusCode = responseMessage.StatusCode;
 
                     return httpResponseInfo;


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I have verified the fix locally. Now I am getting proper error message when trying to start a new remote browser session:
```
OpenQA.Selenium.WebDriverException : The newSession command returned an unexpected error. Unauthorized
```

Instead of 
```
System.NullReferenceException : Object reference not set to an instance of an object.

HttpCommandExecutor.MakeHttpRequest(HttpRequestInfo requestInfo)
HttpCommandExecutor.Execute(Command commandToExecute)
AppiumCommandExecutor.Execute(Command commandToExecute)
WebDriver.Execute(String driverCommandToExecute, Dictionary`2 parameters)
AppiumDriver.Execute(String driverCommandToExecute, Dictionary`2 parameters)
WebDriver.StartSession(ICapabilities desiredCapabilities)
WebDriver.ctor(ICommandExecutor executor, ICapabilities capabilities)
AppiumDriver.ctor(ICommandExecutor commandExecutor, ICapabilities appiumOptions)
AppiumDriver.ctor(Uri remoteAddress, ICapabilities appiumOptions, TimeSpan commandTimeout)
AppiumDriver.ctor(Uri remoteAddress, ICapabilities appiumOptions)
AndroidDriver.ctor(Uri remoteAddress, DriverOptions driverOptions)
```