### PR TITLE
print requested capabilities in SessionNotCreatedException

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -147,7 +147,7 @@ public class RemoteWebDriver implements WebDriver,
 
   public RemoteWebDriver(CommandExecutor executor, Capabilities capabilities) {
     this.executor = Require.nonNull("Command executor", executor);
-    capabilities = init(capabilities);
+    this.capabilities = init(capabilities);
 
     if (executor instanceof NeedsLocalLogs) {
       ((NeedsLocalLogs) executor).setLocalLogs(localLogs);


### PR DESCRIPTION
### Description
Currently `SessionNotCreatedException` always prints out **empty capabilities**:

```java
org.openqa.selenium.SessionNotCreatedException: Could not start a new session...
Host info: ...
Build info: version: '4.8.0'...
System info: ...
Driver info: ...
Command: [null, newSession...}]
Capabilities {}

	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:561)
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

