### PR TITLE
Upgrade Ruby Capabilities

### DIFF
--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -53,7 +53,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities)
+          super(options, capabilities, Options)
         end
       end # Driver
     end # Chrome

--- a/rb/lib/selenium/webdriver/chrome/driver.rb
+++ b/rb/lib/selenium/webdriver/chrome/driver.rb
@@ -53,7 +53,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities, Options)
+          super(options, capabilities)
         end
       end # Driver
     end # Chrome

--- a/rb/lib/selenium/webdriver/chromium/options.rb
+++ b/rb/lib/selenium/webdriver/chromium/options.rb
@@ -221,8 +221,6 @@ module Selenium
           options = browser_options[self.class::KEY]
           options['binary'] ||= binary_path if binary_path
 
-          check_w3c(options[:w3c]) if options.key?(:w3c)
-
           if @profile
             options['args'] ||= []
             options['args'] << "--user-data-dir=#{@profile.directory}"
@@ -231,17 +229,6 @@ module Selenium
           return if (@encoded_extensions + @extensions).empty?
 
           options['extensions'] = @encoded_extensions + @extensions.map { |ext| encode_extension(ext) }
-        end
-
-        def check_w3c(w3c)
-          if w3c
-            WebDriver.logger.warn("Setting 'w3c: true' is redundant and will no longer be allowed", id: :w3c)
-            return
-          end
-
-          raise Error::InvalidArgumentError,
-                "Setting 'w3c: false' is not allowed.\n" \
-                'Please update to W3C Syntax: https://www.selenium.dev/blog/2022/legacy-protocol-support/'
         end
 
         def binary_path

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -314,19 +314,19 @@ module Selenium
         end
       end
 
-      def process_options(options, capabilities, klass = nil)
+      def process_options(options, capabilities)
         if options && capabilities
           msg = "Don't use both :options and :capabilities when initializing #{self.class}, prefer :options"
           raise ArgumentError, msg
         end
 
-        options ? options.as_json : deprecate_capabilities(capabilities, klass)
+        options ? options.as_json : deprecate_capabilities(capabilities)
       end
 
-      def deprecate_capabilities(capabilities, klass)
-        if klass
+      def deprecate_capabilities(capabilities)
+        unless is_a?(Remote::Driver)
           WebDriver.logger.deprecate("The :capabilities parameter for #{self.class}",
-                                     ":options argument with an instance of #{klass}",
+                                     ":options argument with an instance of #{self.class}",
                                      id: :capabilities)
         end
         generate_capabilities(capabilities)

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -314,13 +314,22 @@ module Selenium
         end
       end
 
-      def process_options(options, capabilities)
+      def process_options(options, capabilities, klass = nil)
         if options && capabilities
           msg = "Don't use both :options and :capabilities when initializing #{self.class}, prefer :options"
           raise ArgumentError, msg
         end
 
-        options ? options.as_json : generate_capabilities(capabilities)
+        options ? options.as_json : deprecate_capabilities(capabilities, klass)
+      end
+
+      def deprecate_capabilities(capabilities, klass)
+        if klass
+          WebDriver.logger.deprecate("The :capabilities parameter for #{self.class}",
+                                     ":options argument with an instance of #{klass}",
+                                     id: :capabilities)
+        end
+        generate_capabilities(capabilities)
       end
 
       def generate_capabilities(capabilities)

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -85,7 +85,13 @@ module Selenium
       #
 
       def add_option(name, value = nil)
-        @options[name.keys.first] = name.values.first if value.nil? && name.is_a?(Hash)
+        name, value = name.first if value.nil? && name.is_a?(Hash)
+
+        unless name.to_s.include?(':')
+          WebDriver.logger.deprecate('Options#add_option for w3c or browser specific capabilities',
+                                     'applicable attribute accessors or pass into constructor',
+                                     id: :add_option)
+        end
         @options[name] = value
       end
 

--- a/rb/lib/selenium/webdriver/edge/driver.rb
+++ b/rb/lib/selenium/webdriver/edge/driver.rb
@@ -53,7 +53,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities, Options)
+          super(options, capabilities)
         end
       end # Driver
     end # Edge

--- a/rb/lib/selenium/webdriver/edge/driver.rb
+++ b/rb/lib/selenium/webdriver/edge/driver.rb
@@ -53,7 +53,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities)
+          super(options, capabilities, Options)
         end
       end # Driver
     end # Edge

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -72,7 +72,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities)
+          super(options, capabilities, Options)
         end
       end # Driver
     end # Firefox

--- a/rb/lib/selenium/webdriver/firefox/driver.rb
+++ b/rb/lib/selenium/webdriver/firefox/driver.rb
@@ -72,7 +72,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities, Options)
+          super(options, capabilities)
         end
       end # Driver
     end # Firefox

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -50,7 +50,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities)
+          super(options, capabilities, Options)
         end
       end # Driver
     end # IE

--- a/rb/lib/selenium/webdriver/ie/driver.rb
+++ b/rb/lib/selenium/webdriver/ie/driver.rb
@@ -50,7 +50,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities, Options)
+          super(options, capabilities)
         end
       end # Driver
     end # IE

