### PR TITLE
[WIP][java] Command parameter details are logged conditionally in case of exception

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -94,6 +94,7 @@ import static java.util.logging.Level.SEVERE;
 import static org.openqa.selenium.remote.CapabilityType.LOGGING_PREFS;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 import static org.openqa.selenium.remote.CapabilityType.SUPPORTS_JAVASCRIPT;
+import static org.openqa.selenium.internal.Debug.isDebugging;
 
 @Augmentable
 public class RemoteWebDriver implements WebDriver,
@@ -566,7 +567,11 @@ public class RemoteWebDriver implements WebDriver,
           "Error communicating with the remote browser. It may have died.", e);
       }
       populateWebDriverException(toThrow);
-      toThrow.addInfo("Command", command.toString());
+      if(isDebugging()) {
+        toThrow.addInfo("Command", command.toString());
+      } else {
+        toThrow.addInfo("Command", "[" + sessionId + ", " + command.getName() + " " + command.getParameters().keySet() + "]");
+      }
       throw toThrow;
     } finally {
       Thread.currentThread().setName(currentName);
@@ -576,7 +581,12 @@ public class RemoteWebDriver implements WebDriver,
       errorHandler.throwIfResponseFailed(response, System.currentTimeMillis() - start);
     } catch (WebDriverException ex) {
       populateWebDriverException(ex);
-      ex.addInfo("Command", command.toString());
+      if(isDebugging()) {
+        ex.addInfo("Command", command.toString());
+      } else {
+        ex.addInfo("Command", "[" + sessionId + ", " + command.getName() + " " + command.getParameters().keySet() + "]");
+      }
+      
       throw ex;
     }
     return response;


### PR DESCRIPTION
### Description
This change is for the issue raised: https://github.com/SeleniumHQ/selenium/issues/11275
In case of WebDriverException being thrown, the exception log might contain sensitive command parameters.
This will now only be present if the logging is set to debug mode.

### Motivation and Context
This solves https://github.com/SeleniumHQ/selenium/issues/11275

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
