### PR TITLE
[rust] Support for multiple browser names in Selenium Manager (#11352)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -292,9 +292,17 @@ pub fn get_manager_by_browser(browser_name: String) -> Result<Box<dyn SeleniumMa
         Ok(ChromeManager::new())
     } else if browser_name.eq_ignore_ascii_case("firefox") {
         Ok(FirefoxManager::new())
-    } else if browser_name.eq_ignore_ascii_case("edge") {
+    } else if browser_name.eq_ignore_ascii_case("edge")
+        || browser_name.eq_ignore_ascii_case("msedge")
+        || browser_name.eq_ignore_ascii_case("MicrosoftEdge")
+    {
         Ok(EdgeManager::new())
-    } else if browser_name.eq_ignore_ascii_case("iexplorer") {
+    } else if browser_name.eq_ignore_ascii_case("iexplorer")
+        || browser_name.eq_ignore_ascii_case("ie")
+        || browser_name.eq_ignore_ascii_case("InternetExplorer")
+        || browser_name.eq_ignore_ascii_case("internet-explorer")
+        || browser_name.eq_ignore_ascii_case("internet_explorer")
+    {
         Ok(IExplorerManager::new())
     } else {
         Err(format!("Invalid browser name: {browser_name}"))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -288,20 +288,21 @@ pub trait SeleniumManager {
 // ----------------------------------------------------------
 
 pub fn get_manager_by_browser(browser_name: String) -> Result<Box<dyn SeleniumManager>, String> {
-    if browser_name.eq_ignore_ascii_case("chrome") {
+    let browser_name_lower_case = browser_name.to_ascii_lowercase();
+    if browser_name_lower_case.eq("chrome") {
         Ok(ChromeManager::new())
-    } else if browser_name.eq_ignore_ascii_case("firefox") {
+    } else if browser_name.eq("firefox") {
         Ok(FirefoxManager::new())
-    } else if browser_name.eq_ignore_ascii_case("edge")
-        || browser_name.eq_ignore_ascii_case("msedge")
-        || browser_name.eq_ignore_ascii_case("MicrosoftEdge")
-    {
+    } else if vec!["edge", "msedge", "microsoftedge"].contains(&browser_name_lower_case.as_str()) {
         Ok(EdgeManager::new())
-    } else if browser_name.eq_ignore_ascii_case("iexplorer")
-        || browser_name.eq_ignore_ascii_case("ie")
-        || browser_name.eq_ignore_ascii_case("InternetExplorer")
-        || browser_name.eq_ignore_ascii_case("internet-explorer")
-        || browser_name.eq_ignore_ascii_case("internet_explorer")
+    } else if vec![
+        "iexplorer",
+        "ie",
+        "internetexplorer",
+        "internet-explorer",
+        "internet_explorer",
+    ]
+    .contains(&browser_name_lower_case.as_str())
     {
         Ok(IExplorerManager::new())
     } else {


### PR DESCRIPTION
### Description
This PR allows to use different browser names in Selenium Manager:

- "ie", "InternetExplorer", "internet-explorer", "internet_explorer" (in addition to "iexplorer") for Internet Explorer.
- "msedge", "MicrosoftEdge" (in addition to "edge") for Edge.

### Motivation and Context
This PR implements #11352.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
