### PR TITLE
[py] fix typing in get_full_page_screenshot_as_png

### DIFF
--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -336,7 +336,7 @@ class WebDriver(RemoteWebDriver):
         """
         return self.get_full_page_screenshot_as_file(filename)
 
-    def get_full_page_screenshot_as_png(self) -> str:
+    def get_full_page_screenshot_as_png(self) -> bytes:
         """
         Gets the full document screenshot of the current window as a binary data.
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

Fix for [issue 11157](https://github.com/SeleniumHQ/selenium/issues/11157)

### Motivation and Context

Wrong type for `get_full_page_screenshot_as_png` method causes false positive mypy findings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
Type for returned value was changed from `str` to `bytes` to reflect the reality.