### PR TITLE
[java] Include selenium-manager output in Java exception

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -91,7 +91,7 @@ public class SeleniumManager {
         String output = "";
         try {
             Process process = new ProcessBuilder(command)
-                    .redirectErrorStream(false).start();
+                    .redirectErrorStream(true).start();
             process.waitFor();
             output = CharStreams.toString(new InputStreamReader(
                     process.getInputStream(), StandardCharsets.UTF_8));
@@ -104,7 +104,8 @@ public class SeleniumManager {
                     e.getClass().getSimpleName(), Arrays.toString(command), e.getMessage()));
         }
         if (!output.startsWith(INFO)) {
-          throw new WebDriverException("Error running command: " + Arrays.toString(command));
+          throw new WebDriverException("Error running selenium-manager: " + Arrays.toString(command) +
+                                       ": " + output);
         }
 
         return output.trim();


### PR DESCRIPTION
### Description
This PR changes the exception message when some unexpected error happens executing Selenium Manager, including the command output instead of the command itself (which is already logged as a warning trace).

### Motivation and Context
The Selenium Mangear output will allow to debug future problems (e.g. #11291) easily.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
