### PR TITLE
[grid] Support file downloads on the node

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/DownloadFile.java
+++ b/java/src/org/openqa/selenium/grid/node/DownloadFile.java
@@ -1,0 +1,41 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.node;
+
+import java.io.UncheckedIOException;
+import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.remote.http.HttpHandler;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+class DownloadFile implements HttpHandler {
+
+  private final Node node;
+  private final SessionId id;
+
+  DownloadFile(Node node, SessionId id) {
+    this.node = Require.nonNull("Node", node);
+    this.id = Require.nonNull("Session id", id);
+  }
+
+  @Override
+  public HttpResponse execute(HttpRequest req) throws UncheckedIOException {
+    return node.downloadFile(req, id);
+  }
+}

--- a/java/src/org/openqa/selenium/grid/node/Node.java
+++ b/java/src/org/openqa/selenium/grid/node/Node.java
@@ -150,6 +150,12 @@ public abstract class Node implements HasReadyState, Routable {
       post("/session/{sessionId}/se/file")
         .to(params -> new UploadFile(this, sessionIdFrom(params)))
         .with(spanDecorator("node.upload_file")),
+      get("/session/{sessionId}/file")
+        .to(params -> new DownloadFile(this, sessionIdFrom(params)))
+        .with(spanDecorator("node.download_file")),
+      get("/session/{sessionId}/se/file")
+        .to(params -> new DownloadFile(this, sessionIdFrom(params)))
+        .with(spanDecorator("node.download_file")),
       get("/se/grid/node/owner/{sessionId}")
         .to(params -> new IsSessionOwner(this, sessionIdFrom(params)))
         .with(spanDecorator("node.is_session_owner").andThen(requiresSecret)),
@@ -215,6 +221,8 @@ public abstract class Node implements HasReadyState, Routable {
   }
 
   public abstract HttpResponse uploadFile(HttpRequest req, SessionId id);
+
+  public abstract HttpResponse downloadFile(HttpRequest req, SessionId id);
 
   public abstract void stop(SessionId id) throws NoSuchSessionException;
 

--- a/java/src/org/openqa/selenium/grid/node/Node.java
+++ b/java/src/org/openqa/selenium/grid/node/Node.java
@@ -150,9 +150,6 @@ public abstract class Node implements HasReadyState, Routable {
       post("/session/{sessionId}/se/file")
         .to(params -> new UploadFile(this, sessionIdFrom(params)))
         .with(spanDecorator("node.upload_file")),
-      get("/session/{sessionId}/file")
-        .to(params -> new DownloadFile(this, sessionIdFrom(params)))
-        .with(spanDecorator("node.download_file")),
       get("/session/{sessionId}/se/file")
         .to(params -> new DownloadFile(this, sessionIdFrom(params)))
         .with(spanDecorator("node.download_file")),

--- a/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
@@ -222,12 +222,12 @@ public class NodeFlags implements HasRoles {
   private String nodeImplementation = DEFAULT_NODE_IMPLEMENTATION;
 
   @Parameter(
-    names = {"--downloads-dir"},
+    names = {"--downloads-path"},
     description = "The default location wherein all browser triggered file downloads would be "
       + "available to be retrieved from. This is usually the directory that you configure in "
       + "your browser as the default location for storing downloaded files.")
-  @ConfigValue(section = NODE_SECTION, name = "downloads-dir", example = "")
-  private String downloadsDir = "";
+  @ConfigValue(section = NODE_SECTION, name = "downloads-path", example = "")
+  private String downloadsPath = "";
 
   @Override
   public Set<Role> getRoles() {

--- a/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
@@ -221,6 +221,14 @@ public class NodeFlags implements HasRoles {
     example = DEFAULT_NODE_IMPLEMENTATION)
   private String nodeImplementation = DEFAULT_NODE_IMPLEMENTATION;
 
+  @Parameter(
+    names = {"--downloads-dir"},
+    description = "The default location wherein all browser triggered file downloads would be "
+      + "available to be retrieved from. This is usually the directory that you configure in "
+      + "your browser as the default location for storing downloaded files.")
+  @ConfigValue(section = NODE_SECTION, name = "downloads-dir", example = "")
+  private String downloadsDir = "";
+
   @Override
   public Set<Role> getRoles() {
     return Collections.singleton(NODE_ROLE);

--- a/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -148,7 +148,7 @@ public class NodeOptions {
     }
   }
 
-  public Optional<String> getDownloadsDirectory() {
+  public Optional<String> getDownloadsPath() {
     return config.get(NODE_SECTION, "downloads-path");
   }
 

--- a/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -149,7 +149,7 @@ public class NodeOptions {
   }
 
   public Optional<String> getDownloadsDirectory() {
-    return config.get(NODE_SECTION, "downloads-dir");
+    return config.get(NODE_SECTION, "downloads-path");
   }
 
   public Node getNode() {

--- a/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -148,6 +148,10 @@ public class NodeOptions {
     }
   }
 
+  public Optional<String> getDownloadsDirectory() {
+    return config.get(NODE_SECTION, "downloads-dir");
+  }
+
   public Node getNode() {
     return config.getClass(NODE_SECTION, "implementation", Node.class, DEFAULT_NODE_IMPLEMENTATION);
   }

--- a/java/src/org/openqa/selenium/grid/node/k8s/OneShotNode.java
+++ b/java/src/org/openqa/selenium/grid/node/k8s/OneShotNode.java
@@ -308,6 +308,11 @@ public class OneShotNode extends Node {
   }
 
   @Override
+  public HttpResponse downloadFile(HttpRequest req, SessionId id) {
+    return null;
+  }
+
+  @Override
   public void stop(SessionId id) throws NoSuchSessionException {
     LOG.info("Stop has been called: " + id);
     Require.nonNull("Session ID", id);

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -748,7 +748,7 @@ public class LocalNode extends Node {
     private Duration sessionTimeout = Duration.ofSeconds(NodeOptions.DEFAULT_SESSION_TIMEOUT);
     private HealthCheck healthCheck;
     private Duration heartbeatPeriod = Duration.ofSeconds(NodeOptions.DEFAULT_HEARTBEAT_PERIOD);
-    private String downloadsDir = "";
+    private String downloadsPath = "";
 
     private Builder(
       Tracer tracer,
@@ -803,8 +803,8 @@ public class LocalNode extends Node {
       return this;
     }
 
-    public Builder downloadsDirectory(String dir) {
-      this.downloadsDir = dir;
+    public Builder downloadsPath(String path) {
+      this.downloadsPath = path;
       return this;
     }
 
@@ -824,7 +824,7 @@ public class LocalNode extends Node {
         heartbeatPeriod,
         factories.build(),
         registrationSecret,
-        downloadsDir);
+        downloadsPath);
     }
 
     public Advanced advanced() {

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNodeFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNodeFactory.java
@@ -76,6 +76,8 @@ public class LocalNodeFactory {
     List<DriverService.Builder<?, ?>> builders = new ArrayList<>();
     ServiceLoader.load(DriverService.Builder.class).forEach(builders::add);
 
+    nodeOptions.getDownloadsPath().ifPresent(builder::downloadsPath);
+
     nodeOptions
       .getSessionFactories(
         caps -> createSessionFactory(tracer, clientFactory, sessionTimeout, builders, caps))

--- a/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -190,6 +190,11 @@ public class RemoteNode extends Node {
   }
 
   @Override
+  public HttpResponse downloadFile(HttpRequest req, SessionId id) {
+    return client.execute(req);
+  }
+
+  @Override
   public void stop(SessionId id) throws NoSuchSessionException {
     Require.nonNull("Session ID", id);
     HttpRequest req = new HttpRequest(DELETE, "/se/grid/node/session/" + id);

--- a/java/src/org/openqa/selenium/remote/http/Contents.java
+++ b/java/src/org/openqa/selenium/remote/http/Contents.java
@@ -22,6 +22,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.FileBackedOutputStream;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.zip.ZipOutputStream;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.Json;
 import org.openqa.selenium.json.JsonInput;
@@ -136,6 +141,18 @@ public class Contents {
 
   public static Supplier<InputStream> memoize(Supplier<InputStream> delegate) {
     return new MemoizedSupplier(delegate);
+  }
+
+  public static String string(File input) throws IOException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      InputStream isr = Files.newInputStream(input.toPath())) {
+      int len;
+      byte[] buffer = new byte[4096];
+      while ((len = isr.read(buffer)) != -1) {
+        bos.write(buffer, 0, len);
+      }
+      return Base64.getEncoder().encodeToString(bos.toByteArray());
+    }
   }
 
   private static final class MemoizedSupplier implements Supplier<InputStream> {

--- a/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
@@ -386,7 +386,7 @@ class AddingNodesTest {
 
     @Override
     public HttpResponse downloadFile(HttpRequest req, SessionId id) {
-      throw new UnsupportedOperationException("uploadFile");
+      throw new UnsupportedOperationException("downloadFile");
     }
 
     @Override

--- a/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/AddingNodesTest.java
@@ -385,6 +385,11 @@ class AddingNodesTest {
     }
 
     @Override
+    public HttpResponse downloadFile(HttpRequest req, SessionId id) {
+      throw new UnsupportedOperationException("uploadFile");
+    }
+
+    @Override
     public Session getSession(SessionId id) throws NoSuchSessionException {
       if (running == null || !running.getId().equals(id)) {
         throw new NoSuchSessionException();

--- a/java/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -30,7 +30,7 @@ import static org.openqa.selenium.remote.http.HttpMethod.POST;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Base64;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -495,7 +495,7 @@ class NodeTest {
     Session session = response.right().getSession();
     String hello = "Hello, world!";
 
-    HttpRequest req = new HttpRequest(GET, String.format("/session/%s/file", session.getId()));
+    HttpRequest req = new HttpRequest(GET, String.format("/session/%s/se/file", session.getId()));
     File zip = createTmpFile(hello);
     req.addQueryParameter("filename", zip.getName());
     HttpResponse rsp = node.execute(req);
@@ -503,7 +503,9 @@ class NodeTest {
     Map<String, Object> map = new Json().toType(string(rsp), Json.MAP_TYPE);
     File baseDir = getTemporaryFilesystemBaseDir(TemporaryFilesystem.getDefaultTmpFS());
     String encodedContents = map.get("contents").toString();
-    String decodedContents = new String(Base64.getMimeDecoder().decode(encodedContents));
+    Zip.unzip(encodedContents, baseDir);
+    Path path = new File(baseDir.getAbsolutePath() + "/" + map.get("filename")).toPath();
+    String decodedContents = String.join("", Files.readAllLines(path));
     assertThat(decodedContents).isEqualTo(hello);
   }
 

--- a/java/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -30,6 +30,7 @@ import static org.openqa.selenium.remote.http.HttpMethod.POST;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -115,6 +116,7 @@ class NodeTest {
     caps = new ImmutableCapabilities("browserName", "cheese");
 
     uri = new URI("http://localhost:1234");
+    File downloadsDir = new File(System.getProperty("java.io.tmpdir"));
 
     class Handler extends Session implements HttpHandler {
       private Handler(Capabilities capabilities) {
@@ -131,6 +133,7 @@ class NodeTest {
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
+        .downloadsDirectory(downloadsDir.getAbsolutePath())
         .maximumConcurrentSessions(2)
         .build();
 
@@ -485,6 +488,26 @@ class NodeTest {
   }
 
   @Test
+  void canDownloadAFile() throws IOException {
+    Either<WebDriverException, CreateSessionResponse> response =
+      node.newSession(createSessionRequest(caps));
+    assertThatEither(response).isRight();
+    Session session = response.right().getSession();
+    String hello = "Hello, world!";
+
+    HttpRequest req = new HttpRequest(GET, String.format("/session/%s/file", session.getId()));
+    File zip = createTmpFile(hello);
+    req.addQueryParameter("filename", zip.getName());
+    HttpResponse rsp = node.execute(req);
+    node.stop(session.getId());
+    Map<String, Object> map = new Json().toType(string(rsp), Json.MAP_TYPE);
+    File baseDir = getTemporaryFilesystemBaseDir(TemporaryFilesystem.getDefaultTmpFS());
+    String encodedContents = map.get("contents").toString();
+    String decodedContents = new String(Base64.getMimeDecoder().decode(encodedContents));
+    assertThat(decodedContents).isEqualTo(hello);
+  }
+
+  @Test
   void shouldNotCreateSessionIfDraining() {
     node.drain();
     assertThat(local.isDraining()).isTrue();
@@ -573,6 +596,17 @@ class NodeTest {
     assertThat(latch.getCount()).isEqualTo(1);
   }
 
+  private File createFile(String content, File directory) {
+    try {
+      File f = new File(directory.getAbsolutePath(), UUID.randomUUID().toString());
+      f.deleteOnExit();
+      Files.write(directory.toPath(), content.getBytes(StandardCharsets.UTF_8));
+      return f;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
   private File createTmpFile(String content) {
     try {
       File f = File.createTempFile("webdriver", "tmp");

--- a/java/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -116,7 +116,7 @@ class NodeTest {
     caps = new ImmutableCapabilities("browserName", "cheese");
 
     uri = new URI("http://localhost:1234");
-    File downloadsDir = new File(System.getProperty("java.io.tmpdir"));
+    File downloadsPath = new File(System.getProperty("java.io.tmpdir"));
 
     class Handler extends Session implements HttpHandler {
       private Handler(Capabilities capabilities) {
@@ -133,7 +133,7 @@ class NodeTest {
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
         .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
-        .downloadsDirectory(downloadsDir.getAbsolutePath())
+        .downloadsPath(downloadsPath.getAbsolutePath())
         .maximumConcurrentSessions(2)
         .build();
 


### PR DESCRIPTION
Fixes: #9218

On the node, set the directory to where the browser  will download files to via:

a. The CLI argument `--downloads-path` (or)
b. via the Toml syntax of 

```
[node]
downloads-path = "/path/to/dir/goes/here"
```
The GET end-points that will support file 
download would be (The file will ALWAYS BE DOWNLOADED AS A ZIP FILE):

* `/session/:sessionId:/se/file?filename=`

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X]  All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
