### PR TITLE
Annotate JS

### DIFF
--- a/dotnet/src/webdriver/JavaScriptEngine.cs
+++ b/dotnet/src/webdriver/JavaScriptEngine.cs
@@ -343,7 +343,7 @@ namespace OpenQA.Selenium
                 }
             }
 
-            return listenerScript;
+            return string.Format(CultureInfo.InvariantCulture, "/* mutationListener.js */ {0}", listenerScript);
         }
 
         private void OnScriptBindingCalled(object sender, BindingCalledEventArgs e)

--- a/dotnet/src/webdriver/JavaScriptEngine.cs
+++ b/dotnet/src/webdriver/JavaScriptEngine.cs
@@ -74,7 +74,7 @@ namespace OpenQA.Selenium
         public event EventHandler<JavaScriptExceptionThrownEventArgs> JavaScriptExceptionThrown;
 
         /// <summary>
-        /// Occurs when methods on the JavaScript console are called. 
+        /// Occurs when methods on the JavaScript console are called.
         /// </summary>
         public event EventHandler<JavaScriptConsoleApiCalledEventArgs> JavaScriptConsoleApiCalled;
 
@@ -335,7 +335,7 @@ namespace OpenQA.Selenium
         private string GetMutationListenerScript()
         {
             string listenerScript = string.Empty;
-            using (Stream resourceStream = ResourceUtilities.GetResourceStream("mutation-listener.js", "mutation-listener.js"))
+            using (Stream resourceStream = ResourceUtilities.GetResourceStream("mutationListener.js", "mutationListener.js"))
             {
                 using (StreamReader resourceReader = new StreamReader(resourceStream))
                 {

--- a/dotnet/src/webdriver/RelativeBy.cs
+++ b/dotnet/src/webdriver/RelativeBy.cs
@@ -40,7 +40,7 @@ namespace OpenQA.Selenium
         protected RelativeBy() : base()
         {
             string atom = string.Empty;
-            using (Stream atomStream = ResourceUtilities.GetResourceStream("find-elements.js", "find-elements.js"))
+            using (Stream atomStream = ResourceUtilities.GetResourceStream("findElements.js", "findElements.js"))
             {
                 using (StreamReader atomReader = new StreamReader(atomStream))
                 {

--- a/dotnet/src/webdriver/RelativeBy.cs
+++ b/dotnet/src/webdriver/RelativeBy.cs
@@ -48,7 +48,7 @@ namespace OpenQA.Selenium
                 }
             }
 
-            wrappedAtom = string.Format(CultureInfo.InvariantCulture, "return ({0}).apply(null, arguments);", atom);
+            wrappedAtom = string.Format(CultureInfo.InvariantCulture, "/* findElements.js */ return ({0}).apply(null, arguments);", atom);
         }
 
         private RelativeBy(object root) : this(root, null)

--- a/dotnet/src/webdriver/WebDriver.csproj
+++ b/dotnet/src/webdriver/WebDriver.csproj
@@ -119,19 +119,19 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\webdriver\atoms\get-attribute.js">
       <Visible>False</Visible>
-      <LogicalName>get-attribute.js</LogicalName>
+      <LogicalName>getAttribute.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\atoms\fragments\is-displayed.js">
       <Visible>False</Visible>
-      <LogicalName>is-displayed.js</LogicalName>
+      <LogicalName>isDisplayed.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\atoms\fragments\find-elements.js">
       <Visible>False</Visible>
-      <LogicalName>find-elements.js</LogicalName>
+      <LogicalName>findElements.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)..\..\..\javascript\cdp-support\mutation-listener.js">
       <Visible>False</Visible>
-      <LogicalName>mutation-listener.js</LogicalName>
+      <LogicalName>mutationListener.js</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 
@@ -142,19 +142,19 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)../../../bazel-bin/javascript/webdriver/atoms/get-attribute.js">
       <Visible>False</Visible>
-      <LogicalName>get-attribute.js</LogicalName>
+      <LogicalName>getAttribute.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)../../../bazel-bin/javascript/atoms/fragments/is-displayed.js">
       <Visible>False</Visible>
