### PR TITLE
[java] Add workaround to decode Base64 screenshots non-compliant with RFC 4648

### DIFF
--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -55,7 +55,13 @@ public interface OutputType<T> {
   OutputType<byte[]> BYTES = new OutputType<byte[]>() {
     @Override
     public byte[] convertFromBase64Png(String base64Png) {
-      return Base64.getDecoder().decode(base64Png);
+
+      // https://github.com/SeleniumHQ/selenium/issues/11168:
+      // Workaround for drivers non-compliant with RFC4648 (e.g. Appium).
+      // To be removed in future in order to meet W3C WebDriver spec requirements.
+      String rfc4648CompliantBase64Png = base64Png.replaceAll("\r?\n", "");
+
+      return Base64.getDecoder().decode(rfc4648CompliantBase64Png);
     }
 
     @Override

--- a/java/test/org/openqa/selenium/OutputTypeTest.java
+++ b/java/test/org/openqa/selenium/OutputTypeTest.java
@@ -45,6 +45,17 @@ class OutputTypeTest {
   }
 
   @Test
+  void testBytesWorkaround() {
+    // https://github.com/SeleniumHQ/selenium/issues/11168
+    byte[] bytes = OutputType.BYTES
+      .convertFromBase64Png("ABA\r\nDA\nB\r\n\r\nAD\r\n");
+    assertThat(bytes).hasSameSizeAs(TEST_BYTES);
+    for (int i = 0; i < TEST_BYTES.length; i++) {
+      assertThat(TEST_BYTES[i]).as("index " + i).isEqualTo(bytes[i]);
+    }
+  }
+
+  @Test
   void testFiles() {
     File tmpFile = OutputType.FILE.convertFromBase64Png(TEST_BASE64);
     assertThat(tmpFile.exists()).isTrue();


### PR DESCRIPTION
### Description
Adding workaround for drivers non-compliant with RFC4648 (e.g. Appium) in order to keep backward compatibility. This change should be removed in future in order to meet W3C WebDriver spec requirements.

### Motivation and Context
The root cause: https://github.com/SeleniumHQ/selenium/pull/11107.
Fixes https://github.com/SeleniumHQ/selenium/issues/11168.
Fixes https://github.com/appium/java-client/issues/1783.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
