### PR TITLE
[rust] Improve error handling in Selenium Manager

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f58bdf0fb6e5d88f8406e826ab50c19ff3ccd16a91ce2994029ac5906fbf9334",
+  "checksum": "1c9948ca8dcce0c5961d83210575dbbac2d5650ed855bd6cbd89d7b3b69588eb",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -188,15 +188,15 @@
               "target": "doc_comment"
             },
             {
-              "id": "predicates 2.1.2",
+              "id": "predicates 2.1.3",
               "target": "predicates"
             },
             {
-              "id": "predicates-core 1.0.4",
+              "id": "predicates-core 1.0.5",
               "target": "predicates_core"
             },
             {
-              "id": "predicates-tree 1.0.6",
+              "id": "predicates-tree 1.0.7",
               "target": "predicates_tree"
             },
             {
@@ -727,7 +727,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -741,13 +741,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "cc 1.0.74": {
+    "cc 1.0.76": {
       "name": "cc",
-      "version": "1.0.74",
+      "version": "1.0.76",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.74/download",
-          "sha256": "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.76/download",
+          "sha256": "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
         }
       },
       "targets": [
@@ -795,7 +795,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.74"
+        "version": "1.0.76"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -838,7 +838,7 @@
               "target": "fnv"
             },
             {
-              "id": "uuid 1.2.1",
+              "id": "uuid 1.2.2",
               "target": "uuid"
             }
           ],
@@ -924,13 +924,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap 4.0.22": {
+    "clap 4.0.24": {
       "name": "clap",
-      "version": "4.0.22",
+      "version": "4.0.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/4.0.22/download",
-          "sha256": "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
+          "url": "https://crates.io/api/v1/crates/clap/4.0.24/download",
+          "sha256": "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
         }
       },
       "targets": [
@@ -1013,7 +1013,7 @@
           ],
           "selects": {}
         },
-        "version": "4.0.22"
+        "version": "4.0.24"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1109,7 +1109,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.3.1",
+              "id": "os_str_bytes 6.4.0",
               "target": "os_str_bytes"
             }
           ],
@@ -1913,6 +1913,39 @@
         "version": "0.9.3"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "exitcode 1.1.2": {
+      "name": "exitcode",
+      "version": "1.1.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/exitcode/1.1.2/download",
+          "sha256": "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "exitcode",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "exitcode",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "1.1.2"
+      },
+      "license": "Apache-2.0"
     },
     "fastrand 1.8.0": {
       "name": "fastrand",
@@ -4950,7 +4983,7 @@
               "target": "autocfg"
             },
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             },
             {
@@ -4971,13 +5004,13 @@
       },
       "license": "MIT"
     },
-    "os_str_bytes 6.3.1": {
+    "os_str_bytes 6.4.0": {
       "name": "os_str_bytes",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.3.1/download",
-          "sha256": "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.4.0/download",
+          "sha256": "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
         }
       },
       "targets": [
@@ -5003,7 +5036,7 @@
           "raw_os_str"
         ],
         "edition": "2021",