-      <LogicalName>is-displayed.js</LogicalName>
+      <LogicalName>isDisplayed.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)../../../bazel-bin/javascript/atoms/fragments/find-elements.js">
       <Visible>False</Visible>
-      <LogicalName>find-elements.js</LogicalName>
+      <LogicalName>findElements.js</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(ProjectDir)../../../javascript/cdp-support/mutation-listener.js">
       <Visible>False</Visible>
-      <LogicalName>mutation-listener.js</LogicalName>
+      <LogicalName>mutationListener.js</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/dotnet/src/webdriver/WebElement.cs
+++ b/dotnet/src/webdriver/WebElement.cs
@@ -180,7 +180,7 @@ namespace OpenQA.Selenium
             {
                 Response commandResponse = null;
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
-                string atom = GetAtom("is-displayed.js");
+                string atom = GetAtom("isDisplayed.js");
                 parameters.Add("script", atom);
                 parameters.Add("args", new object[] { this.ToElementReference().ToDictionary() });
                 commandResponse = this.Execute(DriverCommand.ExecuteScript, parameters);
@@ -412,7 +412,7 @@ namespace OpenQA.Selenium
             Response commandResponse = null;
             string attributeValue = string.Empty;
             Dictionary<string, object> parameters = new Dictionary<string, object>();
-            string atom = GetAtom("get-attribute.js");
+            string atom = GetAtom("getAttribute.js");
             parameters.Add("script", atom);
             parameters.Add("args", new object[] { this.ToElementReference().ToDictionary(), attributeName });
             commandResponse = this.Execute(DriverCommand.ExecuteScript, parameters);

--- a/dotnet/src/webdriver/WebElement.cs
+++ b/dotnet/src/webdriver/WebElement.cs
@@ -620,7 +620,7 @@ namespace OpenQA.Selenium
             }
             else
             {
-                String script = "var form = arguments[0];\n" +
+                String script = "/* submit.js */ var form = arguments[0];\n" +
                                 "while (form.nodeName != \"FORM\" && form.parentNode) {\n" +
                                 "  form = form.parentNode;\n" +
                                 "}\n" +
@@ -717,7 +717,9 @@ namespace OpenQA.Selenium
                 }
             }
 
