### PR TITLE
Enable msIEModeAlwaysWaitForUnload for Edge IE Mode

### DIFF
--- a/cpp/iedriver/BrowserFactory.cpp
+++ b/cpp/iedriver/BrowserFactory.cpp
@@ -406,11 +406,21 @@ void BrowserFactory::LaunchEdgeInIEMode(PROCESS_INFORMATION* proc_info,
     this->edge_user_data_dir_ = temp_dir;
   }
 
+  // Prevent Edge from showing first run experience tab.
   executable_and_url.append(L" --no-first-run");
+
+  // Disable Edge prelaunch and other background processes on startup.
   executable_and_url.append(L" --no-service-autorun");
+
+  // Disable profile sync and implicit MS account sign-in.
   executable_and_url.append(L" --disable-sync");
   executable_and_url.append(L" --disable-features=msImplicitSignin");
+
+  // ALways allow popups for testing.
   executable_and_url.append(L" --disable-popup-blocking");
+
+  // Ensure IE Mode tabs have a chance to shut down cleanly before the Edge process exits.
+  executable_and_url.append(L" --enable-features=msIEModeAlwaysWaitForUnload");
 
   executable_and_url.append(L" ");
   executable_and_url.append(this->initial_browser_url_);


### PR DESCRIPTION
### Description
Add a command line flag to Edge IE Mode launch that ensures the IE process has a chance to fire the OnQuit event before being terminated by the Edge process.

Also added some comments for the growing list of command line args.

### Motivation and Context
Sometimes (~5% on my local test runs), the IE process doesn't fire the OnQuit event before the browser terminates. IEDriver uses this for bookkeeping active tabs, so without this event, the Quit() command may hang indefinitely.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
