### PR TITLE
Load Console when grid spun off via code

### DIFF
--- a/java/src/org/openqa/selenium/grid/web/IndependentJarFileResource.java
+++ b/java/src/org/openqa/selenium/grid/web/IndependentJarFileResource.java
@@ -1,0 +1,158 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.web;
+
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class IndependentJarFileResource implements Resource {
+
+  private final File jarFile;
+  private final String prefix;
+  private final String name;
+
+  public IndependentJarFileResource(File jarFile, String prefix, String path) {
+    this.prefix = prefix;
+    this.name = path;
+    this.jarFile = jarFile;
+  }
+
+  private URI uri() {
+    return URI.create("jar:" + jarFile.toURI());
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Optional<Resource> get(String path) {
+    return Optional.of(new IndependentJarFileResource(this.jarFile, this.prefix, path));
+  }
+
+  private String prefixToUse() {
+    String result = prefix;
+    if (prefix.startsWith("/")) {
+      result = prefix.replaceFirst("/", "");
+    }
+    return result + "/" + name;
+  }
+
+  @Override
+  public boolean isDirectory() {
+    String computedPrefix = prefixToUse();
+    try (JarFile jar = new JarFile(jarFile)) {
+      return jar.stream()
+        .filter(eachJarEntry -> eachJarEntry.getName().startsWith(computedPrefix))
+        .anyMatch(eachJarEntry -> matches(eachJarEntry, computedPrefix));
+    } catch (IOException ignored) {
+      return false;
+    }
+  }
+
+  private static boolean matches(JarEntry jarEntry, String prefix) {
+    boolean isDirectory = jarEntry.isDirectory();
+    boolean fullMatch = jarEntry.getName().equals(prefix);
+    return isDirectory || (!fullMatch);
+  }
+
+  private Stream<Path> walk(Path file) {
+    try {
+      return Files.walk(file);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public Set<Resource> list() {
+    try (DirectoryStream<Path> directory = directory(fileSystem())) {
+      return StreamSupport.stream(directory.spliterator(), false)
+        .flatMap(this::walk)
+        .map(
+          each -> new IndependentJarFileResource(jarFile, prefix, each.getFileName().toString()))
+        .collect(Collectors.toSet());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public Optional<byte[]> read() {
+    Function<Path, byte[]> mapper = path -> {
+        try (InputStream is = Files.newInputStream(path);
+          ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+          ByteStreams.copy(is, bos);
+          return bos.toByteArray();
+        } catch (IOException ignored) {
+          return null;
+        }
+    };
+    return Optional.ofNullable(path(mapper));
+  }
+
+  private <T> T path(Function<Path, T> transformer) {
+    try (DirectoryStream<Path> directory = directory(fileSystem())) {
+      Optional<Path> found = StreamSupport.stream(directory.spliterator(), false)
+        .flatMap(this::walk)
+        .filter(each -> each.toString().endsWith(this.name))
+        .findFirst();
+      return found.map(transformer).orElse(null);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private DirectoryStream<Path> directory(FileSystem fs) throws IOException {
+    return Files.newDirectoryStream(fs.getPath(prefix), "*");
+  }
+
+  private FileSystem fileSystem() throws IOException {
+    URI uri = uri();
+    FileSystem jarFs;
+    try {
+      Map<String, String> env = new HashMap<>();
+      jarFs = FileSystems.newFileSystem(uri, env);
+    } catch (FileSystemAlreadyExistsException ignored) {
+      jarFs = FileSystems.getFileSystem(uri);
+    }
+    return jarFs;
+  }
+}

--- a/java/test/org/openqa/selenium/grid/web/IndependentJarFileResourceTest.java
+++ b/java/test/org/openqa/selenium/grid/web/IndependentJarFileResourceTest.java
@@ -1,0 +1,72 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.web;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IndependentJarFileResourceTest {
+
+  private Path target;
+
+  @BeforeEach
+  void downloadJar() throws IOException {
+    String endpoint = "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.5.0/selenium-server-4.5.0.jar";
+    URL url = new URL(endpoint);
+    ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
+    target = Files.createTempFile("test", "jar");
+    target.toFile().deleteOnExit();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(target.toFile())) {
+      fileOutputStream.getChannel()
+        .transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+    }
+  }
+
+  @Test
+  void testCapabilities() throws IOException {
+    assertThat(target.toFile()).exists();
+    assertThat(Files.size(target)).isNotZero();
+    IndependentJarFileResource resource = new IndependentJarFileResource(target.toFile(),
+    "/javascript/grid-ui/build", "");
+    assertThat(resource.isDirectory()).isTrue();
+    assertThat(resource.list()).isNotEmpty();
+
+    Optional<Resource> staticResource = resource.get("static");
+    assertThat(staticResource.isPresent()).isTrue();
+    assertThat(staticResource.get().isDirectory()).isTrue();
+    assertThat(staticResource.get().list()).isNotEmpty();
+
+    Optional<Resource> indexHtml = resource.get("index.html");
+    assertThat(indexHtml.isPresent()).isTrue();
+    Resource index = indexHtml.get();
+    assertThat(index.isDirectory()).isFalse();
+    assertThat(index.read().isPresent()).isTrue();
+    assertThat(new String(index.read().get())).contains("<title>Selenium Grid</title>");
+  }
+
+}


### PR DESCRIPTION
Currently when the Grid is spun off via code
the console loading fails because `Class.getResource()` would return null. 

Fixed this by adding a new Resource implementation That would be wired in when running Grid via code.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
