### PR TITLE
[java] removed the broken escape

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -472,9 +472,6 @@ public class RemoteWebDriver implements WebDriver,
           "You must be using an underlying instance of WebDriver that supports executing javascript");
     }
 
-    // Escape the quote marks
-    script = script.replaceAll("\"", "\\\"");
-
     List<Object> convertedArgs = Stream.of(args).map(new WebElementToJsonConverter()).collect(
         Collectors.toList());
 
@@ -487,9 +484,6 @@ public class RemoteWebDriver implements WebDriver,
       throw new UnsupportedOperationException("You must be using an underlying instance of " +
           "WebDriver that supports executing javascript");
     }
-
-    // Escape the quote marks
-    script = script.replaceAll("\"", "\\\"");
 
     List<Object> convertedArgs = Stream.of(args).map(new WebElementToJsonConverter()).collect(
         Collectors.toList());

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -351,9 +351,6 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
   }
 
   private Map<String, ?> toScript(String script, Object... args) {
-    // Escape the quote marks
-    script = script.replaceAll("\"", "\\\"");
-
     List<Object> convertedArgs = Stream.of(args).map(new WebElementToJsonConverter()).collect(
         Collectors.toList());
 


### PR DESCRIPTION
### Description
The escaping of javascript was broken, it replaced a quote with a identical quote to escape it.

I guess the original author tried to add a backslash to escape the quote, but the magic behind the `String.replaceAll` swallows the backslash. This will lead to a identical string before and after escaping the string.
(To get the assumed behavior it should have been `script.replaceAll("\"", "\\\\\"")` and not `script.replaceAll("\"", "\\\"")` )

The `String.replaceAll` call was dropped in this PR to get rid of this confusing code.

### Motivation and Context
Overhead processing the RegEx / get rid of confusing code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
