### PR TITLE
[rust] Support for beta/dev/canary browser version detection with Selenium Manager (#11239)

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -22,13 +22,13 @@ Automated driver management for Selenium
 Usage: selenium-manager [OPTIONS]
 Options:
   -b, --browser <BROWSER>
-          Browser name (chrome, firefox, or edge) [default: ]
+          Browser name (chrome, firefox, edge, or iexplorer) [default: ]
   -d, --driver <DRIVER>
-          Driver name (chromedriver, geckodriver, or msedgedriver) [default: ]
+          Driver name (chromedriver, geckodriver, msedgedriver, or IEDriverServer) [default: ]
   -v, --driver-version <DRIVER_VERSION>
           Driver version (e.g., 106.0.5249.61, 0.31.0, etc.) [default: ]
   -B, --browser-version <BROWSER_VERSION>
-          Major browser version (e.g., 105, 106, etc.) [default: ]
+          Major browser version (e.g., 105, 106, etc. Also: beta, dev, canary -or nightly- is accepted) [default: ]
   -D, --debug
           Display DEBUG messages
   -T, --trace

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -15,14 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
 
 use crate::downloads::read_content_from_link;
 use crate::files::compose_driver_path_in_cache;
+use crate::is_unstable;
 use crate::manager::ARCH::{ARM64, X32};
-use crate::manager::OS::{MACOS, WINDOWS};
-use crate::manager::{detect_browser_version, BrowserManager};
+use crate::manager::OS::{LINUX, MACOS, WINDOWS};
+use crate::manager::{
+    detect_browser_version, format_one_arg, format_two_args, BrowserManager, BrowserPath, BETA,
+    DASH_DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY, REG_QUERY, STABLE,
+    WMIC_COMMAND,
+};
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
@@ -52,29 +58,72 @@ impl BrowserManager for EdgeManager {
         self.browser_name
     }
 
-    fn get_browser_version(&self, os: &str) -> Option<String> {
-        let (shell, flag, args) = if WINDOWS.is(os) {
+    fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
+        HashMap::from([
             (
-                "cmd",
-                "/C",
-                vec![
-                    r#"wmic datafile where name='%PROGRAMFILES(X86):\=\\%\\Microsoft\\Edge\\Application\\msedge.exe' get Version /value"#,
-                    r#"wmic datafile where name='%PROGRAMFILES:\=\\%\\Microsoft\\Edge\\Application\\msedge.exe' get Version /value"#,
-                    r#"REG QUERY HKCU\Software\Microsoft\Edge\BLBeacon /v version"#,
-                ],
-            )
-        } else if MACOS.is(os) {
+                BrowserPath::new(WINDOWS, STABLE),
+                r#"\\Microsoft\\Edge\\Application\\msedge.exe"#,
+            ),
             (
-                "sh",
-                "-c",
-                vec![
-                    r#"/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge -version"#,
-                ],
-            )
-        } else {
-            ("sh", "-c", vec!["microsoft-edge --version"])
-        };
-        detect_browser_version(self.browser_name, shell, flag, args)
+                BrowserPath::new(WINDOWS, BETA),
+                r#"\\Microsoft\\Edge Beta\\Application\\msedge.exe"#,
+            ),
+            (
+                BrowserPath::new(WINDOWS, DEV),
+                r#"\\Microsoft\\Edge Dev\\Application\\msedge.exe"#,
+            ),
+            (
+                BrowserPath::new(WINDOWS, NIGHTLY),
+                r#"\\Microsoft\\Edge SxS\\Application\\msedge.exe"#,
+            ),
+            (
+                BrowserPath::new(MACOS, STABLE),
+                r#"/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge"#,
+            ),
+            (
+                BrowserPath::new(MACOS, BETA),
+                r#"/Applications/Microsoft\ Edge\ Beta.app/Contents/MacOS/Microsoft\ Edge\ Beta"#,
+            ),
+            (
+                BrowserPath::new(MACOS, DEV),
+                r#"/Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev"#,
+            ),
+            (
+                BrowserPath::new(MACOS, NIGHTLY),
+                r#"/Applications/Microsoft\ Edge\ Canary.app/Contents/MacOS/Microsoft\ Edge\ Canary"#,
+            ),
+            (BrowserPath::new(LINUX, STABLE), "microsoft-edge"),
+            (BrowserPath::new(LINUX, BETA), "microsoft-edge-beta"),
+            (BrowserPath::new(LINUX, DEV), "microsoft-edge-dev"),
+        ])
+    }
+
+    fn get_browser_version(&self, os: &str, browser_version: &str) -> Option<String> {
+        match self.get_browser_path(os, browser_version) {
+            Some(browser_path) => {
+                let (shell, flag, args) = if WINDOWS.is(os) {
+                    let mut commands = vec![
+                        format_two_args(WMIC_COMMAND, ENV_PROGRAM_FILES_X86, browser_path),
+                        format_two_args(WMIC_COMMAND, ENV_PROGRAM_FILES, browser_path),
+                    ];
+                    if !is_unstable(browser_version) {
+                        commands.push(format_one_arg(
+                            REG_QUERY,
+                            r#"REG QUERY HKCU\Software\Microsoft\Edge\BLBeacon"#,
+                        ));
+                    }
+                    ("cmd", "/C", commands)
+                } else {
+                    (
+                        "sh",
+                        "-c",
+                        vec![format_one_arg(DASH_DASH_VERSION, browser_path)],
+                    )
+                };
+                detect_browser_version(self.browser_name, shell, flag, args)
+            }
+            _ => None,
+        }
     }
 
     fn get_driver_name(&self) -> &str {

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -15,13 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
 
 use crate::downloads::read_redirect_from_link;
 use crate::files::compose_driver_path_in_cache;
 
-use crate::manager::{get_minor_version, BrowserManager};
+use crate::manager::{get_minor_version, BrowserManager, BrowserPath};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -51,7 +52,11 @@ impl BrowserManager for IExplorerManager {
         self.browser_name
     }
 
-    fn get_browser_version(&self, _os: &str) -> Option<String> {
+    fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
+        HashMap::new()
+    }
+
+    fn get_browser_version(&self, _os: &str, _browser_version: &str) -> Option<String> {
         None
     }
 

--- a/rust/src/manager.rs
+++ b/rust/src/manager.rs
@@ -15,20 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
 use std::process::Command;
 
 use crate::downloads::download_driver_to_tmp_folder;
 use crate::files::{parse_version, uncompress};
+use crate::manager::OS::{LINUX, MACOS, WINDOWS};
+
 use crate::metadata::{
     create_browser_metadata, get_browser_version_from_metadata, get_metadata, write_metadata,
 };
 
+pub const STABLE: &str = "stable";
+pub const BETA: &str = "beta";
+pub const DEV: &str = "dev";
+pub const CANARY: &str = "canary";
+pub const NIGHTLY: &str = "nightly";
+pub const WMIC_COMMAND: &str = r#"wmic datafile where name='%{}:\=\\%{}' get Version /value"#;
+pub const REG_QUERY: &str = r#"REG QUERY {} /v version"#;
+pub const DASH_VERSION: &str = "{} -v";
+pub const DASH_DASH_VERSION: &str = "{} --version";
+pub const ENV_PROGRAM_FILES: &str = "PROGRAMFILES";
+pub const ENV_PROGRAM_FILES_X86: &str = "PROGRAMFILES(X86)";
+pub const ENV_LOCALAPPDATA: &str = "LOCALAPPDATA";
+
 pub trait BrowserManager {
     fn get_browser_name(&self) -> &str;
 
-    fn get_browser_version(&self, os: &str) -> Option<String>;
+    fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str>;
+
+    fn get_browser_version(&self, os: &str, browser_version: &str) -> Option<String>;
 
     fn get_driver_name(&self) -> &str;
 
@@ -55,10 +73,22 @@ pub trait BrowserManager {
         let driver_path_in_cache = Self::get_driver_path_in_cache(self, driver_version, os, arch);
         uncompress(&driver_zip_file, driver_path_in_cache)
     }
+
+    fn get_browser_path(&self, os: &str, mut browser_version: &str) -> Option<&str> {
+        if browser_version.eq_ignore_ascii_case(CANARY) {
+            browser_version = NIGHTLY;
+        } else if browser_version.is_empty() {
+            browser_version = STABLE;
+        }
+        self.get_browser_path_map()
+            .get(&BrowserPath::new(str_to_os(os), browser_version))
+            .cloned()
+    }
 }
 
 #[allow(dead_code)]
 #[allow(clippy::upper_case_acronyms)]
+#[derive(Hash, Eq, PartialEq, Debug)]
 pub enum OS {
     WINDOWS,
     MACOS,
@@ -68,14 +98,24 @@ pub enum OS {
 impl OS {
     pub fn to_str(&self) -> &str {
         match self {
-            OS::WINDOWS => "windows",
-            OS::MACOS => "macos",
-            OS::LINUX => "linux",
+            WINDOWS => "windows",
+            MACOS => "macos",
+            LINUX => "linux",
         }
     }
 
     pub fn is(&self, os: &str) -> bool {
         self.to_str().eq_ignore_ascii_case(os)
+    }
+}
+
+fn str_to_os(os: &str) -> OS {
+    if WINDOWS.is(os) {
+        WINDOWS
+    } else if MACOS.is(os) {
+        MACOS
+    } else {
+        LINUX
     }
 }
 
@@ -101,9 +141,28 @@ impl ARCH {
     }
 }
 
-pub fn run_shell_command(command: &str, flag: &str, args: &str) -> Result<String, Box<dyn Error>> {
+#[derive(Hash, Eq, PartialEq, Debug)]
+pub struct BrowserPath {
+    os: OS,
+    channel: String,
+}
+
+impl BrowserPath {
+    pub fn new(os: OS, channel: &str) -> BrowserPath {
+        BrowserPath {
+            os,
+            channel: channel.to_string(),
+        }
+    }
+}
+
+pub fn run_shell_command(
+    command: &str,
+    flag: &str,
+    args: String,
+) -> Result<String, Box<dyn Error>> {
     log::debug!("Running {} command: {:?}", command, args);
-    let output = Command::new(command).args([flag, args]).output()?;
+    let output = Command::new(command).args([flag, args.as_str()]).output()?;
     log::debug!("{:?}", output);
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -113,7 +172,7 @@ pub fn detect_browser_version(
     browser_name: &str,
     shell: &str,
     flag: &str,
-    args: Vec<&str>,
+    args: Vec<String>,
 ) -> Option<String> {
     let mut metadata = get_metadata();
 
@@ -129,7 +188,7 @@ pub fn detect_browser_version(
             log::debug!("Using shell command to find out {} version", browser_name);
             let mut browser_version = "".to_string();
             for arg in args.iter() {
-                let output = match run_shell_command(shell, flag, *arg) {
+                let output = match run_shell_command(shell, flag, arg.to_string()) {
                     Ok(out) => out,
                     Err(_e) => continue,
                 };
@@ -172,4 +231,19 @@ fn get_index_version(full_version: &str, index: usize) -> Result<String, Box<dyn
         .get(index)
         .ok_or(format!("Wrong version: {}", full_version))?
         .to_string())
+}
+
+pub fn format_one_arg(string: &str, arg1: &str) -> String {
+    string.replacen("{}", arg1, 1)
+}
+
+pub fn format_two_args(string: &str, arg1: &str, arg2: &str) -> String {
+    string.replacen("{}", arg1, 1).replacen("{}", arg2, 2)
+}
+
+pub fn is_unstable(browser_version: &str) -> bool {
+    browser_version.eq_ignore_ascii_case(BETA)
+        || browser_version.eq_ignore_ascii_case(DEV)
+        || browser_version.eq_ignore_ascii_case(NIGHTLY)
+        || browser_version.eq_ignore_ascii_case(CANARY)
 }

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -24,11 +24,14 @@ use std::str;
 #[case("chrome", "chromedriver", "", "")]
 #[case("chrome", "chromedriver", "105", "105.0.5195.52")]
 #[case("chrome", "chromedriver", "106", "106.0.5249.61")]
+#[case("chrome", "chromedriver", "beta", "")]
 #[case("edge", "msedgedriver", "", "")]
 #[case("edge", "msedgedriver", "105", "105.0")]
 #[case("edge", "msedgedriver", "106", "106.0")]
+#[case("edge", "msedgedriver", "beta", "")]
 #[case("firefox", "geckodriver", "", "")]
 #[case("firefox", "geckodriver", "105", "0.32.0")]
+#[case("firefox", "geckodriver", "beta", "")]
 #[case("iexplorer", "IEDriverServer", "", "")]
 fn ok_test(
     #[case] browser: String,


### PR DESCRIPTION
### Description
This PR include support for browser version detection, considering not only stable versions, but also beta/canary/dev for Chrome, Firefox, Edge.

### Motivation and Context
As discussed in TLC, the detection of non-prod browsers will be a feature that needs to be explicitly requested, e.g.:

```
./selenium-manager --browser chrome --browser-version beta
./selenium-manager --browser firefox --browser-version dev
./selenium-manager --browser edge --browser-version canary
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
