### PR TITLE
[java] Overload methods creating interactions to accept `Point`

### DIFF
--- a/java/src/org/openqa/selenium/interactions/PointerInput.java
+++ b/java/src/org/openqa/selenium/interactions/PointerInput.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.interactions;
 
+import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.internal.Require;
@@ -71,8 +72,16 @@ public class PointerInput implements InputSource, Encodable {
     return new Move(this, duration, origin, x, y);
   }
 
+  public Interaction createPointerMove(Duration duration, Origin origin, Point offset) {
+    return createPointerMove(duration, origin, offset.x, offset.y);
+  }
+
   public Interaction createPointerMove(Duration duration, Origin origin, int x, int y, PointerEventProperties eventProperties) {
     return new Move(this, duration, origin, x, y, eventProperties);
+  }
+
+  public Interaction createPointerMove(Duration duration, Origin origin, Point offset, PointerEventProperties eventProperties) {
+    return createPointerMove(duration, origin, offset.x, offset.y, eventProperties);
   }
 
   public Interaction createPointerDown(int button) {

--- a/java/src/org/openqa/selenium/interactions/WheelInput.java
+++ b/java/src/org/openqa/selenium/interactions/WheelInput.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.internal.Require;
@@ -52,6 +53,10 @@ public class WheelInput implements InputSource, Encodable {
 
   public Interaction createScroll(int x, int y, int deltaX, int deltaY, Duration duration, ScrollOrigin origin) {
     return new ScrollInteraction(this, x, y, deltaX, deltaY, duration, origin);
+  }
+
+  public Interaction createScroll(Point start, int deltaX, int deltaY, Duration duration, ScrollOrigin origin) {
+    return createScroll(start.x, start.y, deltaX, deltaY, duration, origin);
   }
 
   @Override

--- a/java/test/org/openqa/selenium/interactions/PenPointerTest.java
+++ b/java/test/org/openqa/selenium/interactions/PenPointerTest.java
@@ -312,7 +312,7 @@ class PenPointerTest extends JupiterTestBase {
       wait.until(fuzzyMatchingOfCoordinates(reporter, 40, 20));
     } finally {
       Sequence actionList = new Sequence(defaultPen, 0)
-        .addAction(defaultPen.createPointerMove(Duration.ZERO, PointerInput.Origin.pointer(), -50, -100));
+        .addAction(defaultPen.createPointerMove(Duration.ZERO, PointerInput.Origin.pointer(), new Point(-50, -100)));
       ((RemoteWebDriver) driver).perform(Collections.singletonList(actionList));
     }
   }
@@ -394,7 +394,7 @@ class PenPointerTest extends JupiterTestBase {
     Sequence actionListPen = new Sequence(pen, 0)
       .addAction(pen.createPointerMove(Duration.ZERO, origin, 0, 0))
       .addAction(pen.createPointerDown(0))
-      .addAction(pen.createPointerMove(Duration.ofMillis(800), origin, 2, 2, eventProperties))
+      .addAction(pen.createPointerMove(Duration.ofMillis(800), origin, new Point(2, 2), eventProperties))
       .addAction(pen.createPointerUp(0));
 
     ((RemoteWebDriver) driver).perform(List.of(actionListPen));

--- a/java/test/org/openqa/selenium/interactions/WheelInputTest.java
+++ b/java/test/org/openqa/selenium/interactions/WheelInputTest.java
@@ -22,6 +22,7 @@ import static org.openqa.selenium.remote.Dialect.W3C;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrappedWebElement;
 import org.openqa.selenium.json.Json;
@@ -43,8 +44,7 @@ class WheelInputTest {
 
     WheelInput wheelInput = new WheelInput("wheel");
     Interaction scroll = wheelInput.createScroll(
-      20,
-      30,
+      new Point(20, 30),
       0,
       0,
       Duration.ofMillis(100),
@@ -75,8 +75,7 @@ class WheelInputTest {
   @Test
   void shouldEncodeScrollInteractionWithViewPortOrigin() {
     WheelInput wheelInput = new WheelInput("test-wheel");
-    WheelInput.ScrollInteraction interaction = new WheelInput.ScrollInteraction(
-      wheelInput,
+    WheelInput.ScrollInteraction interaction = (WheelInput.ScrollInteraction) wheelInput.createScroll(
       25,
       50,
       30,
@@ -101,10 +100,8 @@ class WheelInputTest {
     innerElement.setId("12345");
 
     WheelInput wheelInput = new WheelInput("test-wheel");
-    WheelInput.ScrollInteraction interaction = new WheelInput.ScrollInteraction(
-      wheelInput,
-      25,
-      50,
+    WheelInput.ScrollInteraction interaction = (WheelInput.ScrollInteraction) wheelInput.createScroll(
+      new Point(25, 50),
       30,
       60,
       Duration.ofSeconds(1),


### PR DESCRIPTION
### Description
Add overloaded methods creating interactions to accept `Point` instead of (`x`, `y`) pair.

### Motivation and Context
New methods are more convenient for users how work with point objects.
Invocations like
```
..., point.getX(), point.getY(), ...
```
can be replaced with simple
```
..., point, ...
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
