### PR TITLE
[py] fix sdist publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ pip install bazel-bin/py/selenium-*.whl
 To publish run:
 
 ```sh
-bazel build //py:selenium-wheel
-twine upload bazel-bin/py/selenium-*.whl
+bazel build //py:selenium-wheel //py:selenium-sdist
+twine upload bazel-bin/py/selenium-*.whl bazel-bin/py/selenium-*.tar.gz
 ```
 </details>
 


### PR DESCRIPTION
It appears that only wheels are being published to pypi, this should fix the publishing procedure to include sdists.

<!--- Provide a general summary of your changes in the Title above -->

### Description
Update publish procedure to include sdists.

### Motivation and Context
Sdists on pypi are missing as reported in #9917

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