--- a/rb/lib/selenium/webdriver/remote/capabilities.rb
+++ b/rb/lib/selenium/webdriver/remote/capabilities.rb
@@ -83,12 +83,14 @@ module Selenium
 
         class << self
           def chrome(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.chrome', 'Options.chrome', id: :caps_browsers)
             new({
               browser_name: 'chrome'
             }.merge(opts))
           end
 
           def edge(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.edge', 'Options.edge', id: :caps_browsers)
             new({
               browser_name: 'MicrosoftEdge'
             }.merge(opts))
@@ -96,6 +98,7 @@ module Selenium
           alias microsoftedge edge
 
           def firefox(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.firefox', 'Options.firefox', id: :caps_browsers)
             new({
               browser_name: 'firefox'
             }.merge(opts))
@@ -103,18 +106,23 @@ module Selenium
           alias ff firefox
 
           def safari(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.safari', 'Options.safari', id: :caps_browsers)
             new({
               browser_name: Selenium::WebDriver::Safari.technology_preview? ? 'Safari Technology Preview' : 'safari'
             }.merge(opts))
           end
 
           def htmlunit(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.htmlunit',
+                                       'as argument in constructor',
+                                       id: :caps_browsers)
             new({
               browser_name: 'htmlunit'
             }.merge(opts))
           end
 
           def internet_explorer(opts = {})
+            WebDriver.logger.deprecate('Remote::Capabilities.ie', 'Options.ie', id: :caps_browsers)
             new({
               browser_name: 'internet explorer',
               platform_name: :windows

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -51,7 +51,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities, Options)
+          super(options, capabilities)
         end
       end # Driver
     end # Safari

--- a/rb/lib/selenium/webdriver/safari/driver.rb
+++ b/rb/lib/selenium/webdriver/safari/driver.rb
@@ -51,7 +51,7 @@ module Selenium
             options = Options.new
           end
 
-          super(options, capabilities)
+          super(options, capabilities, Options)
         end
       end # Driver
     end # Safari

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -48,7 +48,7 @@ module Selenium
         end
 
         it 'accepts provided Options as sole parameter' do
-          opts = {invalid: 'foobar', args: ['-f']}
+          opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', 'goog:chromeOptions': opts}}})
 
           expect { described_class.new(options: Options.new(**opts)) }.not_to raise_exception

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -71,35 +71,43 @@ module Selenium
         context 'with :capabilities' do
           it 'accepts value as a Symbol' do
             expect_request
-            expect { described_class.new(capabilities: :chrome) }.not_to raise_exception
+            expect { described_class.new(capabilities: :chrome) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts Capabilities.chrome' do
-            capabilities = Remote::Capabilities.chrome(invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect {
+              capabilities = Remote::Capabilities.chrome(invalid: 'foobar')
+              described_class.new(capabilities: capabilities)
+            }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do
-            capabilities = Remote::Capabilities.new(browser_name: 'chrome', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect {
+              capabilities = Remote::Capabilities.new(browser_name: 'chrome', invalid: 'foobar')
+              expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Symbols' do
-            capabilities = Remote::Capabilities.new(browserName: 'chrome', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect {
+              capabilities = Remote::Capabilities.new(browserName: 'chrome', invalid: 'foobar')
+              expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Strings' do
-            capabilities = Remote::Capabilities.new('browserName' => 'chrome', 'invalid' => 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect {
+              capabilities = Remote::Capabilities.new('browserName' => 'chrome', 'invalid' => 'foobar')
+              expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            }.to have_deprecated(:capabilities)
           end
 
           context 'when value is an Array' do
@@ -116,7 +124,11 @@ module Selenium
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome',
                                                                  'goog:chromeOptions': {args: ['-f']}}}})
 
-              expect { described_class.new(capabilities: [options]) }.not_to raise_exception
+              expect {
+                expect {
+                  described_class.new(capabilities: [options])
+                }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance with profile' do
@@ -128,21 +140,27 @@ module Selenium
                                        {alwaysMatch: {browserName: 'chrome',
                                                       'goog:chromeOptions': {args: ['--user-data-dir=PROF_DIR']}}}})
 
-              expect { described_class.new(capabilities: [options]) }.not_to raise_exception
+              expect {
+                expect {
+                  described_class.new(capabilities: [options])
+                }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Capabilities instance' do
               capabilities = Remote::Capabilities.new(browser_name: 'chrome', invalid: 'foobar')
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
 
-              expect { described_class.new(capabilities: [capabilities]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [capabilities]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance and an instance of a custom object responding to #as_json' do
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome',
                                                                  'goog:chromeOptions': {},
                                                                  'company:key': 'value'}}})
-              expect { described_class.new(capabilities: [Options.new, as_json_object.new]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new, as_json_object.new])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
@@ -154,7 +172,7 @@ module Selenium
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])
-              }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
           end
         end

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -27,7 +27,7 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.chrome}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'chrome'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -64,7 +64,7 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::Chrome::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.new, capabilities: Remote::Capabilities.chrome)
+            described_class.new(options: Options.new, capabilities: Remote::Capabilities.new(browser_name: 'chrome'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -72,15 +72,6 @@ module Selenium
           it 'accepts value as a Symbol' do
             expect_request
             expect { described_class.new(capabilities: :chrome) }.to have_deprecated(:capabilities)
-          end
-
-          it 'accepts Capabilities.chrome' do
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
-
-            expect {
-              capabilities = Remote::Capabilities.chrome(invalid: 'foobar')
-              described_class.new(capabilities: capabilities)
-            }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -188,13 +188,27 @@ module Selenium
 
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
           end
 
           it 'adds an option with Hash' do
-            options.add_option(foo: 'bar')
+            expect {
+              options.add_option(foo: 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
+          end
+
+          it 'adds vendor namespaced options with ordered pairs' do
+            options.add_option('foo:bar', {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
+          end
+
+          it 'adds vendor namespaced options with Hash' do
+            options.add_option('foo:bar' => {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
           end
         end
 
@@ -250,18 +264,24 @@ module Selenium
           end
 
           it 'raises error when w3c is false' do
-            options.add_option(:w3c, false)
+            expect {
+              options.add_option(:w3c, false)
+            }.to have_deprecated(:add_option)
             expect { options.as_json }.to raise_error(Error::InvalidArgumentError)
           end
 
           it 'raises error when w3c is true' do
             msg = /WARN Selenium \[:w3c\]/
-            options.add_option(:w3c, true)
+            expect {
+              options.add_option(:w3c, true)
+            }.to have_deprecated(:add_option)
             expect { options.as_json }.to output(msg).to_stdout_from_any_process
           end
 
           it 'returns added options' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'chrome',
                                           'foo:bar' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -263,29 +263,24 @@ module Selenium
             expect(options.as_json).to eq('browserName' => 'chrome', 'goog:chromeOptions' => {})
           end
 
-          it 'raises error when w3c is false' do
+          it 'errors when unrecognized capability is passed' do
             expect {
-              options.add_option(:w3c, false)
+              options.add_option(:foo, 'bar')
             }.to have_deprecated(:add_option)
-            expect { options.as_json }.to raise_error(Error::InvalidArgumentError)
-          end
 
-          it 'raises error when w3c is true' do
-            msg = /WARN Selenium \[:w3c\]/
             expect {
-              options.add_option(:w3c, true)
-            }.to have_deprecated(:add_option)
-            expect { options.as_json }.to output(msg).to_stdout_from_any_process
+              options.as_json
+            }.to output(/WARN Selenium These options are not w3c compliant/).to_stdout_from_any_process
           end
 
           it 'returns added options' do
             expect {
-              options.add_option(:foo, 'bar')
+              options.add_option(:detach, true)
             }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'chrome',
                                           'foo:bar' => {'foo' => 'bar'},
-                                          'goog:chromeOptions' => {'foo' => 'bar'})
+                                          'goog:chromeOptions' => {'detach' => true})
           end
 
           it 'converts profile' do
@@ -322,7 +317,6 @@ module Selenium
                                        binary: '/foo/bar',
                                        extensions: ['foo.crx', 'bar.crx'],
                                        encoded_extensions: ['encoded_foobar'],
-                                       foo: 'bar',
                                        emulation: {device_name: :mine},
                                        local_state: {
                                          foo: 'bar',
@@ -359,7 +353,6 @@ module Selenium
                                                            'nested_one' => {'nested_two' => 'bazbar'}},
                                                'binary' => '/foo/bar',
                                                'extensions' => %w[encoded_foobar encoded_foo encoded_bar],
-                                               'foo' => 'bar',
                                                'mobileEmulation' => {'deviceName' => 'mine'},
                                                'localState' => {
                                                  'foo' => 'bar',

--- a/rb/spec/unit/selenium/webdriver/common/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/options_spec.rb
@@ -22,7 +22,7 @@ require File.expand_path('../spec_helper', __dir__)
 module Selenium
   module WebDriver
     describe Options do
-      subject(:options) { described_class.new(local_state: {}) }
+      subject(:options) { described_class.new('localState' => {}) }
 
       before do
         stub_const("#{described_class}::BROWSER", 'foo')
@@ -30,18 +30,8 @@ module Selenium
       end
 
       describe '#as_json' do
-        it 'does not override options set via symbol name' do
-          expect {
-            options.add_option(:local_state, {foo: 'bar'})
-          }.to have_deprecated(:add_option)
-          expect(options.as_json).to include('localState' => {'foo' => 'bar'})
-        end
-
-        it 'does not override options set via string name' do
-          expect {
-            options.add_option('localState', {foo: 'bar'})
-          }.to have_deprecated(:add_option)
-          expect(options.as_json).to include('localState' => {'foo' => 'bar'})
+        it 'Using camel case string value is deprecated' do
+          expect { options.as_json }.to have_deprecated(:option_symbols)
         end
       end
     end # Options

--- a/rb/spec/unit/selenium/webdriver/common/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/options_spec.rb
@@ -31,12 +31,16 @@ module Selenium
 
       describe '#as_json' do
         it 'does not override options set via symbol name' do
-          options.add_option(:local_state, {foo: 'bar'})
+          expect {
+            options.add_option(:local_state, {foo: 'bar'})
+          }.to have_deprecated(:add_option)
           expect(options.as_json).to include('localState' => {'foo' => 'bar'})
         end
 
         it 'does not override options set via string name' do
-          options.add_option('localState', {foo: 'bar'})
+          expect {
+            options.add_option('localState', {foo: 'bar'})
+          }.to have_deprecated(:add_option)
           expect(options.as_json).to include('localState' => {'foo' => 'bar'})
         end
       end

--- a/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
@@ -27,7 +27,7 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.edge}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'MicrosoftEdge'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -69,7 +69,7 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::Edge::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.new, capabilities: Remote::Capabilities.edge)
+            described_class.new(options: Options.new, capabilities: Remote::Capabilities.new(browser_name: 'msedge'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -81,13 +81,6 @@ module Selenium
                 described_class.new(capabilities: :edge)
               }.to have_deprecated(:capabilities)
             }.not_to raise_exception
-          end
-
-          it 'accepts Capabilities.edge' do
-            capabilities = Remote::Capabilities.edge(invalid: 'foobar')
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
-
-            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
@@ -76,35 +76,39 @@ module Selenium
         context 'with :capabilities' do
           it 'accepts value as a Symbol' do
             expect_request
-            expect { described_class.new(capabilities: :edge) }.not_to raise_exception
+            expect {
+              expect {
+                described_class.new(capabilities: :edge)
+              }.to have_deprecated(:capabilities)
+            }.not_to raise_exception
           end
 
           it 'accepts Capabilities.edge' do
             capabilities = Remote::Capabilities.edge(invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do
             capabilities = Remote::Capabilities.new(browser_name: 'MicrosoftEdge', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Symbols' do
             capabilities = Remote::Capabilities.new(browserName: 'MicrosoftEdge', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Strings' do
             capabilities = Remote::Capabilities.new('browserName' => 'MicrosoftEdge', 'invalid' => 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           context 'when value is an Array' do
@@ -121,7 +125,7 @@ module Selenium
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge',
                                                                  'ms:edgeOptions': {args: ['-f']}}}})
 
-              expect { described_class.new(capabilities: [options]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [options]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance with profile' do
@@ -132,21 +136,23 @@ module Selenium
                                       {alwaysMatch: {browserName: 'MicrosoftEdge',
                                                      'ms:edgeOptions': {args: ['--user-data-dir=PROF_DIR']}}}})
 
-              expect { described_class.new(capabilities: [options]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [options]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Capabilities instance' do
               capabilities = Remote::Capabilities.new(browser_name: 'MicrosoftEdge', invalid: 'foobar')
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', invalid: 'foobar'}}})
 
-              expect { described_class.new(capabilities: [capabilities]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [capabilities]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance and an instance of a custom object responding to #as_json' do
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge',
                                                                  'ms:edgeOptions': {},
                                                                  'company:key': 'value'}}})
-              expect { described_class.new(capabilities: [Options.new, as_json_object.new]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new, as_json_object.new])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
@@ -158,7 +164,7 @@ module Selenium
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])
-              }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
           end
         end

--- a/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
@@ -48,7 +48,7 @@ module Selenium
         end
 
         it 'accepts provided Options as sole parameter' do
-          opts = {invalid: 'foobar', args: ['-f']}
+          opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', 'ms:edgeOptions': opts}}})
 
           expect { described_class.new(options: Options.new(**opts)) }.not_to raise_exception

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -143,13 +143,27 @@ module Selenium
 
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
           end
 
           it 'adds an option with Hash' do
-            options.add_option(foo: 'bar')
+            expect {
+              options.add_option(foo: 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
+          end
+
+          it 'adds vendor namespaced options with ordered pairs' do
+            options.add_option('foo:bar', {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
+          end
+
+          it 'adds vendor namespaced options with Hash' do
+            options.add_option('foo:bar' => {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
           end
         end
 
@@ -205,18 +219,24 @@ module Selenium
           end
 
           it 'raises error when w3c is false' do
-            options.add_option(:w3c, false)
+            expect {
+              options.add_option(:w3c, false)
+            }.to have_deprecated(:add_option)
             expect { options.as_json }.to raise_error(Error::InvalidArgumentError)
           end
 
           it 'raises error when w3c is true' do
             msg = /WARN Selenium \[:w3c\]/
-            options.add_option(:w3c, true)
+            expect {
+              options.add_option(:w3c, true)
+            }.to have_deprecated(:add_option)
             expect { options.as_json }.to output(msg).to_stdout_from_any_process
           end
 
           it 'returns added options' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'MicrosoftEdge',
                                           'foo:bar' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -218,29 +218,24 @@ module Selenium
             expect(options.as_json).to eq('browserName' => 'MicrosoftEdge', 'ms:edgeOptions' => {})
           end
 
-          it 'raises error when w3c is false' do
+          it 'errors when unrecognized capability is passed' do
             expect {
-              options.add_option(:w3c, false)
+              options.add_option(:foo, 'bar')
             }.to have_deprecated(:add_option)
-            expect { options.as_json }.to raise_error(Error::InvalidArgumentError)
-          end
 
-          it 'raises error when w3c is true' do
-            msg = /WARN Selenium \[:w3c\]/
             expect {
-              options.add_option(:w3c, true)
-            }.to have_deprecated(:add_option)
-            expect { options.as_json }.to output(msg).to_stdout_from_any_process
+              options.as_json
+            }.to output(/WARN Selenium These options are not w3c compliant/).to_stdout_from_any_process
           end
 
           it 'returns added options' do
             expect {
-              options.add_option(:foo, 'bar')
+              options.add_option(:detach, true)
             }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'MicrosoftEdge',
                                           'foo:bar' => {'foo' => 'bar'},
-                                          'ms:edgeOptions' => {'foo' => 'bar'})
+                                          'ms:edgeOptions' => {'detach' => true})
           end
 
           it 'returns a JSON hash' do
@@ -266,7 +261,6 @@ module Selenium
                                        binary: '/foo/bar',
                                        extensions: ['foo.crx', 'bar.crx'],
                                        encoded_extensions: ['encoded_foobar'],
-                                       foo: 'bar',
                                        emulation: {device_name: :mine},
                                        local_state: {foo: 'bar'},
                                        detach: true,
@@ -299,7 +293,6 @@ module Selenium
                                                            'key_that_should_not_be_camelcased' => 'baz'},
                                                'binary' => '/foo/bar',
                                                'extensions' => %w[encoded_foobar encoded_foo encoded_bar],
-                                               'foo' => 'bar',
                                                'mobileEmulation' => {'deviceName' => 'mine'},
                                                'localState' => {'foo' => 'bar'},
                                                'detach' => true,

--- a/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
@@ -51,7 +51,7 @@ module Selenium
         end
 
         it 'accepts provided Options as sole parameter' do
-          opts = {invalid: 'foobar', args: ['-f']}
+          opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {acceptInsecureCerts: true,
                                                              browserName: 'firefox',
                                                              'moz:firefoxOptions': opts,

--- a/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
@@ -27,7 +27,7 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.firefox}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'firefox'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -69,7 +69,7 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::Firefox::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.new, capabilities: Remote::Capabilities.firefox)
+            described_class.new(options: Options.new, capabilities: Remote::Capabilities.new(browser_name: 'firefox'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -77,13 +77,6 @@ module Selenium
           it 'accepts value as a Symbol' do
             expect_request
             expect { described_class.new(capabilities: :firefox) }.to have_deprecated(:capabilities)
-          end
-
-          it 'accepts Capabilities.firefox' do
-            capabilities = Remote::Capabilities.firefox(invalid: 'foobar')
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
-
-            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
@@ -76,35 +76,35 @@ module Selenium
         context 'with :capabilities' do
           it 'accepts value as a Symbol' do
             expect_request
-            expect { described_class.new(capabilities: :firefox) }.not_to raise_exception
+            expect { described_class.new(capabilities: :firefox) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts Capabilities.firefox' do
             capabilities = Remote::Capabilities.firefox(invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do
             capabilities = Remote::Capabilities.new(browser_name: 'firefox', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Symbols' do
             capabilities = Remote::Capabilities.new(browserName: 'firefox', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Strings' do
             capabilities = Remote::Capabilities.new('browserName' => 'firefox', 'invalid' => 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           context 'when value is an Array' do
@@ -122,14 +122,14 @@ module Selenium
                                                                  browserName: 'firefox',
                                                                  'moz:firefoxOptions': {args: ['-f']},
                                                                  'moz:debuggerAddress': true}}})
-              expect { described_class.new(capabilities: [options]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [options]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Capabilities instance' do
               capabilities = Remote::Capabilities.new(browser_name: 'firefox', invalid: 'foobar')
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'firefox', invalid: 'foobar'}}})
 
-              expect { described_class.new(capabilities: [capabilities]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [capabilities]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance and an instance of a custom object responding to #as_json' do
@@ -138,7 +138,9 @@ module Selenium
                                                                  'moz:firefoxOptions': {},
                                                                  'moz:debuggerAddress': true,
                                                                  'company:key': 'value'}}})
-              expect { described_class.new(capabilities: [Options.new, as_json_object.new]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new, as_json_object.new])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
@@ -152,7 +154,7 @@ module Selenium
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])
-              }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
           end
         end

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -212,14 +212,14 @@ module Selenium
 
           it 'returns added options' do
             expect {
-              options.add_option(foo: 'bar')
+              options.add_option(:args, %w[foo bar])
             }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('acceptInsecureCerts' => true,
                                           'browserName' => 'firefox',
                                           'foo:bar' => {'foo' => 'bar'},
                                           'moz:debuggerAddress' => true,
-                                          'moz:firefoxOptions' => {'foo' => 'bar'})
+                                          'moz:firefoxOptions' => {'args' => %w[foo bar]})
           end
 
           it 'converts to a json hash' do
