### PR TITLE
[rust] Disable TTL for browsers in Selenium Manager (#11209)

### DIFF
--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::files::get_cache_folder;
 
 const METADATA_FILE: &str = "selenium-manager.json";
-const TTL_BROWSERS_SEC: u64 = 3600;
+const TTL_BROWSERS_SEC: u64 = 0;
 const TTL_DRIVERS_SEC: u64 = 86400;
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
### Description
This PR changes the value of TTL for browsers, previously 3600 seconds, to 0.

### Motivation and Context
As discussed on the TLC meeting on 10 November 2022, TTL for browsers should be disabled in Selenium Manager.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
