### PR TITLE
[build] Re-enabling browser-actions/setup-geckodriver@latest

### DIFF
--- a/.github/actions/setup-firefox/action.yml
+++ b/.github/actions/setup-firefox/action.yml
@@ -12,9 +12,5 @@ runs:
       uses: browser-actions/setup-firefox@latest
       with:
         firefox-version: ${{ inputs.version }}
-    - name: Check GeckoDriver
-      run: geckodriver --version
-      shell: bash
-# Deactivating until https://github.com/mozilla/geckodriver/issues/2009 gets fixed
-#    - name: Setup GeckoDriver
-#      uses: browser-actions/setup-geckodriver@latest
+    - name: Setup geckodriver
+      uses: browser-actions/setup-geckodriver@latest

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -179,10 +179,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@latest
-      - name: Setup GeckoDriver
-        uses: browser-actions/setup-geckodriver@latest
+      - name: Setup Firefox and GeckoDriver
+        uses: ./.github/actions/setup-firefox
       - name: Start XVFB
         run: Xvfb :99 &
       - name: Run browser tests in Firefox (Remote)
@@ -219,10 +217,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@latest
-      - name: Setup GeckoDriver
-        uses: browser-actions/setup-geckodriver@latest
+      - name: Setup Firefox and GeckoDriver
+        uses: ./.github/actions/setup-firefox
       - name: Start XVFB
         run: Xvfb :99 &
       - name: Run browser tests in Firefox

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -107,10 +107,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-
       - uses: ./.github/actions/setup-bazelisk
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@latest
-      - name: Setup GeckoDriver
-        uses: browser-actions/setup-geckodriver@latest
+      - name: Setup Firefox and GeckoDriver
+        uses: ./.github/actions/setup-firefox
       - run: Xvfb :99 &
       - uses: ./.github/actions/bazel
         with:


### PR DESCRIPTION
### Description
[mozilla/geckodriver#2009](https://github.com/mozilla/geckodriver/issues/2009) got fixed a while ago and getting the latest geckodriver binary is working again.