@@ -240,7 +240,6 @@ module Selenium
                                        binary: '/foo/bar',
                                        prefs: {foo: 'bar'},
                                        env: {'FOO' => 'bar'},
-                                       foo: 'bar',
                                        profile: profile,
                                        log_level: :debug,
                                        android_package: 'package',
@@ -269,7 +268,6 @@ module Selenium
                                                'env' => {'FOO' => 'bar'},
                                                'profile' => 'encoded_profile',
                                                'log' => {'level' => 'debug'},
-                                               'foo' => 'bar',
                                                'androidPackage' => 'package',
                                                'androidActivity' => 'activity',
                                                'androidDeviceSerial' => '123',

--- a/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/options_spec.rb
@@ -141,13 +141,27 @@ module Selenium
 
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
           end
 
           it 'adds an option with Hash' do
-            options.add_option(foo: 'bar')
+            expect {
+              options.add_option(foo: 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
+          end
+
+          it 'adds vendor namespaced options with ordered pairs' do
+            options.add_option('foo:bar', {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
+          end
+
+          it 'adds vendor namespaced options with Hash' do
+            options.add_option('foo:bar' => {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
           end
         end
 
@@ -197,7 +211,9 @@ module Selenium
           end
 
           it 'returns added options' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(foo: 'bar')
+            }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('acceptInsecureCerts' => true,
                                           'browserName' => 'firefox',

--- a/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
@@ -27,7 +27,7 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.ie}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'internet explorer'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -67,7 +67,8 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::IE::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.new, capabilities: Remote::Capabilities.ie)
+            described_class.new(options: Options.new,
+                                capabilities: Remote::Capabilities.new(browser_name: 'internet explorer'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -75,15 +76,6 @@ module Selenium
           it 'accepts value as a Symbol' do
             expect_request
             expect { described_class.new(capabilities: :ie) }.to have_deprecated(:capabilities)
-          end
-
-          it 'accepts Capabilities.ie' do
-            capabilities = Remote::Capabilities.ie(invalid: 'foobar')
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer',
-                                                               platformName: 'windows',
-                                                               invalid: 'foobar'}}})
-
-            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
@@ -74,7 +74,7 @@ module Selenium
         context 'with :capabilities' do
           it 'accepts value as a Symbol' do
             expect_request
-            expect { described_class.new(capabilities: :ie) }.not_to raise_exception
+            expect { described_class.new(capabilities: :ie) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts Capabilities.ie' do
@@ -83,28 +83,28 @@ module Selenium
                                                                platformName: 'windows',
                                                                invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do
             capabilities = Remote::Capabilities.new(browser_name: 'internet explorer', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Symbols' do
             capabilities = Remote::Capabilities.new(browserName: 'internet explorer', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Strings' do
             capabilities = Remote::Capabilities.new('browserName' => 'internet explorer', 'invalid' => 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           context 'when value is an Array' do
@@ -122,14 +122,16 @@ module Selenium
                                                                  'se:ieOptions' => {'initialBrowserUrl' => 'http://selenium.dev',
                                                                                     'nativeEvents' => true}}}})
 
-              expect { described_class.new(capabilities: [Options.new(**browser_opts)]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new(**browser_opts)])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Capabilities instance' do
               capabilities = Remote::Capabilities.new(browser_name: 'internet explorer', invalid: 'foobar')
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer', invalid: 'foobar'}}})
 
-              expect { described_class.new(capabilities: [capabilities]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [capabilities]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance and an instance of a custom object responding to #as_json' do
@@ -137,7 +139,9 @@ module Selenium
                                                                  'se:ieOptions': {nativeEvents: true},
                                                                  'company:key': 'value'}}})
 
