### PR TITLE
[ruby] Remove unnecessary and bug-creating code in platform.rb.

### DIFF
--- a/rb/lib/selenium/webdriver/common/platform.rb
+++ b/rb/lib/selenium/webdriver/common/platform.rb
@@ -105,7 +105,6 @@ module Selenium
 
       def cygwin?
         RUBY_PLATFORM.include?('cygwin')
-        !Regexp.last_match.nil?
       end
 
       def null_device


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
When calling selenium's `cygwin?` method from ruby on cygwin, regexp match results was returning different judgment result from the actual one, so it was removed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I ran it from cygwin, but it didn't return the correct results, so I looked into it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
