### PR TITLE
[rust] Include --driver flag to Selenium Manager

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -19,17 +19,19 @@ $ cargo run -- --help
 selenium-manager 1.0.0-M1
 Automated driver management for Selenium
 
-Usage: selenium-manager [OPTIONS] --browser <BROWSER>
+Usage: selenium-manager [OPTIONS]
 Options:
   -b, --browser <BROWSER>
-          Browser type (e.g., chrome, firefox, edge)
-  -D, --driver-version <DRIVER_VERSION>
+          Browser name (chrome, firefox, or edge) [default: ]
+  -d, --driver <DRIVER>
+          Driver name (chromedriver, geckodriver, or msedgedriver) [default: ]
+  -v, --driver-version <DRIVER_VERSION>
           Driver version (e.g., 106.0.5249.61, 0.31.0, etc.) [default: ]
   -B, --browser-version <BROWSER_VERSION>
           Major browser version (e.g., 105, 106, etc.) [default: ]
-  -d, --debug
+  -D, --debug
           Display DEBUG messages
-  -t, --trace
+  -T, --trace
           Display TRACE messages
   -c, --clear-cache
           Clear driver cache


### PR DESCRIPTION
### Description
This PR includes a new argument to Selenium Manager called  `--driver`, which is equivalent to `--browser` (i.e., it allows to select the driver to be managed), but using the driver name (i.e., chromedriver, geckodriver, or msedgedriver) instead of the browser name (chrome, firefox, edge).

### Motivation and Context
This is part of the development of Selenium Manager M1, to ease the integration with the Selenium bindings (e.g., in the `DriverService` class of the Java bindings, we have the driver name instead the browser name).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
