### PR TITLE
JDKHttpClient: Handle RQST with no Body [POST/PUT]

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
@@ -115,7 +115,12 @@ class JdkHttpMessages {
 
     if (length == null) {
       // read the data into a byte array to know the length
-      return BodyPublishers.ofByteArray(Contents.bytes(req.getContent()));
+      byte[] bytes = Contents.bytes(req.getContent());
+      if (bytes.length == 0) {
+        //Looks like we were given a request with no payload.
+        return BodyPublishers.noBody();
+      }
+      return BodyPublishers.ofByteArray(bytes);
     }
 
     // we know the length of the request and use it


### PR DESCRIPTION
Fixes: #11342

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Here's what I have as analysis:

1. We got rid of all places wherein we are setting the content length explicitly to zero.
2. When starting a container, we use the [Docker container API ](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStart) with a POST message, but it has no body and so its content length now gets evaluated to zero.
3. We are using the JDK client by default for all of our http client needs. 
4. We create a HttpRequest via `org.openqa.selenium.remote.http.jdk.JdkHttpMessages#createRequest`  which internally calls `org.openqa.selenium.remote.http.jdk.JdkHttpMessages#notChunkingBodyPublisher` for a `POST` message.
5. Since as per the docker api spec, there's no payload for this request, we end up getting evaluated to a content length of zero.
6. This in turn triggers the validation check at the JDK HttpClient level saying 

```
grid-node-docker-1    | java.lang.IllegalArgumentException: non-positive contentLength: 0
grid-node-docker-1    |         at java.net.http/java.net.http.HttpRequest$BodyPublishers.fromPublisher(HttpRequest.java:539)
grid-node-docker-1    |         at org.openqa.selenium.remote.http.jdk.JdkHttpMessages.notChunkingBodyPublisher(JdkHttpMessages.java:124)
grid-node-docker-1    |         at org.openqa.selenium.remote.http.jdk.JdkHttpMessages.createRequest(JdkHttpMessages.java:76)
grid-node-docker-1    |         at org.openqa.selenium.remote.http.jdk.JdkHttpClient.execute(JdkHttpClient.java:292)
```

Note: 
We cannot set a payload also for this request, since when we do that, I hit an error as below

```
{
    "message": "starting container with non-empty request body was deprecated since API v1.22 and removed in v1.24"
}
```
with a `400 BAD REQUEST`

This PR fixes this discrepancy by ensuring that when we are confronted with empty payloads for POST|PUT messages and when we are using the JDK provided HTTP Client, we resort to using an empty body

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
