### PR TITLE
[rust] Include support for Safari in Selenium Manager

### DIFF
--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -26,7 +26,8 @@ use crate::files::BrowserPath;
 
 use crate::config::OS::MACOS;
 use crate::{
-    create_default_http_client, Logger, SeleniumManager, BETA, DEV, PLIST_COMMAND, STABLE,
+    create_default_http_client, format_one_arg, Logger, SeleniumManager, BETA, DEV, PLIST_COMMAND,
+    STABLE,
 };
 
 pub const SAFARI: &str = "safari";
@@ -89,16 +90,12 @@ impl SeleniumManager for SafariManager {
                 _ => return None,
             }
         }
-        let (shell, flag, args) = if MACOS.is(self.get_os()) {
-            (
-                "sh",
-                "-c",
-                vec![self.format_one_arg(PLIST_COMMAND, browser_path)],
-            )
+        let command = if MACOS.is(self.get_os()) {
+            vec![format_one_arg(PLIST_COMMAND, browser_path)]
         } else {
             return None;
         };
-        self.detect_browser_version(shell, flag, args)
+        self.detect_browser_version(command)
     }
 
     fn get_driver_name(&self) -> &str {

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -1,0 +1,139 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::config::ManagerConfig;
+use reqwest::Client;
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::PathBuf;
+use std::string::ToString;
+
+use crate::files::BrowserPath;
+
+use crate::config::OS::MACOS;
+use crate::{
+    create_default_http_client, Logger, SeleniumManager, BETA, DEV, PLIST_COMMAND, STABLE,
+};
+
+pub const SAFARI: &str = "safari";
+const DRIVER_NAME: &str = "safaridriver";
+
+pub struct SafariManager {
+    pub browser_name: &'static str,
+    pub driver_name: &'static str,
+    pub config: ManagerConfig,
+    pub http_client: Client,
+    pub log: Logger,
+}
+
+impl SafariManager {
+    pub fn new() -> Box<Self> {
+        Box::new(SafariManager {
+            browser_name: SAFARI,
+            driver_name: DRIVER_NAME,
+            config: ManagerConfig::default(),
+            http_client: create_default_http_client(),
+            log: Logger::default(),
+        })
+    }
+}
+
+impl SeleniumManager for SafariManager {
+    fn get_browser_name(&self) -> &str {
+        self.browser_name
+    }
+
+    fn get_http_client(&self) -> &Client {
+        &self.http_client
+    }
+
+    fn set_http_client(&mut self, http_client: Client) {
+        self.http_client = http_client;
+    }
+
+    fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
+        HashMap::from([
+            (
+                BrowserPath::new(MACOS, STABLE),
+                r#"/Applications/Safari.app"#,
+            ),
+            (BrowserPath::new(MACOS, BETA), r#"/Applications/Safari.app"#),
+            (
+                BrowserPath::new(MACOS, DEV),
+                r#"/Applications/Safari\ Technology\ Preview.app"#,
+            ),
+        ])
+    }
+
+    fn discover_browser_version(&self) -> Option<String> {
+        let mut browser_path = self.get_browser_path();
+        if browser_path.is_empty() {
+            match self.detect_browser_path() {
+                Some(path) => {
+                    browser_path = path;
+                }
+                _ => return None,
+            }
+        }
+        let (shell, flag, args) = if MACOS.is(self.get_os()) {
+            (
+                "sh",
+                "-c",
+                vec![self.format_one_arg(PLIST_COMMAND, browser_path)],
+            )
+        } else {
+            return None;
+        };
+        self.detect_browser_version(shell, flag, args)
+    }
+
+    fn get_driver_name(&self) -> &str {
+        self.driver_name
+    }
+
+    fn request_driver_version(&self) -> Result<String, Box<dyn Error>> {
+        Ok("(local)".to_string())
+    }
+
+    fn get_driver_url(&self) -> Result<String, Box<dyn Error>> {
+        Err(format!("{} not available for download", self.get_driver_name()).into())
+    }
+
+    fn get_driver_path_in_cache(&self) -> PathBuf {
+        if !self.is_browser_version_dev() {
+            PathBuf::from("/usr/bin/safaridriver")
+        } else {
+            PathBuf::from("/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver")
+        }
+    }
+
+    fn get_config(&self) -> &ManagerConfig {
+        &self.config
+    }
+
+    fn set_config(&mut self, config: ManagerConfig) {
+        self.config = config;
+    }
+
+    fn get_logger(&self) -> &Logger {
+        &self.log
+    }
+
+    fn set_logger(&mut self, log: Logger) {
+        self.log = log;
+    }
+}

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -30,10 +30,10 @@ use crate::{
     STABLE,
 };
 
-pub const SAFARI: &str = "safari";
+const BROWSER_NAME: &str = "safaritp";
 const DRIVER_NAME: &str = "safaridriver";
 
-pub struct SafariManager {
+pub struct SafariTPManager {
     pub browser_name: &'static str,
     pub driver_name: &'static str,
     pub config: ManagerConfig,
@@ -41,10 +41,10 @@ pub struct SafariManager {
     pub log: Logger,
 }
 
-impl SafariManager {
+impl SafariTPManager {
     pub fn new() -> Box<Self> {
-        Box::new(SafariManager {
-            browser_name: SAFARI,
+        Box::new(SafariTPManager {
+            browser_name: BROWSER_NAME,
             driver_name: DRIVER_NAME,
             config: ManagerConfig::default(),
             http_client: create_default_http_client(),
@@ -53,7 +53,7 @@ impl SafariManager {
     }
 }
 
-impl SeleniumManager for SafariManager {
+impl SeleniumManager for SafariTPManager {
     fn get_browser_name(&self) -> &str {
         self.browser_name
     }
@@ -69,7 +69,7 @@ impl SeleniumManager for SafariManager {
     fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str> {
         HashMap::from([(
             BrowserPath::new(MACOS, STABLE),
-            r#"/Applications/Safari.app"#,
+            r#"/Applications/Safari\ Technology\ Preview.app"#,
         )])
     }
 
@@ -104,7 +104,7 @@ impl SeleniumManager for SafariManager {
     }
 
     fn get_driver_path_in_cache(&self) -> PathBuf {
-        PathBuf::from("/usr/bin/safaridriver")
+        PathBuf::from("/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver")
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -29,7 +29,6 @@ use std::str;
 #[case("edge", "msedgedriver", "106", "106.0")]
 #[case("firefox", "geckodriver", "", "")]
 #[case("iexplorer", "IEDriverServer", "", "")]
-#[case("safari", "safaridriver", "", "")]
 fn ok_test(
     #[case] browser: String,
     #[case] driver_name: String,

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -29,6 +29,7 @@ use std::str;
 #[case("edge", "msedgedriver", "106", "106.0")]
 #[case("firefox", "geckodriver", "", "")]
 #[case("iexplorer", "IEDriverServer", "", "")]
+#[case("safari", "safaridriver", "", "")]
 fn ok_test(
     #[case] browser: String,
     #[case] driver_name: String,

--- a/rust/tests/safari_tests.rs
+++ b/rust/tests/safari_tests.rs
@@ -1,0 +1,31 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use assert_cmd::Command;
+use std::env::consts::OS;
+
+#[test]
+fn safari_test() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    let safari_assert = cmd.args(["--browser", "safari"]).assert();
+
+    if OS.eq("macos") {
+        safari_assert.success();
+    } else {
+        safari_assert.failure();
+    }
+}


### PR DESCRIPTION
### Description
This PR implements the support of Safari in Selenium Manager, as requested in #11522.

In addition to the stable release of Safari, and according to its [resources page](https://developer.apple.com/safari/resources/), there are two more distributions of Safari: beta, and _Technology Preview_. For symmetry with the rest of the browser (Chrome, Firefox, etc.), the "technology preview" is considered in Selenium Manager using the `dev` label (for browser version). The beta version is also considered.

Here it is some example executed in macOS (with Safari stable and Technology Preview installed):

```
bonigarcia@SL-2030 rust % cargo run -- --browser safari --debug     
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/selenium-manager --browser safari --debug`
DEBUG	Using shell command to find out safari version
DEBUG	Running sh command: "/usr/libexec/PlistBuddy -c \"print :CFBundleShortVersionString\" /Applications/Safari.app/Contents/Info.plist"
DEBUG	Output { status: ExitStatus(unix_wait_status(0)), stdout: "16.1\n", stderr: "" }
DEBUG	The version of safari is 16.1
DEBUG	Required driver: safaridriver (local)
INFO	/usr/bin/safaridriver
```

```
bonigarcia@SL-2030 rust % cargo run -- --browser safari --debug --browser-version dev
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/selenium-manager --browser safari --debug --browser-version dev`
DEBUG	Using shell command to find out safari version
DEBUG	Running sh command: "/usr/libexec/PlistBuddy -c \"print :CFBundleShortVersionString\" /Applications/Safari\\ Technology\\ Preview.app/Contents/Info.plist"
DEBUG	Output { status: ExitStatus(unix_wait_status(0)), stdout: "16.4\n", stderr: "" }
DEBUG	The version of safari is 16.4
DEBUG	Required driver: safaridriver (local)
INFO	/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver
```

### Motivation and Context
Part of Selenium Manager M3, requested in #11522.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