-              expect { described_class.new(capabilities: [Options.new, as_json_object.new]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new, as_json_object.new])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
@@ -151,7 +155,7 @@ module Selenium
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])
-              }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
           end
         end

--- a/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
@@ -49,10 +49,9 @@ module Selenium
         end
 
         it 'accepts provided Options as sole parameter' do
-          opts = {invalid: 'foobar', args: ['-f']}
+          opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer',
-                                                             'se:ieOptions': {invalid: 'foobar',
-                                                                              nativeEvents: true,
+                                                             'se:ieOptions': {nativeEvents: true,
                                                                               'ie.browserCommandLineSwitches': '-f'}}}})
 
           expect { described_class.new(options: Options.new(**opts)) }.not_to raise_exception
@@ -118,10 +117,10 @@ module Selenium
             end
 
             it 'with Options instance' do
-              browser_opts = {start_page: 'http://selenium.dev'}
-              expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer',
-                                                                 'se:ieOptions': {startPage: 'http://selenium.dev',
-                                                                                  nativeEvents: true}}}})
+              browser_opts = {initial_browser_url: 'http://selenium.dev'}
+              expect_request(body: {capabilities: {alwaysMatch: {'browserName' => 'internet explorer',
+                                                                 'se:ieOptions' => {'initialBrowserUrl' => 'http://selenium.dev',
+                                                                                    'nativeEvents' => true}}}})
 
               expect { described_class.new(capabilities: [Options.new(**browser_opts)]) }.not_to raise_exception
             end
