### PR TITLE
Ie find edge

### DIFF
--- a/cpp/iedriver/BrowserFactory.cpp
+++ b/cpp/iedriver/BrowserFactory.cpp
@@ -43,6 +43,7 @@
 #define IE_SERVER_CHILD_WINDOW_CLASS "Internet Explorer_Server"
 #define ANDIE_FRAME_WINDOW_CLASS "Chrome_WidgetWin_1"
 
+#define EDGE_REGISTRY_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\msedge.exe"
 #define IE_CLSID_REGISTRY_KEY L"SOFTWARE\\Classes\\InternetExplorer.Application\\CLSID"
 #define IE_SECURITY_ZONES_REGISTRY_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones"
 #define IE_TABPROCGROWTH_REGISTRY_KEY L"Software\\Microsoft\\Internet Explorer\\Main"
@@ -94,7 +95,8 @@ namespace webdriver {
 
 BrowserFactory::BrowserFactory(void) {
   // Must be done in the constructor. Do not move to Initialize().
-  this->GetExecutableLocation();
+  this->GetEdgeExecutableLocation();
+  this->GetIEExecutableLocation();
   this->GetIEVersion();
   this->oleacc_instance_handle_ = NULL;
   this->edge_ie_mode_ = false;
@@ -240,7 +242,7 @@ bool BrowserFactory::IsIELaunchURLAvailable() {
     FARPROC proc_address = 0;
     proc_address = ::GetProcAddress(library_handle, IELAUNCHURL_FUNCTION_NAME);
     if (proc_address == NULL || proc_address == 0) {
-      LOGERR(DEBUG) << "Unable to get address of " << IELAUNCHURL_FUNCTION_NAME 
+      LOGERR(DEBUG) << "Unable to get address of " << IELAUNCHURL_FUNCTION_NAME
                     << " method in " << IEFRAME_LIBRARY_NAME;
     } else {
       api_is_available = true;
@@ -385,7 +387,10 @@ void BrowserFactory::LaunchEdgeInIEMode(PROCESS_INFORMATION* proc_info,
 
   std::wstring executable_and_url = this->edge_executable_location_;
   if (executable_and_url == L"") {
-    executable_and_url = L"msedge.exe"; // Assume it's on the path if it's not passed
+    executable_and_url = this->edge_executable_located_location_; // Locate Edge via Registry if not passed
+    if (executable_and_url == L"") {
+      executable_and_url = L"msedge.exe"; // Assume it's on the path
+    }
   }
 
   // These flags force Edge into a mode where it will only run MSHTML
@@ -511,7 +516,7 @@ bool BrowserFactory::AttachToBrowser(ProcessWindowInfo* process_window_info,
       zoom_level = this->GetBrowserZoomLevel(process_window_info->pBrowser);
     }
     if (zoom_level != 100) {
-      std::string zoom_level_error = 
+      std::string zoom_level_error =
           StringUtilities::Format(ZOOM_SETTING_ERROR_MESSAGE, zoom_level);
       LOG(WARN) << zoom_level_error;
       *error_message = zoom_level_error;
@@ -664,7 +669,7 @@ bool BrowserFactory::AttachToBrowserUsingShellWindows(
         hr = shell_browser->GetWindow(&hwnd);
         if (SUCCEEDED(hr)) {
           ::EnumChildWindows(hwnd,
-                             &BrowserFactory::FindChildWindowForProcess, 
+                             &BrowserFactory::FindChildWindowForProcess,
                              reinterpret_cast<LPARAM>(process_window_info));
           if (process_window_info->hwndBrowser != NULL) {
             LOG(DEBUG) << "Found window handle "
@@ -876,7 +881,7 @@ IWebBrowser2* BrowserFactory::CreateBrowser(bool is_protected_mode) {
                 << "be successfully created.";
   }
   clock_t timeout = clock() + (45 * CLOCKS_PER_SEC);
-  while (FAILED(hr) && 
+  while (FAILED(hr) &&
          HRESULT_CODE(hr) == ERROR_SHUTDOWN_IS_SCHEDULED &&
          clock() < timeout) {
     ::Sleep(500);
@@ -925,7 +930,7 @@ bool BrowserFactory::CreateLowIntegrityLevelToken(HANDLE* process_token_handle,
     }
    }
 
-  if (result) {     
+  if (result) {
     result = ::ConvertStringSidToSid(SDDL_ML_LOW, sid);
     if (result) {
       tml.Label.Attributes = SE_GROUP_INTEGRITY;
@@ -969,13 +974,13 @@ void BrowserFactory::InvokeClearCacheUtility(bool use_low_integrity_level) {
   PSID    sid = NULL;
 
   bool can_create_process = true;
-  if (!use_low_integrity_level || 
+  if (!use_low_integrity_level ||
       this->CreateLowIntegrityLevelToken(&process_token, &mic_token, &sid)) {
     if (0 != system_path_size &&
         system_path_size <= static_cast<int>(system_path_buffer.size())) {
       if (::PathCombine(&rundll_exe_path_buffer[0],
                         &system_path_buffer[0],
-                        RUNDLL_EXE_NAME) && 
+                        RUNDLL_EXE_NAME) &&
           ::PathCombine(&inetcpl_path_buffer[0],
                         &system_path_buffer[0],
                         INTERNET_CONTROL_PANEL_APPLET_NAME)) {
@@ -1202,14 +1207,14 @@ BOOL CALLBACK BrowserFactory::FindDialogWindowForProcess(HWND hwnd, LPARAM arg) 
     // No match found. Skip
     return TRUE;
   }
-  
-  if (strcmp(ALERT_WINDOW_CLASS, name) != 0 && 
+
+  if (strcmp(ALERT_WINDOW_CLASS, name) != 0 &&
       strcmp(HTML_DIALOG_WINDOW_CLASS, name) != 0 &&
       strcmp(SECURITY_DIALOG_WINDOW_CLASS, name) != 0) {
     return TRUE;
   } else {
-    // If the window style has the WS_DISABLED bit set or the 
-    // WS_VISIBLE bit unset, it can't be handled via the UI, 
+    // If the window style has the WS_DISABLED bit set or the
+    // WS_VISIBLE bit unset, it can't be handled via the UI,
     // and must not be a visible dialog. Furthermore, if the
     // window style does not display a caption bar, it's not a
     // dialog displayed by the browser, but likely by an add-on
@@ -1235,15 +1240,15 @@ BOOL CALLBACK BrowserFactory::FindDialogWindowForProcess(HWND hwnd, LPARAM arg) 
   return TRUE;
 }
 
-void BrowserFactory::GetExecutableLocation() {
-  LOG(TRACE) << "Entering BrowserFactory::GetExecutableLocation";
+void BrowserFactory::GetIEExecutableLocation() {
+  LOG(TRACE) << "Entering BrowserFactory::GetIEExecutableLocation";
 
   std::wstring class_id;
   if (RegistryUtilities::GetRegistryValue(HKEY_LOCAL_MACHINE,
                                           IE_CLSID_REGISTRY_KEY,
                                           L"",
                                           &class_id)) {
-    std::wstring location_key = L"SOFTWARE\\Classes\\CLSID\\" + 
+    std::wstring location_key = L"SOFTWARE\\Classes\\CLSID\\" +
                                 class_id +
                                 L"\\LocalServer32";
     std::wstring executable_location;
@@ -1284,11 +1289,40 @@ void BrowserFactory::GetExecutableLocation() {
   }
 }
 
+void BrowserFactory::GetEdgeExecutableLocation() {
+   LOG(TRACE) << "Entering BrowserFactory::GetEdgeExecutableLocation";
+ std::wstring edge_executable_location;
+  if (RegistryUtilities::GetRegistryValue(HKEY_LOCAL_MACHINE,
+                                          EDGE_REGISTRY_KEY,
+                                          L"",
+                                          true,
+                                          &edge_executable_location)) {
+    // If the executable location in the registry has an environment
+    // variable in it, expand the environment variable to an absolute
+    // path.
+    DWORD expanded_location_size = ::ExpandEnvironmentStrings(edge_executable_location.c_str(), NULL, 0);
+    std::vector<wchar_t> expanded_location(expanded_location_size);
+    ::ExpandEnvironmentStrings(edge_executable_location.c_str(), &expanded_location[0], expanded_location_size);
+    edge_executable_location = &expanded_location[0];
+    this->edge_executable_located_location_ = edge_executable_location;
+    size_t arg_start_pos = edge_executable_location.find(L" -");
+    if (arg_start_pos != std::string::npos) {
+      this->edge_executable_located_location_ = edge_executable_location.substr(0, arg_start_pos);
+    }
+    if (this->edge_executable_located_location_.substr(0, 1) == L"\"") {
+      this->edge_executable_located_location_.erase(0, 1);
+      this->edge_executable_located_location_.erase(this->edge_executable_located_location_.size() - 1, 1);
+    }
+  } else {
+    LOG(WARN) << "Unable to get Edge executable location from registry";
+  }
+}
+
 void BrowserFactory::GetIEVersion() {
   LOG(TRACE) << "Entering BrowserFactory::GetIEVersion";
 
   std::string ie_version = FileUtilities::GetFileVersion(this->ie_executable_location_);
-  
+
   if (ie_version.size() == 0) {
     // 64-bit Windows 8 has a bug where it does not return the executable location properly
     this->ie_major_version_ = -1;
@@ -1446,7 +1480,7 @@ bool BrowserFactory::IsWindowsVersionOrGreater(unsigned short major_version,
                             VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
                             dwlConditionMask) != FALSE;
 }
- 
+
 bool BrowserFactory::IsWindowsVistaOrGreater() {
   return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_VISTA), LOBYTE(_WIN32_WINNT_VISTA), 0);
 }
@@ -1457,7 +1491,7 @@ bool BrowserFactory::IsEdgeMode() const {
 
 // delete a folder recursively
 int BrowserFactory::DeleteDirectory(const std::wstring &dir_name) {
-  WIN32_FIND_DATA file_info;      
+  WIN32_FIND_DATA file_info;
 
   std::wstring file_pattern = dir_name + L"\\*.*";
   HANDLE file_handle = ::FindFirstFile(file_pattern.c_str(), &file_info);

--- a/cpp/iedriver/BrowserFactory.h
+++ b/cpp/iedriver/BrowserFactory.h
@@ -101,7 +101,8 @@ class BrowserFactory {
       ProcessWindowInfo* process_window_info,
       std::string* error_message);
 
-  void GetExecutableLocation(void);
+  void GetEdgeExecutableLocation(void);
+  void GetIEExecutableLocation(void);
   void GetIEVersion(void);
   bool ProtectedModeSettingsAreValid(void);
   int GetZoneProtectedModeSetting(const HKEY key_handle,
@@ -131,6 +132,7 @@ class BrowserFactory {
 
   int ie_major_version_;
   std::wstring ie_executable_location_;
+  std::wstring edge_executable_located_location_;
 
   bool edge_ie_mode_;
   std::wstring edge_executable_location_;

--- a/cpp/iedriver/BrowserFactory.h
+++ b/cpp/iedriver/BrowserFactory.h
@@ -133,6 +133,7 @@ class BrowserFactory {
   int ie_major_version_;
   std::wstring ie_executable_location_;
   std::wstring edge_executable_located_location_;
+  bool ie_redirects_edge_;
 
   bool edge_ie_mode_;
   std::wstring edge_executable_location_;


### PR DESCRIPTION
Full disclosure: I don't know C++
Narrator: This did not stop him from "writing" C++ code

fwiw, I think we should get rid of all standalone IE Support in future versions of IE Driver and *only support IE Mode in Edge; I'm not sure the best way to go about this.

In the meantime, if a user specifies to use Edge, the driver should attempt to automatically locate it.

Further, if `iexplore.exe` is set to automatically redirect to Edge (i.e., IE is effectively not installed), then it should default to using Edge.

This will allow a user to get an Edge session without adding any additional flags on Windows 11 and any Win 10 box that no longer uses IE.

I've built this and tested that it starts the session the way I expect, but I'm still hitting https://github.com/MicrosoftEdge/EdgeWebDriver/issues/38 so I can't do a lot of testing right now.

@jimevans or @bwalderman if you have any feedback for me, please let me know.