### PR TITLE
[java] Ensure options presents in capabilities are merged as expected

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -280,7 +280,46 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
   protected void mergeInPlace(Capabilities capabilities) {
     Require.nonNull("Capabilities to merge", capabilities);
 
-    capabilities.getCapabilityNames().forEach(name -> setCapability(name, capabilities.getCapability(name)));
+    capabilities.getCapabilityNames().forEach(name -> {
+      if (!name.equals("binary") && !name.equals("extensions") && !name.equals("args")) {
+        setCapability(name, capabilities.getCapability(name));
+        return;
+      }
+
+      if (name.equals("args") && capabilities.getCapability(name) != null) {
+        List<String> arguments = (List<String>) (capabilities.getCapability(("args")));
+        arguments.forEach(arg -> {
+          if (!args.contains(arg)) {
+            addArguments(arg);
+          }
+        });
+        return;
+      }
+
+      if (name.equals("extensions") && capabilities.getCapability(name) != null) {
+        List<Object> extensionList = (List<Object>) (capabilities.getCapability(("extensions")));
+        extensionList.forEach(extension -> {
+          if (!extensions.contains(extension)) {
+            if (extension instanceof File) {
+              addExtensions((File) extension);
+            } else if (extension instanceof String) {
+              addEncodedExtensions((String) extension);
+            }
+          }
+        });
+        return;
+      }
+
+      if (name.equals("binary") && capabilities.getCapability(name) != null) {
+        Object binary = capabilities.getCapability("binary");
+        if (binary instanceof String) {
+          setBinary((String) binary);
+        } else if (binary instanceof File) {
+          setBinary((File) binary);
+        }
+      }
+    });
+
     if (capabilities instanceof ChromiumOptions) {
       ChromiumOptions<?> options = (ChromiumOptions<?>) capabilities;
       for (String arg : options.args) {

--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -280,7 +280,9 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
   protected void mergeInPlace(Capabilities capabilities) {
     Require.nonNull("Capabilities to merge", capabilities);
 
-    capabilities.getCapabilityNames().forEach(name -> {
+    Set<String> capabilityNames = capabilities.getCapabilityNames();
+
+    for (String name : capabilityNames) {
       if (!name.equals("binary") && !name.equals("extensions") && !name.equals("args")) {
         setCapability(name, capabilities.getCapability(name));
         return;
@@ -318,7 +320,7 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
           setBinary((File) binary);
         }
       }
-    });
+    }
 
     if (capabilities instanceof ChromiumOptions) {
       ChromiumOptions<?> options = (ChromiumOptions<?>) capabilities;

--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -280,12 +280,9 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
   protected void mergeInPlace(Capabilities capabilities) {
     Require.nonNull("Capabilities to merge", capabilities);
 
-    Set<String> capabilityNames = capabilities.getCapabilityNames();
-
-    for (String name : capabilityNames) {
+    for (String name : capabilities.getCapabilityNames()) {
       if (!name.equals("binary") && !name.equals("extensions") && !name.equals("args")) {
         setCapability(name, capabilities.getCapability(name));
-        return;
       }
 
       if (name.equals("args") && capabilities.getCapability(name) != null) {
@@ -295,7 +292,6 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
             addArguments(arg);
           }
         });
-        return;
       }
 
       if (name.equals("extensions") && capabilities.getCapability(name) != null) {
@@ -309,7 +305,6 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
             }
           }
         });
-        return;
       }
 
       if (name.equals("binary") && capabilities.getCapability(name) != null) {

--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -333,25 +333,32 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     getCapabilityNames().forEach(name -> newInstance.setCapability(name, getCapability(name)));
     newInstance.mirror(this);
 
-    capabilities.getCapabilityNames().forEach(name -> {
-      if (name.equals("args") && capabilities.getCapability(name) != null) {
+    for (String name : capabilities.getCapabilityNames()) {
+
+      if (!name.equals(Keys.ARGS.key) &&
+          !name.equals(Keys.PREFS.key) &&
+          !name.equals(Keys.PROFILE.key) &&
+          !name.equals(Keys.BINARY.key) &&
+          !name.equals(Keys.LOG.key)) {
+        newInstance.setCapability(name, capabilities.getCapability(name));
+      }
+
+      if (name.equals(Keys.ARGS.key) && capabilities.getCapability(name) != null) {
         List<String> arguments = (List<String>) (capabilities.getCapability(("args")));
         arguments.forEach(arg -> {
           if (!((List<String>) newInstance.firefoxOptions.get(Keys.ARGS.key())).contains(arg)) {
             newInstance.addArguments(arg);
           }
         });
-        return;
       }
 
-      if (name.equals("prefs") && capabilities.getCapability(name) != null) {
+      if (name.equals(Keys.PREFS.key) && capabilities.getCapability(name) != null) {
         Map<String, Object> prefs =
           (Map<String, Object>) (capabilities.getCapability(("prefs")));
         prefs.forEach(newInstance::addPreference);
-        return;
       }
 
-      if (name.equals("profile") && capabilities.getCapability(name) != null) {
+      if (name.equals(Keys.PROFILE.key) && capabilities.getCapability(name) != null) {
         String rawProfile =
           (String) capabilities.getCapability("profile");
         try {
@@ -359,10 +366,9 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
         } catch (IOException e) {
           throw new WebDriverException(e);
         }
-        return;
       }
 
-      if (name.equals("binary") && capabilities.getCapability(name) != null) {
+      if (name.equals(Keys.BINARY.key) && capabilities.getCapability(name) != null) {
         Object binary = capabilities.getCapability("binary");
         if (binary instanceof String) {
           newInstance.setBinary((String) binary);
@@ -371,10 +377,9 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
         } else if (binary instanceof FirefoxBinary) {
           newInstance.setBinary((FirefoxBinary) binary);
         }
-        return;
       }
 
-      if (name.equals("log") && capabilities.getCapability(name) != null) {
+      if (name.equals(Keys.LOG.key) && capabilities.getCapability(name) != null) {
         Map<String, Object> logLevelMap =
           (Map<String, Object>) capabilities.getCapability("log");
         FirefoxDriverLogLevel logLevel =
@@ -382,11 +387,8 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
         if (logLevel != null) {
           newInstance.setLogLevel(logLevel);
         }
-        return;
       }
-
-      newInstance.setCapability(name, capabilities.getCapability(name));
-    });
+    }
 
     if (capabilities instanceof FirefoxOptions) {
       newInstance.mirror((FirefoxOptions) capabilities);

--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -332,6 +332,7 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     FirefoxOptions newInstance = new FirefoxOptions();
     getCapabilityNames().forEach(name -> newInstance.setCapability(name, getCapability(name)));
     newInstance.mirror(this);
+
     capabilities.getCapabilityNames().forEach(name -> {
       if (name.equals("args") && capabilities.getCapability(name) != null) {
         List<String> arguments = (List<String>) (capabilities.getCapability(("args")));

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.testing.TestUtilities;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -252,6 +253,67 @@ class ChromeOptionsTest {
 
     assertThat(map).asInstanceOf(MAP)
       .extractingByKey(ACCEPT_INSECURE_CERTS).isExactlyInstanceOf(Boolean.class);
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(ChromeOptions.CAPABILITY).asInstanceOf(MAP)
+      .extractingByKey("extensions").asInstanceOf(LIST)
+      .containsExactly(ext1Encoded, ext2);
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(ChromeOptions.CAPABILITY).asInstanceOf(MAP)
+      .extractingByKey("binary").asInstanceOf(STRING)
+      .isEqualTo(binary.getPath());
+  }
+
+  @Test
+  void mergingOptionsWithOptionsAsMutableCapabilities() {
+    File ext1 = TestUtilities.createTmpFile("ext1");
+    String ext1Encoded = Base64.getEncoder().encodeToString("ext1".getBytes());
+    String ext2 = Base64.getEncoder().encodeToString("ext2".getBytes());
+    ArrayList<Object> extensions = new ArrayList<>();
+    extensions.add(ext1);
+    extensions.add(ext2);
+
+    ArrayList<Object> args = new ArrayList<>();
+    args.add("silent");
+    args.add("verbose");
+
+    MutableCapabilities browserCaps = new MutableCapabilities();
+
+    File binary = TestUtilities.createTmpFile("binary");
+
+    browserCaps.setCapability("binary", binary.getPath());
+    browserCaps.setCapability("opt1", "val1");
+    browserCaps.setCapability("opt2", "val4");
+    browserCaps.setCapability("args", args);
+    browserCaps.setCapability("extensions", extensions);
+
+    MutableCapabilities one = new MutableCapabilities();
+    one.setCapability(ChromeOptions.CAPABILITY, browserCaps);
+
+    ChromeOptions two = new ChromeOptions();
+    two.addArguments("verbose");
+    two.setExperimentalOption("opt2", "val2");
+    two.setExperimentalOption("opt3", "val3");
+    two = two.merge(one);
+
+    Map<String, Object> map = two.asMap();
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(ChromeOptions.CAPABILITY).asInstanceOf(MAP)
+      .extractingByKey("args").asInstanceOf(LIST)
+      .containsExactly("verbose", "silent");
+
+    assertThat(map).asInstanceOf(MAP)
+      .containsEntry("opt1", "val1");
+
+    assertThat(map).asInstanceOf(MAP)
+      .containsEntry("opt2", "val4");
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(ChromeOptions.CAPABILITY).asInstanceOf(MAP)
+      .containsEntry("opt2", "val2")
+      .containsEntry("opt3", "val3");
 
     assertThat(map).asInstanceOf(MAP)
       .extractingByKey(ChromeOptions.CAPABILITY).asInstanceOf(MAP)

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -27,7 +27,7 @@ import org.openqa.selenium.testing.TestUtilities;
 
 import java.io.File;
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -270,13 +270,6 @@ class ChromeOptionsTest {
     File ext1 = TestUtilities.createTmpFile("ext1");
     String ext1Encoded = Base64.getEncoder().encodeToString("ext1".getBytes());
     String ext2 = Base64.getEncoder().encodeToString("ext2".getBytes());
-    ArrayList<Object> extensions = new ArrayList<>();
-    extensions.add(ext1);
-    extensions.add(ext2);
-
-    ArrayList<Object> args = new ArrayList<>();
-    args.add("silent");
-    args.add("verbose");
 
     MutableCapabilities browserCaps = new MutableCapabilities();
 
@@ -285,8 +278,8 @@ class ChromeOptionsTest {
     browserCaps.setCapability("binary", binary.getPath());
     browserCaps.setCapability("opt1", "val1");
     browserCaps.setCapability("opt2", "val4");
-    browserCaps.setCapability("args", args);
-    browserCaps.setCapability("extensions", extensions);
+    browserCaps.setCapability("args", Arrays.asList("silent", "verbose"));
+    browserCaps.setCapability("extensions", Arrays.asList(ext1, ext2));
 
     MutableCapabilities one = new MutableCapabilities();
     one.setCapability(ChromeOptions.CAPABILITY, browserCaps);

--- a/java/test/org/openqa/selenium/edge/EdgeOptionsTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeOptionsTest.java
@@ -31,7 +31,6 @@ import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -153,13 +152,6 @@ class EdgeOptionsTest {
     File ext1 = TestUtilities.createTmpFile("ext1");
     String ext1Encoded = Base64.getEncoder().encodeToString("ext1".getBytes());
     String ext2 = Base64.getEncoder().encodeToString("ext2".getBytes());
-    ArrayList<Object> extensions = new ArrayList<>();
-    extensions.add(ext1);
-    extensions.add(ext2);
-
-    ArrayList<Object> args = new ArrayList<>();
-    args.add("silent");
-    args.add("verbose");
 
     MutableCapabilities browserCaps = new MutableCapabilities();
 
@@ -168,8 +160,8 @@ class EdgeOptionsTest {
     browserCaps.setCapability("binary", binary.getPath());
     browserCaps.setCapability("opt1", "val1");
     browserCaps.setCapability("opt2", "val4");
-    browserCaps.setCapability("args", args);
-    browserCaps.setCapability("extensions", extensions);
+    browserCaps.setCapability("args", Arrays.asList("silent", "verbose"));
+    browserCaps.setCapability("extensions", Arrays.asList(ext1, ext2));
 
     MutableCapabilities one = new MutableCapabilities();
     one.setCapability(EdgeOptions.CAPABILITY, browserCaps);

--- a/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
@@ -58,7 +58,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -401,6 +403,72 @@ class FirefoxOptionsTest {
     options.setBinary(binary.toPath());
 
     one.setCapability(FIREFOX_OPTIONS, options);
+
+    FirefoxOptions two = new FirefoxOptions();
+    two.addArguments("verbose");
+    two.addPreference("opt2", "val2");
+    two.addPreference("opt3", "val3");
+    two = two.merge(one);
+
+    Map<String, Object> map = two.asMap();
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(FIREFOX_OPTIONS).asInstanceOf(MAP)
+      .extractingByKey("args").asInstanceOf(LIST)
+      .containsExactly("verbose", "silent");
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(FIREFOX_OPTIONS).asInstanceOf(MAP)
+      .extractingByKey("prefs").asInstanceOf(MAP)
+      .containsEntry("opt1", "val1")
+      .containsEntry("opt2", "val4")
+      .containsEntry("opt3", "val3");
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(ACCEPT_INSECURE_CERTS).isExactlyInstanceOf(Boolean.class);
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(FIREFOX_OPTIONS).asInstanceOf(MAP)
+      .extractingByKey("binary").asInstanceOf(STRING)
+      .isEqualTo(binary.getPath());
+
+    assertThat(map).asInstanceOf(MAP)
+      .extractingByKey(FIREFOX_OPTIONS).asInstanceOf(MAP)
+      .extractingByKey("log").asInstanceOf(MAP)
+      .containsEntry("level", "debug");
+
+    FirefoxProfile extractedProfile = two.getProfile();
+    assertThat(extractedProfile.getStringPreference(key, "-")).isEqualTo(value);
+  }
+
+  @Test
+  void mergingOptionsWithOptionsAsMutableCapabilities() throws IOException {
+    ArrayList<Object> args = new ArrayList<>();
+    args.add("verbose");
+    args.add("silent");
+
+    Map<String, String> prefs = new HashMap<>();
+    prefs.put("opt1", "val1");
+    prefs.put("opt2", "val4");
+
+    String key = "browser.startup.homepage";
+    String value = "about:robots";
+
+    FirefoxProfile profile = new FirefoxProfile();
+    profile.setPreference(key, value);
+
+    File binary = TestUtilities.createTmpFile("binary");
+
+    MutableCapabilities browserCaps = new MutableCapabilities();
+
+    browserCaps.setCapability("args", args);
+    browserCaps.setCapability("prefs", prefs);
+    browserCaps.setCapability("profile", profile.toJson());
+    browserCaps.setCapability("binary", binary.getPath());
+    browserCaps.setCapability("log", DEBUG.toJson());
+
+    MutableCapabilities one = new MutableCapabilities();
+    one.setCapability(FIREFOX_OPTIONS, browserCaps);
 
     FirefoxOptions two = new FirefoxOptions();
     two.addArguments("verbose");

--- a/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
@@ -58,7 +58,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -443,10 +442,6 @@ class FirefoxOptionsTest {
 
   @Test
   void mergingOptionsWithOptionsAsMutableCapabilities() throws IOException {
-    ArrayList<Object> args = new ArrayList<>();
-    args.add("verbose");
-    args.add("silent");
-
     Map<String, String> prefs = new HashMap<>();
     prefs.put("opt1", "val1");
     prefs.put("opt2", "val4");
@@ -461,7 +456,7 @@ class FirefoxOptionsTest {
 
     MutableCapabilities browserCaps = new MutableCapabilities();
 
-    browserCaps.setCapability("args", args);
+    browserCaps.setCapability("args", Arrays.asList("verbose", "silent"));
     browserCaps.setCapability("prefs", prefs);
     browserCaps.setCapability("profile", profile.toJson());
     browserCaps.setCapability("binary", binary.getPath());


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Ensure options present in capabilities are merged as expected

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```
  MutableCapabilities browserCaps = new MutableCapabilities();
    browserCaps.setCapability("binary", "/path/to/browser");
    MutableCapabilities addCaps = new MutableCapabilities();
    addCaps.setCapability("goog:chromeOptions", browserCaps);
    ChromeOptions options = existingOptions.merge(addCaps);

```
The above example is a valid use-case that was not accounted for earlier. The changes address the same and fix it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