@@ -143,12 +142,12 @@ module Selenium
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
               capabilities = Remote::Capabilities.new(browser_name: 'internet explorer', invalid: 'foobar')
-              options = Options.new(start_page: 'http://selenium.dev')
-              expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer',
-                                                                 invalid: 'foobar',
-                                                                 'se:ieOptions': {startPage: 'http://selenium.dev',
-                                                                                  nativeEvents: true},
-                                                                 'company:key': 'value'}}})
+              options = Options.new(initial_browser_url: 'http://selenium.dev')
+              expect_request(body: {capabilities: {alwaysMatch: {'browserName' => 'internet explorer',
+                                                                 'invalid' => 'foobar',
+                                                                 'se:ieOptions' => {'initialBrowserUrl' => 'http://selenium.dev',
+                                                                                    'nativeEvents' => true},
+                                                                 'company:key' => 'value'}}})
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])

--- a/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
@@ -134,13 +134,10 @@ module Selenium
           end
 
           it 'returns added options' do
-            expect {
-              options.add_option(:foo, 'bar')
-            }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'internet explorer',
                                           'foo:bar' => {'foo' => 'bar'},
-                                          'se:ieOptions' => {'nativeEvents' => true, 'foo' => 'bar'})
+                                          'se:ieOptions' => {'nativeEvents' => true})
           end
 
           it 'returns a JSON hash' do

