### PR TITLE
[rust] Selenium Manager processes PATH

### DIFF
--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -139,14 +139,11 @@ impl SeleniumManager for ChromeManager {
         } else {
             commands = vec![self.format_one_arg(WMIC_COMMAND, browser_path)];
         }
-        let (shell, flag, args) = if WINDOWS.is(self.get_os()) {
-            ("cmd", "/C", commands)
+        let (shell, flag) = self.get_shell_command();
+        let args = if WINDOWS.is(self.get_os()) {
+            commands
         } else {
-            (
-                "sh",
-                "-c",
-                vec![self.format_one_arg(DASH_DASH_VERSION, browser_path)],
-            )
+            vec![self.format_one_arg(DASH_DASH_VERSION, browser_path)]
         };
         self.detect_browser_version(shell, flag, args)
     }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -139,14 +139,11 @@ impl SeleniumManager for EdgeManager {
         } else {
             commands = vec![self.format_one_arg(WMIC_COMMAND, browser_path)];
         }
-        let (shell, flag, args) = if WINDOWS.is(self.get_os()) {
-            ("cmd", "/C", commands)
+        let (shell, flag) = self.get_shell_command();
+        let args = if WINDOWS.is(self.get_os()) {
+            commands
         } else {
-            (
-                "sh",
-                "-c",
-                vec![self.format_one_arg(DASH_DASH_VERSION, browser_path)],
-            )
+            vec![self.format_one_arg(DASH_DASH_VERSION, browser_path)]
         };
         self.detect_browser_version(shell, flag, args)
     }

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -183,6 +183,14 @@ pub fn parse_version(version_text: String) -> Result<String, Box<dyn Error>> {
     if version_text.to_ascii_lowercase().contains("error") {
         return Err(PARSE_ERROR.into());
     }
-    let re = Regex::new(r"[^\d^.]").unwrap();
-    Ok(re.replace_all(&version_text, "").to_string())
+    let mut parsed_version = "".to_string();
+    let re_numbers_dots = Regex::new(r"[^\d^.]")?;
+    let re_versions = Regex::new(r"(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)")?;
+    for token in version_text.split(' ') {
+        parsed_version = re_numbers_dots.replace_all(token, "").to_string();
+        if re_versions.is_match(parsed_version.as_str()) {
+            break;
+        }
+    }
+    Ok(parsed_version)
 }

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -129,14 +129,11 @@ impl SeleniumManager for FirefoxManager {
         } else {
             commands = vec![self.format_one_arg(WMIC_COMMAND, browser_path)];
         }
-        let (shell, flag, args) = if WINDOWS.is(self.get_os()) {
-            ("cmd", "/C", commands)
+        let (shell, flag) = self.get_shell_command();
+        let args = if WINDOWS.is(self.get_os()) {
+            commands
         } else {
-            (
-                "sh",
-                "-c",
-                vec![self.format_one_arg(DASH_VERSION, browser_path)],
-            )
+            vec![self.format_one_arg(DASH_VERSION, browser_path)]
         };
         self.detect_browser_version(shell, flag, args)
     }

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -55,7 +55,7 @@ fn ok_test(
     println!("{}", output);
 
     assert!(output.contains(&driver_name));
-    if !browser_version.is_empty() {
+    if !browser_version.is_empty() && output.contains("cache") {
         assert!(output.contains(&driver_version));
     }
 }


### PR DESCRIPTION
### Description
With this PR, Selenium process the `PATH`, i.e., it tries to find the required driver (e.g., chromedriver 109) in the set of local directories where executable programs are located. If the driver is found but is not compatible, it shows a `WARN` trace (which can be captured by the bindings using the JSON output format). If found and compatible, it uses it. Here a couple of examples:

1. Found but incompatible (chromedriver 107 in the `PATH` in a computer with Chrome 109):
```
> cargo run -- --browser chrome
	 
WARN    Incompatible release of chromedriver (version 107.0.5304.62) detected in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
INFO    C:\Users\boni\.cache\selenium\chromedriver\win32\109.0.5414.74\chromedriver.exe
```

2. Found and compatible (the same situation than before, but forcing to use Chrome 107):
```
> cargo run -- --browser chrome --browser-version 107

INFO    C:\Users\boni\Documents\bat\chromedriver.exe
```

### Motivation and Context
This PR implements #11356 (and #11373).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
