### PR TITLE
[java] Ensure event firing decorator can accept a target class

### DIFF
--- a/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
+++ b/java/src/org/openqa/selenium/support/events/EventFiringDecorator.java
@@ -165,6 +165,11 @@ public class EventFiringDecorator<T extends WebDriver> extends WebDriverDecorato
     this.listeners = Arrays.asList(listeners);
   }
 
+  public EventFiringDecorator(Class<T> targetClass, WebDriverListener... listeners) {
+    super(targetClass);
+    this.listeners = Arrays.asList(listeners);
+  }
+
   @Override
   public void beforeCall(Decorated<?> target, Method method, Object[] args) {
     listeners.forEach(listener -> fireBeforeEvents(listener, target, method, args));

--- a/java/test/org/openqa/selenium/support/BUILD.bazel
+++ b/java/test/org/openqa/selenium/support/BUILD.bazel
@@ -7,6 +7,7 @@ java_test_suite(
     srcs = glob(["*Test.java"]),
     deps = [
         "//java/src/org/openqa/selenium:core",
+        "//java/src/org/openqa/selenium/remote",
         "//java/src/org/openqa/selenium/support",
         "//java/test/org/openqa/selenium/support/ui:clock",
         "//java/test/org/openqa/selenium/testing:annotations",

--- a/java/test/org/openqa/selenium/support/events/BUILD.bazel
+++ b/java/test/org/openqa/selenium/support/events/BUILD.bazel
@@ -7,6 +7,7 @@ java_test_suite(
     srcs = glob(["*.java"]),
     deps = [
         "//java/src/org/openqa/selenium:core",
+        "//java/src/org/openqa/selenium/remote",
         "//java/src/org/openqa/selenium/support",
         "//java/test/org/openqa/selenium:helpers",
         "//java/test/org/openqa/selenium/testing:annotations",

--- a/java/test/org/openqa/selenium/support/events/EventFiringDecoratorTest.java
+++ b/java/test/org/openqa/selenium/support/events/EventFiringDecoratorTest.java
@@ -29,10 +29,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -81,7 +84,7 @@ public class EventFiringDecoratorTest {
         acc.append("afterGet\n");
       }
     };
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     decorated.get("http://example.com/");
 
@@ -134,7 +137,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     decorated.findElement(By.id("test")).click();
 
@@ -183,7 +186,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     decorated.navigate().back();
 
@@ -231,7 +234,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     decorated.switchTo().alert().dismiss();
 
@@ -273,7 +276,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     ((JavascriptExecutor) decorated).executeScript("sum", "2", "2");
 
@@ -297,7 +300,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     assertThatNoException().isThrownBy(decorated::getWindowHandle);
   }
@@ -327,7 +330,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     assertThatNoException().isThrownBy(decorated::getWindowHandle);
   }
@@ -342,7 +345,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     assertThatNoException().isThrownBy(decorated::getWindowHandle);
   }
@@ -358,7 +361,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     assertThatNoException().isThrownBy(decorated::getWindowHandle);
   }
@@ -373,7 +376,7 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
 
     assertThatNoException().isThrownBy(decorated::getWindowHandle);
   }
@@ -389,7 +392,46 @@ public class EventFiringDecoratorTest {
       }
     };
 
-    WebDriver decorated = new EventFiringDecorator(listener).decorate(driver);
+    WebDriver decorated = new EventFiringDecorator<>(listener).decorate(driver);
+
+    assertThatExceptionOfType(WebDriverException.class)
+      .isThrownBy(decorated::getWindowHandle);
+  }
+
+  @Test
+  public void shouldBeAbleToDecorateAChildClassOfWebDriver() {
+    RemoteWebDriver driver = mock(RemoteWebDriver.class);
+    when(driver.getCapabilities()).thenReturn(new ImmutableCapabilities("browserName", "firefox"));
+
+    WebDriverListener listener = new WebDriverListener() {
+      @Override
+      public void onError(Object target, Method method, Object[] args, InvocationTargetException e) {
+        throw new RuntimeException("listener");
+      }
+    };
+
+    RemoteWebDriver decorated =
+      new EventFiringDecorator<>(RemoteWebDriver.class, listener).decorate(driver);
+
+    Capabilities caps = decorated.getCapabilities();
+
+    assertThat(caps.getBrowserName()).isEqualTo("firefox");
+  }
+
+  @Test
+  public void shouldBeAbleToCallDecoratedMethodForDecoratedChildClass() {
+    RemoteWebDriver driver = mock(RemoteWebDriver.class);
+    when(driver.getWindowHandle()).thenThrow(new WebDriverException());
+
+    WebDriverListener listener = new WebDriverListener() {
+      @Override
+      public void onError(Object target, Method method, Object[] args, InvocationTargetException e) {
+        throw new RuntimeException("listener");
+      }
+    };
+
+    RemoteWebDriver decorated =
+      new EventFiringDecorator<>(RemoteWebDriver.class, listener).decorate(driver);
 
     assertThatExceptionOfType(WebDriverException.class)
       .isThrownBy(decorated::getWindowHandle);

--- a/java/test/org/openqa/selenium/support/events/EventFiringDecoratorTest.java
+++ b/java/test/org/openqa/selenium/support/events/EventFiringDecoratorTest.java
@@ -399,7 +399,7 @@ public class EventFiringDecoratorTest {
   }
 
   @Test
-  public void shouldBeAbleToDecorateAChildClassOfWebDriver() {
+  void shouldBeAbleToDecorateAChildClassOfWebDriver() {
     RemoteWebDriver driver = mock(RemoteWebDriver.class);
     when(driver.getCapabilities()).thenReturn(new ImmutableCapabilities("browserName", "firefox"));
 
@@ -419,7 +419,7 @@ public class EventFiringDecoratorTest {
   }
 
   @Test
-  public void shouldBeAbleToCallDecoratedMethodForDecoratedChildClass() {
+  void shouldBeAbleToCallDecoratedMethodForDecoratedChildClass() {
     RemoteWebDriver driver = mock(RemoteWebDriver.class);
     when(driver.getWindowHandle()).thenThrow(new WebDriverException());
 


### PR DESCRIPTION
Related to #1694

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Ensure event firing decorator can accept a target class

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
EventFiringDecorator extends the WebDriverDecorator. However, changes made in https://github.com/SeleniumHQ/selenium/pull/10737 needed to be extended to EventFiringDecorator to solve the class cast exception faced when using EventFiringDecorator. The changes in the PR help fix it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