--- a/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/options_spec.rb
@@ -103,13 +103,27 @@ module Selenium
 
         describe '#add_option' do
           it 'adds an option with ordered pairs' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
           end
 
           it 'adds an option with Hash' do
-            options.add_option(foo: 'bar')
+            expect {
+              options.add_option(foo: 'bar')
+            }.to have_deprecated(:add_option)
             expect(options.instance_variable_get(:@options)[:foo]).to eq('bar')
+          end
+
+          it 'adds vendor namespaced options with ordered pairs' do
+            options.add_option('foo:bar', {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
+          end
+
+          it 'adds vendor namespaced options with Hash' do
+            options.add_option('foo:bar' => {bar: 'foo'})
+            expect(options.instance_variable_get(:@options)['foo:bar']).to eq({bar: 'foo'})
           end
         end
 
@@ -120,7 +134,9 @@ module Selenium
           end
 
           it 'returns added options' do
-            options.add_option(:foo, 'bar')
+            expect {
+              options.add_option(:foo, 'bar')
+            }.to have_deprecated(:add_option)
             options.add_option('foo:bar', {foo: 'bar'})
             expect(options.as_json).to eq('browserName' => 'internet explorer',
                                           'foo:bar' => {'foo' => 'bar'},

--- a/rb/spec/unit/selenium/webdriver/remote/bridge_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/bridge_spec.rb
@@ -33,12 +33,11 @@ module Selenium
           let(:http) { WebDriver::Remote::Http::Default.new }
           let(:bridge) { described_class.new(http_client: http, url: 'http://localhost') }
 
-          it 'sends plain capabilities' do
+          it 'accepts Hash' do
             payload = JSON.generate(
               capabilities: {
                 alwaysMatch: {
-                  browserName: 'internet explorer',
-                  platformName: 'windows'
+                  browserName: 'internet explorer'
                 }
               }
             )
@@ -47,27 +46,7 @@ module Selenium
               .with(any_args, payload)
               .and_return('status' => 200, 'value' => {'sessionId' => 'foo', 'capabilities' => {}})
 
-            bridge.create_session(Capabilities.ie)
-            expect(http).to have_received(:request).with(any_args, payload)
-          end
-
-          it 'passes options as capabilities' do
-            payload = JSON.generate(
-              capabilities: {
-                alwaysMatch: {
-                  'browserName' => 'chrome',
-                  'goog:chromeOptions' => {
-                    args: %w[foo bar]
-                  }
-                }
-              }
-            )
-
-            allow(http).to receive(:request)
-              .with(any_args, payload)
-              .and_return('status' => 200, 'value' => {'sessionId' => 'foo', 'capabilities' => {}})
-
-            bridge.create_session(Options.chrome(args: %w[foo bar]).as_json)
+            bridge.create_session(browserName: 'internet explorer')
             expect(http).to have_received(:request).with(any_args, payload)
           end
 
@@ -84,7 +63,7 @@ module Selenium
               .with(any_args, payload)
               .and_return('status' => 200, 'value' => {'sessionId' => 'foo', 'capabilities' => {}})
 
-            bridge.create_session(Capabilities.always_match(Capabilities.chrome).as_json)
+            bridge.create_session('alwaysMatch' => {'browserName' => 'chrome'})
             expect(http).to have_received(:request).with(any_args, payload)
           end
 
@@ -102,7 +81,10 @@ module Selenium
               .with(any_args, payload)
               .and_return('status' => 200, 'value' => {'sessionId' => 'foo', 'capabilities' => {}})
 
-            bridge.create_session(Capabilities.first_match(Capabilities.chrome, Capabilities.firefox).as_json)
+            bridge.create_session('firstMatch' => [
+                                    {'browserName' => 'chrome'},
+                                    {'browserName' => 'firefox'}
+                                  ])
             expect(http).to have_received(:request).with(any_args, payload)
           end
 

--- a/rb/spec/unit/selenium/webdriver/remote/capabilities_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/capabilities_spec.rb
@@ -24,28 +24,45 @@ module Selenium
     module Remote
       describe Capabilities do
         it 'has default capabilities for Chrome' do
-          caps = described_class.chrome
-          expect(caps.browser_name).to eq('chrome')
+          expect {
+            caps = described_class.chrome
+            expect(caps.browser_name).to eq('chrome')
+          }.to have_deprecated(:caps_browsers)
         end
 
         it 'has default capabilities for Edge' do
-          caps = described_class.edge
-          expect(caps.browser_name).to eq('MicrosoftEdge')
+          expect {
+            caps = described_class.edge
+            expect(caps.browser_name).to eq('MicrosoftEdge')
+          }.to have_deprecated(:caps_browsers)
         end
 
         it 'has default capabilities for Firefox' do
-          caps = described_class.firefox
-          expect(caps.browser_name).to eq('firefox')
+          expect {
+            caps = described_class.firefox
+            expect(caps.browser_name).to eq('firefox')
+          }.to have_deprecated(:caps_browsers)
         end
 
         it 'has default capabilities for HtmlUnit' do
-          caps = described_class.htmlunit
-          expect(caps.browser_name).to eq('htmlunit')
+          expect {
+            caps = described_class.htmlunit
+            expect(caps.browser_name).to eq('htmlunit')
+          }.to have_deprecated(:caps_browsers)
         end
 
         it 'has default capabilities for Internet Explorer' do
-          caps = described_class.internet_explorer
-          expect(caps.browser_name).to eq('internet explorer')
+          expect {
+            caps = described_class.internet_explorer
+            expect(caps.browser_name).to eq('internet explorer')
+          }.to have_deprecated(:caps_browsers)
+        end
+
+        it 'has default capabilities for Safari' do
+          expect {
+            caps = described_class.safari
+            expect(caps.browser_name).to eq('safari')
+          }.to have_deprecated(:caps_browsers)
         end
 
         it 'converts noProxy from string to array' do
@@ -75,7 +92,7 @@ module Selenium
         end
 
         it 'can set and get arbitrary capabilities' do
-          caps = described_class.chrome
+          caps = described_class.new(browser_name: 'chrome')
           caps['chrome'] = :foo
           expect(caps['chrome']).to eq(:foo)
         end
@@ -99,8 +116,8 @@ module Selenium
         end
 
         it 'can merge capabilities' do
-          a = described_class.chrome
-          b = described_class.firefox
+          a = described_class.new(browser_name: 'chrome')
+          b = described_class.new(browser_name: 'firefox')
           a.merge!(b)
 
           expect(a.browser_name).to eq('firefox')
@@ -121,7 +138,7 @@ module Selenium
           expected = {'alwaysMatch' => {'browserName' => 'chrome'}}
           expect(described_class.always_match(browser_name: 'chrome').as_json).to eq(expected)
           expect(described_class.always_match('browserName' => 'chrome').as_json).to eq(expected)
-          expect(described_class.always_match(described_class.chrome).as_json).to eq(expected)
+          expect(described_class.always_match(described_class.new(browser_name: 'chrome')).as_json).to eq(expected)
         end
 
         it 'allows to set firstMatch' do
@@ -130,7 +147,8 @@ module Selenium
                                              {browser_name: 'firefox'}).as_json).to eq(expected)
           expect(described_class.first_match({'browserName' => 'chrome'},
                                              {'browserName' => 'firefox'}).as_json).to eq(expected)
-          expect(described_class.first_match(described_class.chrome, described_class.firefox).as_json).to eq(expected)
+          expect(described_class.first_match(described_class.new(browser_name: 'chrome'),
+                                             described_class.new(browser_name: 'firefox')).as_json).to eq(expected)
         end
 
         it 'sets browser version with version' do
@@ -178,7 +196,7 @@ module Selenium
           end
 
           it 'processes timeouts as hash' do
-            caps = described_class.chrome(timeouts: {implicit: 1, page_load: 2, script: 3})
+            caps = described_class.new(browser_name: 'chrome', timeouts: {implicit: 1, page_load: 2, script: 3})
             expect(caps.timeouts).to eq(implicit: 1, page_load: 2, script: 3)
             expect(caps.implicit_timeout).to eq(1)
             expect(caps.page_load_timeout).to eq(2)
@@ -187,7 +205,7 @@ module Selenium
           end
 
           it 'processes timeouts via timeouts reader' do
-            caps = described_class.chrome
+            caps = described_class.new(browser_name: 'chrome')
             caps.timeouts[:implicit] = 1
             caps.timeouts[:page_load] = 2
             caps.timeouts[:script] = 3
@@ -199,7 +217,7 @@ module Selenium
           end
 
           it 'processes timeouts via per-timeout writers' do
-            caps = described_class.chrome
+            caps = described_class.new(browser_name: 'chrome')
             caps.implicit_timeout = 1
             caps.page_load_timeout = 2
             caps.script_timeout = 3

--- a/rb/spec/unit/selenium/webdriver/remote/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/driver_spec.rb
@@ -25,7 +25,7 @@ module Selenium
       describe Driver do
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.chrome}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'chrome'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -44,14 +44,14 @@ module Selenium
           server = 'https://example.com:4646/wd/hub'
           expect_request(endpoint: "#{server}/session")
 
