### PR TITLE
[rust] Update Selenium Manager to fully support geckodriver 0.32.0

### DIFF
--- a/rust/src/manager.rs
+++ b/rust/src/manager.rs
@@ -114,3 +114,8 @@ pub fn get_major_version(full_version: &str) -> String {
     let version_vec: Vec<&str> = full_version.split('.').collect();
     version_vec.first().unwrap().to_string()
 }
+
+pub fn get_minor_version(full_version: &str) -> String {
+  let version_vec: Vec<&str> = full_version.split('.').collect();
+  version_vec.get(1).unwrap().to_string()
+}

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -10,7 +10,7 @@ use rstest::rstest;
 #[case("edge", "105", "105.0")]
 #[case("edge", "106", "106.0")]
 #[case("firefox", "", "")]
-#[case("firefox", "105", "0.31.0")]
+#[case("firefox", "105", "0.32.0")]
 fn ok_test(#[case] browser: String, #[case] browser_version: String, #[case] driver_version: String) {
     println!("CLI test browser={} -- browser_version={} -- driver_version={}", browser, browser_version, driver_version);
 


### PR DESCRIPTION
### Description
As of version 0.32.0, geckodriver ships aarch64 binaries for Linux and Windows. See:

https://twitter.com/FirefoxDevTools/status/1580662948384546816
https://github.com/mozilla/geckodriver/releases/tag/v0.32.0
 
This PR updates Selenium Manager to download also these  aarch64 binaries.

### Motivation and Context
Context: development of Selenium Manager M1. Motivation: recent release of geckodriver.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
