### PR TITLE
[grid] do not offload from multiple threads to a single worker

### DIFF
--- a/java/src/org/openqa/selenium/netty/server/RequestConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/RequestConverter.java
@@ -17,7 +17,8 @@
 
 package org.openqa.selenium.netty.server;
 
-import com.google.common.io.ByteStreams;
+import com.google.common.io.ByteSource;
+import com.google.common.io.FileBackedOutputStream;
 
 import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.remote.http.HttpMethod;
@@ -26,7 +27,6 @@ import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.tracing.AttributeKey;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -41,13 +41,9 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 
 import static io.netty.handler.codec.http.HttpMethod.DELETE;
@@ -55,16 +51,14 @@ import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpMethod.HEAD;
 import static io.netty.handler.codec.http.HttpMethod.OPTIONS;
 import static io.netty.handler.codec.http.HttpMethod.POST;
-import static org.openqa.selenium.remote.http.Contents.memoize;
 
 class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
 
   private static final Logger LOG = Logger.getLogger(RequestConverter.class.getName());
-  private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
-  private static final ExecutorService SHUTDOWN_EXECUTOR = Executors.newSingleThreadExecutor();
   private static final List<io.netty.handler.codec.http.HttpMethod> SUPPORTED_METHODS =
     Arrays.asList(DELETE, GET, POST, OPTIONS);
-  private volatile PipedOutputStream out;
+  private volatile FileBackedOutputStream buffer;
+  private volatile HttpRequest request;
 
   @Override
   protected void channelRead0(
@@ -91,68 +85,71 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
         return;
       }
 
