### PR TITLE
[java] Make sure `EventFiringWebElement` implements all `WebElement` methods

### DIFF
--- a/java/src/org/openqa/selenium/support/events/EventFiringWebDriver.java
+++ b/java/src/org/openqa/selenium/support/events/EventFiringWebDriver.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
@@ -416,8 +417,23 @@ public class EventFiringWebDriver implements
     }
 
     @Override
+    public String getDomProperty(String name) {
+      return element.getDomProperty(name);
+    }
+
+    @Override
     public String getAttribute(String name) {
       return element.getAttribute(name);
+    }
+
+    @Override
+    public String getAriaRole() {
+      return element.getAriaRole();
+    }
+
+    @Override
+    public String getAccessibleName() {
+      return element.getAccessibleName();
     }
 
     @Override
@@ -441,6 +457,11 @@ public class EventFiringWebDriver implements
       String text = element.getText();
       dispatcher.afterGetText(element, driver, text);
       return text;
+    }
+
+    @Override
+    public SearchContext getShadowRoot() {
+      return element.getShadowRoot();
     }
 
     @Override


### PR DESCRIPTION
### Description
`EventFiringWebElement` should implement all `WebElement` methods: `WebElement` default implementations throw exception, but `EventFiringWebElement` should perform delegation. (See similar fix: https://github.com/SeleniumHQ/selenium/pull/9394).

### Motivation and Context
Despite the fact `EventFiringWebDriver` is deprecated, it's still in use and can't be replaced easily. New `EventFiringDecorator` doesn't work well for all cases yet (e.g. https://github.com/appium/java-client/issues/1694#issuecomment-1281998055).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
