### PR TITLE
[rust] Build static Rust binaries for Selenium Manager (#11400)

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -6,36 +6,46 @@ jobs:
   windows:
     name: "[Windows] Build selenium-manager"
     runs-on: windows-latest
+    env:
+      RUSTFLAGS: '-C target-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
-      - name: "Build release"
+      - name: "Update Rust"
         run: |
           rustup update
+          rustc -vV
+      - name: "Build release"
+        run: |
           cd rust
-          cargo build --release
+          cargo build --release --target x86_64-pc-windows-msvc
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:
           name: selenium-manager_windows-x64
-          path: rust/target/release/selenium-manager.exe
+          path: rust/target/x86_64-pc-windows-msvc/release/selenium-manager.exe
           retention-days: 6
 
   linux:
     name: "[Linux] Build selenium-manager"
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-C target-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
-      - name: "Build release"
+      - name: "Update Rust"
         run: |
           rustup update
+          rustc -vV
+      - name: "Build release"
+        run: |
           cd rust
-          cargo build --release
+          cargo build --release --target x86_64-unknown-linux-gnu
       - name: "Tar binary (to keep executable permission)"
         run: |
-          cd rust/target/release
-          tar -cvf ../../../selenium-manager.tar selenium-manager
+          cd rust/target/x86_64-unknown-linux-gnu/release
+          tar -cvf ../../../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:
@@ -46,18 +56,23 @@ jobs:
   macos:
     name: "[macOS] Build selenium-manager"
     runs-on: macos-latest
+    env:
+      RUSTFLAGS: '-C target-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
-      - name: "Build release"
+      - name: "Update Rust"
         run: |
           rustup update
+          rustc -vV
+      - name: "Build release"
+        run: |
           cd rust
-          cargo build --release
+          cargo build --release --target x86_64-apple-darwin
       - name: "Tar binary (to keep executable permission)"
         run: |
-          cd rust/target/release
-          tar -cvf ../../../selenium-manager.tar selenium-manager
+          cd rust/target/x86_64-apple-darwin/release
+          tar -cvf ../../../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Description
This PR includes some Rusts flags (`-C target-feature=+crt-static`) for building the Selenium Manager binaries.

### Motivation and Context
Static linking will prevent issues like #11400.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
