### PR TITLE
[java] Make public constant storing capability name for IE options

### DIFF
--- a/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
+++ b/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
@@ -58,7 +58,7 @@ import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
  */
 public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplorerOptions> {
 
-  final static String IE_OPTIONS = "se:ieOptions";
+  public static final String IE_OPTIONS = "se:ieOptions";
 
   private static final String FULL_PAGE_SCREENSHOT = "ie.enableFullPageScreenshot";
   private static final String UPLOAD_DIALOG_TIMEOUT = "ie.fileUploadDialogTimeout";


### PR DESCRIPTION
### Description
Make public constant storing capability name for IE options

### Motivation and Context
The change will allow users to refer this constant instead of keeping own constants. All other drivers keep such constants public.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
