### PR TITLE
Adding instructions for a shallow clone in the CONTRIBUTING page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,10 @@ Fork the project [on Github](https://github.com/seleniumhq/selenium)
 and check out your copy locally.
 
 ```shell
-% git clone git@github.com:username/selenium.git
+% git clone --depth 1 git@github.com:username/selenium.git # shallow clone recommended
 % cd selenium
 % git remote add upstream git://github.com/seleniumhq/selenium.git
+% git remote update
 ```
 
 #### Dependencies

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 <a href="https://selenium.dev"><img src="https://selenium.dev/images/selenium_logo_square_green.png" width="180" alt="Selenium"/></a>
 
+TOTES SMALL CHANGE FOR TESTING PURPOSES
+
 Selenium is an umbrella project encapsulating a variety of tools and
 libraries enabling web browser automation. Selenium specifically
 provides an infrastructure for the [W3C WebDriver specification](https://w3c.github.io/webdriver/)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 <a href="https://selenium.dev"><img src="https://selenium.dev/images/selenium_logo_square_green.png" width="180" alt="Selenium"/></a>
 
-TOTES SMALL CHANGE FOR TESTING PURPOSES
-
 Selenium is an umbrella project encapsulating a variety of tools and
 libraries enabling web browser automation. Selenium specifically
 provides an infrastructure for the [W3C WebDriver specification](https://w3c.github.io/webdriver/)


### PR DESCRIPTION
### Description
For faster development, it's recommended to use a shallow clone (`--depth 1`) instead of a full clone. I have updated the CONTRIBUTING doc to mention this.

### Motivation and Context
Every little bit helps. If a new or existing contributor can get the Selenium code base in a clone operation more quickly, they may see a better chance to make a change and open a PR. This change helps these new contributors get up and started quickly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
