### PR TITLE
[grid] Allow users to wire-in custom routes

### DIFF
--- a/java/src/org/openqa/selenium/grid/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/BUILD.bazel
@@ -61,6 +61,7 @@ java_binary(
 BASE_COMMAND_SRCS = [
     "TemplateGridCommand.java",
     "TemplateGridServerCommand.java",
+    "UserDefinedRoute.java",
 ]
 
 java_library(
@@ -76,7 +77,7 @@ java_library(
         "//java/src/org/openqa/selenium/grid/log",
         "//java/src/org/openqa/selenium/grid/server",
         "//java/src/org/openqa/selenium/netty/server",
-        "//java/src/org/openqa/selenium/remote/http",
+        "//java/src/org/openqa/selenium/remote",
         artifact("com.beust:jcommander"),
         artifact("com.google.guava:guava"),
     ],

--- a/java/src/org/openqa/selenium/grid/UserDefinedRoute.java
+++ b/java/src/org/openqa/selenium/grid/UserDefinedRoute.java
@@ -1,0 +1,91 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.openqa.selenium.grid.config.Config;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.tracing.Tracer;
+
+/**
+ * Represents custom routes that can be wired in by a user to customise some aspects of the Grid. A
+ * custom route can be wired in via a service loader by doing the following:
+ * <ol>
+ *   <li>Create a folder named <code>META-INF/services</code></li>
+ *   <li>Within the aforementioned folder create a file named
+ *   <code>org.openqa.selenium.grid.UserDefinedRoute</code></li>
+ *   <li>Add references to fully qualified class names of all classes that implement this interface</li>
+ * </ol>
+ *
+ * The added custom routes would be available in the Grid ecosystem under
+ * <code>/admin/</code> URI path.
+ */
+public interface UserDefinedRoute {
+
+  /**
+   * @param config - A {@link Config} object to be injected and which can be used by the custom
+   *               route to interact with the configuration.
+   */
+  void setConfig(Config config);
+
+  /**
+   * @param supplier - A {@link Supplier} that can optionally provide a reference to a
+   *                 {@link Tracer} instance to perform/integrate tracing aspects to custom routes
+   *                 built by the user.
+   */
+  void setTracer(Supplier<Optional<Tracer>> supplier);
+
+  /**
+   * A route that handles <code>GET</code> requests.
+   *
+   * @param request - A {@link HttpRequest} that represents the input request.
+   * @return - A {@link HttpResponse} that represents the response.
+   */
+  HttpResponse get(HttpRequest request);
+
+  /**
+   * A route that handles <code>POST</code> requests.
+   *
+   * @param request - A {@link HttpRequest} that represents the input request.
+   * @return - A {@link HttpResponse} that represents the response.
+   */
+  HttpResponse post(HttpRequest request);
+
+  /**
+   * A route that handles <code>DELETE</code> requests.
+   *
+   * @param request - A {@link HttpRequest} that represents the input request.
+   * @return - A {@link HttpResponse} that represents the response.
+   */
+  HttpResponse delete(HttpRequest request);
+
+  /**
+   * A route that handles <code>OPTIONS</code> requests.
+   *
+   * @param request - A {@link HttpRequest} that represents the input request.
+   * @return - A {@link HttpResponse} that represents the response.
+   */
+  HttpResponse options(HttpRequest request);
+
+  /**
+   * @return - The URL for which the current route is applicable.
+   */
+  String url();
+}

--- a/java/src/org/openqa/selenium/grid/commands/Hub.java
+++ b/java/src/org/openqa/selenium/grid/commands/Hub.java
@@ -203,6 +203,7 @@ public class Hub extends TemplateGridServerCommand {
     // Allow the liveness endpoint to be reached, since k8s doesn't make it easy to authenticate these checks
     httpHandler = combine(httpHandler, Route.get("/readyz").to(() -> readinessCheck));
 
+    httpHandler = combine(httpHandler, considerUserDefinedRoutes(config, tracer));
     return new Handlers(httpHandler, new ProxyWebsocketsIntoGrid(clientFactory, sessions));
   }
 

--- a/java/src/org/openqa/selenium/grid/commands/Standalone.java
+++ b/java/src/org/openqa/selenium/grid/commands/Standalone.java
@@ -228,6 +228,8 @@ public class Standalone extends TemplateGridServerCommand {
         .start();
     }));
 
+    httpHandler = combine(httpHandler, considerUserDefinedRoutes(config, tracer));
+
     return new Handlers(httpHandler, new ProxyNodeWebsockets(clientFactory, node));
   }
 

--- a/java/src/org/openqa/selenium/grid/distributor/httpd/DistributorServer.java
+++ b/java/src/org/openqa/selenium/grid/distributor/httpd/DistributorServer.java
@@ -100,17 +100,17 @@ public class DistributorServer extends TemplateGridServerCommand {
         .setContent(Contents.utf8String("Distributor is " + ready));
     };
 
