### PR TITLE
[java] close the CDP connection on quit for FF

### DIFF
--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -88,6 +88,7 @@ public class FirefoxDriver extends RemoteWebDriver
   private final Optional<URI> cdpUri;
   private final Optional<URI> biDiUri;
   protected FirefoxBinary binary;
+  private Connection connection;
   private DevTools devTools;
   private BiDi biDi;
   public FirefoxDriver() {
@@ -246,7 +247,7 @@ public class FirefoxDriver extends RemoteWebDriver
     ClientConfig wsConfig = ClientConfig.defaultConfig().baseUri(wsUri);
     HttpClient wsClient = clientFactory.createClient(wsConfig);
 
-    Connection connection = new Connection(wsClient, wsUri.toString());
+    connection = new Connection(wsClient, wsUri.toString());
     CdpInfo cdpInfo = new CdpVersionFinder().match("85.0").orElseGet(NoOpCdpInfo::new);
     devTools = new DevTools(cdpInfo::getDomains, connection);
 
@@ -296,6 +297,14 @@ public class FirefoxDriver extends RemoteWebDriver
 
     return maybeGetBiDi()
       .orElseThrow(() -> new DevToolsException("Unable to initialize Bidi connection"));
+  }
+
+  @Override
+  public void quit() {
+    if (connection != null) {
+      connection.close();
+    }
+    super.quit();
   }
 
   public static final class SystemProperty {


### PR DESCRIPTION
### Description
The FirefoxDriver did not close the CDP connection on quit like the ChromiumDriver does.

### Motivation and Context
It is desirable to gracefully close all opened connections. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