-          expect { described_class.new(capabilities: :chrome, url: server) }.not_to raise_exception
+          expect { described_class.new(options: Options.chrome, url: server) }.not_to raise_exception
         end
 
         it 'uses provided HTTP Client' do
           client = Remote::Http::Default.new
           expect_request
 
-          driver = described_class.new(capabilities: :chrome, http_client: client)
+          driver = described_class.new(options: Options.chrome, http_client: client)
           expect(driver.send(:bridge).http).to eq client
         end
 
@@ -66,7 +66,7 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::Remote::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.chrome, capabilities: Remote::Capabilities.chrome)
+            described_class.new(options: Options.chrome, capabilities: Remote::Capabilities.new(browser_name: 'chrome'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -74,13 +74,6 @@ module Selenium
           it 'accepts value as a Symbol' do
             expect_request
             expect { described_class.new(capabilities: :chrome) }.not_to raise_exception
-          end
-
-          it 'accepts generated Capabilities instance' do
-            capabilities = Remote::Capabilities.chrome(invalid: 'foobar')
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'chrome', invalid: 'foobar'}}})
-
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
@@ -27,7 +27,7 @@ module Selenium
         let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
         let(:valid_response) do
           {status: 200,
-           body: {value: {sessionId: 0, capabilities: Remote::Capabilities.safari}}.to_json,
+           body: {value: {sessionId: 0, capabilities: {browserName: 'safari'}}}.to_json,
            headers: {content_type: 'application/json'}}
         end
 
