### PR TITLE
[grid] ignore more protected headers

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
@@ -83,11 +83,16 @@ class JdkHttpMessages {
     }
 
     for (String name : req.getHeaderNames()) {
-      // Avoid explicitly setting content-length
-      // This prevents the IllegalArgumentException that states 'restricted header name: "Content-Length"'
-      if (name.equalsIgnoreCase("content-length")) {
+      // Avoid explicitly setting "connection", "content-length", "host"
+      // This prevents the IllegalArgumentException that states 'restricted header name: "{header name}"'
+      if (name.equalsIgnoreCase("connection")) {
+        continue;
+      } else if (name.equalsIgnoreCase("content-length")) {
+        continue;
+      } else if (name.equalsIgnoreCase("host")) {
         continue;
       }
+
       for (String value : req.getHeaders(name)) {
         builder = builder.header(name, value);
       }


### PR DESCRIPTION
### Description
ignore more of the protected http headers

### Motivation and Context
This PR fill fix the IllegalArgumentException while running the standalone server with the new http client via:
`java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-4.5.0.jar --ext selenium-http-jdk-client-4.5.0.jar standalone`



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
