### PR TITLE
Generate a Maven BOM

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,31 +93,6 @@ task '//java/test/org/openqa/selenium/environment/webserver:webserver:uber' => [
   '//java/test/org/openqa/selenium/environment:webserver'
 ]
 
-# Java targets required for release. These should all be java_export targets.
-# Generated from: bazel query 'kind(maven_publish, set(//java/... //third_party/...))' | sort
-JAVA_RELEASE_TARGETS = %w[
-  //java/src/org/openqa/selenium/chrome:chrome.publish
-  //java/src/org/openqa/selenium/chromium:chromium.publish
-  //java/src/org/openqa/selenium/devtools/v85:v85.publish
-  //java/src/org/openqa/selenium/devtools/v102:v102.publish
-  //java/src/org/openqa/selenium/devtools/v103:v103.publish
-  //java/src/org/openqa/selenium/devtools/v104:v104.publish
-  //java/src/org/openqa/selenium/edge:edge.publish
-  //java/src/org/openqa/selenium/firefox:firefox.publish
-  //java/src/org/openqa/selenium/grid/sessionmap/jdbc:jdbc.publish
-  //java/src/org/openqa/selenium/grid/sessionmap/redis:redis.publish
-  //java/src/org/openqa/selenium/grid:grid.publish
-  //java/src/org/openqa/selenium/ie:ie.publish
-  //java/src/org/openqa/selenium/json:json.publish
-  //java/src/org/openqa/selenium/lift:lift.publish
-  //java/src/org/openqa/selenium/remote/http:http.publish
-  //java/src/org/openqa/selenium/remote:remote.publish
-  //java/src/org/openqa/selenium/safari:safari.publish
-  //java/src/org/openqa/selenium/support:support.publish
-  //java/src/org/openqa/selenium:client-combined.publish
-  //java/src/org/openqa/selenium:core.publish
-]
-
 # Notice that because we're using rake, anything you can do in a normal rake
 # build can also be done here. For example, here we set the default task
 task default: [:grid]
@@ -397,17 +372,13 @@ def read_user_pass_from_m2_settings
   return [user, pass]
 end
 
-task 'publish-maven': JAVA_RELEASE_TARGETS do
+task 'publish-maven': ['//java:bindings'] do
  creds = read_user_pass_from_m2_settings
-  JAVA_RELEASE_TARGETS.each do |p|
-    Bazel::execute('run', ['--stamp', '--define', 'maven_repo=https://oss.sonatype.org/service/local/staging/deploy/maven2', '--define', "maven_user=#{creds[0]}", '--define', "maven_password=#{creds[1]}", '--define', 'gpg_sign=true'], p)
-  end
+ Bazel::execute('run', ['--stamp', '--define', 'maven_repo=https://oss.sonatype.org/service/local/staging/deploy/maven2', '--define', "maven_user=#{creds[0]}", '--define', "maven_password=#{creds[1]}", '--define', 'gpg_sign=true'], '//java:bindings')
 end
 
 task :'maven-install' do
