### PR TITLE
[iedriver] ignore zoom if running on Edge

### DIFF
--- a/cpp/iedriver/BrowserFactory.cpp
+++ b/cpp/iedriver/BrowserFactory.cpp
@@ -120,7 +120,6 @@ std::string BrowserFactory::browser_command_line_switches(void) {
 void BrowserFactory::Initialize(BrowserFactorySettings settings) {
   LOG(TRACE) << "Entering BrowserFactory::Initialize";
   this->ignore_protected_mode_settings_ = settings.ignore_protected_mode_settings;
-  this->ignore_zoom_setting_ = settings.ignore_zoom_setting;
   this->browser_attach_timeout_ = settings.browser_attach_timeout;
   this->force_createprocess_api_ = settings.force_create_process_api;
   this->force_shell_windows_api_ = settings.force_shell_windows_api;
@@ -128,6 +127,7 @@ void BrowserFactory::Initialize(BrowserFactorySettings settings) {
   this->browser_command_line_switches_ = StringUtilities::ToWString(settings.browser_command_line_switches);
   this->initial_browser_url_ = StringUtilities::ToWString(settings.initial_browser_url);
   this->edge_ie_mode_ = settings.attach_to_edge_ie || this->ie_redirects_edge_;
+  this->ignore_zoom_setting_ = settings.ignore_zoom_setting || this->edge_ie_mode_;
   LOG(DEBUG) << "path before was " << settings.edge_executable_path << "\n";
   this->edge_executable_location_ = StringUtilities::ToWString(settings.edge_executable_path);
   LOG(DEBUG) << "path after was " << this->edge_executable_location_.c_str() << "\n";


### PR DESCRIPTION
I can't figure out any way to change the zoom level for IE inside of Edge. So the only way to run in IE Mode is by setting ignore zoom level. At that point, Selenium should set it on behalf of the user. That said, I believe it isn't the default because it could cause problems with native mouse events not identifying the coordinates correctly? I don't know the underlying issue, so perhaps it needs to be fixed?

@bwalderman what do you think?