### PR TITLE
New headless

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -186,6 +186,11 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
     return (T) this;
   }
 
+  /**
+   * @deprecated Chrome provides two headless modes use `addArguments("--headless")`
+   * or preferably `addArguments("--headless=chrome")`
+   */
+  @Deprecated
   public T setHeadless(boolean headless) {
     args.remove("--headless");
     if (headless) {

--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -254,6 +254,10 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     return setFirefoxOption(Keys.LOG, logLevel.toJson());
   }
 
+  /**
+   * @deprecated Set this directly with `addArguments("--headless=chrome")`
+   */
+  @Deprecated
   public FirefoxOptions setHeadless(boolean headless) {
     Object rawArgs = firefoxOptions.getOrDefault(Keys.ARGS.key(), new ArrayList<>());
     Require.stateCondition(rawArgs instanceof List, "Arg list of unexpected type: %s", rawArgs);

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
@@ -92,26 +92,6 @@ public class ChromeDriverFunctionalTest extends JupiterTestBase {
     assertThat(checkPermission(driver, CLIPBOARD_WRITE)).isEqualTo("prompt");
   }
 
-  @Test
-  @NoDriverBeforeTest
-  public void canSetPermissionHeadless() {
-    ChromeOptions options = new ChromeOptions();
-    options.setHeadless(true);
-
-    localDriver = new WebDriverBuilder().get(options);
-    HasPermissions permissions = (HasPermissions) localDriver;
-
-    localDriver.get(pages.clicksPage);
-    assertThat(checkPermission(localDriver, CLIPBOARD_READ)).isEqualTo("prompt");
-    assertThat(checkPermission(localDriver, CLIPBOARD_WRITE)).isEqualTo("prompt");
-
-    permissions.setPermission(CLIPBOARD_READ, "granted");
-    permissions.setPermission(CLIPBOARD_WRITE, "granted");
-
-    assertThat(checkPermission(localDriver, CLIPBOARD_READ)).isEqualTo("granted");
-    assertThat(checkPermission(localDriver, CLIPBOARD_WRITE)).isEqualTo("granted");
-  }
-
   public String checkPermission(WebDriver driver, String permission){
     @SuppressWarnings("unchecked")
     Map<String, Object> result = (Map<String, Object>) ((JavascriptExecutor) driver).executeAsyncScript(

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsFunctionalTest.java
@@ -43,9 +43,6 @@ public class ChromeOptionsFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void canStartChromeWithCustomOptions() {
     ChromeOptions options = new ChromeOptions();
-    if (TestUtilities.isOnTravis()) {
-      options.setHeadless(true);
-    }
     options.addArguments("user-agent=foo;bar");
     localDriver = new ChromeDriver(options);
 
@@ -67,9 +64,6 @@ public class ChromeOptionsFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void canSetAcceptInsecureCerts() {
     ChromeOptions options = new ChromeOptions();
-    if (TestUtilities.isOnTravis()) {
-      options.setHeadless(true);
-    }
     options.setAcceptInsecureCerts(true);
     localDriver = new ChromeDriver(options);
 
@@ -80,9 +74,6 @@ public class ChromeOptionsFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void canAddExtensionFromFile() {
     ChromeOptions options = new ChromeOptions();
-    if (TestUtilities.isOnTravis()) {
-      options.setHeadless(true);
-    }
     options.addExtensions(InProject.locate(EXT_PATH).toFile());
     localDriver = new ChromeDriver(options);
 
@@ -98,9 +89,6 @@ public class ChromeOptionsFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void canAddExtensionFromStringEncodedInBase64() throws IOException {
     ChromeOptions options = new ChromeOptions();
-    if (TestUtilities.isOnTravis()) {
-      options.setHeadless(true);
-    }
     options.addEncodedExtensions(Base64.getEncoder().encodeToString(
       Files.readAllBytes(InProject.locate(EXT_PATH))));
     localDriver = new ChromeDriver(options);

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -91,26 +91,6 @@ public class EdgeDriverFunctionalTest extends JupiterTestBase {
     assertThat(checkPermission(driver, CLIPBOARD_WRITE)).isEqualTo("prompt");
   }
 
-  @Test
-  @NoDriverBeforeTest
-  public void canSetPermissionHeadless() {
-    EdgeOptions options = new EdgeOptions();
-    options.setHeadless(true);
-
-    localDriver = new WebDriverBuilder().get(options);
-    HasPermissions permissions = (HasPermissions) localDriver;
-
-    localDriver.get(pages.clicksPage);
-    assertThat(checkPermission(localDriver, CLIPBOARD_READ)).isEqualTo("prompt");
-    assertThat(checkPermission(localDriver, CLIPBOARD_WRITE)).isEqualTo("prompt");
-
-    permissions.setPermission(CLIPBOARD_READ, "granted");
-    permissions.setPermission(CLIPBOARD_WRITE, "granted");
-
-    assertThat(checkPermission(localDriver, CLIPBOARD_READ)).isEqualTo("granted");
-    assertThat(checkPermission(localDriver, CLIPBOARD_WRITE)).isEqualTo("granted");
-  }
-
   public String checkPermission(WebDriver driver, String permission){
     @SuppressWarnings("unchecked")
     Map<String, Object> result = (Map<String, Object>) ((JavascriptExecutor) driver).executeAsyncScript(

--- a/javascript/node/selenium-webdriver/chromium.js
+++ b/javascript/node/selenium-webdriver/chromium.js
@@ -36,19 +36,6 @@
  *     a unique browser session with a clean user profile (unless otherwise
  *     configured through the {@link Options} class).
  *
- * __Headless Chromium__ <a id="headless"></a>
- *
- * To start the browser in headless mode, simply call
- * {@linkplain Options#headless Options.headless()}.
- *
- *     let chrome = require('selenium-webdriver/chrome');
- *     let {Builder} = require('selenium-webdriver');
- *
- *     let driver = new Builder()
- *         .forBrowser('chrome')
- *         .setChromeOptions(new chrome.Options().headless())
- *         .build();
- *
  * __Customizing the Chromium WebDriver Server__ <a id="custom-server"></a>
  *
  * Subclasses of {@link Driver} are expected to provide a static
@@ -323,9 +310,10 @@ class Options extends Capabilities {
    * > downloads, saving files in the specified directory.
    *
    * @return {!Options} A self reference.
+   * @deprecated Use {@link #addArguments} with "headless" or preferably "headless=chrome" instead.
    */
   headless() {
-    return this.addArguments('headless')
+    return this.addArguments('headless=chrome')
   }
 
   /**

--- a/javascript/node/selenium-webdriver/firefox.js
+++ b/javascript/node/selenium-webdriver/firefox.js
@@ -301,6 +301,7 @@ class Options extends Capabilities {
    * Configures the geckodriver to start Firefox in headless mode.
    *
    * @return {!Options} A self reference.
+   * @deprecated Use {@link #addArguments} with "-headless" instead.
    */
   headless() {
     return this.addArguments('-headless')

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -342,7 +342,7 @@ py_test_suite(
     args = [
         "--instafail",
         "--driver=chrome",
-        "--headless=true",
+        "--headless=chrome",
     ],
     tags = [
         "no-sandbox",

--- a/py/selenium/webdriver/chromium/options.py
+++ b/py/selenium/webdriver/chromium/options.py
@@ -144,6 +144,12 @@ class ChromiumOptions(ArgOptions):
         """
         :Returns: True if the headless argument is set, else False
         """
+        warnings.warn(
+            "headless method has been deprecated. Please check for '--headless' in arguments()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         return "--headless" in self._arguments
 
     @headless.setter
@@ -153,6 +159,11 @@ class ChromiumOptions(ArgOptions):
         :Args:
           value: boolean value indicating to set the headless option
         """
+        warnings.warn(
+            "This method for setting headless has been deprecated. Please use add_argument() with '--headless' or preferably '--headless=chrome'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         args = {"--headless"}
         if value is True:
             self._arguments.extend(args)

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -109,6 +109,12 @@ class Options(ArgOptions):
         """
         :Returns: True if the headless argument is set, else False
         """
+        warnings.warn(
+            "headless method has been deprecated. Please check for '--headless' in arguments()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         return "-headless" in self._arguments
 
     @headless.setter
@@ -119,6 +125,11 @@ class Options(ArgOptions):
         Args:
           value: boolean value indicating to set the headless option
         """
+        warnings.warn(
+            "This method for setting headless has been deprecated. Please use add_argument() with '--headless' or preferably '--headless=chrome'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if value:
             self._arguments.append("-headless")
         elif "-headless" in self._arguments:

--- a/py/test/unit/selenium/webdriver/chrome/chrome_options_tests.py
+++ b/py/test/unit/selenium/webdriver/chrome/chrome_options_tests.py
@@ -112,22 +112,6 @@ def test_get_experimental_options(options):
     assert options.experimental_options["foo"] == "bar"
 
 
-def test_set_headless(options):
-    options.headless = True
-    assert "--headless" in options._arguments
-
-
-def test_unset_headless(options):
-    options._arguments = ["--headless"]
-    options.headless = False
-    assert "--headless" not in options._arguments
-
-
-def test_get_headless(options):
-    options._arguments = ["--headless"]
-    assert options.headless is True
-
-
 def test_creates_capabilities(options):
     options._arguments = ["foo"]
     options._binary_location = "/bar"

--- a/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
+++ b/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
@@ -127,22 +127,6 @@ def test_set_log_level(options):
     assert options.log.level == "debug"
 
 
-def test_set_headless(options):
-    options.headless = True
-    assert "-headless" in options._arguments
-
-
-def test_unset_headless(options):
-    options._arguments = ["-headless"]
-    options.headless = False
-    assert "-headless" not in options._arguments
-
-
-def test_get_headless(options):
-    options._arguments = ["-headless"]
-    assert options.headless
-
-
 def test_creates_capabilities(options):
     profile = FirefoxProfile()
     options._arguments = ["foo"]

--- a/rb/lib/selenium/webdriver/chrome/options.rb
+++ b/rb/lib/selenium/webdriver/chrome/options.rb
@@ -171,6 +171,9 @@ module Selenium
         #
 
         def headless!
+          WebDriver.logger.deprecate('Options#headless!',
+                                     "Options#add_argument with '--headless'",
+                                     id: :headless)
           add_argument '--headless'
         end
 

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -108,6 +108,9 @@ module Selenium
         #
 
         def headless!
+          WebDriver.logger.deprecate('Options#headless!',
+                                     "Options#add_argument with '--headless'",
+                                     id: :headless)
           add_argument '-headless'
         end
 

--- a/rb/spec/integration/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/options_spec.rb
@@ -53,15 +53,6 @@ module Selenium
             expect(ua).to eq('foo;bar')
           end
         end
-
-        it 'should be able to run in headless mode with #headless!' do
-          options.headless!
-
-          create_driver!(options: options) do |driver|
-            ua = driver.execute_script 'return window.navigator.userAgent'
-            expect(ua).to match(/HeadlessChrome/)
-          end
-        end
       end
     end # Chrome
   end # WebDriver

--- a/rb/spec/integration/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/edge/options_spec.rb
@@ -51,15 +51,6 @@ module Selenium
             expect(ua).to eq('foo;bar')
           end
         end
-
-        it 'should be able to run in headless mode with #headless!' do
-          options.headless!
-
-          create_driver!(options: options) do |driver|
-            ua = driver.execute_script 'return window.navigator.userAgent'
-            expect(ua).to match(/HeadlessChrome/)
-          end
-        end
       end
     end # Edge
   end # WebDriver

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -177,13 +177,6 @@ module Selenium
           end
         end
 
-        describe '#headless!' do
-          it 'should add necessary command-line arguments' do
-            options.headless!
-            expect(options.args).to eql(['--headless'])
-          end
-        end
-
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -133,13 +133,6 @@ module Selenium
           end
         end
 
-        describe '#headless!' do
-          it 'should add necessary command-line arguments' do
-            options.headless!
-            expect(options.args.to_a).to eql(['--headless'])
-          end
-        end
-
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
             options.add_option(:foo, 'bar')


### PR DESCRIPTION
Most Selenium languages have implemented convenience methods for Headless mode in Chrome & Firefox.

Currently implemented:
* Ruby - Set
* JS - Set
* Java - Set & Unset
* Python - Set, Unset, Get
* .NET - N/A

The Chrome Headless mode we've set is not the production browser, and has many limitations (including not being able to load extensions).

Thanks to @mdmintz I learned that Chrome implemented a new Headless mode that is the full production browser:
https://chromium.googlesource.com/chromium/src/+/833543a511a970f44fb074b9f30c6b6268e0be71
It's been available since Chrome 94, but this change should be backwards compatible since it picks up anything it doesn't recognize (e.g., `--headless=xx`) as just `--headless`.

There may be slight performance benefit to using the old mode of headless (because it strips out functionality), but I believe the new mode more accurately represents what Selenium should encourage. If we are going to maintain a convenience feature (tbh, I would also be ok with deprecating/removing all of these), then I believe this new mode is the correct one.

I'm not adding Unsetters to Ruby or JS, or Getters to non-Python because I just don't see them as that important. I am implementing Headless in .NET (both Chrome & Firefox) to match Java implementation.

I've verified that the new headless mode works on a Linux box without a GUI / xvfb. I have not evaluated performance.

Which do you prefer:
1. Accept PR
2. Keep old implementation
3. Deprecate convenience method and let users decide