-  JAVA_RELEASE_TARGETS.each do |p|
-    Bazel::execute('run', ['--stamp', '--define', "maven_repo=file://#{ENV['HOME']}/.m2/repository", '--define', 'gpg_sign=false'], p)
-  end
+  Bazel::execute('run', ['--stamp', '--define', "maven_repo=file://#{ENV['HOME']}/.m2/repository", '--define', 'gpg_sign=false'], '//java:bindings')
 end
 
 desc 'Build the selenium client jars'

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@contrib_rules_jvm//java:defs.bzl", "spotbugs_config")
+load(":defs.bzl", "artifact", "maven_bom")
+load(":version.bzl", "SE_VERSION")
 
 exports_files(
     srcs = [
@@ -10,6 +11,36 @@ exports_files(
     visibility = [
         "//visibility:public",
     ],
+)
+
+# Generated from: bazel query 'kind(maven_publish, set(//java/... //third_party/...))' | sort
+maven_bom(
+    name = "bindings",
+    java_exports = [
+        "//java/src/com/thoughtworks/selenium/webdriven",
+        "//java/src/org/openqa/selenium/chrome",
+        "//java/src/org/openqa/selenium/chromium",
+        "//java/src/org/openqa/selenium/devtools/v102",
+        "//java/src/org/openqa/selenium/devtools/v103",
+        "//java/src/org/openqa/selenium/devtools/v104",
+        "//java/src/org/openqa/selenium/devtools/v85",
+        "//java/src/org/openqa/selenium/edge",
+        "//java/src/org/openqa/selenium/firefox",
+        "//java/src/org/openqa/selenium/grid/sessionmap/jdbc",
+        "//java/src/org/openqa/selenium/grid/sessionmap/redis",
+        "//java/src/org/openqa/selenium/grid",
+        "//java/src/org/openqa/selenium/ie",
+        "//java/src/org/openqa/selenium/json",
+        "//java/src/org/openqa/selenium/lift",
+        "//java/src/org/openqa/selenium/remote/http/jdk",
+        "//java/src/org/openqa/selenium/remote/http",
+        "//java/src/org/openqa/selenium/remote",
+        "//java/src/org/openqa/selenium/safari",
+        "//java/src/org/openqa/selenium/support",
+        "//java/src/org/openqa/selenium:client-combined",
+        "//java/src/org/openqa/selenium:core",
+    ],
+    maven_coordinates = "org.seleniumhq.selenium:selenium-parent:%s" % SE_VERSION,
 )
 
 java_plugin(

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -3,7 +3,7 @@ load(
     _java_binary = "java_binary",
     _java_import = "java_import",
 )
-load("@rules_jvm_external//:defs.bzl", _artifact = "artifact", _javadoc = "javadoc")
+load("@rules_jvm_external//:defs.bzl", _artifact = "artifact", _javadoc = "javadoc", _maven_bom = "maven_bom")
 load("//java/private:dist_zip.bzl", _java_dist_zip = "java_dist_zip")
 load("//java/private:library.bzl", _java_export = "java_export", _java_library = "java_library", _java_test = "java_test")
 load("//java/private:merge_jars.bzl", _merge_jars = "merge_jars")
@@ -29,6 +29,7 @@ java_module = _java_module
 java_selenium_test_suite = _java_selenium_test_suite
 java_test = _java_test
 javadoc = _javadoc
+maven_bom = _maven_bom
 merge_jars = _merge_jars
 selenium_test = _selenium_test
 JUNIT5_DEPS = _JUNIT5_DEPS

--- a/java/private/export.bzl
+++ b/java/private/export.bzl
@@ -3,6 +3,7 @@ load(
     "javadoc",
     "pom_file",
 )
+load("@rules_jvm_external//private/rules:maven_bom_fragment.bzl", "maven_bom_fragment")
 load("@rules_jvm_external//private/rules:maven_project_jar.bzl", "maven_project_jar")
 load("@rules_jvm_external//private/rules:maven_publish.bzl", "maven_publish")
 load("//java/private:module.bzl", "java_module")
@@ -91,6 +92,17 @@ def java_export(
         javadocs = "%s-docs" % name,
         artifact_jar = ":%s-maven-module" % name,
         source_jar = ":%s-maven-source" % name,
+        visibility = visibility,
+    )
+
+    maven_bom_fragment(
+        name = "%s.bom-fragment" % name,
+        maven_coordinates = maven_coordinates,
+        artifact = ":%s" % lib_name,
+        src_artifact = "%s-maven-source" % name,
+        javadoc_artifact = None if "no-javadocs" in tags else "%s-docs" % name,
+        pom_template = pom_template,
+        tags = tags,
         visibility = visibility,
     )
 

--- a/java/src/org/openqa/selenium/pom.xml
+++ b/java/src/org/openqa/selenium/pom.xml
@@ -73,4 +73,14 @@
   <dependencies>
 {dependencies}
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+{parent}
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
### Description
Creates `selenium-bom` and `selenium-dependencies-bom` artifacts so people can pull in all our deps in one go.

### Motivation and Context
People using Maven like BOMs

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
