### PR TITLE
[rust] Fix msedgedriver uncompression in Selenium Manager

### DIFF
--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -60,7 +60,7 @@ pub fn unzip(file: File, target: PathBuf) {
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
-        if (file.name()).ends_with('/') {
+        if (file.name()).ends_with('/') || target.file_name().unwrap().to_str().unwrap() != file.name() {
             continue;
         } else {
             log::debug!("File extracted to {} ({} bytes)", target.display(), file.size());


### PR DESCRIPTION
### Description
This PR fix a bug in Selenium Manager, related to the uncompression of msedgedriver. 

### Motivation and Context
@titusfortner recently discovered that there was a problem when downloading msedgedriver with Selenium Manager (it uses the licence terms instead of the actual binary). This PR solves that bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
