### PR TITLE
[grid] improved exception handling when no cause is set

### DIFF
--- a/java/src/org/openqa/selenium/grid/router/HandleSession.java
+++ b/java/src/org/openqa/selenium/grid/router/HandleSession.java
@@ -147,8 +147,12 @@ class HandleSession implements HttpHandler {
         Throwable cause = e.getCause();
         if (cause instanceof RuntimeException) {
           throw (RuntimeException) cause;
+        } else if (cause != null) {
+          throw new RuntimeException(errorMessage, cause);
+        } else if (e instanceof RuntimeException) {
+          throw (RuntimeException) e;
         }
-        throw new RuntimeException(errorMessage, cause);
+        throw new RuntimeException(errorMessage, e);
       }
     }
   }


### PR DESCRIPTION
### Description
In cases where the exception thrown has no cause there was no helpful stack trace to localize the issue.

### Motivation and Context
I was playing with another PR and added a `ImmutableMap.of("value", null)` call, this lead to an exception without cause set. I was not able to get the origin in code of the exception due to the missing infos in the server answer.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
