### PR TITLE
[grid] ensure all states of StartOrDie are handled

### DIFF
--- a/java/src/org/openqa/selenium/os/CommandLine.java
+++ b/java/src/org/openqa/selenium/os/CommandLine.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WebDriverException;
 import java.io.File;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class CommandLine {
 
@@ -98,6 +99,10 @@ public class CommandLine {
   public void execute() {
     executeAsync();
     waitFor();
+  }
+
+  public boolean waitForProcessStarted(long duration, TimeUnit unit) {
+    return process.waitForProcessStarted(duration, unit);
   }
 
   public void waitFor() {


### PR DESCRIPTION
### Description
DriverService.start did not fail, if the execution of the driver process was never started or the process did not bind the port.
In this case the status was PROCESS_IS_ACTIVE and the execution continued, trying to connect to the not bound port. Now there are meaningful exceptions raised to indicate the issue either "Timed out waiting for driver process to start." or "Timed out waiting for driver server to bind the port."

### Motivation and Context
I had some driver/browser startup error with a SessionNotCreatedException caused by a ConnectionException, without a helpful message.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
