### PR TITLE
[java] allow Edge to set driver log level as well

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -21,6 +21,7 @@ import com.google.auto.service.AutoService;
 
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.File;
@@ -154,7 +155,7 @@ public class ChromeDriverService extends DriverService {
     private boolean verbose = Boolean.getBoolean(CHROME_DRIVER_VERBOSE_LOG_PROPERTY);
     private boolean silent = Boolean.getBoolean(CHROME_DRIVER_SILENT_OUTPUT_PROPERTY);
     private String whitelistedIps = System.getProperty(CHROME_DRIVER_WHITELISTED_IPS_PROPERTY);
-    private ChromeDriverLogLevel logLevel = null;
+    private ChromiumDriverLogLevel logLevel = null;
 
     @Override
     public int score(Capabilities capabilities) {
@@ -197,10 +198,10 @@ public class ChromeDriverService extends DriverService {
     /**
      * Configures the driver server verbosity.
      *
-     * @param logLevel {@link ChromeDriverLogLevel} for desired log level output.
+     * @param logLevel {@link ChromiumDriverLogLevel} for desired log level output.
      * @return A self reference.
      */
-    public Builder withLogLevel(ChromeDriverLogLevel logLevel) {
+    public Builder withLogLevel(ChromiumDriverLogLevel logLevel) {
       this.logLevel = logLevel;
       return this;
     }
@@ -250,7 +251,7 @@ public class ChromeDriverService extends DriverService {
         withVerbose(false);
       }
       if (verbose) {
-        withLogLevel(ChromeDriverLogLevel.ALL);
+        withLogLevel(ChromiumDriverLogLevel.ALL);
       }
 
       List<String> args = new ArrayList<>();

--- a/java/src/org/openqa/selenium/chrome/ChromeOptions.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeOptions.java
@@ -52,15 +52,9 @@ public class ChromeOptions extends ChromiumOptions<ChromeOptions> {
    */
   public static final String CAPABILITY = "goog:chromeOptions";
   public static final String LOGGING_PREFS = "goog:loggingPrefs";
-  private ChromeDriverLogLevel logLevel;
 
   public ChromeOptions() {
     super(CapabilityType.BROWSER_NAME, CHROME.browserName(), CAPABILITY);
-  }
-
-  public ChromeOptions setLogLevel(ChromeDriverLogLevel logLevel){
-    this.logLevel = Require.nonNull("Log level", logLevel);
-    return this;
   }
 
   @Override
@@ -73,9 +67,5 @@ public class ChromeOptions extends ChromiumOptions<ChromeOptions> {
     newInstance.mergeInOptionsFromCaps(CAPABILITY, extraCapabilities);
 
     return newInstance;
-  }
-
-  public ChromeDriverLogLevel getLogLevel(){
-    return logLevel;
   }
 }

--- a/java/src/org/openqa/selenium/chromium/ChromiumDriverLogLevel.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriverLogLevel.java
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.openqa.selenium.chrome;
+package org.openqa.selenium.chromium;
 
 import com.google.common.collect.ImmutableMap;
-import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
 
 import java.util.Map;
 import java.util.logging.Level;
@@ -26,10 +25,8 @@ import java.util.logging.Level;
 /**
  * <a href="https://source.chromium.org/chromium/chromium/src/+/master:chrome/test/chromedriver/logging.cc">
  *   Log levels</a> defined by ChromeDriver
- * @deprecated use {@link ChromiumDriverLogLevel}
  */
-@Deprecated
-public enum ChromeDriverLogLevel {
+public enum ChromiumDriverLogLevel {
   ALL,
   INFO,
   DEBUG,
@@ -37,8 +34,8 @@ public enum ChromeDriverLogLevel {
   SEVERE,
   OFF;
 
-  private static final Map<Level, ChromeDriverLogLevel> logLevelToChromeLevelMap
-    = new ImmutableMap.Builder<Level, ChromeDriverLogLevel>()
+  private static final Map<Level, ChromiumDriverLogLevel> logLevelToChromeLevelMap
+    = new ImmutableMap.Builder<Level, ChromiumDriverLogLevel>()
     .put(Level.ALL, ALL)
     .put(Level.FINEST, DEBUG)
     .put(Level.FINER, DEBUG)
@@ -54,9 +51,9 @@ public enum ChromeDriverLogLevel {
     return super.toString().toLowerCase();
   }
 
-  public static ChromeDriverLogLevel fromString(String text) {
+  public static ChromiumDriverLogLevel fromString(String text) {
     if (text != null) {
-      for (ChromeDriverLogLevel b : ChromeDriverLogLevel.values()) {
+      for (ChromiumDriverLogLevel b : ChromiumDriverLogLevel.values()) {
         if (text.equalsIgnoreCase(b.toString())) {
           return b;
         }
@@ -65,7 +62,7 @@ public enum ChromeDriverLogLevel {
     return null;
   }
 
-  public static ChromeDriverLogLevel fromLevel(Level level) {
+  public static ChromiumDriverLogLevel fromLevel(Level level) {
     return logLevelToChromeLevelMap.getOrDefault(level, ALL);
   }
 }

--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -68,6 +68,7 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
   private final List<String> extensions = new ArrayList<>();
   private final Map<String, Object> experimentalOptions = new HashMap<>();
   private Map<String, Object> androidOptions = new HashMap<>();
+  private ChromiumDriverLogLevel logLevel;
 
   private final String capabilityName;
 
@@ -229,6 +230,15 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
     newOptions.put(name, value);
     androidOptions = Collections.unmodifiableMap(newOptions);
     return (T) this;
+  }
+
+  public T setLogLevel(ChromiumDriverLogLevel logLevel){
+    this.logLevel = Require.nonNull("Log level", logLevel);
+    return (T) this;
+  }
+
+  public ChromiumDriverLogLevel getLogLevel(){
+    return logLevel;
   }
 
   @Override

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.AcceptedW3CCapabilityKeys;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.PageLoadStrategy;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
+import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
 import org.openqa.selenium.testing.TestUtilities;
 
 import java.io.File;
@@ -40,8 +41,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
-import static org.openqa.selenium.chrome.ChromeDriverLogLevel.OFF;
-import static org.openqa.selenium.chrome.ChromeDriverLogLevel.SEVERE;
+import static org.openqa.selenium.chromium.ChromiumDriverLogLevel.OFF;
+import static org.openqa.selenium.chromium.ChromiumDriverLogLevel.SEVERE;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 
@@ -69,8 +70,8 @@ class ChromeOptionsTest {
 
   @Test
   void canBuildLogLevelFromStringRepresentation() {
-    assertThat(ChromeDriverLogLevel.fromString("off")).isEqualTo(OFF);
-    assertThat(ChromeDriverLogLevel.fromString("SEVERE")).isEqualTo(SEVERE);
+    assertThat(ChromiumDriverLogLevel.fromString("off")).isEqualTo(OFF);
+    assertThat(ChromiumDriverLogLevel.fromString("SEVERE")).isEqualTo(SEVERE);
   }
 
   @Test
@@ -269,7 +270,7 @@ class ChromeOptionsTest {
     Map<String, Object> converted = new ChromeOptions()
       .setBinary("some/path")
       .addArguments("--headless")
-      .setLogLevel(ChromeDriverLogLevel.INFO)
+      .setLogLevel(ChromiumDriverLogLevel.INFO)
       .asMap();
 
     Predicate<String> badKeys = new AcceptedW3CCapabilityKeys().negate();


### PR DESCRIPTION
Chrome allows setting log level in Options class, and consumes it in the Service class.

I want to provide the same functionality to Edge. This PR just deals with moving the things to the super class so that Edge has access to them.

This PR does not wire in the functionality in the Edge Service class. Trying to do this in smaller, easier to parse chunks. Is this the right way to do this?

Marking it as Draft since it can't be used as-is. I have other changes in mind for Service classes if this is ok.