### PR TITLE
[rust] Include support for IEDriverServer in Selenium Manager

### DIFF
--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -104,7 +104,7 @@ pub fn unzip(file: File, target: PathBuf) -> Result<(), Box<dyn Error>> {
             continue;
         }
         let target_file_name = target.file_name().unwrap().to_str().unwrap();
-        if target_file_name == file.name() {
+        if target_file_name.eq_ignore_ascii_case(file.name()) {
             log::debug!(
                 "File extracted to {} ({} bytes)",
                 target.display(),

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -1,0 +1,115 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use crate::downloads::read_redirect_from_link;
+use crate::files::compose_driver_path_in_cache;
+
+use crate::manager::{get_minor_version, BrowserManager};
+
+use crate::metadata::{
+    create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
+};
+
+const BROWSER_NAME: &str = "iexplorer";
+const DRIVER_NAME: &str = "IEDriverServer";
+const DRIVER_URL: &str = "https://github.com/SeleniumHQ/selenium/releases/";
+const LATEST_RELEASE: &str = "latest";
+
+pub struct IExplorerManager {
+    pub browser_name: &'static str,
+    pub driver_name: &'static str,
+}
+
+impl IExplorerManager {
+    pub fn new() -> Box<Self> {
+        Box::new(IExplorerManager {
+            browser_name: BROWSER_NAME,
+            driver_name: DRIVER_NAME,
+        })
+    }
+}
+
+impl BrowserManager for IExplorerManager {
+    fn get_browser_name(&self) -> &str {
+        self.browser_name
+    }
+
+    fn get_browser_version(&self, _os: &str) -> Option<String> {
+        None
+    }
+
+    fn get_driver_name(&self) -> &str {
+        self.driver_name
+    }
+
+    fn get_driver_version(
+        &self,
+        browser_version: &str,
+        _os: &str,
+    ) -> Result<String, Box<dyn Error>> {
+        let mut metadata = get_metadata();
+
+        match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
+        {
+            Some(driver_version) => {
+                log::trace!(
+                    "Driver TTL is valid. Getting {} version from metadata",
+                    &self.driver_name
+                );
+                Ok(driver_version)
+            }
+            _ => {
+                let latest_url = format!("{}{}", DRIVER_URL, LATEST_RELEASE);
+                let driver_version = read_redirect_from_link(latest_url)?;
+
+                if !browser_version.is_empty() {
+                    metadata.drivers.push(create_driver_metadata(
+                        browser_version,
+                        self.driver_name,
+                        &driver_version,
+                    ));
+                    write_metadata(&metadata);
+                }
+
+                Ok(driver_version)
+            }
+        }
+    }
+
+    fn get_driver_url(
+        &self,
+        driver_version: &str,
+        _os: &str,
+        _arch: &str,
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(format!(
+            "{}download/selenium-{}/IEDriverServer_Win32_{}.zip",
+            DRIVER_URL, driver_version, driver_version
+        ))
+    }
+
+    fn get_driver_path_in_cache(&self, driver_version: &str, os: &str, _arch: &str) -> PathBuf {
+        let _minor_driver_version = get_minor_version(driver_version)
+            .unwrap_or_default()
+            .parse::<i32>()
+            .unwrap_or_default();
+        compose_driver_path_in_cache(self.driver_name, os, "win32", driver_version)
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -31,6 +31,7 @@ use crate::chrome::ChromeManager;
 use crate::edge::EdgeManager;
 use crate::files::clear_cache;
 use crate::firefox::FirefoxManager;
+use crate::iexplorer::IExplorerManager;
 use crate::manager::BrowserManager;
 
 mod chrome;
@@ -38,6 +39,7 @@ mod downloads;
 mod edge;
 mod files;
 mod firefox;
+mod iexplorer;
 mod manager;
 mod metadata;
 
@@ -49,11 +51,11 @@ mod metadata;
 {usage-heading} {usage}
 {all-args}")]
 struct Cli {
-    /// Browser name (chrome, firefox, or edge)
+    /// Browser name (chrome, firefox, edge, or iexplorer)
     #[clap(short, long, value_parser, default_value = "")]
     browser: String,
 
-    /// Driver name (chromedriver, geckodriver, or msedgedriver)
+    /// Driver name (chromedriver, geckodriver, msedgedriver, or IEDriverServer)
     #[clap(short, long, value_parser, default_value = "")]
     driver: String,
 
@@ -104,6 +106,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         || driver_name.eq_ignore_ascii_case("msedgedriver")
     {
         EdgeManager::new()
+    } else if browser_name.eq_ignore_ascii_case("iexplorer")
+        || driver_name.eq_ignore_ascii_case("iedriverserver")
+    {
+        IExplorerManager::new()
     } else {
         exit_with_error("Invalid browser/driver name".to_string());
         exit(exitcode::DATAERR);
@@ -125,7 +131,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     log::debug!("Detected browser: {} {}", browser_name, browser_version);
                 }
                 None => {
-                    log::warn!(
+                    log::debug!(
                         "The version of {} cannot be detected. Trying with latest driver version",
                         browser_name
                     );

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -21,16 +21,18 @@ use rstest::rstest;
 use std::str;
 
 #[rstest]
-#[case("chrome", "", "")]
-#[case("chrome", "105", "105.0.5195.52")]
-#[case("chrome", "106", "106.0.5249.61")]
-#[case("edge", "", "")]
-#[case("edge", "105", "105.0")]
-#[case("edge", "106", "106.0")]
-#[case("firefox", "", "")]
-#[case("firefox", "105", "0.32.0")]
+#[case("chrome", "chromedriver", "", "")]
+#[case("chrome", "chromedriver", "105", "105.0.5195.52")]
+#[case("chrome", "chromedriver", "106", "106.0.5249.61")]
+#[case("edge", "msedgedriver", "", "")]
+#[case("edge", "msedgedriver", "105", "105.0")]
+#[case("edge", "msedgedriver", "106", "106.0")]
+#[case("firefox", "geckodriver", "", "")]
+#[case("firefox", "geckodriver", "105", "0.32.0")]
+#[case("iexplorer", "IEDriverServer", "", "")]
 fn ok_test(
     #[case] browser: String,
+    #[case] driver_name: String,
     #[case] browser_version: String,
     #[case] driver_version: String,
 ) {
@@ -52,7 +54,7 @@ fn ok_test(
     };
     println!("{}", output);
 
-    assert!(output.contains("driver"));
+    assert!(output.contains(&driver_name));
     if !browser_version.is_empty() {
         assert!(output.contains(&driver_version));
     }
@@ -65,6 +67,7 @@ fn ok_test(
 #[case("firefox", "", "wrong-driver-version", exitcode::DATAERR)]
 #[case("edge", "wrong-browser-version", "", exitcode::DATAERR)]
 #[case("edge", "", "wrong-driver-version", exitcode::DATAERR)]
+#[case("iexplorer", "", "wrong-driver-version", exitcode::DATAERR)]
 fn error_test(
     #[case] browser: String,
     #[case] browser_version: String,


### PR DESCRIPTION
### Description
This PR implements the support for IEDriverServer (i.e., the driver required to use Internet Explorer) with Selenium Manager.

### Motivation and Context
This feature is part of the development of Selenium Manager M2.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
