### PR TITLE
[py] Fix sdist tar package_dir

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -175,6 +175,7 @@ pkg_tar(
     srcs = [":selenium-sdist-pkg"],
     extension = "tar.gz",
     mode = "0644",
+    package_dir = "selenium-%s" % SE_VERSION,
     package_file_name = "selenium-%s.tar.gz" % SE_VERSION,
 )
 


### PR DESCRIPTION
We need to set package_dir so that the tar file extracts to the expected directory.

Tar paths currently look like this:
```
$ tar -tvf selenium-4.7.2.tar.gz 
-rw-r--r--  0 0      0       45052 Dec 31  1999 CHANGES
-rw-r--r--  0 0      0         834 Dec 31  1999 MANIFEST.in
-rw-r--r--  0 0      0        7160 Dec 31  1999 PKG-INFO
-rw-r--r--  0 0      0        6241 Dec 31  1999 README.rst
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium/
-rw-r--r--  0 0      0         811 Dec 31  1999 selenium/__init__.py
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium/common/
-rw-r--r--  0 0      0        3546 Dec 31  1999 selenium/common/__init__.py
-rw-r--r--  0 0      0        8865 Dec 31  1999 selenium/common/exceptions.py
-rw-r--r--  0 0      0           0 Dec 31  1999 selenium/py.typed
-rw-r--r--  0 0      0        1010 Dec 31  1999 selenium/types.py
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium/webdriver/
-rw-r--r--  0 0      0        2415 Dec 31  1999 selenium/webdriver/__init__.py
```

This adds the correct path prefix so that they look like this:
```
$ tar -tvf selenium-4.7.2.tar.gz
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium-4.7.2/
-rw-r--r--  0 0      0       45052 Dec 31  1999 selenium-4.7.2/CHANGES
-rw-r--r--  0 0      0         834 Dec 31  1999 selenium-4.7.2/MANIFEST.in
-rw-r--r--  0 0      0        7160 Dec 31  1999 selenium-4.7.2/PKG-INFO
-rw-r--r--  0 0      0        6241 Dec 31  1999 selenium-4.7.2/README.rst
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium-4.7.2/selenium/
-rw-r--r--  0 0      0         811 Dec 31  1999 selenium-4.7.2/selenium/__init__.py
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium-4.7.2/selenium/common/
-rw-r--r--  0 0      0        3546 Dec 31  1999 selenium-4.7.2/selenium/common/__init__.py
-rw-r--r--  0 0      0        8865 Dec 31  1999 selenium-4.7.2/selenium/common/exceptions.py
-rw-r--r--  0 0      0           0 Dec 31  1999 selenium-4.7.2/selenium/py.typed
-rw-r--r--  0 0      0        1010 Dec 31  1999 selenium-4.7.2/selenium/types.py
drwxr-xr-x  0 0      0           0 Dec 31  1999 selenium-4.7.2/selenium/webdriver/
-rw-r--r--  0 0      0        2415 Dec 31  1999 selenium-4.7.2/selenium/webdriver/__init__.py
```