### PR TITLE
[rust] Selenium-Manager fails when a browser detection fails with browser version (#11382)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -142,23 +142,32 @@ pub trait SeleniumManager {
                     .browsers
                     .push(create_browser_metadata(browser_name, &browser_version));
                 write_metadata(&metadata);
-                Some(browser_version)
+                if !browser_version.is_empty() {
+                    Some(browser_version)
+                } else {
+                    None
+                }
             }
         }
     }
 
-    fn discover_driver_version(&mut self) -> String {
-        if self.get_browser_version().is_empty() || self.is_browser_version_unstable() {
+    fn discover_driver_version(&mut self) -> Result<String, String> {
+        let browser_version = self.get_browser_version();
+        if browser_version.is_empty() || self.is_browser_version_unstable() {
             match self.discover_browser_version() {
                 Some(version) => {
                     log::debug!("Detected browser: {} {}", self.get_browser_name(), version);
                     self.set_browser_version(version);
                 }
                 None => {
-                    log::debug!(
+                    if self.is_browser_version_unstable() {
+                        return Err(format!("Browser version '{browser_version}' not found"));
+                    } else {
+                        log::debug!(
                         "The version of {} cannot be detected. Trying with latest driver version",
                         self.get_browser_name()
-                    );
+                        );
+                    }
                 }
             }
         }
@@ -170,7 +179,7 @@ pub trait SeleniumManager {
             self.get_driver_name(),
             driver_version
         );
-        driver_version
+        Ok(driver_version)
     }
 
     fn is_browser_version_unstable(&self) -> bool {
@@ -183,7 +192,7 @@ pub trait SeleniumManager {
 
     fn resolve_driver(&mut self) -> Result<PathBuf, Box<dyn Error>> {
         if self.get_driver_version().is_empty() {
-            let driver_version = self.discover_driver_version();
+            let driver_version = self.discover_driver_version()?;
             self.set_driver_version(driver_version);
         }
 


### PR DESCRIPTION
### Description
When a browser version is specified in Selenium Manager (using `--browser-version`), for instance, an unstable version (e.g., `beta`, `dev`, or `canary`/`nightly`), instead of falling back to the latest driver, Selenium Manager should raise an error.

### Motivation and Context
This PR implements #11382. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
