### PR TITLE
Make BaseLogEntry.LogLevel public

### DIFF
--- a/java/src/org/openqa/selenium/bidi/log/BaseLogEntry.java
+++ b/java/src/org/openqa/selenium/bidi/log/BaseLogEntry.java
@@ -51,7 +51,7 @@ public class BaseLogEntry {
     this.stackTrace = stackTrace;
   }
 
-  enum LogLevel {
+  public enum LogLevel {
     DEBUG("debug"),
     ERROR("error"),
     INFO("info"),


### PR DESCRIPTION
### Description

Change visibility of BaseLogEntry.LogLevel to public

### Motivation and Context

`getLevel` exposes the log level but because the enum is private you cannot do anything useful with it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
