### PR TITLE
[java] WIP - proof of concept for using options with Selenium Manager

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -46,7 +46,7 @@ public class ChromeDriver extends ChromiumDriver {
    * @see #ChromeDriver(ChromeDriverService, ChromeOptions)
    */
   public ChromeDriver() {
-    this(ChromeDriverService.createDefaultService(), new ChromeOptions());
+    this(new ChromeOptions());
   }
 
   /**

--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -138,8 +138,19 @@ public class ChromeDriverService extends DriverService {
    */
   public static ChromeDriverService createServiceWithConfig(ChromeOptions options) {
     return new Builder()
+      .withOptions(options)
       .withLogLevel(options.getLogLevel())
       .build();
+  }
+
+  protected static Map<String, String> getSeleniumManagerArguments() {
+    Map<String, String> arguments = DriverService.getSeleniumManagerArguments();
+    // This is not implemented yet
+    //    String location = ((ChromeOptions) options).getBinary();
+    //    if (location != null) {
+    //      arguments.put("--location", location);
+    //    }
+    return arguments;
   }
 
   /**
@@ -228,12 +239,18 @@ public class ChromeDriverService extends DriverService {
       return this;
     }
 
+    private Builder withOptions(ChromeOptions options) {
+      ChromeDriverService.options = options;
+      return this;
+    }
+
     @Override
     protected File findDefaultExecutable() {
       return findExecutable(
         "chromedriver", CHROME_DRIVER_EXE_PROPERTY,
         "https://chromedriver.chromium.org/",
-        "https://chromedriver.chromium.org/downloads");
+        "https://chromedriver.chromium.org/downloads",
+        getSeleniumManagerArguments());
     }
 
     @Override

--- a/java/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -78,4 +78,8 @@ public class ChromeOptions extends ChromiumOptions<ChromeOptions> {
   public ChromeDriverLogLevel getLogLevel(){
     return logLevel;
   }
+
+  public String getBinary() {
+    return binary;
+  }
 }

--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -62,7 +62,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDriverOptions<ChromiumOptions<?>> {
 
-  private String binary;
+  protected String binary;
   private final List<String> args = new ArrayList<>();
   private final List<File> extensionFiles = new ArrayList<>();
   private final List<String> extensions = new ArrayList<>();


### PR DESCRIPTION
### Description

I think this is the best way to get needed information from Options class to Selenium Manager.

* Ensure driver constructor uses `createServiceWithConfig` by default.
* new private `withOptions()` method that stores protected static options instance on DriverService
* Browser DriverService class can pull browser-specific functionality (`getBinary()`); though, I guess we *could implement this in all driver service classes and essentially avoid all subclasses for now.
* Couple things get cleaned up when we implement this in all browsers, but I wanted to show the idea with one to get feedback.

**Questions**:
* Does storing a protected static options instance make the most sense?
* Should we create `getBinary()` in all options classes and avoid subclassing requirements? (fwiw, Firefox's current implementation might complicate using Selenium Manager; Chrome was much easier to show the idea)
* Is there anything we can think of that we might be doing with Selenium Manager in the future that this implementation would complicate?

### Motivation

* Provide support for #11372 
* Provide support for #11351 when it is available
* It might be relevant to how we do #11353 

Previously, I was thinking about the need to specifically wrap `--driver-version`, which is why I brought up #11360 
As of now, though, I think everything that we need to be supporting in Selenium Manager we can pull from the Options class, and this is the best way I came up with for doing that.
