### PR TITLE
[java] timely get rid of the SelectorManager threads

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
@@ -300,5 +300,14 @@ public class JdkHttpClient implements HttpClient {
       Objects.requireNonNull(config, "Client config must be set");
       return new JdkHttpClient(config);
     }
+
+    @Override
+    public void cleanupIdleClients() {
+      HttpClient.Factory.super.cleanupIdleClients();
+
+      // The SelectorManager thread uses internally a WeakReference to the HttpClient to check if it
+      // is still used or the thread can be stopped. Calling the GC will clear the WeakReference.
+      System.gc();
+    }
   }
 }


### PR DESCRIPTION
### Description
In cases where a lot of WebDrivers are created, timely closed and there is no GC done, a lot of SelectorManager threads are running. Calling the GC explicit is not best practice, but it is the only way to stop these threads. 

Has been reported in #11270

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
