### PR TITLE
[rust] Use optional arguments for CLI parsing in Selenium Manager

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -16,19 +16,19 @@ Selenium Manager can be executed using Cargo as follows:
 
 ```
 $ cargo run -- --help
-selenium-manager 1.0.0-M1
-Automated driver management for Selenium
+selenium-manager 1.0.0-M2
+Selenium Manager is a CLI tool that automatically manages the browser/driver infrastructure required by Selenium.
 
 Usage: selenium-manager [OPTIONS]
 Options:
   -b, --browser <BROWSER>
-          Browser name (chrome, firefox, edge, or iexplorer) [default: ]
+          Browser name (chrome, firefox, edge, or iexplorer)
   -d, --driver <DRIVER>
-          Driver name (chromedriver, geckodriver, msedgedriver, or IEDriverServer) [default: ]
+          Driver name (chromedriver, geckodriver, msedgedriver, or IEDriverServer)
   -v, --driver-version <DRIVER_VERSION>
-          Driver version (e.g., 106.0.5249.61, 0.31.0, etc.) [default: ]
+          Driver version (e.g., 106.0.5249.61, 0.31.0, etc.)
   -B, --browser-version <BROWSER_VERSION>
-          Major browser version (e.g., 105, 106, etc. Also: beta, dev, canary -or nightly- is accepted) [default: ]
+          Major browser version (e.g., 105, 106, etc. Also: beta, dev, canary -or nightly- is accepted)
   -D, --debug
           Display DEBUG messages
   -T, --trace

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -41,20 +41,20 @@ use selenium_manager::{
 {all-args}")]
 struct Cli {
     /// Browser name (chrome, firefox, edge, or iexplorer)
-    #[clap(short, long, value_parser, default_value = "")]
-    browser: String,
+    #[clap(short, long, value_parser)]
+    browser: Option<String>,
 
     /// Driver name (chromedriver, geckodriver, msedgedriver, or IEDriverServer)
-    #[clap(short, long, value_parser, default_value = "")]
-    driver: String,
+    #[clap(short, long, value_parser)]
+    driver: Option<String>,
 
     /// Driver version (e.g., 106.0.5249.61, 0.31.0, etc.)
-    #[clap(short = 'v', long, value_parser, default_value = "")]
-    driver_version: String,
+    #[clap(short = 'v', long, value_parser)]
+    driver_version: Option<String>,
 
     /// Major browser version (e.g., 105, 106, etc. Also: beta, dev, canary -or nightly- is accepted)
-    #[clap(short = 'B', long, value_parser, default_value = "")]
-    browser_version: String,
+    #[clap(short = 'B', long, value_parser)]
+    browser_version: Option<String>,
 
     /// Display DEBUG messages
     #[clap(short = 'D', long)]
@@ -77,8 +77,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         clear_cache();
     }
 
-    let browser_name: String = cli.browser;
-    let driver_name: String = cli.driver;
+    let browser_name: String = cli.browser.unwrap_or_default();
+    let driver_name: String = cli.driver.unwrap_or_default();
 
     let mut selenium_manager: Box<dyn SeleniumManager> = if !browser_name.is_empty() {
         get_manager_by_browser(browser_name).unwrap_or_else(|err| {
@@ -95,8 +95,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         exit(DATAERR);
     };
 
-    selenium_manager.set_browser_version(cli.browser_version);
-    selenium_manager.set_driver_version(cli.driver_version);
+    selenium_manager.set_browser_version(cli.browser_version.unwrap_or_default());
+    selenium_manager.set_driver_version(cli.driver_version.unwrap_or_default());
 
     match selenium_manager.resolve_driver() {
         Ok(driver_path) => log::info!("{}", driver_path.display()),


### PR DESCRIPTION
### Description
This PR improves the way in which optional parameters (e.g., `browser-version` or `driver-version`) are handled in the Rust logic of Selenium Manager.

### Motivation and Context
This PR is a preparation for #11365.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
