### PR TITLE
Add workflow to build Selenium Manager in CI (for Windows, Linux, and macOS)

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -1,0 +1,63 @@
+name: build-selenium-manager
+
+on: workflow_dispatch
+
+jobs:
+  windows:
+    name: "[Windows] Build selenium-manager"
+    runs-on: windows-latest
+    steps:
+      - name: "Checkout project"
+        uses: actions/checkout@master
+      - name: "Build release"
+        run: |
+          cd rust
+          cargo build --release
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-manager_windows-x64
+          path: rust/target/release/selenium-manager.exe
+          retention-days: 6
+
+  linux:
+    name: "[Linux] Build selenium-manager"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout project"
+        uses: actions/checkout@master
+      - name: "Build release"
+        run: |
+          cd rust
+          cargo build --release
+      - name: "Tar binary (to keep executable permission)"
+        run: |
+          cd rust/target/release
+          tar -cvf ../../../selenium-manager.tar selenium-manager
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-manager_linux-x64
+          path: selenium-manager.tar
+          retention-days: 6
+
+  macos:
+    name: "[macOS] Build selenium-manager"
+    runs-on: macos-latest
+    steps:
+      - name: "Checkout project"
+        uses: actions/checkout@master
+      - name: "Build release"
+        run: |
+          cd rust
+          cargo build --release
+      - name: "Tar binary (to keep executable permission)"
+        run: |
+          cd rust/target/release
+          tar -cvf ../../../selenium-manager.tar selenium-manager
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-manager_macos-x64
+          path: selenium-manager.tar
+          retention-days: 6


### PR DESCRIPTION
### Description
This PR creates a GH Actions workflow to build Selenium Manager for the three main operating systems: Windows, Linux, and macOS. This workflow is manually triggered. The objective is to use the generated binaries (attached as artifacts at the end of the workflow execution) in the future releases of Selenium Manager.

### Motivation and Context
This PR is part of the development of Selenium Manager M1. Since it is non-trivial to cross-compile Rust (e.g., generate a Windows binary from a macOS machine), we can use the virtual environments of GH Actions (`windows-latest`, `ubuntu-latest`, and `macos-latest`) to that aim.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
