### PR TITLE
[py] fix file upload in remote_connection.py for python >= 3.9

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -222,7 +222,7 @@ class RemoteConnection:
             Command.GET_ELEMENT_TEXT: ('GET', '/session/$sessionId/element/$id/text'),
             Command.SEND_KEYS_TO_ELEMENT:
                 ('POST', '/session/$sessionId/element/$id/value'),
-            Command.UPLOAD_FILE: ('POST', "/session/$sessionId/se/file"),
+            Command.UPLOAD_FILE: ('POST', "/session/$sessionId/file"),
             Command.GET_ELEMENT_TAG_NAME:
                 ('GET', '/session/$sessionId/element/$id/name'),
             Command.IS_ELEMENT_SELECTED:


### PR DESCRIPTION
Stack Overflow issue: https://stackoverflow.com/questions/70503219/python-selenium-webdrive-cannot-upload-file-with-unknown-command-exception

Cannot upload files using any version of python >= 3.9

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