-        "version": "6.3.1"
+        "version": "6.4.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5392,13 +5425,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "predicates 2.1.2": {
+    "predicates 2.1.3": {
       "name": "predicates",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates/2.1.2/download",
-          "sha256": "ab68289ded120dcbf9d571afcf70163233229052aec9b08ab09532f698d0e1e6"
+          "url": "https://crates.io/api/v1/crates/predicates/2.1.3/download",
+          "sha256": "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
         }
       },
       "targets": [
@@ -5434,24 +5467,24 @@
               "target": "itertools"
             },
             {
-              "id": "predicates-core 1.0.4",
+              "id": "predicates-core 1.0.5",
               "target": "predicates_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.1.2"
+        "version": "2.1.3"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "predicates-core 1.0.4": {
+    "predicates-core 1.0.5": {
       "name": "predicates-core",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates-core/1.0.4/download",
-          "sha256": "a6e7125585d872860e9955ca571650b27a4979c5823084168c5ed5bbfb016b56"
+          "url": "https://crates.io/api/v1/crates/predicates-core/1.0.5/download",
+          "sha256": "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
         }
       },
       "targets": [
@@ -5474,17 +5507,17 @@
           "**"
         ],
         "edition": "2021",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "predicates-tree 1.0.6": {
+    "predicates-tree 1.0.7": {
       "name": "predicates-tree",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/predicates-tree/1.0.6/download",
-          "sha256": "ad3f7fa8d61e139cbc7c3edfebf3b6678883a53f5ffac65d1259329a93ee43a5"
+          "url": "https://crates.io/api/v1/crates/predicates-tree/1.0.7/download",
+          "sha256": "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
         }
       },
       "targets": [
@@ -5509,7 +5542,7 @@
         "deps": {
           "common": [
             {
-              "id": "predicates-core 1.0.4",
+              "id": "predicates-core 1.0.5",
               "target": "predicates_core"
             },
             {
@@ -5520,7 +5553,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.6"
+        "version": "1.0.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6725,9 +6758,9 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "selenium-manager 1.0.0-M1": {
+    "selenium-manager 1.0.0-M2": {
       "name": "selenium-manager",
-      "version": "1.0.0-M1",
+      "version": "1.0.0-M2",
       "repository": null,
       "targets": [
         {
@@ -6751,7 +6784,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.0.22",
+              "id": "clap 4.0.24",
               "target": "clap"
             },
             {
@@ -6761,6 +6794,10 @@
             {
               "id": "env_logger 0.9.3",
               "target": "env_logger"
+            },
+            {
+              "id": "exitcode 1.1.2",
+              "target": "exitcode"
             },
             {
               "id": "flate2 1.0.24",
@@ -6823,7 +6860,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.0-M1"
+        "version": "1.0.0-M2"
       },
       "license": null
     },
@@ -8879,13 +8916,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "uuid 1.2.1": {
+    "uuid 1.2.2": {
       "name": "uuid",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/uuid/1.2.1/download",
-          "sha256": "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+          "url": "https://crates.io/api/v1/crates/uuid/1.2.2/download",
+          "sha256": "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
         }
       },
       "targets": [
@@ -8912,7 +8949,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "1.2.1"
+        "version": "1.2.2"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -11190,7 +11227,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.76",
               "target": "cc"
             }
           ],
@@ -11203,12 +11240,12 @@
   },
   "binary_crates": [
     "assert_cmd 2.0.6",
-    "cc 1.0.74",
-    "clap 4.0.22",
+    "cc 1.0.76",
+    "clap 4.0.24",
     "wait-timeout 0.2.0"
   ],
   "workspace_members": {
-    "selenium-manager 1.0.0-M1": "rust"
+    "selenium-manager 1.0.0-M2": "rust"
   },
   "conditions": {
     "aarch64-apple-darwin": [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +364,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -781,7 +787,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -895,7 +901,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1156,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1190,12 +1196,13 @@ dependencies = [
 
 [[package]]
 name = "selenium-manager"
-version = "1.0.0-M1"
+version = "1.0.0-M2"
 dependencies = [
  "assert_cmd",
  "clap",
  "directories",
  "env_logger",
+ "exitcode",
  "flate2",
  "infer",
  "log",
@@ -1721,11 +1728,11 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_i686_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_i686_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_x86_64_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_x86_64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -1735,12 +1742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.22"
+version = "4.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
+checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
 dependencies = [
  "atty",
  "bitflags",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "parking_lot"
@@ -953,9 +953,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "predicates"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab68289ded120dcbf9d571afcf70163233229052aec9b08ab09532f698d0e1e6"
+checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
 dependencies = [
  "difflib",
  "itertools",
@@ -964,15 +964,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7125585d872860e9955ca571650b27a4979c5823084168c5ed5bbfb016b56"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3f7fa8d61e139cbc7c3edfebf3b6678883a53f5ffac65d1259329a93ee43a5"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "vcpkg"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selenium-manager"
-version = "1.0.0-M1"
+version = "1.0.0-M2"
 edition = "2021"
 
 [dependencies]
@@ -18,6 +18,7 @@ serde_json = "1.0.87"
 flate2 = "1.0.24"
 tar = "0.4.38"
 infer = "0.11.0"
+exitcode = "1.1.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -117,15 +117,21 @@ impl BrowserManager for ChromeManager {
         }
     }
 
-    fn get_driver_url(&self, driver_version: &str, os: &str, arch: &str) -> String {
+    fn get_driver_url(
+        &self,
+        driver_version: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<String, Box<dyn Error>> {
         let driver_label = if WINDOWS.is(os) {
             "win32"
         } else if MACOS.is(os) {
             if ARM64.is(arch) {
                 // As of chromedriver 106, the naming convention for macOS ARM64 releases changed. See:
                 // https://groups.google.com/g/chromedriver-users/c/JRuQzH3qr2c
-                let major_driver_version =
-                    get_major_version(driver_version).parse::<i32>().unwrap();
+                let major_driver_version = get_major_version(driver_version)?
+                    .parse::<i32>()
+                    .unwrap_or_default();
                 if major_driver_version < 106 {
                     "mac64_m1"
                 } else {
@@ -137,10 +143,10 @@ impl BrowserManager for ChromeManager {
         } else {
             "linux64"
         };
-        format!(
+        Ok(format!(
             "{}{}/{}_{}.zip",
             DRIVER_URL, driver_version, self.driver_name, driver_label
-        )
+        ))
     }
 
     fn get_driver_path_in_cache(&self, driver_version: &str, os: &str, arch: &str) -> PathBuf {

--- a/rust/src/downloads.rs
+++ b/rust/src/downloads.rs
@@ -60,12 +60,10 @@ pub async fn download_driver_to_tmp_folder(
 
 #[tokio::main]
 pub async fn read_content_from_link(url: String) -> Result<String, Box<dyn Error>> {
-    Ok(parse_version(reqwest::get(url).await?.text().await?))
+    parse_version(reqwest::get(url).await?.text().await?)
 }
 
 #[tokio::main]
 pub async fn read_redirect_from_link(url: String) -> Result<String, Box<dyn Error>> {
-    Ok(parse_version(
-        reqwest::get(&url).await?.url().path().to_string(),
-    ))
+    parse_version(reqwest::get(&url).await?.url().path().to_string())
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -126,7 +126,12 @@ impl BrowserManager for EdgeManager {
         }
     }
 
-    fn get_driver_url(&self, driver_version: &str, os: &str, arch: &str) -> String {
+    fn get_driver_url(
+        &self,
+        driver_version: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<String, Box<dyn Error>> {
         let driver_label = if WINDOWS.is(os) {
             if ARM64.is(arch) {
                 "arm64"
@@ -144,10 +149,10 @@ impl BrowserManager for EdgeManager {
         } else {
             "linux64"
         };
-        format!(
+        Ok(format!(
             "{}{}/edgedriver_{}.zip",
             DRIVER_URL, driver_version, driver_label
-        )
+        ))
     }
 
     fn get_driver_path_in_cache(&self, driver_version: &str, os: &str, arch: &str) -> PathBuf {

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use assert_cmd::Command;
+
 use rstest::rstest;
 use std::str;
 
@@ -58,9 +59,12 @@ fn ok_test(
 }
 
 #[rstest]
-#[case("wrong-browser", "", "", 1)]
-#[case("chrome", "wrong-version", "", 101)]
-#[case("chrome", "", "wrong-version", 101)]
+#[case("wrong-browser", "", "", exitcode::DATAERR)]
+#[case("chrome", "wrong-browser-version", "", exitcode::DATAERR)]
+#[case("chrome", "", "wrong-driver-version", exitcode::DATAERR)]
+#[case("firefox", "", "wrong-driver-version", exitcode::DATAERR)]
+#[case("edge", "wrong-browser-version", "", exitcode::DATAERR)]
+#[case("edge", "", "wrong-driver-version", exitcode::DATAERR)]
 fn error_test(
     #[case] browser: String,
     #[case] browser_version: String,


### PR DESCRIPTION
### Description
This PR improves the Rust logic related to error handling. It is part of the development of Selenium Manager M2, implementing #11238, and being a replacement of #11213.

### Motivation and Context
In the development with Rust, there is some controversy about the use of `.wrap()` (see [To unwrap or not to unwrap?](https://users.rust-lang.org/t/to-unwrap-or-not-to-unwrap/10900) or [Using unwrap() in Rust is Okay](https://blog.burntsushi.net/unwrap/)). For Selenium Manager, I propose the following approach about it:

- Panic is ok for uncontrolled errors, i.e., behaviour not expected (e.g., an unexpected error when connecting to a driver repository). In this situations, using `.wrap()` is ok.
- For errors due to a bad input from the user (e.g. a wrong driver version using the flag `--driver-version`) Selenium Manager should not panic, and instead, it show a descriptive error message using `ERROR` log trace and finishing with a known error code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
