### PR TITLE
[JS] Fix: Do not allow Select class to select disabled options

### DIFF
--- a/javascript/node/selenium-webdriver/lib/select.js
+++ b/javascript/node/selenium-webdriver/lib/select.js
@@ -37,6 +37,7 @@
 'use strict'
 
 const { By, escapeCss } = require('./by')
+const error = require('./error')
 
 /**
  * ISelect interface makes a protocol for all kind of select elements (standard html and custom
@@ -191,9 +192,7 @@ class Select {
 
     for (let option of options) {
       if ((await option.getAttribute('index')) === index.toString()) {
-        if (!(await option.isSelected())) {
-          await option.click()
-        }
+        await this.setSelected(option)
       }
     }
   }
@@ -224,9 +223,7 @@ class Select {
     })
 
     for (let option of options) {
-      if (!(await option.isSelected())) {
-        await option.click()
-      }
+      await this.setSelected(option)
 
       if (!isMulti) {
         return
@@ -282,9 +279,7 @@ class Select {
     const optionElement = await this.element.findElement({
       xpath: selections.join('|'),
     })
-    if (!(await optionElement.isSelected())) {
-      await optionElement.click()
-    }
+    await this.setSelected(optionElement)
   }
 
   /**
@@ -453,6 +448,17 @@ class Select {
 
     if (!matched) {
       throw new Error(`Cannot locate option with value: ${value}`)
+    }
+  }
+
+  async setSelected(option) {
+    if (!(await option.isSelected())) {
+      if (!(await option.isEnabled())) {
+        throw new error.UnsupportedOperationError(
+          `You may not select a disabled option`
+        )
+      }
+      await option.click()
     }
   }
 }

--- a/javascript/node/selenium-webdriver/test/select_test.js
+++ b/javascript/node/selenium-webdriver/test/select_test.js
@@ -26,7 +26,16 @@ let singleSelectValues1 = {
   name: 'selectomatic',
   values: ['One', 'Two', 'Four', 'Still learning how to count, apparently'],
 }
-let disabledSelect = { name: 'no-select', values: ['Foo'] }
+
+let disabledSingleSelect = {
+  name: 'single_disabled',
+  values: ['Enabled', 'Disabled'],
+}
+let disabledMultiSelect = {
+  name: 'multi_disabled',
+  values: ['Enabled', 'Disabled'],
+}
+
 let multiSelectValues1 = {
   name: 'multi',
   values: ['Eggs', 'Ham', 'Sausages', 'Onion gravy'],
@@ -98,60 +107,6 @@ suite(
         }
       })
 
-      ignore(browsers(Browser.FIREFOX)).it(
-        'Should check selected option if select is disabled by index',
-        async function () {
-          await driver.get(Pages.formPage)
-
-          let selectorObject = new Select(
-            driver.findElement(By.name(disabledSelect['name']))
-          )
-          let firstSelected = await selectorObject.getFirstSelectedOption()
-          await selectorObject.selectByIndex(1)
-          let lastSelected = await selectorObject.getFirstSelectedOption()
-          assert.deepEqual(
-            await firstSelected.getAttribute('value'),
-            await lastSelected.getAttribute('value')
-          )
-        }
-      )
-
-      ignore(browsers(Browser.FIREFOX)).it(
-        'Should check selected option if select is disabled by value',
-        async function () {
-          await driver.get(Pages.formPage)
-
-          let selectorObject = new Select(
-            driver.findElement(By.name(disabledSelect['name']))
-          )
-          let firstSelected = await selectorObject.getFirstSelectedOption()
-          await selectorObject.selectByValue('bar')
-          let lastSelected = await selectorObject.getFirstSelectedOption()
-          assert.deepEqual(
-            await firstSelected.getAttribute('value'),
-            await lastSelected.getAttribute('value')
-          )
-        }
-      )
-
-      ignore(browsers(Browser.FIREFOX)).it(
-        'Should check selected option if select is disabled by visible text',
-        async function () {
-          await driver.get(Pages.formPage)
-
-          let selectorObject = new Select(
-            driver.findElement(By.name(disabledSelect['name']))
-          )
-          let firstSelected = await selectorObject.getFirstSelectedOption()
-          await selectorObject.selectByVisibleText('Bar')
-          let lastSelected = await selectorObject.getFirstSelectedOption()
-          assert.deepEqual(
-            await firstSelected.getAttribute('value'),
-            await lastSelected.getAttribute('value')
-          )
-        }
-      )
-
       it('Should select by multiple index', async function () {
         await driver.get(Pages.formPage)
 
@@ -216,6 +171,142 @@ suite(
             multiSelectValues2['values'][x]
           )
         }
+      })
+
+      it('Should raise exception select by value single disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledSingleSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByValue(
+              disabledSingleSelect.values[1].toLowerCase()
+            )
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
+      })
+
+      it('Should raise exception select by index single disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledSingleSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByIndex(1)
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
+      })
+
+      it('Should raise exception select by text single disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledSingleSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByVisibleText(disabledSingleSelect.values[1])
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
+      })
+
+      it('Should raise exception select by index multiple disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledMultiSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByIndex(1)
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
+      })
+
+      it('Should raise exception select by value multiple disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledMultiSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByValue(
+              disabledMultiSelect.values[1].toLowerCase()
+            )
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
+      })
+
+      it('Should raise exception select by text multiple disabled', async function () {
+        await driver.get(Pages.formPage)
+
+        let selector = new Select(
+          driver.findElement(By.name(disabledMultiSelect['name']))
+        )
+
+        await assert.rejects(
+          async () => {
+            await selector.selectByVisibleText(disabledMultiSelect.values[1])
+          },
+          (err) => {
+            assert.strictEqual(err.name, 'UnsupportedOperationError')
+            assert.strictEqual(
+              err.message,
+              'You may not select a disabled option'
+            )
+            return true
+          }
+        )
       })
     })
   },


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Selecting disabled option will throw Error

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix for https://github.com/SeleniumHQ/selenium/issues/10812

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
