### PR TITLE
[rust] Support different output types (logger, json, shell) in Selenium Manager (#11365)

### DIFF
--- a/rust/src/downloads.rs
+++ b/rust/src/downloads.rs
@@ -24,18 +24,20 @@ use std::io::Cursor;
 use tempfile::{Builder, TempDir};
 
 use crate::files::parse_version;
+use crate::Logger;
 
 #[tokio::main]
 pub async fn download_driver_to_tmp_folder(
     http_client: &Client,
     url: String,
+    log: &Logger,
 ) -> Result<(TempDir, String), Box<dyn Error>> {
     let tmp_dir = Builder::new().prefix("selenium-manager").tempdir()?;
-    log::trace!(
+    log.trace(format!(
         "Downloading {} to temporal folder {:?}",
         url,
         tmp_dir.path()
-    );
+    ));
 
     let response = http_client.get(url).send().await?;
     let target_path;
@@ -47,11 +49,14 @@ pub async fn download_driver_to_tmp_folder(
             .and_then(|name| if name.is_empty() { None } else { Some(name) })
             .unwrap_or("tmp.bin");
 
-        log::trace!("File to be downloaded: {}", target_name);
+        log.trace(format!("File to be downloaded: {}", target_name));
         let target_name = tmp_dir.path().join(target_name);
         target_path = String::from(target_name.to_str().unwrap());
 
-        log::trace!("Temporal folder for driver package: {}", target_path);
+        log.trace(format!(
+            "Temporal folder for driver package: {}",
+            target_path
+        ));
         File::create(target_name)?
     };
     let mut content = Cursor::new(response.bytes().await?);

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -30,6 +30,7 @@ use tar::Archive;
 use zip::ZipArchive;
 
 use crate::config::OS::WINDOWS;
+use crate::Logger;
 
 const CACHE_FOLDER: &str = ".cache/selenium";
 const ZIP: &str = "zip";
@@ -57,20 +58,24 @@ pub fn create_path_if_not_exists(path: &Path) {
     }
 }
 
-pub fn uncompress(compressed_file: &String, target: PathBuf) -> Result<(), Box<dyn Error>> {
+pub fn uncompress(
+    compressed_file: &String,
+    target: PathBuf,
+    log: &Logger,
+) -> Result<(), Box<dyn Error>> {
     let file = File::open(compressed_file)?;
     let kind = infer::get_from_path(compressed_file)?
         .ok_or(format!("Format for file {:?} cannot be inferred", file))?;
     let extension = kind.extension();
-    log::trace!(
+    log.trace(format!(
         "The detected extension of the compressed file is {}",
         extension
-    );
+    ));
 
     if extension.eq_ignore_ascii_case(ZIP) {
-        unzip(file, target)?
+        unzip(file, target, log)?
     } else if extension.eq_ignore_ascii_case(GZ) {
-        untargz(file, target)?
+        untargz(file, target, log)?
     } else if extension.eq_ignore_ascii_case(XML) {
         return Err("Wrong browser/driver version".into());
     } else {
@@ -83,8 +88,8 @@ pub fn uncompress(compressed_file: &String, target: PathBuf) -> Result<(), Box<d
     Ok(())
 }
 
-pub fn untargz(file: File, target: PathBuf) -> Result<(), Box<dyn Error>> {
-    log::trace!("Untargz file to {}", target.display());
+pub fn untargz(file: File, target: PathBuf, log: &Logger) -> Result<(), Box<dyn Error>> {
+    log.trace(format!("Untargz file to {}", target.display()));
     let tar = GzDecoder::new(&file);
     let mut archive = Archive::new(tar);
     let parent_path = target
@@ -96,8 +101,8 @@ pub fn untargz(file: File, target: PathBuf) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn unzip(file: File, target: PathBuf) -> Result<(), Box<dyn Error>> {
-    log::trace!("Unzipping file to {}", target.display());
+pub fn unzip(file: File, target: PathBuf, log: &Logger) -> Result<(), Box<dyn Error>> {
+    log.trace(format!("Unzipping file to {}", target.display()));
     let mut archive = ZipArchive::new(file)?;
 
     for i in 0..archive.len() {
@@ -107,11 +112,11 @@ pub fn unzip(file: File, target: PathBuf) -> Result<(), Box<dyn Error>> {
         }
         let target_file_name = target.file_name().unwrap().to_str().unwrap();
         if target_file_name.eq_ignore_ascii_case(file.name()) {
-            log::debug!(
+            log.debug(format!(
                 "File extracted to {} ({} bytes)",
                 target.display(),
                 file.size()
-            );
+            ));
             if let Some(p) = target.parent() {
                 create_path_if_not_exists(p);
             }

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -29,8 +29,8 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    create_default_http_client, SeleniumManager, BETA, DASH_VERSION, DEV, ENV_PROGRAM_FILES,
-    ENV_PROGRAM_FILES_X86, NIGHTLY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    create_default_http_client, Logger, SeleniumManager, BETA, DASH_VERSION, DEV,
+    ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 const BROWSER_NAME: &str = "firefox";
@@ -43,6 +43,7 @@ pub struct FirefoxManager {
     pub driver_name: &'static str,
     pub config: ManagerConfig,
     pub http_client: Client,
+    pub log: Logger,
 }
 
 impl FirefoxManager {
@@ -52,6 +53,7 @@ impl FirefoxManager {
             driver_name: DRIVER_NAME,
             config: ManagerConfig::default(),
             http_client: create_default_http_client(),
+            log: Logger::default(),
         })
     }
 }
@@ -141,15 +143,15 @@ impl SeleniumManager for FirefoxManager {
 
     fn request_driver_version(&self) -> Result<String, Box<dyn Error>> {
         let browser_version = self.get_browser_version();
-        let mut metadata = get_metadata();
+        let mut metadata = get_metadata(self.get_logger());
 
         match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
         {
             Some(driver_version) => {
-                log::trace!(
+                self.log.trace(format!(
                     "Driver TTL is valid. Getting {} version from metadata",
                     &self.driver_name
-                );
+                ));
                 Ok(driver_version)
             }
             _ => {
@@ -162,7 +164,7 @@ impl SeleniumManager for FirefoxManager {
                         self.driver_name,
                         &driver_version,
                     ));
-                    write_metadata(&metadata);
+                    write_metadata(&metadata, self.get_logger());
                 }
 
                 Ok(driver_version)
@@ -247,6 +249,14 @@ impl SeleniumManager for FirefoxManager {
 
     fn set_config(&mut self, config: ManagerConfig) {
         self.config = config;
+    }
+
+    fn get_logger(&self) -> &Logger {
+        &self.log
+    }
+
+    fn set_logger(&mut self, log: Logger) {
+        self.log = log;
     }
 }
 

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use crate::downloads::read_redirect_from_link;
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
 
-use crate::{create_default_http_client, SeleniumManager};
+use crate::{create_default_http_client, Logger, SeleniumManager};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -40,6 +40,7 @@ pub struct IExplorerManager {
     pub driver_name: &'static str,
     pub config: ManagerConfig,
     pub http_client: Client,
+    pub log: Logger,
 }
 
 impl IExplorerManager {
@@ -49,6 +50,7 @@ impl IExplorerManager {
             driver_name: DRIVER_NAME,
             config: ManagerConfig::default(),
             http_client: create_default_http_client(),
+            log: Logger::default(),
         })
     }
 }
@@ -76,15 +78,15 @@ impl SeleniumManager for IExplorerManager {
 
     fn request_driver_version(&self) -> Result<String, Box<dyn Error>> {
         let browser_version = self.get_browser_version();
-        let mut metadata = get_metadata();
+        let mut metadata = get_metadata(self.get_logger());
 
         match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
         {
             Some(driver_version) => {
-                log::trace!(
+                self.log.trace(format!(
                     "Driver TTL is valid. Getting {} version from metadata",
                     &self.driver_name
-                );
+                ));
                 Ok(driver_version)
             }
             _ => {
@@ -97,7 +99,7 @@ impl SeleniumManager for IExplorerManager {
                         self.driver_name,
                         &driver_version,
                     ));
-                    write_metadata(&metadata);
+                    write_metadata(&metadata, self.get_logger());
                 }
 
                 Ok(driver_version)
@@ -129,5 +131,13 @@ impl SeleniumManager for IExplorerManager {
 
     fn set_config(&mut self, config: ManagerConfig) {
         self.config = config;
+    }
+
+    fn get_logger(&self) -> &Logger {
+        &self.log
+    }
+
+    fn set_logger(&mut self, log: Logger) {
+        self.log = log;
     }
 }

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -33,6 +33,8 @@ enum OutputType {
 }
 
 pub struct Logger {
+    debug: bool,
+    trace: bool,
     output: OutputType,
     json: RefCell<JsonOutput>,
 }
@@ -103,6 +105,8 @@ impl Logger {
         }
 
         Logger {
+            debug,
+            trace,
             output: output_type,
             json: RefCell::new(JsonOutput { logs: Vec::new() }),
         }
@@ -131,10 +135,15 @@ impl Logger {
     fn logger(&self, message: String, level: Level) {
         match self.output {
             OutputType::Json => {
-                self.json
-                    .borrow_mut()
-                    .logs
-                    .push(self.create_json_log(message, level));
+                let trace = level <= Level::Trace && self.trace;
+                let debug = level <= Level::Debug && self.debug;
+                let other = level <= Level::Info;
+                if trace || debug || other {
+                    self.json
+                        .borrow_mut()
+                        .logs
+                        .push(self.create_json_log(message, level));
+                }
             }
             OutputType::Shell => {
                 if level == Level::Info {

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -81,9 +81,8 @@ impl Logger {
                 if trace {
                     filter = Trace
                 }
-
                 env_logger::Builder::new()
-                    .filter_module("selenium_manager", filter)
+                    .filter_module(env!("CARGO_CRATE_NAME"), filter)
                     .target(Stdout)
                     .format(|buf, record| {
                         let mut level_style = buf.style();

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -163,9 +163,9 @@ impl Logger {
             }
             OutputType::Shell => {
                 if level == Level::Info {
-                    println!("{}", message);
+                    print!("{}", message);
                 } else if level == Level::Error {
-                    eprintln!("{}", message);
+                    eprint!("{}", message);
                 }
             }
             _ => {
@@ -190,7 +190,7 @@ impl Logger {
         let json_output = &self.json.borrow();
         let json = json_output.deref();
         if !json.logs.is_empty() {
-            println!("{}", serde_json::to_string_pretty(json.deref()).unwrap());
+            print!("{}", serde_json::to_string_pretty(json.deref()).unwrap());
         }
     }
 }

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -47,8 +47,15 @@ pub struct Logs {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct Result {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct JsonOutput {
     pub logs: Vec<Logs>,
+    pub result: Result,
 }
 
 impl Logger {
@@ -108,7 +115,13 @@ impl Logger {
             debug,
             trace,
             output: output_type,
-            json: RefCell::new(JsonOutput { logs: Vec::new() }),
+            json: RefCell::new(JsonOutput {
+                logs: Vec::new(),
+                result: Result {
+                    code: 0,
+                    message: "".to_string(),
+                },
+            }),
         }
     }
 
@@ -142,7 +155,10 @@ impl Logger {
                     self.json
                         .borrow_mut()
                         .logs
-                        .push(self.create_json_log(message, level));
+                        .push(self.create_json_log(message.to_string(), level));
+                }
+                if level == Level::Info || level <= Level::Error {
+                    self.json.borrow_mut().result.message = message;
                 }
             }
             OutputType::Shell => {
@@ -164,6 +180,10 @@ impl Logger {
             timestamp: now_unix_timestamp(),
             message,
         }
+    }
+
+    pub fn set_code(&self, code: i32) {
+        self.json.borrow_mut().result.code = code;
     }
 
     pub fn flush(&self) {

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -1,0 +1,167 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::metadata::now_unix_timestamp;
+use env_logger::fmt::Color;
+use env_logger::Target::Stdout;
+use log::Level;
+use log::LevelFilter::{Debug, Info, Trace};
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::io::Write;
+use std::ops::Deref;
+use Color::{Blue, Cyan, Green, Red, Yellow};
+
+enum OutputType {
+    Logger,
+    Json,
+    Shell,
+}
+
+pub struct Logger {
+    output: OutputType,
+    json: RefCell<JsonOutput>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Logs {
+    pub level: String,
+    pub timestamp: u64,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct JsonOutput {
+    pub logs: Vec<Logs>,
+}
+
+impl Logger {
+    pub fn default() -> Self {
+        Logger::create("".to_string(), false, false)
+    }
+
+    pub fn create(output: String, debug: bool, trace: bool) -> Self {
+        let output_type;
+        if output.eq_ignore_ascii_case("json") {
+            output_type = OutputType::Json;
+        } else if output.eq_ignore_ascii_case("shell") {
+            output_type = OutputType::Shell;
+        } else {
+            output_type = OutputType::Logger;
+        }
+        match output_type {
+            OutputType::Logger => {
+                let mut filter = match debug {
+                    true => Debug,
+                    false => Info,
+                };
+                if trace {
+                    filter = Trace
+                }
+
+                env_logger::Builder::new()
+                    .filter_module("selenium_manager", filter)
+                    .target(Stdout)
+                    .format(|buf, record| {
+                        let mut level_style = buf.style();
+                        match record.level() {
+                            Level::Trace => level_style.set_color(Cyan),
+                            Level::Debug => level_style.set_color(Blue),
+                            Level::Info => level_style.set_color(Green),
+                            Level::Warn => level_style.set_color(Yellow),
+                            Level::Error => level_style.set_color(Red).set_bold(true),
+                        };
+                        writeln!(
+                            buf,
+                            "{}\t{}",
+                            level_style.value(record.level()),
+                            record.args()
+                        )
+                    })
+                    .try_init()
+                    .unwrap_or_default();
+            }
+            _ => {
+                env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+                    .try_init()
+                    .unwrap_or_default();
+            }
+        }
+
+        Logger {
+            output: output_type,
+            json: RefCell::new(JsonOutput { logs: Vec::new() }),
+        }
+    }
+
+    pub fn error(&self, message: String) {
+        self.logger(message, Level::Error);
+    }
+
+    pub fn warn(&self, message: String) {
+        self.logger(message, Level::Warn);
+    }
+
+    pub fn info(&self, message: String) {
+        self.logger(message, Level::Info);
+    }
+
+    pub fn debug(&self, message: String) {
+        self.logger(message, Level::Debug);
+    }
+
+    pub fn trace(&self, message: String) {
+        self.logger(message, Level::Trace);
+    }
+
+    fn logger(&self, message: String, level: Level) {
+        match self.output {
+            OutputType::Json => {
+                self.json
+                    .borrow_mut()
+                    .logs
+                    .push(self.create_json_log(message, level));
+            }
+            OutputType::Shell => {
+                if level == Level::Info {
+                    println!("{}", message);
+                } else if level == Level::Error {
+                    eprintln!("{}", message);
+                }
+            }
+            _ => {
+                log::log!(level, "{}", message);
+            }
+        }
+    }
+
+    fn create_json_log(&self, message: String, level: Level) -> Logs {
+        Logs {
+            level: level.to_string().to_uppercase(),
+            timestamp: now_unix_timestamp(),
+            message,
+        }
+    }
+
+    pub fn flush(&self) {
+        let json_output = &self.json.borrow();
+        let json = json_output.deref();
+        if !json.logs.is_empty() {
+            println!("{}", serde_json::to_string_pretty(json.deref()).unwrap());
+        }
+    }
+}

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -1,0 +1,61 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use assert_cmd::Command;
+use std::path::Path;
+
+use selenium_manager::logger::JsonOutput;
+use std::str;
+
+#[test]
+fn json_output_test() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.args(["--browser", "chrome", "--output", "json"])
+        .assert()
+        .success()
+        .code(0);
+
+    let stdout = &cmd.unwrap().stdout;
+    let output = str::from_utf8(stdout).unwrap();
+    println!("{}", output);
+
+    let json: JsonOutput = serde_json::from_str(output).unwrap();
+    assert!(!json.logs.is_empty());
+}
+
+#[test]
+fn shell_output_test() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.args(["--browser", "chrome", "--output", "shell"])
+        .assert()
+        .success()
+        .code(0);
+
+    let stdout = &cmd.unwrap().stdout;
+    let output = str::from_utf8(stdout).unwrap();
+    println!("{}", output);
+
+    let path = Path::new(strip_trailing_newline(output));
+    assert!(path.exists());
+}
+
+fn strip_trailing_newline(input: &str) -> &str {
+    input
+        .strip_suffix("\r\n")
+        .or(input.strip_suffix('\n'))
+        .unwrap_or(input)
+}

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -55,13 +55,6 @@ fn shell_output_test() {
     let output = str::from_utf8(stdout).unwrap();
     println!("{}", output);
 
-    let driver = Path::new(strip_trailing_newline(output));
+    let driver = Path::new(output);
     assert!(driver.exists());
-}
-
-fn strip_trailing_newline(input: &str) -> &str {
-    input
-        .strip_suffix("\r\n")
-        .or_else(|| input.strip_suffix('\n'))
-        .unwrap_or(input)
 }

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -56,6 +56,6 @@ fn shell_output_test() {
 fn strip_trailing_newline(input: &str) -> &str {
     input
         .strip_suffix("\r\n")
-        .or(input.strip_suffix('\n'))
+        .or_else(|| input.strip_suffix('\n'))
         .unwrap_or(input)
 }

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -35,6 +35,9 @@ fn json_output_test() {
 
     let json: JsonOutput = serde_json::from_str(output).unwrap();
     assert!(!json.logs.is_empty());
+
+    let driver = Path::new(&json.result.message);
+    assert!(driver.exists());
 }
 
 #[test]
@@ -49,8 +52,8 @@ fn shell_output_test() {
     let output = str::from_utf8(stdout).unwrap();
     println!("{}", output);
 
-    let path = Path::new(strip_trailing_newline(output));
-    assert!(path.exists());
+    let driver = Path::new(strip_trailing_newline(output));
+    assert!(driver.exists());
 }
 
 fn strip_trailing_newline(input: &str) -> &str {

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -36,6 +36,9 @@ fn json_output_test() {
     let json: JsonOutput = serde_json::from_str(output).unwrap();
     assert!(!json.logs.is_empty());
 
+    let output_code = json.result.code;
+    assert_eq!(output_code, 0);
+
     let driver = Path::new(&json.result.message);
     assert!(driver.exists());
 }


### PR DESCRIPTION
### Description
This PR implements the flag `--output` for Selenium Manager. The accepted values for this flag are:

- `LOGGER` : Usual log traces (`INFO`, `WARN`, etc.) used in the CLI. Default value.
- `JSON` : Custom JSON notation (see below).
- `SHELL` : Minimal Unix-like output (i.e., only full path when the driver is resolved or an error message if not).

To simplify things, the implemented JSON notation in this PR is simpler than proposed in #11365. The JSON basically contains the logs (level, timestamp, and message) displayed by Selenium Manager.

The bindings can invoke Selenium Manager using `--output json` and try parse its output. Then, the protocol to interpret the parsed JSON is as follows:

- When the return code is `0`: The last (and only) `INFO` message contains the driver path (when in future releases Selenium Manager also manages browsers, this message can be the browser path).
- When the return code is different than `0`: The last (and only) `ERROR` message contains the error message to throw an exception to the user.

In both cases, the `WARN` messages can be displayed to the user, since they contain some warning to the users (e.g., when a fallback is used to resolve the driver). In principle, the `DEBUG` and `TRACE` logs can safely ignored in the bindings.

Does it make sense?

An example of the JSON output is as follows (running Selenium Manager from the source code with Cargo):

```
> cargo run -- --browser chrome --output json
{
  "logs": [
    {
      "level": "TRACE",
      "timestamp": 1673373731,
      "message": "Reading metadata from C:\\Users\\boni\\.cache\\selenium\\selenium-manager.json"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "Using shell command to find out chrome version"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "Running cmd command: \"wmic datafile where name='%PROGRAMFILES:\\\\=\\\\\\\\%\\\\\\\\Google\\\\\\\\Chrome\\\\\\\\Application\\\\\\\\chrome.exe' get Version /value\""
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "Output { status: ExitStatus(ExitStatus(0)), stdout: \"\\r\\r\\n\\r\\r\\nVersion=108.0.5359.125\\r\\r\\n\\r\\r\\n\\r\\r\\n\\r\\r\\n\", stderr: \"\" }"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "The version of chrome is 108.0.5359.125"
    },
    {
      "level": "TRACE",
      "timestamp": 1673373731,
      "message": "Writing metadata to C:\\Users\\boni\\.cache\\selenium\\selenium-manager.json"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "Detected browser: chrome 108"
    },
    {
      "level": "TRACE",
      "timestamp": 1673373731,
      "message": "Reading metadata from C:\\Users\\boni\\.cache\\selenium\\selenium-manager.json"
    },
    {
      "level": "TRACE",
      "timestamp": 1673373731,
      "message": "Driver TTL is valid. Getting chromedriver version from metadata"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "Required driver: chromedriver 108.0.5359.71"
    },
    {
      "level": "DEBUG",
      "timestamp": 1673373731,
      "message": "chromedriver 108.0.5359.71 already in the cache"
    },
    {
      "level": "INFO",
      "timestamp": 1673373731,
      "message": "C:\\Users\\boni\\.cache\\selenium\\chromedriver\\win32\\108.0.5359.71\\chromedriver.exe"
    }
  ]
}
```

### Motivation and Context
Feature requested on #11365. Discussed at the [Selenium TLC Meeting](https://www.selenium.dev/meetings/2022/tlc-12-08/#proposalsdecisions).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