@@ -65,7 +65,7 @@ module Selenium
           msg = "Don't use both :options and :capabilities when initializing Selenium::WebDriver::Safari::Driver, " \
                 'prefer :options'
           expect {
-            described_class.new(options: Options.new, capabilities: Remote::Capabilities.safari)
+            described_class.new(options: Options.new, capabilities: Remote::Capabilities.new(browser_name: 'safari'))
           }.to raise_exception(ArgumentError, msg)
         end
 
@@ -73,14 +73,6 @@ module Selenium
           it 'accepts value as a Symbol' do
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari'}}})
             expect { described_class.new(capabilities: :safari) }.to have_deprecated(:capabilities)
-          end
-
-          it 'accepts Capabilities.safari' do
-            capabilities = Remote::Capabilities.safari(invalid: 'foobar')
-            expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari',
-                                                               invalid: 'foobar'}}})
-
-            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do

--- a/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
@@ -72,7 +72,7 @@ module Selenium
         context 'with :capabilities' do
           it 'accepts value as a Symbol' do
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari'}}})
-            expect { described_class.new(capabilities: :safari) }.not_to raise_exception
+            expect { described_class.new(capabilities: :safari) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts Capabilities.safari' do
@@ -80,28 +80,28 @@ module Selenium
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari',
                                                                invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Snake Case as Symbols' do
             capabilities = Remote::Capabilities.new(browser_name: 'safari', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Symbols' do
             capabilities = Remote::Capabilities.new(browserName: 'safari', invalid: 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           it 'accepts constructed Capabilities with Camel Case as Strings' do
             capabilities = Remote::Capabilities.new('browserName' => 'safari', 'invalid' => 'foobar')
             expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari', invalid: 'foobar'}}})
 
-            expect { described_class.new(capabilities: capabilities) }.not_to raise_exception
+            expect { described_class.new(capabilities: capabilities) }.to have_deprecated(:capabilities)
           end
 
           context 'when value is an Array' do
@@ -118,21 +118,25 @@ module Selenium
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari',
                                                                  'safari:automaticInspection': true}}})
 
-              expect { described_class.new(capabilities: [Options.new(**browser_opts)]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new(**browser_opts)])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Capabilities instance' do
               capabilities = Remote::Capabilities.new(browser_name: 'safari', invalid: 'foobar')
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari', invalid: 'foobar'}}})
 
-              expect { described_class.new(capabilities: [capabilities]) }.not_to raise_exception
+              expect { described_class.new(capabilities: [capabilities]) }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance and an instance of a custom object responding to #as_json' do
               expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari',
                                                                  'company:key': 'value'}}})
 
-              expect { described_class.new(capabilities: [Options.new, as_json_object.new]) }.not_to raise_exception
+              expect {
+                described_class.new(capabilities: [Options.new, as_json_object.new])
+              }.to have_deprecated(:capabilities)
             end
 
             it 'with Options instance, Capabilities instance and instance of a custom object responding to #as_json' do
@@ -145,7 +149,7 @@ module Selenium
 
               expect {
                 described_class.new(capabilities: [capabilities, options, as_json_object.new])
-              }.not_to raise_exception
+              }.to have_deprecated(:capabilities)
             end
           end
         end

--- a/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/options_spec.rb
@@ -65,19 +65,23 @@ module Selenium
               expect(options.instance_variable_get(:@options)['safari:foo']).to eq('bar')
             end
 
-            it 'adds an option with Hash' do
+            it 'adds an option with keyword' do
               options.add_option('safari:foo': 'bar')
               expect(options.instance_variable_get(:@options)[:'safari:foo']).to eq('bar')
             end
           end
 
           context 'when not namespaced' do
-            it 'raises exception with ordered pairs' do
-              expect { options.add_option('foo', 'bar') }.to raise_exception(ArgumentError)
+            it 'adds an option with ordered pairs' do
+              expect {
+                options.add_option(:foo, 'bar')
+              }.to raise_error(ArgumentError, /Safari does not support options that are not namespaced/)
             end
 
-            it 'raises exception with Hash' do
-              expect { options.add_option(foo: 'bar') }.to raise_exception(ArgumentError)
+            it 'raises exception with keyword' do
+              expect {
+                options.add_option(foo: 'bar')
+              }.to raise_error(ArgumentError, /Safari does not support options that are not namespaced/)
             end
           end
         end


### PR DESCRIPTION
**UPDATE** - I committed all the basic refactoring things and all the obvious bits we want to do. What is left is the various deprecations and logic changes. Updated the contents below accordingly.

-----
I've been avoiding this one for a while because I feel like we (I) keep making Ruby capabilities code harder.
Each commit is pretty self contained with explanations; if there is anything I'm doing in here that we definitely don't like, let me know.

I'm going to write a blog post explaining all of this stuff before it gets released. Also planning to test it with Watir and Capybara to see how much work this would create for those projects.

## Motivation
Selenium Manager is going to need Options information in/around the Service class to get the right browser/driver going forward. So this PR improves the inheritance a bit and differentiates logic allowed for local and remote drivers so the logic for getting the required info is much easier.
Plus, this brings the Ruby implementation in line with all the other bindings.

## Contents

1. `Options#add_option` is sugar that I've never loved because this is what accessors are for, and we support everything in constructor as well. We could do validation here instead of deprecation, but I prefer to keep `add_option` to be just for vendor name-spaced options
2. Require all options in constructor to be snake cased symbols in the `CAPABILITIES` list for the respective browser. Any unrecognized capability is deprecated
3. Deprecate allowing `:capabilities` argument for local drivers. It is still allowed in Remote drivers
4. Deprecate browser class methods for Capabilities (e.g., `Remote::Capabilities.chrome`) just like Java removed `DesiredCapabilities.chrome()` in 4.0 to encourage peole to switch to Options. Using `Remote::Capabilities.new(browser_name: 'chrome')` is also an easy alternative if you don't want to switch to Options.