-      HttpRequest req = createRequest(ctx, nettyRequest);
-      if (req == null) {
+      request = createRequest(ctx, nettyRequest);
+      if (request == null) {
         return;
       }
 
-      req.setAttribute(AttributeKey.HTTP_SCHEME.getKey(),
+      request.setAttribute(AttributeKey.HTTP_SCHEME.getKey(),
         nettyRequest.protocolVersion().protocolName());
-      req.setAttribute(AttributeKey.HTTP_FLAVOR.getKey(),
+      request.setAttribute(AttributeKey.HTTP_FLAVOR.getKey(),
         nettyRequest.protocolVersion().majorVersion());
 
-      out = new PipedOutputStream();
-      InputStream in = new PipedInputStream(out);
-
-      req.setContent(memoize(() -> in));
-      ctx.fireChannelRead(req);
+      buffer = null;
     }
 
     if (msg instanceof HttpContent) {
       ByteBuf buf = ((HttpContent) msg).content().retain();
-      PipedOutputStream target = out;
+      int nBytes = buf.readableBytes();
 
-      EXECUTOR.submit(() -> {
-        try (InputStream inputStream = new ByteBufInputStream(buf)) {
-          ByteStreams.copy(inputStream, target);
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
+      if (nBytes > 0) {
+        if (buffer == null) {
+          buffer = new FileBackedOutputStream(3 * 1024 * 1024, true);
+        }
+
+        try {
+          buf.readBytes(buffer, nBytes);
         } finally {
           buf.release();
         }
-      });
-    }
+      }
 
-    if (msg instanceof LastHttpContent) {
-      LOG.log(Debug.getDebugLogLevel(), "Closing input pipe.");
-      PipedOutputStream target = out;
+      if (msg instanceof LastHttpContent) {
+        LOG.log(Debug.getDebugLogLevel(), "End of http request: " + msg);
 
-      EXECUTOR.submit(() -> {
-        try {
-          target.close();
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
+        if (buffer != null) {
+          ByteSource source = buffer.asByteSource();
+
+          request.setContent(() -> {
+            try {
+              return source.openBufferedStream();
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          });
+        } else {
+          request.setContent(() -> new InputStream() {
+            @Override
+            public int read() throws IOException {
+              return -1;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+              return -1;
+            }
+          });
         }
-      });
+
+        ctx.fireChannelRead(request);
+      }
     }
   }
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-    LOG.log(Debug.getDebugLogLevel(), "Closing input pipe, channel became inactive.");
-    closeInputPipe();
+    LOG.log(Debug.getDebugLogLevel(), "Channel became inactive.");
     super.channelInactive(ctx);
-  }
-
-  public void closeInputPipe() {
-    PipedOutputStream target = out;
-    SHUTDOWN_EXECUTOR.submit(() -> {
-      try {
-        target.close();
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
   }
 
   private HttpRequest createRequest(

--- a/java/src/org/openqa/selenium/netty/server/ResponseConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/ResponseConverter.java
@@ -58,13 +58,6 @@ public class ResponseConverter extends ChannelOutboundHandlerAdapter {
     }
 
     HttpResponse seResponse = (HttpResponse) msg;
-    if (seResponse.getStatus() == 404) {
-      // In some cases the resource is not found, and if we have not read completely the input
-      // stream, a read/write lock will happen since the client gets a response and won't stream
-      // the remaining content. Closing the pipe avoids a lock and leaves the RequestConverter
-      // ready for upcoming requests.
-      ((RequestConverter) ctx.pipeline().context("se-request").handler()).closeInputPipe();
-    }
 
     // We may not know how large the response is, but figure it out if we can.
     byte[] ary = new byte[CHUNK_SIZE];


### PR DESCRIPTION
The RequestConverter did read the payload of http request in a single worker thread. The netty framework creates multiple 
threads to read concurrent http requests, these where all send to this single worker thread and had to wait for this thread
to finish reading. Even GET http requests without payload had to wait until the `PipedOutputStream` was closed. On the other side
the reading thread had to wait after writing 1024 bytes to the `PipedOutputStream` for the netty framework thread to read the data. 

It was not possible to just increase the single thread to multiple threads to optimize this situation. The jobs submitted to the work-queue could have been executed in the incorrect order (e.g. the close is called before all data is red).

If something went wrong while processing a read/write lock could happen
https://github.com/SeleniumHQ/docker-selenium/issues/1646
https://github.com/SeleniumHQ/docker-selenium/issues/1605

This PR will:
- read the payload inside the thread handling the netty callback
- not kind of synchronize requests on a single thread 
- have less overhead while handling GET requests
- ensure there will be no other read/write lock issues
- remove the workaround added in [#f569d7f](https://github.com/SeleniumHQ/selenium/commit/f569d7f6b1f2a35ea41d9604cdc69dbbd5f58485)

I had some benchmarks on my local system and could not see any regression due to this change.
Some benchmark runs got slightly faster and might even get faster with more concurrent sessions.


This is one of the benchmarks, i know this is a synthetic benchmark and the results might be different with real workloads:
```
		System.setProperty("webdriver.http.factory", "jdk-http-client");

		AtomicInteger done = new AtomicInteger(0);
		final int rounds = 10000;

		Thread a = new Thread(() -> {
			try {
				WebDriver driver = new RemoteWebDriver(new URL("http://127.0.0.1:4444"),  new ChromeOptions());
				driver.manage().window().maximize();
				driver.get("https://justepourtester.net/selenium/selenium_wait.html");

				WebElement input = driver.findElement(By.tagName("input"));

				Instant start = Instant.now();
				Instant end = null;

				for (int i = 0; done.get() != 4; i++){
					if (i == rounds) {
						end = Instant.now();
						done.incrementAndGet();
					} else if (i % 2000 == 0) {
						System.out.println("A@" + i);
					}
					input.getAttribute("class");
				}


				System.out.println("A took " + Duration.between(start, end).getSeconds());
				driver.quit();
			} catch (Exception e) {
				e.printStackTrace();
				System.exit(111);
			}
		});

		Thread b = new Thread(() -> {
			try {
				WebDriver driver = new RemoteWebDriver(new URL("http://127.0.0.1:4444"),  new ChromeOptions());
				driver.manage().window().maximize();
				driver.get("https://justepourtester.net/selenium/selenium_wait.html");

				WebElement body = driver.findElement(By.tagName("body"));

				Instant start = Instant.now();
				Instant end = null;

				for (int i = 0; done.get() != 4; i++){
					if (i == rounds) {
						end = Instant.now();
						done.incrementAndGet();
					} else if (i % 2000 == 0) {
						System.out.println("B@" + i);
					}
					body.isDisplayed();
				}

				System.out.println("B took " + Duration.between(start, end).getSeconds());
				driver.quit();
			} catch (Exception e) {
				e.printStackTrace();
				System.exit(222);
			}
		});

		Thread c = new Thread(() -> {
			try {
				WebDriver driver = new RemoteWebDriver(new URL("http://127.0.0.1:4444"),  new ChromeOptions());
				driver.manage().window().maximize();
				driver.get("https://justepourtester.net/selenium/selenium_wait.html");

				Instant start = Instant.now();
				Instant end = null;

				for (int i = 0; done.get() != 4; i++){
					if (i == rounds) {
						end = Instant.now();
						done.incrementAndGet();
					} else if (i % 2000 == 0) {
						System.out.println("C@" + i);
					}
					driver.findElement(By.tagName("body"));
				}

				System.out.println("C took " + Duration.between(start, end).getSeconds());
				driver.quit();
			} catch (Exception e) {
				e.printStackTrace();
				System.exit(333);
			}

		});


		Thread d = new Thread(() -> {
			try {
				WebDriver driver = new RemoteWebDriver(new URL("http://127.0.0.1:4444"),  new ChromeOptions());
				driver.manage().window().maximize();
				driver.get("https://justepourtester.net/selenium/selenium_wait.html");

				Instant start = Instant.now();
				Instant end = null;

				for (int i = 0; done.get() != 4; i++){
					if (i == rounds) {
						end = Instant.now();
						done.incrementAndGet();
					} else if (i % 2000 == 0) {
						System.out.println("D@" + i);
					}
					driver.getCurrentUrl();
				}

				System.out.println("D took " + Duration.between(start, end).getSeconds());
				driver.quit();
			} catch (Exception e) {
				e.printStackTrace();
				System.exit(333);
			}

		});

		a.start();
		b.start();
		c.start();
		d.start();

		a.join();
		b.join();
		c.join();
		d.join();
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
