### PR TITLE
[rb][spec] ruby3.2: redirect stdout directly instead of using Logger.…

### DIFF
--- a/rb/spec/unit/selenium/server_spec.rb
+++ b/rb/spec/unit/selenium/server_spec.rb
@@ -46,6 +46,7 @@ module Selenium
 
     it 'uses the given jar file and port' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
+      allow(File).to receive(:exist?).with('<STDOUT>').and_return(false)
       allow(WebDriver::ChildProcess).to receive(:build)
         .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
         .and_return(mock_process)


### PR DESCRIPTION
…reopen

In selenium rb rspec test suite, rspec mocks `File.exist?` method partway. With ruby3.2, this may confuse `::Logger.new` using `$stdout` as output because of `IO` class being changed to accept `#path` method. Then it may close `$stdout` with `::Logger.reopen` via `have_deprecated` rspec matcher defined in selenium internally.

So when using have_deprecated matcher defined inside selenium, instead of using Logger.reopen, redirect stdout directly, using `Tempfile` and reopen `$stdout` directly.

Also, as said above, with ruby 3.2 `IO` also accepts `#path` method, so `IO#path.exists?` is now valid on ruby3.2. This affects 'uses the given jar file and port' testsuite in spec/unit/selenium/server_spec.rb: `File` class must be mocked so that `#exist?` method accepts also '<STDOUT>` argument.

Closes #11498 .


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
