### PR TITLE
[rust] Reuse common http client in Selenium Manager

### DIFF
--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -170,6 +170,9 @@ impl SeleniumManager for ChromeManager {
                     } else {
                         format!("{}{}_{}", DRIVER_URL, LATEST_RELEASE, browser_version_int)
                     };
+                    if !browser_version.is_empty() && browser_version_int <= 0 {
+                        break;
+                    }
                     log::debug!("Reading {} version from {}", &self.driver_name, driver_url);
                     let content = read_content_from_link(self.get_http_client(), driver_url);
                     match content {

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -164,22 +164,21 @@ impl SeleniumManager for ChromeManager {
             _ => {
                 let mut driver_version = "".to_string();
                 let mut browser_version_int = browser_version.parse::<i32>().unwrap_or_default();
-                if browser_version_int > 0 {
-                    for i in 0..FALLBACK_RETRIES {
-                        let driver_url = if browser_version.is_empty() {
-                            format!("{}{}", DRIVER_URL, LATEST_RELEASE)
-                        } else {
-                            format!("{}{}_{}", DRIVER_URL, LATEST_RELEASE, browser_version_int)
-                        };
-                        log::debug!("Reading {} version from {}", &self.driver_name, driver_url);
-                        let content = read_content_from_link(self.get_http_client(), driver_url);
-                        match content {
-                            Ok(version) => {
-                                driver_version = version;
-                                break;
-                            }
-                            _ => {
-                                log::warn!(
+                for i in 0..FALLBACK_RETRIES {
+                    let driver_url = if browser_version.is_empty() {
+                        format!("{}{}", DRIVER_URL, LATEST_RELEASE)
+                    } else {
+                        format!("{}{}_{}", DRIVER_URL, LATEST_RELEASE, browser_version_int)
+                    };
+                    log::debug!("Reading {} version from {}", &self.driver_name, driver_url);
+                    let content = read_content_from_link(self.get_http_client(), driver_url);
+                    match content {
+                        Ok(version) => {
+                            driver_version = version;
+                            break;
+                        }
+                        _ => {
+                            log::warn!(
                                 "Error getting version of {} {}. Retrying with {} {} (attempt {}/{})",
                                 &self.driver_name,
                                 browser_version_int,
@@ -187,8 +186,7 @@ impl SeleniumManager for ChromeManager {
                                 browser_version_int - 1,
                                 i + 1, FALLBACK_RETRIES
                             );
-                                browser_version_int -= 1;
-                            }
+                            browser_version_int -= 1;
                         }
                     }
                 }

--- a/rust/src/downloads.rs
+++ b/rust/src/downloads.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use reqwest::Client;
 use std::error::Error;
 use std::fs::File;
 use std::io::copy;
@@ -26,6 +27,7 @@ use crate::files::parse_version;
 
 #[tokio::main]
 pub async fn download_driver_to_tmp_folder(
+    http_client: &Client,
     url: String,
 ) -> Result<(TempDir, String), Box<dyn Error>> {
     let tmp_dir = Builder::new().prefix("selenium-manager").tempdir()?;
@@ -35,7 +37,7 @@ pub async fn download_driver_to_tmp_folder(
         tmp_dir.path()
     );
 
-    let response = reqwest::get(url).await?;
+    let response = http_client.get(url).send().await?;
     let target_path;
     let mut tmp_file = {
         let target_name = response
@@ -59,11 +61,17 @@ pub async fn download_driver_to_tmp_folder(
 }
 
 #[tokio::main]
-pub async fn read_content_from_link(url: String) -> Result<String, Box<dyn Error>> {
-    parse_version(reqwest::get(url).await?.text().await?)
+pub async fn read_content_from_link(
+    http_client: &Client,
+    url: String,
+) -> Result<String, Box<dyn Error>> {
+    parse_version(http_client.get(url).send().await?.text().await?)
 }
 
 #[tokio::main]
-pub async fn read_redirect_from_link(url: String) -> Result<String, Box<dyn Error>> {
-    parse_version(reqwest::get(&url).await?.url().path().to_string())
+pub async fn read_redirect_from_link(
+    http_client: &Client,
+    url: String,
+) -> Result<String, Box<dyn Error>> {
+    parse_version(http_client.get(&url).send().await?.url().path().to_string())
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use reqwest::Client;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
@@ -28,8 +29,9 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    SeleniumManager, BETA, DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES,
-    ENV_PROGRAM_FILES_X86, NIGHTLY, REG_QUERY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    create_default_http_client, SeleniumManager, BETA, DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA,
+    ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY, REG_QUERY, STABLE, WMIC_COMMAND,
+    WMIC_COMMAND_ENV,
 };
 
 const BROWSER_NAME: &str = "edge";
@@ -42,6 +44,7 @@ pub struct EdgeManager {
     pub browser_name: &'static str,
     pub driver_name: &'static str,
     pub config: ManagerConfig,
+    pub http_client: Client,
 }
 
 impl EdgeManager {
@@ -50,6 +53,7 @@ impl EdgeManager {
             browser_name: BROWSER_NAME,
             driver_name: DRIVER_NAME,
             config: ManagerConfig::default(),
+            http_client: create_default_http_client(),
         })
     }
 }
@@ -57,6 +61,10 @@ impl EdgeManager {
 impl SeleniumManager for EdgeManager {
     fn get_browser_name(&self) -> &str {
         self.browser_name
+    }
+
+    fn get_http_client(&self) -> &Client {
+        &self.http_client
     }
 
     fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
@@ -167,7 +175,7 @@ impl SeleniumManager for EdgeManager {
                     )
                 };
                 log::debug!("Reading {} version from {}", &self.driver_name, driver_url);
-                let driver_version = read_content_from_link(driver_url)?;
+                let driver_version = read_content_from_link(self.get_http_client(), driver_url)?;
 
                 if !browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use reqwest::Client;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
@@ -23,7 +24,7 @@ use std::path::PathBuf;
 use crate::downloads::read_redirect_from_link;
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
 
-use crate::SeleniumManager;
+use crate::{create_default_http_client, SeleniumManager};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -38,6 +39,7 @@ pub struct IExplorerManager {
     pub browser_name: &'static str,
     pub driver_name: &'static str,
     pub config: ManagerConfig,
+    pub http_client: Client,
 }
 
 impl IExplorerManager {
@@ -46,6 +48,7 @@ impl IExplorerManager {
             browser_name: BROWSER_NAME,
             driver_name: DRIVER_NAME,
             config: ManagerConfig::default(),
+            http_client: create_default_http_client(),
         })
     }
 }
@@ -53,6 +56,10 @@ impl IExplorerManager {
 impl SeleniumManager for IExplorerManager {
     fn get_browser_name(&self) -> &str {
         self.browser_name
+    }
+
+    fn get_http_client(&self) -> &Client {
+        &self.http_client
     }
 
     fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
@@ -82,7 +89,7 @@ impl SeleniumManager for IExplorerManager {
             }
             _ => {
                 let latest_url = format!("{}{}", DRIVER_URL, LATEST_RELEASE);
-                let driver_version = read_redirect_from_link(latest_url)?;
+                let driver_version = read_redirect_from_link(self.get_http_client(), latest_url)?;
 
                 if !browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(


### PR DESCRIPTION
### Description
This PR creates a shared instance of the HTTP client used in the Rust logic of Selenium Manager, using `rusttls` instead of native TLS (to prevent #11291), and accepting self-signed certificates (to prevent #11406).

### Motivation and Context
This PR will prevent issues like #11406 in the upcoming releases of Selenium Manager. Moreover, the shared HTTP client will be helpful in Selenium Manager M3 (e.g., for proxy setup).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
