### PR TITLE
Setup Ruby tests CI on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 try-import .bazelrc.local
+try-import .bazelrc.windows.local
 
 # Ensure Windows support is accurate.
 

--- a/.github/.bazelrc.windows.local
+++ b/.github/.bazelrc.windows.local
@@ -1,0 +1,4 @@
+# Use predefined path for building so we could cache `external/`.
+startup --output_base=D:/_bazel
+build --disk_cache=D:/_bazel-disk
+build --repository_cache=D:/_bazel-repo

--- a/.github/actions/bazel/action.yml
+++ b/.github/actions/bazel/action.yml
@@ -7,7 +7,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        cp .github/.bazelrc.local .
-        bazel ${{ inputs.command }}
+    - run: copy .github\.bazelrc.windows.local .
+      if: runner.os == 'Windows'
+      shell: cmd
+    - run: bazel ${{ inputs.command }}
+      if: runner.os == 'Windows'
+      shell: cmd
+    - run: cp .github/.bazelrc.local .
+      if: runner.os != 'Windows'
+      shell: bash
+    - run: bazel ${{ inputs.command }}
+      if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/cache-bazel/action.yml
+++ b/.github/actions/cache-bazel/action.yml
@@ -1,0 +1,48 @@
+name: Store Bazel cache
+description: Stores Bazel cache using actions/cache
+inputs:
+  workflow:
+    description: Workflow name
+    required: true
+  key:
+    description: Extra cache key
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - if: runner.os == 'Windows'
+      name: Use GNU tar
+      shell: cmd
+      # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
+      # Bazel relies heavily on symlinks, so enable native support
+      run: |
+        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+        echo MSYS=winsymlinks:native>>"%GITHUB_ENV%"
+    - if: runner.os == 'Windows'
+      uses: actions/cache@v3
+      with:
+        # Ideally we would cache the whole external/ but it causes various
+        # issues both on packing and unpacking cache.
+        # The whole caching approached needs overhaul to make it work good
+        # on Windows.
+        path: |
+          D:\_bazel\external\bundle
+          D:\_bazel\external\rules_ruby
+          D:\_bazel\external\rules_ruby_dist
+          D:\_bazel-disk
+          D:\_bazel-repo
+        key: ${{ runner.os }}-bazel-${{ inputs.workflow }}-${{ inputs.key }}-${{ hashFiles('**/BUILD.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-${{ inputs.workflow }}-${{ inputs.key }}-
+          ${{ runner.os }}-bazel-${{ inputs.workflow }}-
+    - if: runner.os != 'Windows'
+      uses: actions/cache@v3
+      with:
+        path: |
+          /tmp/bazel/external
+          ~/.cache/bazel-disk
+          ~/.cache/bazel-repo
+        key: ${{ runner.os }}-bazel-${{ inputs.workflow }}-${{ inputs.key }}-${{ hashFiles('**/BUILD.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-${{ inputs.workflow }}-${{ inputs.key }}-
+          ${{ runner.os }}-bazel-${{ inputs.workflow }}-

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -48,11 +48,12 @@ jobs:
   chrome-test:
     if: ${{ needs.check_workflow.outputs.result == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(toJson(github.event.commits), '[run ruby]') == true }}
     needs: check_workflow
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         target: [ 'chrome-test', 'remote-chrome-test' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v2
@@ -66,13 +67,21 @@ jobs:
           workflow: ruby
           key: ${{ matrix.target }}
       - name: Setup Fluxbox
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get -y install fluxbox
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
       - name: Start XVFB
+        if: matrix.os == 'ubuntu-latest'
         run: Xvfb :99 &
       - name: Start Fluxbox
+        if: matrix.os == 'ubuntu-latest'
         run: fluxbox -display :99 &
+      - name: Set resolution
+        if: matrix.os == 'windows-latest'
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
       - name: Run Chrome tests
         uses: ./.github/actions/bazel
         with:

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -90,6 +90,37 @@ jobs:
         env:
           DISPLAY: :99
 
+  edge-test:
+    if: ${{ needs.check_workflow.outputs.result == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(toJson(github.event.commits), '[run ruby]') == true }}
+    needs: check_workflow
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ 'edge-test', 'remote-edge-test' ]
+        os: [ 'windows-latest' ]
+    steps:
+      - name: Checkout source tree
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Bazel artifacts
+        uses: ./.github/actions/cache-bazel
+        with:
+          workflow: ruby
+          key: ${{ matrix.target }}
+      - name: Setup Edge
+        uses: browser-actions/setup-edge@latest
+        with:
+          edge-version: stable
+      - name: Run Edge tests
+        uses: ./.github/actions/bazel
+        with:
+          command: test --cache_test_results=no --test_output=all //rb:${{ matrix.target }}
+          attempts: 3
+
   firefox-test:
     if: ${{ needs.check_workflow.outputs.result == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(toJson(github.event.commits), '[run ruby]') == true }}
     needs: check_workflow

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -200,8 +200,8 @@ jobs:
           key: ${{ runner.os }}-bazel-ruby-unit-test-${{ matrix.ruby }}-${{ hashFiles('**/BUILD.bazel') }}
           restore-keys: |
             ${{ runner.os }}-bazel-ruby-unit-test-${{ matrix.ruby }}-
-      - name: Patch WORKSPACE to select Ruby ${{ matrix.ruby }}
-        run: sed -i -E "s/(rb_download\(version = \")(.+)(\"\))/\1${{ matrix.ruby }}\3/" WORKSPACE
+      - name: Set Ruby version to ${{ matrix.ruby }}
+        run: echo 'RUBY_VERSION = "${{ matrix.ruby }}"' > rb/ruby_version.bzl
       - name: Run unit tests
         uses: ./.github/actions/bazel
         with:

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -93,11 +93,12 @@ jobs:
   firefox-test:
     if: ${{ needs.check_workflow.outputs.result == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(toJson(github.event.commits), '[run ruby]') == true }}
     needs: check_workflow
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         target: [ 'firefox-test', 'remote-firefox-test' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v2
@@ -111,6 +112,7 @@ jobs:
           workflow: ruby
           key: ${{ matrix.target }}
       - name: Setup Fluxbox
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get -y install fluxbox
       - name: Setup Firefox
         uses: abhi1693/setup-browser@v0.3.4
@@ -118,9 +120,14 @@ jobs:
           browser: firefox
           version: latest
       - name: Start XVFB
+        if: matrix.os == 'ubuntu-latest'
         run: Xvfb :99 &
       - name: Start Fluxbox
+        if: matrix.os == 'ubuntu-latest'
         run: fluxbox -display :99 &
+      - name: Set resolution
+        if: matrix.os == 'windows-latest'
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
       - name: Run Firefox tests
         uses: ./.github/actions/bazel
         with:

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -36,15 +36,10 @@ jobs:
         with:
           java-version: 11
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-build-gem-${{ matrix.target }}-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-build-gem-${{ matrix.target }}-
+          workflow: ruby
+          key: gem-${{ matrix.target }}
       - name: Build Gems
         uses: ./.github/actions/bazel
         with:
@@ -66,15 +61,10 @@ jobs:
         with:
           java-version: 11
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-
+          workflow: ruby
+          key: ${{ matrix.target }}
       - name: Setup Fluxbox
         run: sudo apt-get -y install fluxbox
       - name: Setup Chrome
@@ -107,15 +97,10 @@ jobs:
         with:
           java-version: 11
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-
+          workflow: ruby
+          key: ${{ matrix.target }}
       - name: Setup Fluxbox
         run: sudo apt-get -y install fluxbox
       - name: Setup Firefox
@@ -143,15 +128,10 @@ jobs:
       - name: Checkout source tree
         uses: actions/checkout@v2
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-docs-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-${{ matrix.target }}-
+          workflow: ruby
+          key: docs
       - name: Run docs tests
         uses: ./.github/actions/bazel
         with:
@@ -165,15 +145,10 @@ jobs:
       - name: Checkout source tree
         uses: actions/checkout@v2
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-lint-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-lint-
+          workflow: ruby
+          key: lint
       - name: Run lint tests
         uses: ./.github/actions/bazel
         with:
@@ -191,15 +166,10 @@ jobs:
       - name: Checkout source tree
         uses: actions/checkout@v2
       - name: Cache Bazel artifacts
-        uses: actions/cache@v2
+        uses: ./.github/actions/cache-bazel
         with:
-          path: |
-            /tmp/bazel/external
-            ~/.cache/bazel-disk
-            ~/.cache/bazel-repo
-          key: ${{ runner.os }}-bazel-ruby-unit-test-${{ matrix.ruby }}-${{ hashFiles('**/BUILD.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-ruby-unit-test-${{ matrix.ruby }}-
+          workflow: ruby
+          key: unit-test-${{ matrix.ruby }}
       - name: Set Ruby version to ${{ matrix.ruby }}
         run: echo 'RUBY_VERSION = "${{ matrix.ruby }}"' > rb/ruby_version.bzl
       - name: Run unit tests

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -157,11 +157,15 @@ jobs:
   unit-test:
     if: ${{ needs.check_workflow.outputs.result == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(toJson(github.event.commits), '[run ruby]') == true }}
     needs: check_workflow
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         ruby: [ '2.7.6', '3.1.2', 'jruby-9.4.0.0', 'truffleruby-22.3.0' ]
+        os: ['ubuntu-latest']
+        include:
+          - ruby: 2.7.6
+            os: windows-latest
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -318,13 +318,14 @@ http_archive(
     url = "https://github.com/p0deje/rules_ruby/archive/0799d724aeca58d42ecbe3b7ebde112dc6565c9f.zip",
 )
 
+load("//rb:ruby_version.bzl", "RUBY_VERSION")
 load(
     "@rules_ruby//ruby:deps.bzl",
     "rb_bundle",
     "rb_download",
 )
 
-rb_download(version = "2.7.6")
+rb_download(version = RUBY_VERSION)
 
 rb_bundle(
     name = "bundle",

--- a/rb/BUILD.bazel
+++ b/rb/BUILD.bazel
@@ -18,6 +18,8 @@ CDP_VERSIONS = [
     "v107",
 ]
 
+exports_files(["ruby_version.bzl"])
+
 copy_file(
     name = "find-elements",
     src = "//javascript/atoms/fragments:find-elements.js",

--- a/rb/lib/selenium/webdriver/common/websocket_connection.rb
+++ b/rb/lib/selenium/webdriver/common/websocket_connection.rb
@@ -22,6 +22,11 @@ require 'websocket'
 module Selenium
   module WebDriver
     class WebSocketConnection
+      CONNECTION_ERRORS = [
+        Errno::ECONNRESET, # connection is aborted (browser process was killed)
+        Errno::EPIPE # broken pipe (browser process was killed)
+      ].freeze
+
       RESPONSE_WAIT_TIMEOUT = 30
       RESPONSE_WAIT_INTERVAL = 0.1
 
@@ -90,6 +95,8 @@ module Selenium
               end
             end
           end
+        rescue *CONNECTION_ERRORS
+          Thread.stop
         end
       end
 
@@ -122,6 +129,8 @@ module Selenium
           Thread.current.report_on_exception = true
 
           yield params
+        rescue *CONNECTION_ERRORS
+          Thread.stop
         end
       end
 

--- a/rb/ruby_version.bzl
+++ b/rb/ruby_version.bzl
@@ -1,0 +1,1 @@
+RUBY_VERSION = "2.7.6"

--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -202,7 +202,10 @@ module Selenium
           expect(element.attribute(:value)).to eq('Clicked')
         end
 
-        it 'moves to element with offset' do
+        it 'moves to element with offset', except: {browser: :firefox,
+                                                    ci: :github,
+                                                    platform: :windows,
+                                                    reason: 'Some issues with resolution?'} do
           driver.navigate.to url_for('javascriptPage.html')
           origin = driver.find_element(id: 'keyUpArea')
           destination = driver.find_element(id: 'clickField')
@@ -317,7 +320,7 @@ module Selenium
 
       describe '#scroll_by', only: {browser: %i[chrome edge firefox]} do
         it 'scrolls by given amount', except: {browser: :firefox,
-                                               platform: %i[macosx windows],
+                                               platform: :macosx,
                                                reason: 'scrolls insufficient number of pixels'} do
           driver.navigate.to url_for('scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html')
           footer = driver.find_element(tag_name: 'footer')

--- a/rb/spec/integration/selenium/webdriver/devtools_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/devtools_spec.rb
@@ -30,20 +30,21 @@ module Selenium
       end
 
       it 'supports events' do
-        callback = instance_double(Proc, call: nil)
-
-        driver.devtools.page.enable
-        driver.devtools.page.on(:load_event_fired) { callback.call }
-        driver.navigate.to url_for('xhtmlTest.html')
-        sleep 0.5
-
-        expect(callback).to have_received(:call).at_least(:once)
+        expect { |block|
+          driver.devtools.page.enable
+          driver.devtools.page.on(:load_event_fired, &block)
+          driver.navigate.to url_for('xhtmlTest.html')
+          sleep 0.5
+        }.to yield_control
       end
 
       it 'propagates errors in events' do
-        driver.devtools.page.enable
-        driver.devtools.page.on(:load_event_fired) { raise "This is fine!" }
-        expect { driver.navigate.to url_for('xhtmlTest.html') }.to raise_error(RuntimeError, "This is fine!")
+        expect {
+          driver.devtools.page.enable
+          driver.devtools.page.on(:load_event_fired) { raise "This is fine!" }
+          driver.navigate.to url_for('xhtmlTest.html')
+          sleep 0.5
+        }.to raise_error(RuntimeError, "This is fine!")
       end
 
       context 'authentication', except: {browser: %i[firefox firefox_nightly],

--- a/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/driver_spec.rb
@@ -44,7 +44,9 @@ module Selenium
                                      page: {width: 30})).to include(magic_number)
           end
 
-          it 'should print full page' do
+          it 'should print full page', except: {ci: :github,
+                                                platform: :windows,
+                                                reason: 'Some issues with resolution?'} do
             viewport_width = driver.execute_script("return window.innerWidth;")
             viewport_height = driver.execute_script("return window.innerHeight;")
 

--- a/rb/spec/integration/selenium/webdriver/manager_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/manager_spec.rb
@@ -123,7 +123,7 @@ module Selenium
         it 'should not add secure cookie when http',
            except: [{browser: %i[firefox firefox_nightly],
                      reason: 'https://github.com/mozilla/geckodriver/issues/1840'},
-                    {browser: :chrome,
+                    {browser: %i[chrome edge],
                      reason: 'https://bugs.chromium.org/p/chromium/issues/detail?id=1177877#c7'}] do
           driver.manage.add_cookie name: 'secure',
                                    value: 'http',

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |c|
     guards = WebDriver::Support::Guards.new(example, bug_tracker: 'https://github.com/SeleniumHQ/selenium/issues')
     guards.add_condition(:driver, GlobalTestEnv.driver)
     guards.add_condition(:browser, GlobalTestEnv.browser)
+    guards.add_condition(:ci, WebDriver::Platform.ci)
     guards.add_condition(:platform, WebDriver::Platform.os)
 
     results = guards.disposition

--- a/rb/spec/integration/selenium/webdriver/takes_screenshot_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/takes_screenshot_spec.rb
@@ -91,7 +91,12 @@ module Selenium
           expect(height).to be <= viewport_height
         end
 
-        it 'takes full page screenshot', exclusive: {browser: :firefox} do
+        it 'takes full page screenshot', exclusive: {browser: :firefox},
+                                         except: {
+                                           ci: :github,
+                                           platform: :windows,
+                                           reason: 'Some issues with resolution?'
+                                         } do
           viewport_width = driver.execute_script("return window.innerWidth;")
           viewport_height = driver.execute_script("return window.innerHeight;")
 

--- a/rb/spec/unit/selenium/webdriver/socket_poller_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/socket_poller_spec.rb
@@ -24,7 +24,7 @@ module Selenium
     describe SocketPoller do
       before(:context) do
         @server_thread = Thread.new do
-          server = TCPServer.open(9250)
+          server = TCPServer.open(Platform.localhost, 9250)
           Thread.current.thread_variable_set(:server, server)
           loop { server.accept.close }
         end


### PR DESCRIPTION
Adds support for running Ruby tests on Windows. This includes Chrome, Firefox, Edge, and unit tests.

Running tests on the WIndows is much slower (e.g. https://github.com/SeleniumHQ/selenium/actions/runs/3524631700/usage) partially because the cache cannot be easily re-used. Hopefully, setting up Bazel remote caching and remote execution would allow us to overcome this.

It's also worth mentioning that running tests on the Windows is more flaky (remote Firefox tests in particular) but I suggest we iron this in trunk already.