### PR TITLE
[py] Make `get_screenshot_as_file()` work with pathlib.Paths

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -920,7 +920,7 @@ class WebDriver(BaseWebDriver):
 
                 driver.get_screenshot_as_file('/Screenshots/foo.png')
         """
-        if not filename.lower().endswith(".png"):
+        if not str(filename).lower().endswith(".png"):
             warnings.warn(
                 "name used for saved screenshot does not match file " "type. It should end with a `.png` extension",
                 UserWarning,


### PR DESCRIPTION
It currently expects a string (or something with .lower()), but accepting Paths seems quite reasonable.

I supposed if we wanted to be more strict and ensure the passed thing was path-like, we could instead do `str(Path(filename)).lower()`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
