### PR TITLE
[dotnet] Capture error output from selenium manager

### DIFF
--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -66,7 +66,14 @@ namespace OpenQA.Selenium
             string executablePath = Path.Combine(servicePath, driverServiceExecutableName);
             if (!File.Exists(executablePath))
             {
-                executablePath = SeleniumManager.DriverPath(driverServiceExecutableName);
+                try
+                {
+                    executablePath = SeleniumManager.DriverPath(driverServiceExecutableName);
+                }
+                catch (Exception e)
+                {
+                  // No-op; entirely a fall-back feature
+                }
 
                 if (File.Exists(executablePath))
                 {
@@ -309,7 +316,14 @@ namespace OpenQA.Selenium
 
             if (string.IsNullOrEmpty(serviceDirectory))
             {
-                serviceDirectory = Path.GetDirectoryName(SeleniumManager.DriverPath(executableName));
+                try
+                {
+                    serviceDirectory = Path.GetDirectoryName(SeleniumManager.DriverPath(executableName));
+                }
+                catch (Exception e)
+                {
+                    // No-op; entirely a fall-back feature
+                }
 
                 if (string.IsNullOrEmpty(serviceDirectory))
                 {

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -66,14 +66,7 @@ namespace OpenQA.Selenium
             string executablePath = Path.Combine(servicePath, driverServiceExecutableName);
             if (!File.Exists(executablePath))
             {
-                try
-                {
-                    executablePath = SeleniumManager.DriverPath(driverServiceExecutableName);
-                }
-                catch (Exception e)
-                {
-                  // No-op; entirely a fall-back feature
-                }
+                executablePath = SeleniumManager.DriverPath(driverServiceExecutableName);
 
                 if (File.Exists(executablePath))
                 {
@@ -316,14 +309,7 @@ namespace OpenQA.Selenium
 
             if (string.IsNullOrEmpty(serviceDirectory))
             {
-                try
-                {
-                    serviceDirectory = Path.GetDirectoryName(SeleniumManager.DriverPath(executableName));
-                }
-                catch (Exception e)
-                {
-                    // No-op; entirely a fall-back feature
-                }
+                serviceDirectory = Path.GetDirectoryName(SeleniumManager.DriverPath(executableName));
 
                 if (string.IsNullOrEmpty(serviceDirectory))
                 {

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -24,6 +24,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 #endif
 
+using System.Text;
+
 namespace OpenQA.Selenium
 {
     /// <summary>
@@ -112,22 +114,38 @@ namespace OpenQA.Selenium
             process.StartInfo.Arguments = arguments;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
 
-            string output;
+            StringBuilder outputBuilder = new StringBuilder();
+            
+            DataReceivedEventHandler outputHandler = (sender, e) => outputBuilder.AppendLine(e.Data);
 
             try
             {
+                process.OutputDataReceived += outputHandler;
+                process.ErrorDataReceived += outputHandler;
+                
                 process.Start();
-                output = process.StandardOutput.ReadToEnd();
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
                 process.WaitForExit();
             }
             catch (Exception ex)
             {
                 throw new WebDriverException($"Error starting process: {fileName} {arguments}", ex);
             }
+            finally
+            {
+                process.OutputDataReceived -= outputHandler;
+                process.ErrorDataReceived -= outputHandler;
+            }
+
+            string output = outputBuilder.ToString();
 
             if (!output.StartsWith("INFO")) {
-                throw new WebDriverException($"Invalid response from process: {fileName} {arguments}");
+                throw new WebDriverException($"Invalid response from process: {fileName} {arguments}\n{output}");
             }
 
             return output;


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

### Description
If selenium manager binary fails then user sees exception
```
OpenQA.Selenium.WebDriverException : Invalid response from process: selenium-manager/windows/selenium-manager.exe 12345
error: Found argument '12345' which wasn't expected, or isn't valid in this context

Usage: selenium-manager.exe [OPTIONS]

For more information try '--help'
```

### Motivation and Context
Related to https://github.com/SeleniumHQ/selenium/issues/11301

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
