### PR TITLE
[dotnet] IJavascriptEngine implements IDisposable where available

### DIFF
--- a/dotnet/src/webdriver/IJavaScriptEngine.cs
+++ b/dotnet/src/webdriver/IJavaScriptEngine.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium
     /// <summary>
     /// Defines an interface allowing the user to manage settings in the browser's JavaScript engine.
     /// </summary>
-    public interface IJavaScriptEngine
+    public interface IJavaScriptEngine : IDisposable
     {
         /// <summary>
         /// Occurs when a JavaScript callback with a named binding is executed.

--- a/dotnet/src/webdriver/JavaScriptEngine.cs
+++ b/dotnet/src/webdriver/JavaScriptEngine.cs
@@ -40,6 +40,7 @@ namespace OpenQA.Selenium
         private Dictionary<string, PinnedScript> pinnedScripts = new Dictionary<string, PinnedScript>();
         private List<string> bindings = new List<string>();
         private bool isEnabled = false;
+        private bool isDisposed = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JavaScriptEngine"/> class.
@@ -392,6 +393,27 @@ namespace OpenQA.Selenium
                     MessageTimeStamp = e.Timestamp,
                     MessageType = e.Type
                 });
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    if (this.session.IsValueCreated)
+                    {
+                        this.session.Value.Dispose();
+                    }
+                }
+
+                this.isDisposed = true;
             }
         }
     }


### PR DESCRIPTION
JavascriptExecutor takes an IWebDriver and, on a lazy basis, opens a DevToolsSession which it currently leaves open. This PR disposes on that DevToolsSession if it was instantiated.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Closes the DevToolsSession in JavascriptEngine if it's been opened.

### Motivation and Context
cq

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
