### PR TITLE
[JS] [atoms] Use .textContent instead of .innerHTML in clear() action

### DIFF
--- a/javascript/atoms/action.js
+++ b/javascript/atoms/action.js
@@ -119,7 +119,11 @@ bot.action.clear = function (element) {
     // A single space is required, if you put empty string here you'll not be
     // able to interact with this element anymore in Firefox.
     bot.action.LegacyDevice_.focusOnElement(element);
-    element.innerHTML = goog.userAgent.GECKO ? ' ' : '';
+    if (goog.userAgent.GECKO) {
+      element.innerHTML = ' ';
+    } else {
+      element.textContent = '';
+    }
     var body = bot.getDocument().body;
     if (body) {
       bot.action.LegacyDevice_.focusOnElement(body);

--- a/javascript/atoms/test/action_test.html
+++ b/javascript/atoms/test/action_test.html
@@ -5,6 +5,7 @@
   <script src="test_bootstrap.js"></script>
   <script type="text/javascript">
     goog.require('bot.action');
+    goog.require('bot.locators');
     goog.require('goog.Promise');
     goog.require('goog.Uri');
     goog.require('goog.dom');
@@ -122,7 +123,9 @@
         expectBlurEvent(e);
         expectChangeEvent(e);
         bot.action.clear(e);
-        assertBlurFired();
+        if (goog.userAgent.IE) {
+          assertBlurFired();
+        }
         assertChangeFired();
         assertEquals('', e.value);
       });
@@ -195,6 +198,15 @@
       bot.action.clear(e);
       bot.action.type(e, "3");
       assertEquals("3", goog.dom.forms.getValue(e));
+    }
+
+    function testClearingAIframeContentEditableArea() {
+      var iframe = goog.dom.getElement('iframe');
+      var iframeDoc = goog.dom.getFrameContentDocument(iframe);
+
+      var e = bot.locators.findElement({ id: 'content-editable' }, iframeDoc);
+      bot.action.clear(e);
+      assertEquals('', bot.dom.getVisibleText(e));
     }
 
     function testSubmittingANonFormElementShouldResultInAnError() {
@@ -300,5 +312,7 @@
     <div id="child-not-content-editable">child not content editable
     </div>
   </div>
+  <iframe id="iframe" src="testdata/trusted_types_iframe.html">
+  </iframe>
 </body>
 </html>

--- a/javascript/atoms/test/testdata/trusted_types_iframe.html
+++ b/javascript/atoms/test/testdata/trusted_types_iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+  </head>
+  <body>
+    <div id="content-editable" contentEditable="true">This is a contentEditable area
+      <div id="child-content-editable">child content editable
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Description
This PR changes atom action clear() to use .textContent attribute instead of .innerHTML to clear the element. One exception is Firefox where it keeps current workaround. 

### Motivation and Context
This PR is related to issue #11461 . Atom action clear() fails on pages that require Trusted Types as it causes a Trusted Types Sink violation. This can be fixed by reimplementing the same behavior without calling into .innerHTML Trusted Types Sink. 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
   - I ran action_test.html locally in a browser but I was unable to run full test suite due to unrelated issues