### PR TITLE
[grid] & [java] jdk http client - avoid chunking without buffering to memory

### DIFF
--- a/java/src/org/openqa/selenium/remote/ProtocolHandshake.java
+++ b/java/src/org/openqa/selenium/remote/ProtocolHandshake.java
@@ -97,8 +97,7 @@ public class ProtocolHandshake {
          Writer writer = new OutputStreamWriter(counter, UTF_8)) {
       payload.writeTo(writer);
 
-      try (InputStream rawIn = os.asByteSource().openBufferedStream();
-           BufferedInputStream contentStream = new BufferedInputStream(rawIn)) {
+      try (InputStream contentStream = os.asByteSource().openBufferedStream()) {
         return createSession(client, contentStream, counter.getCount());
       }
     } finally {
@@ -113,6 +112,9 @@ public class ProtocolHandshake {
     HttpResponse response;
     long start = System.currentTimeMillis();
 
+    // Setting the CONTENT_LENGTH will allow a http client implementation not to read the data in
+    // memory. Usually the payload is small and buffering it to memory is okay, except for a new
+    // session e.g. with profiles.
     request.setHeader(CONTENT_LENGTH, String.valueOf(size));
     request.setHeader(CONTENT_TYPE, JSON_UTF_8);
     request.setContent(() -> newSessionBlob);


### PR DESCRIPTION
### Description
Some drivers do not implement transfer-encoding chunked e.g. [Chrome](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1850) 
The jdk http client implementation did solve this by buffering the request body into a byte array.
The new implementation will only buffer into memory if the content-length is not know.

@pujagani I think this was the reason the `BodyPublishers.ofInputStream` did not work, while `BodyPublishers.ofByteArray` did work with Edge and Chrome drivers.

### Motivation and Context
The implementation of `ProtocolHandshake#createSession` does use a `FileBackedOutputStream` to keep the memory
consumption low for big requests. The jdk http client did not handle this and did buffer the complete request to memory.
This change will help not to buffer the new session request.

When the jdk http client is used for the grid, the size of the payload is usually known.
This change will also help not to buffer these request while sending them to the driver.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
