### PR TITLE
[rb] update logger with link on how to use it

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -94,8 +94,8 @@ module Selenium
     # @return [Logger]
     #
 
-    def self.logger
-      @logger ||= WebDriver::Logger.new
+    def self.logger(**opts)
+      @logger ||= WebDriver::Logger.new('Selenium', **opts)
     end
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -48,9 +48,10 @@ module Selenium
       #
       # @param [String] progname Allow child projects to use Selenium's Logger pattern
       #
-      def initialize(progname = 'Selenium')
+      def initialize(progname = 'Selenium', ignored: nil)
         @logger = create_logger(progname)
-        @ignored = []
+        @ignored = Array(ignored)
+        @first_warning = false
       end
 
       #
@@ -94,6 +95,13 @@ module Selenium
       # @yield see #deprecate
       #
       def warn(message, id: [])
+        unless @first_warning
+          @first_warning = true
+          warn("Details on how to use and modify Selenium logger:\n", id: [:logger_info]) do
+            "https://selenium.dev/documentation/webdriver/troubleshooting/logging#ruby\n"
+          end
+        end
+
         id = Array(id)
         return if (@ignored & id).any?
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -28,7 +28,6 @@ module Selenium
           @create_driver_error_count = 0
 
           populate_from_bazel_target
-          WebDriver.logger
 
           @driver = ENV.fetch('WD_SPEC_DRIVER', :chrome).to_sym
           @driver_instance = nil

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -22,7 +22,7 @@ require File.expand_path('../spec_helper', __dir__)
 module Selenium
   module WebDriver
     describe Logger do
-      subject(:logger) { Logger.new('Selenium') }
+      subject(:logger) { Logger.new('Selenium', ignored: [:logger_info]) }
 
       around do |example|
         debug = $DEBUG
@@ -36,6 +36,12 @@ module Selenium
           other_logger = Logger.new('NotSelenium')
           msg = /WARN NotSelenium message/
           expect { other_logger.warn('message') }.to output(msg).to_stdout_from_any_process
+        end
+
+        it 'does not log info from constructor' do
+          expect {
+            Logger.new('Selenium')
+          }.not_to output(/.+/).to_stdout_from_any_process
         end
       end
 
@@ -79,6 +85,12 @@ module Selenium
       end
 
       describe '#warn' do
+        it 'logs info on first warning but not second' do
+          logger = Logger.new('Selenium')
+          expect { logger.warn('first') }.to output(/:logger_info/).to_stdout_from_any_process
+          expect { logger.warn('second') }.not_to output(/:logger_info/).to_stdout_from_any_process
+        end
+
         it 'logs with String' do
           expect { logger.warn "String Value" }.to output(/WARN Selenium String Value/).to_stdout_from_any_process
         end

--- a/rb/spec/unit/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/unit/selenium/webdriver/spec_helper.rb
@@ -43,7 +43,7 @@ RSpec.configure do |c|
   c.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true
   end
-  Selenium::WebDriver.logger
+  Selenium::WebDriver.logger(ignored: [:logger_info])
 
   c.include Selenium::WebDriver::UnitSpecHelper
 


### PR DESCRIPTION
### Description

* Add a description with a link to info about Selenium logger when the logger gets used for the first time.

### Motivation and Context

We periodically get complaints about the Ruby Selenium logger and how chatty it gets. Especially with deprecation warnings. The Selenium Logger code lets you ignore any or all messages, but it isn't clearly documented anywhere. This PR points to all of the info on what it does and how to update it.

This code shouldn't be merged until it's actually added in the documentation — https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1271

Let me know any issues with wording.
