### PR TITLE
[rust] Use LOCALAPPDATA env for Edge version detection in Windows

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -28,8 +28,8 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    SeleniumManager, BETA, DASH_DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86,
-    NIGHTLY, REG_QUERY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    SeleniumManager, BETA, DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES,
+    ENV_PROGRAM_FILES_X86, NIGHTLY, REG_QUERY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 const BROWSER_NAME: &str = "edge";
@@ -109,6 +109,7 @@ impl SeleniumManager for EdgeManager {
                     commands = vec![
                         self.format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES_X86, browser_path),
                         self.format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES, browser_path),
+                        self.format_two_args(WMIC_COMMAND, ENV_LOCALAPPDATA, browser_path),
                     ];
                     if !self.is_browser_version_unstable() {
                         commands.push(


### PR DESCRIPTION
### Description
This PR includes the use of the `LOCALAPPDATA` environment variable in Windows for the detection of Edge.

### Motivation and Context
This logic was already implemented in Selenium Manager, but it has been lost in some former patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
