### PR TITLE
Fix description of move_to_element_with_offset

### DIFF
--- a/py/selenium/webdriver/common/action_chains.py
+++ b/py/selenium/webdriver/common/action_chains.py
@@ -236,12 +236,12 @@ class ActionChains:
 
     def move_to_element_with_offset(self, to_element, xoffset, yoffset):
         """Move the mouse by an offset of the specified element. Offsets are
-        relative to the top-left corner of the element.
+        relative to the in-view center point of the element.
 
         :Args:
          - to_element: The WebElement to move to.
-         - xoffset: X offset to move to.
-         - yoffset: Y offset to move to.
+         - xoffset: X offset to move to, as a positive or negative integer.
+         - yoffset: Y offset to move to, as a positive or negative integer.
         """
 
         self.w3c_actions.pointer_action.move_to(to_element, int(xoffset), int(yoffset))


### PR DESCRIPTION
Fix the function comments according to the w3c spec:

https://w3c.github.io/webdriver/#dfn-dispatch-a-pointermove-action

Fixes #10261

### Description

This commit fixes the incorrect function description of `move_to_element_with_offset`, which has caused confusion in issue #10261.

### Motivation and Context

The current code behaves correctly (following w3c spec), but the comment is incorrect.

Documentation fix: SeleniumHQ/seleniumhq.github.io#1259

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