-            string wrappedAtom = string.Format(CultureInfo.InvariantCulture, "return ({0}).apply(null, arguments);", atom);
+            string wrappedAtom = string.Format(CultureInfo.InvariantCulture, "/* {0} */ return ({1}).apply(null, arguments);",
+                atomResourceName,
+                atom);
             return wrappedAtom;
         }
 

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -308,7 +308,7 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
 
       case SUBMIT_ELEMENT:
         return toScript(
-          "var form = arguments[0];\n" +
+          "/* submit.js */ var form = arguments[0];\n" +
           "while (form.nodeName != \"FORM\" && form.parentNode) {\n" +
           "  form = form.parentNode;\n" +
           "}\n" +
@@ -342,7 +342,8 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
 
       String rawFunction = Resources.toString(url, StandardCharsets.UTF_8);
       String script = String.format(
-        "return (%s).apply(null, arguments);",
+        "/* %s */ return (%s).apply(null, arguments);",
+        atomFileName,
         rawFunction);
       return toScript(script, args);
     } catch (IOException | NullPointerException e) {

--- a/java/src/org/openqa/selenium/support/locators/RelativeLocatorScript.java
+++ b/java/src/org/openqa/selenium/support/locators/RelativeLocatorScript.java
@@ -38,7 +38,7 @@ class RelativeLocatorScript {
       URL url = RelativeLocator.class.getResource(location);
 
       String rawFunction = Resources.toString(url, StandardCharsets.UTF_8);
-      FIND_ELEMENTS = String.format("return (%s).apply(null, arguments);", rawFunction);
+      FIND_ELEMENTS = String.format("/* findElements.js */ return (%s).apply(null, arguments);", rawFunction);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/javascript/node/selenium-webdriver/lib/http.js
+++ b/javascript/node/selenium-webdriver/lib/http.js
@@ -189,7 +189,7 @@ function toExecuteAtomCommand(command, atom, ...params) {
 
   return new cmd.Command(cmd.Name.EXECUTE_SCRIPT)
     .setParameter('sessionId', command.getParameter('sessionId'))
-    .setParameter('script', `return (${atom}).apply(null, arguments)`)
+    .setParameter('script', `/* ${atom} */ return (${atom}).apply(null, arguments)`)
     .setParameter(
       'args',
       params.map((param) => command.getParameter(param))

--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -1488,7 +1488,7 @@ class WebDriver {
         .toString()
     }
 
-    this.executeScript(mutationListener)
+    this.executeScript('/* mutationListener.js */ ' + mutationListener)
 
     await connection.execute(
       'Page.addScriptToEvaluateOnNewDocument',
@@ -2863,7 +2863,7 @@ class WebElement {
    */
   submit() {
     const script =
-      'var form = arguments[0];\n' +
+      '/* submit.js */ var form = arguments[0];\n' +
       'while (form.nodeName != "FORM" && form.parentNode) {\n' +
       '  form = form.parentNode;\n' +
       '}\n' +

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -14,11 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import logging
 import os
 import platform
 import socket
 import subprocess
+import sys
 import time
 from test.selenium.webdriver.common.network import get_lan_ip
 from test.selenium.webdriver.common.webserver import SimpleWebServer
@@ -69,6 +70,18 @@ def pytest_ignore_collect(path, config):
 
 
 driver_instance = None
+
+@pytest.fixture(scope="function")
+def logger(caplog):
+    selenium_logger = logging.getLogger("selenium")
+    selenium_logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s Selenium %(message)s",
+                                           "%Y-%m-%d %H:%M:%S"))
+    selenium_logger.addHandler(handler)
+
+    yield caplog
+    selenium_logger.setLevel(logging.WARN)
 
 
 @pytest.fixture(scope="function")

--- a/py/pytest.ini
+++ b/py/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 console_output_style = progress
 faulthandler_timeout = 60
-log_cli = True
+log_cli = 1
+log_cli_level = INFO
 trio_mode = true
 markers =
     xfail_chrome: Tests expected to fail in Chrome

--- a/py/selenium/webdriver/common/log.py
+++ b/py/selenium/webdriver/common/log.py
@@ -77,7 +77,7 @@ class Log:
             self.devtools.page.add_script_to_evaluate_on_new_document(self._mutation_listener_js)
         )
         self.driver.pin_script(self._mutation_listener_js, script_key)
-        self.driver.execute_script(f"return {self._mutation_listener_js}")
+        self.driver.execute_script(f"/* mutationListener.js */ return {self._mutation_listener_js}")
         event = {}
         async with runtime.wait_for(self.devtools.runtime.BindingCalled) as evnt:
             yield event

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -873,7 +873,7 @@ class WebDriver(BaseWebDriver):
         if isinstance(by, RelativeBy):
             _pkg = ".".join(__name__.split(".")[:-1])
             raw_function = pkgutil.get_data(_pkg, "findElements.js").decode("utf8")
-            find_element_js = f"return ({raw_function}).apply(null, arguments);"
+            find_element_js = f"/* findElements.js */ return ({raw_function}).apply(null, arguments);"
             return self.execute_script(find_element_js, by.to_dict())
 
         if by == By.ID:

--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -95,7 +95,7 @@ class WebElement(BaseWebElement):
     def submit(self):
         """Submits a form."""
         script = (
-            "var form = arguments[0];\n"
+            "/* submit.js */ var form = arguments[0];\n"
             'while (form.nodeName != "FORM" && form.parentNode) {\n'
             "  form = form.parentNode;\n"
             "}\n"
@@ -177,7 +177,7 @@ class WebElement(BaseWebElement):
         if getAttribute_js is None:
             _load_js()
         attribute_value = self.parent.execute_script(
-            "return (%s).apply(null, arguments);" % getAttribute_js, self, name
+            "/* getAttribute.js */ return (%s).apply(null, arguments);" % getAttribute_js, self, name
         )
         return attribute_value
 
@@ -261,7 +261,7 @@ class WebElement(BaseWebElement):
         # Only go into this conditional for browsers that don't use the atom themselves
         if isDisplayed_js is None:
             _load_js()
-        return self.parent.execute_script("return (%s).apply(null, arguments);" % isDisplayed_js, self)
+        return self.parent.execute_script("/* isDisplayed.js */ return (%s).apply(null, arguments);" % isDisplayed_js, self)
 
     @property
     def location_once_scrolled_into_view(self) -> dict:

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -160,11 +160,12 @@ def test_navigate(driver, pages):
     assert "We Arrive Here" == driver.title
 
 
-def test_get_attribute(driver, pages):
+def test_get_attribute(driver, pages, logger):
     url = pages.url("xhtmlTest.html")
     driver.get(url)
     elem = driver.find_element(By.ID, "id1")
     attr = elem.get_attribute("href")
+    assert "getAttribute.js" in logger.text
     assert f"{url}#" == attr
 
 

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -64,7 +64,7 @@ async def test_collect_js_exceptions(driver, pages):
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_safari
 @pytest.mark.xfail_remote
-async def test_collect_log_mutations(driver, pages):
+async def test_collect_log_mutations(driver, pages, logger):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
         async with log.mutation_events() as event:
@@ -74,6 +74,7 @@ async def test_collect_log_mutations(driver, pages):
                 EC.visibility_of(driver.find_element(By.ID, "revealed"))
             )
 
+    assert "mutationListener.js" in logger.text
     assert event["attribute_name"] == "style"
     assert event["current_value"] == ""
     assert event["old_value"] == "display:none;"

--- a/py/test/selenium/webdriver/common/form_handling_tests.py
+++ b/py/test/selenium/webdriver/common/form_handling_tests.py
@@ -40,9 +40,10 @@ def test_should_be_able_to_click_image_buttons(driver, pages):
     WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
 
-def test_should_submit_input_in_form(driver, pages):
+def test_should_submit_input_in_form(driver, pages, logger):
     pages.load("formPage.html")
     driver.find_element(By.NAME, "login").submit()
+    assert "submit.js" in logger.text
     WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
 

--- a/py/test/selenium/webdriver/common/visibility_tests.py
+++ b/py/test/selenium/webdriver/common/visibility_tests.py
@@ -22,10 +22,11 @@ from selenium.common.exceptions import ElementNotVisibleException
 from selenium.webdriver.common.by import By
 
 
-def test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not(driver, pages):
+def test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not(driver, pages, logger):
     pages.load("javascriptPage.html")
 
     assert driver.find_element(by=By.ID, value="displayed").is_displayed() is True
+    assert "isDisplayed.js" in logger.text
     assert driver.find_element(by=By.ID, value="none").is_displayed() is False
     assert driver.find_element(by=By.ID, value="suppressedParagraph").is_displayed() is False
     assert driver.find_element(by=By.ID, value="hidden").is_displayed() is False

--- a/py/test/selenium/webdriver/support/relative_by_tests.py
+++ b/py/test/selenium/webdriver/support/relative_by_tests.py
@@ -22,12 +22,13 @@ from selenium.webdriver.support.relative_locator import locate_with
 from selenium.webdriver.support.relative_locator import with_tag_name
 
 
-def test_should_be_able_to_find_first_one(driver, pages):
+def test_should_be_able_to_find_first_one(driver, pages, logger):
     pages.load("relative_locators.html")
     lowest = driver.find_element(By.ID, "below")
 
     el = driver.find_element(with_tag_name("p").above(lowest))
 
+    assert "findElements.js" in logger.text
     assert el.get_attribute("id") == "mid"
 
 

--- a/rb/lib/selenium/webdriver/atoms.rb
+++ b/rb/lib/selenium/webdriver/atoms.rb
@@ -28,7 +28,9 @@ module Selenium
       end
 
       def execute_atom(function_name, *arguments)
-        script = format("return (%<atom>s).apply(null, arguments)", atom: read_atom(function_name))
+        script = format("/* %<function>s.js */ return (%<atom>s).apply(null, arguments)",
+                        function: function_name,
+                        atom: read_atom(function_name))
         execute_script(script, *arguments)
       end
 

--- a/rb/lib/selenium/webdriver/common/driver_extensions/has_log_events.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/has_log_events.rb
@@ -135,7 +135,7 @@ module Selenium
         end
 
         def mutation_listener
-          @mutation_listener ||= read_atom(:mutationListener)
+          @mutation_listener ||= "/* mutationListener.js */ #{read_atom(:mutationListener)}"
         end
 
       end # HasLogEvents

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -425,7 +425,7 @@ module Selenium
         end
 
         def submit_element(element)
-          script = "var form = arguments[0];\n" \
+          script = "/* submit.js */ var form = arguments[0];\n" \
                    "while (form.nodeName != \"FORM\" && form.parentNode) {\n  " \
                    "form = form.parentNode;\n" \
                    "}\n" \
@@ -449,7 +449,6 @@ module Selenium
         end
 
         def element_attribute(element, name)
-          WebDriver.logger.info "Using script for :getAttribute of #{name}"
           execute_atom :getAttribute, element, name
         end
 
@@ -509,7 +508,6 @@ module Selenium
         end
 
         def element_displayed?(element)
-          WebDriver.logger.info 'Using script for :isDisplayed'
           execute_atom :isDisplayed, element
         end
 

--- a/rb/spec/integration/selenium/webdriver/devtools_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/devtools_spec.rb
@@ -72,7 +72,12 @@ module Selenium
 
       it 'notifies about log messages' do
         logs = []
-        driver.on_log_event(:console) { |log| logs.push(log) }
+        WebDriver.logger.level = :info
+        expect {
+          driver.on_log_event(:console) { |log| logs.push(log) }
+        }.to output(/mutationListener.js/).to_stdout_from_any_process
+        WebDriver.logger.level = :warn
+
         driver.navigate.to url_for('javascriptPage.html')
 
         driver.execute_script("console.log('I like cheese');")

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -111,8 +111,13 @@ module Selenium
         it 'should find above another' do
           driver.navigate.to url_for('relative_locators.html')
 
-          above = driver.find_element(relative: {tag_name: 'td', above: {id: 'center'}})
-          expect(above.attribute('id')).to eq('second')
+          WebDriver.logger.level = :info
+          expect {
+            @above = driver.find_element(relative: {tag_name: 'td', above: {id: 'center'}})
+          }.to output(/findElements.js/).to_stdout_from_any_process
+          WebDriver.logger.level = :warn
+
+          expect(@above.attribute('id')).to eq('second')
         end
 
         it 'should find child element' do

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -43,7 +43,11 @@ module Selenium
       describe '#submit' do
         it 'valid submit button' do
           driver.navigate.to url_for('formPage.html')
-          driver.find_element(id: 'submitButton').submit
+          WebDriver.logger.level = :info
+          expect {
+            driver.find_element(id: 'submitButton').submit
+          }.to output(/submit.js/).to_stdout_from_any_process
+          WebDriver.logger.level = :warn
 
           sleep 0.5
           expect(driver.title).to eq('We Arrive Here')
@@ -139,7 +143,11 @@ module Selenium
           end
 
           it '#attribute returns value' do
-            expect(element.attribute(prop_or_attr)).to eq 'checkbox'
+            WebDriver.logger.level = :info
+            expect {
+              expect(element.attribute(prop_or_attr)).to eq 'checkbox'
+            }.to output(/getAttribute.js/).to_stdout_from_any_process
+            WebDriver.logger.level = :warn
           end
         end
 
@@ -463,7 +471,11 @@ module Selenium
 
       it 'should get displayed' do
         driver.navigate.to url_for('xhtmlTest.html')
-        expect(driver.find_element(class: 'header')).to be_displayed
+        WebDriver.logger.level = :info
+        expect {
+          expect(driver.find_element(class: 'header')).to be_displayed
+        }.to output(/isDisplayed.js/).to_stdout_from_any_process
+        WebDriver.logger.level = :warn
       end
 
       context 'size and location' do


### PR DESCRIPTION
Still a WIP while I figure out how to make sure everything is actually getting reported properly

Still working on Java & .NET

Essentially, when looking at logs (especially with service providers), it is hard to know what large JS blobs are doing. This provides an easy comment in the payload to see what it is doing.

See the difference in payload from
https://app.saucelabs.com/tests/b9722309476044b0b3e970beb702d178#3
to
https://app.saucelabs.com/tests/e1605700c8724a2abe63aa9949778feb#3

I'm not saying this is a good way to test things, but I created a way to turn on logs and verify the output in the logs for Python & Ruby. I might just verify manually for Java & .NET