### PR TITLE
[rust] Create a separate Selenium Manager test for beta browsers

### DIFF
--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -24,14 +24,11 @@ use std::str;
 #[case("chrome", "chromedriver", "", "")]
 #[case("chrome", "chromedriver", "105", "105.0.5195.52")]
 #[case("chrome", "chromedriver", "106", "106.0.5249.61")]
-#[case("chrome", "chromedriver", "beta", "")]
 #[case("edge", "msedgedriver", "", "")]
 #[case("edge", "msedgedriver", "105", "105.0")]
 #[case("edge", "msedgedriver", "106", "106.0")]
-#[case("edge", "msedgedriver", "beta", "")]
 #[case("firefox", "geckodriver", "", "")]
 #[case("firefox", "geckodriver", "105", "0.32.0")]
-#[case("firefox", "geckodriver", "beta", "")]
 #[case("iexplorer", "IEDriverServer", "", "")]
 fn ok_test(
     #[case] browser: String,
@@ -94,6 +91,24 @@ fn error_test(
     .assert()
     .failure()
     .code(error_code);
+}
+
+#[rstest]
+#[case("chrome", "chromedriver")]
+#[case("edge", "msedgedriver")]
+#[case("firefox", "geckodriver")]
+fn beta_test(#[case] browser: String, #[case] driver_name: String) {
+    println!("Beta test browser={browser} -- driver_name={driver_name}");
+
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    let assert = cmd
+        .args(["--browser", &browser, "--browser-version", "beta"])
+        .assert();
+
+    let stdout = &assert.get_output().stdout;
+    let output = str::from_utf8(stdout).unwrap();
+    println!("output {:?}", output);
+    assert!(output.contains(&driver_name) || output.contains("ERROR"));
 }
 
 #[rstest]


### PR DESCRIPTION
### Description
This PR creates a new test for Selenium Manager for beta browsers.

### Motivation and Context
Beta browsers are not installed in GH actions and so, the test `ok_test` is failing in CI (e.g. [run workflow](https://github.com/SeleniumHQ/selenium/actions/runs/3905385936)). To make the build green, I have created a new test that does not fail when the beta browsers are not available.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
