### PR TITLE
[grid] fixed reading the Connection header

### DIFF
--- a/java/src/org/openqa/selenium/netty/server/RequestConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/RequestConverter.java
@@ -84,7 +84,7 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
       }
 
       if (nettyRequest.headers().contains("Sec-WebSocket-Version") &&
-          "upgrade".equals(nettyRequest.headers().get("Connection"))) {
+          "upgrade".equalsIgnoreCase(nettyRequest.headers().get("Connection"))) {
         // Pass this on to later in the pipeline.
         ReferenceCountUtil.retain(msg);
         ctx.fireChannelRead(msg);


### PR DESCRIPTION
### Description
The value of the `Connection` header should be handled as case-insensitive value, see [Reading the Client's Opening Handshake of rfc6455](https://www.rfc-editor.org/rfc/rfc6455#section-4.2.1).

### Motivation and Context
A client handshake was differently handled if `Upgrade` was used instead of the expected `upgrade`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
