### PR TITLE
[java] Return new input stream to allow multiple reads

### DIFF
--- a/java/src/org/openqa/selenium/remote/ProtocolHandshake.java
+++ b/java/src/org/openqa/selenium/remote/ProtocolHandshake.java
@@ -34,7 +34,6 @@ import org.openqa.selenium.remote.http.HttpMethod;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
@@ -43,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -91,21 +91,23 @@ public class ProtocolHandshake {
 
   public Either<SessionNotCreatedException, Result> createSession(HttpHandler client, NewSessionPayload payload) throws IOException {
     int threshold = (int) Math.min(Runtime.getRuntime().freeMemory() / 10, Integer.MAX_VALUE);
-    FileBackedOutputStream os = new FileBackedOutputStream(threshold);
+    FileBackedOutputStream os = new FileBackedOutputStream(threshold, true);
 
     try (CountingOutputStream counter = new CountingOutputStream(os);
          Writer writer = new OutputStreamWriter(counter, UTF_8)) {
       payload.writeTo(writer);
-
-      try (InputStream contentStream = os.asByteSource().openBufferedStream()) {
-        return createSession(client, contentStream, counter.getCount());
-      }
-    } finally {
-      os.reset();
+      Supplier<InputStream> contentSupplier = () -> {
+        try {
+          return os.asByteSource().openBufferedStream();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      };
+      return createSession(client, contentSupplier, counter.getCount());
     }
   }
 
-  private Either<SessionNotCreatedException, Result> createSession(HttpHandler client, InputStream newSessionBlob, long size) {
+  private Either<SessionNotCreatedException, Result> createSession(HttpHandler client, Supplier<InputStream> contentSupplier, long size) {
     // Create the http request and send it
     HttpRequest request = new HttpRequest(HttpMethod.POST, "/session");
 
@@ -117,7 +119,7 @@ public class ProtocolHandshake {
     // session e.g. with profiles.
     request.setHeader(CONTENT_LENGTH, String.valueOf(size));
     request.setHeader(CONTENT_TYPE, JSON_UTF_8);
-    request.setContent(() -> newSessionBlob);
+    request.setContent(contentSupplier);
 
     response = client.execute(request);
     long time = System.currentTimeMillis() - start;


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Related to #11068 .

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ProtocolHanshake returns a supplier with the same InputStream instance each time for a POST request body. This causes problems when the HttpClient needs to read the POST request body more than once. To ensure multiple reads are allowed, the chances returns a new instance of InputStream each time. The changes are inspired from the Selenium's memoized supplier.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