-    return new Handlers(
-      Route.combine(
-        distributor,
-        Route.matching(req -> GET.equals(req.getMethod()) && "/status".equals(req.getUri()))
-          .to(() -> req -> new HttpResponse()
-            .setContent(Contents.asJson(
-              ImmutableMap.of("value", ImmutableMap.of(
-                "ready", true,
-                "message", "Distributor is ready"))))),
-        get("/readyz").to(() -> readinessCheck)),
-      null);
+    Route route = Route.combine(
+      distributor,
+      Route.matching(req -> GET.equals(req.getMethod()) && "/status".equals(req.getUri()))
+        .to(() -> req -> new HttpResponse()
+          .setContent(Contents.asJson(
+            ImmutableMap.of("value", ImmutableMap.of(
+              "ready", true,
+              "message", "Distributor is ready"))))),
+      get("/readyz").to(() -> readinessCheck));
+    route = Route.combine(route, considerUserDefinedRoutes(config, null));
+    return new Handlers(route, null);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
+++ b/java/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
@@ -170,7 +170,7 @@ public class NodeServer extends TemplateGridServerCommand {
     Route httpHandler = Route.combine(
       node,
       get("/readyz").to(() -> readinessCheck));
-
+    httpHandler = Route.combine(httpHandler, considerUserDefinedRoutes(config, tracer));
     return new Handlers(httpHandler, new ProxyNodeWebsockets(clientFactory, node));
   }
 

--- a/java/src/org/openqa/selenium/grid/router/httpd/RouterServer.java
+++ b/java/src/org/openqa/selenium/grid/router/httpd/RouterServer.java
@@ -186,6 +186,8 @@ public class RouterServer extends TemplateGridServerCommand {
       route,
       get("/readyz").to(() -> readinessCheck));
 
+    routeWithLiveness = Route.combine(routeWithLiveness, considerUserDefinedRoutes(config, tracer));
+
     return new Handlers(routeWithLiveness, new ProxyWebsocketsIntoGrid(clientFactory, sessions));
   }
 

--- a/java/src/org/openqa/selenium/grid/sessionqueue/httpd/NewSessionQueueServer.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/httpd/NewSessionQueueServer.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.grid.sessionqueue.NewSessionQueue;
 import org.openqa.selenium.grid.sessionqueue.config.NewSessionQueueOptions;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.http.Routable;
 import org.openqa.selenium.remote.http.Route;
 
 import java.util.Collections;
@@ -88,18 +89,18 @@ public class NewSessionQueueServer extends TemplateGridServerCommand {
 
     NewSessionQueue sessionQueue = queueOptions.getSessionQueue(LOCAL_NEW_SESSION_QUEUE);
 
-    return new Handlers(
-      Route.combine(
-        sessionQueue,
-        get("/status").to(() -> req ->
-          new HttpResponse()
-            .addHeader("Content-Type", JSON_UTF_8)
-            .setContent(asJson(
-              ImmutableMap.of("value", ImmutableMap.of(
-                "ready", true,
-                "message", "New Session Queue is ready."))))),
-        get("/readyz").to(() -> req -> new HttpResponse().setStatus(HTTP_NO_CONTENT))),
-      null);
+    Routable route = Route.combine(
+      sessionQueue,
+      get("/status").to(() -> req ->
+        new HttpResponse()
+          .addHeader("Content-Type", JSON_UTF_8)
+          .setContent(asJson(
+            ImmutableMap.of("value", ImmutableMap.of(
+              "ready", true,
+              "message", "New Session Queue is ready."))))),
+      get("/readyz").to(() -> req -> new HttpResponse().setStatus(HTTP_NO_CONTENT)));
+    route = Route.combine(route, considerUserDefinedRoutes(config, null));
+    return new Handlers(route, null);
   }
 
   @Override


### PR DESCRIPTION
Grid3 allowed users to wire in custom servlets 
So that a user could add customisations to the node.

Adding similar support to Grid4 via the interface
`org.openqa.selenium.grid.UserDefinedRoute` by 
Leveraging Service Provider Interface driven wire-in mechanism.

All the custom routes added by the user would be 
available under the base path “/admin” in the Grid eco-system depending on to which component the route was added.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Grid3 allowed users to add in custom servlets. Providing a similar support in Grid4 by allowing a user do the following:

1. Implement the interface `org.openqa.selenium.grid.UserDefinedRoute`
2. Create a folder named `META-INF/services`
3. Within the aforementioned folder create a file named `org.openqa.selenium.grid.UserDefinedRoute`
4. Add references to fully qualified class names of all classes that implement this interface


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Grid3 allowed users to add in custom servlets. Providing for a similar capability in Grid4.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
