### PR TITLE
[java] Fix test ignorance custom logic

### DIFF
--- a/java/test/org/openqa/selenium/CookieImplementationTest.java
+++ b/java/test/org/openqa/selenium/CookieImplementationTest.java
@@ -203,10 +203,7 @@ public class CookieImplementationTest extends JupiterTestBase {
 
   @SwitchToTopAfterTest
   @Test
-  @NotYetImplemented(value = CHROME, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=3153")
-  @NotYetImplemented(value = EDGE, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=3153")
   @Ignore(SAFARI)
-  @NotYetImplemented(value = FIREFOX, reason = "https://github.com/mozilla/geckodriver/issues/1104")
   public void testGetCookiesInAFrame() {
     driver.get(domainHelper.getUrlForFirstValidHostname("/common/animals"));
     Cookie cookie1 = new Cookie.Builder("fish", "cod").path("/common/animals").build();
@@ -424,7 +421,6 @@ public class CookieImplementationTest extends JupiterTestBase {
 
   @Test
   @Ignore(SAFARI)
-  @NotYetImplemented(CHROME)
   public void canHandleHttpOnlyCookie() {
     Cookie addedCookie =
       new Cookie.Builder("fish", "cod")

--- a/java/test/org/openqa/selenium/testing/IgnoreComparator.java
+++ b/java/test/org/openqa/selenium/testing/IgnoreComparator.java
@@ -45,7 +45,7 @@ public class IgnoreComparator {
     return ignore != null && shouldIgnore(Stream.of(ignore));
   }
 
-  private boolean shouldIgnore(Stream<Ignore> ignoreList) {
+  public boolean shouldIgnore(Stream<Ignore> ignoreList) {
     return ignoreList.anyMatch(
       driver -> (ignored.contains(driver.value()) || driver.value() == Browser.ALL)
                 && ((!driver.travis() || TestUtilities.isOnTravis())

--- a/java/test/org/openqa/selenium/testing/TestIgnorance.java
+++ b/java/test/org/openqa/selenium/testing/TestIgnorance.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.testing.drivers.Browser;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -72,10 +73,14 @@ public class TestIgnorance {
     Optional<Method> testMethod = extensionContext.getTestMethod();
 
     // Ignored because of Selenium's custom extensions
-    boolean ignored = findAnnotation(testClass, IgnoreList.class).isPresent() ||
-      !findRepeatableAnnotations(testClass, Ignore.class).isEmpty() ||
-      findAnnotation(testMethod, IgnoreList.class).isPresent() ||
-      !findRepeatableAnnotations(testMethod, Ignore.class).isEmpty();
+    Optional<IgnoreList> ignoreListClass = findAnnotation(testClass, IgnoreList.class);
+    List<Ignore> ignoreClass = findRepeatableAnnotations(testClass, Ignore.class);
+    Optional<IgnoreList> ignoreListMethod = findAnnotation(testMethod, IgnoreList.class);
+    List<Ignore> ignoreMethod = findRepeatableAnnotations(testMethod, Ignore.class);
+    boolean ignored = (ignoreListClass.isPresent() && ignoreComparator.shouldIgnore(ignoreListClass.get())) ||
+      (!ignoreClass.isEmpty() && ignoreComparator.shouldIgnore(ignoreClass.stream())) ||
+      (ignoreListMethod.isPresent() && ignoreComparator.shouldIgnore(ignoreListMethod.get())) ||
+      (!ignoreMethod.isEmpty() && ignoreComparator.shouldIgnore(ignoreMethod.stream()));
 
     // Ignored because of Jupiter's @Disabled
     ignored |= findAnnotation(testClass, Disabled.class).isPresent();


### PR DESCRIPTION
### Description
This PR fix the logic for ignoring test based on the custom annotation `@Ignore`.

### Motivation and Context
In the migration from JUnit 4 to JUnit 5, the existing test custom logic based on JUnit 4 was migrated to Jupiter. Nevertheless, the custom annotation `@Ignore` was not properly migrated. This PR fixes that issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
