### PR TITLE
[java] use the correct base64 decoder

### DIFF
--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -55,7 +55,7 @@ public interface OutputType<T> {
   OutputType<byte[]> BYTES = new OutputType<byte[]>() {
     @Override
     public byte[] convertFromBase64Png(String base64Png) {
-      return Base64.getMimeDecoder().decode(base64Png);
+      return Base64.getDecoder().decode(base64Png);
     }
 
     @Override


### PR DESCRIPTION
### Description
Use the correct base64 decoder (RFC4648) as defined by the WebDriver specification.

### Motivation and Context
Selenium should follow the WebDriver specification

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
