### PR TITLE
[ruby] Support for sending firefox addon directory as temporary in remote

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/features.rb
+++ b/rb/lib/selenium/webdriver/firefox/features.rb
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'zip'
+
 module Selenium
   module WebDriver
     module Firefox
@@ -35,7 +37,23 @@ module Selenium
         end
 
         def install_addon(path, temporary)
-          addon = File.open(path, 'rb') { |crx_file| Base64.strict_encode64 crx_file.read }
+          if File.directory?(path)
+            zip = "#{path}.zip"
+            # Delete zip file if it already exists
+            File.delete(zip) if File.file?(zip)
+
+            Zip::File.open(zip, Zip::File::CREATE) do |z_file|
+              Dir[File.join(path, "**", "**")].each do |file|
+                z_file.add(file.sub("#{path}/", ""), file)
+              end
+            end
+
+            addon = File.open(zip, 'rb') { |crx_file| Base64.strict_encode64 crx_file.read }
+            # Delete the zip file
+            File.delete(zip)
+          else
+            addon = File.open(path, 'rb') { |crx_file| Base64.strict_encode64 crx_file.read }
+          end
 
           payload = {addon: addon}
           payload[:temporary] = temporary unless temporary.nil?

--- a/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
@@ -24,6 +24,7 @@ module Selenium
     module Firefox
       describe Driver, exclusive: {browser: :firefox} do
         let(:extension) { '../../../../../../third_party/firebug/favourite_colour-1.1-an+fx.xpi' }
+        let(:extension_dir) { '../../../../../../common/extensions/webextensions-selenium-example' }
 
         describe '#print_options' do
           let(:magic_number) { 'JVBER' }
@@ -72,6 +73,11 @@ module Selenium
 
           it 'with temporary as parameter' do
             ext = File.expand_path(extension, __dir__)
+            driver.install_addon(ext, true)
+          end
+
+          it 'with path as unpacked directory' do
+            ext = File.expand_path(extension_dir, __dir__)
             driver.install_addon(ext, true)
           end
         end


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Modified the `install_addon()` to send firefox addon directory as temporary in remote session.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- to implement ruby solution for https://github.com/SeleniumHQ/selenium/issues/10265
- References made : https://github.com/SeleniumHQ/selenium/issues/8357#issuecomment-643047209

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
