### PR TITLE
[rust] Fix local architecture discovery in Selenium Manager

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -16,11 +16,12 @@
 // under the License.
 
 use crate::config::OS::{LINUX, MACOS, WINDOWS};
-use crate::REQUEST_TIMEOUT_SEC;
 use crate::TTL_BROWSERS_SEC;
 use crate::TTL_DRIVERS_SEC;
 
 use std::env::consts::{ARCH, OS};
+use crate::{run_shell_command, ENV_PROCESSOR_ARCHITECTURE, REQUEST_TIMEOUT_SEC, UNAME_COMMAND};
+use std::env;
 
 pub struct ManagerConfig {
     pub browser_version: String,
@@ -36,11 +37,17 @@ pub struct ManagerConfig {
 
 impl ManagerConfig {
     pub fn default() -> ManagerConfig {
+        let self_os = OS;
+        let self_arch = if WINDOWS.is(self_os) {
+            env::var(ENV_PROCESSOR_ARCHITECTURE).unwrap_or_default()
+        } else {
+            run_shell_command(self_os, UNAME_COMMAND.to_string()).unwrap_or_default()
+        };
         ManagerConfig {
             browser_version: "".to_string(),
             driver_version: "".to_string(),
-            os: OS.to_string(),
-            arch: ARCH.to_string(),
+            os: self_os.to_string(),
+            arch: self_arch,
             browser_path: "".to_string(),
             proxy: "".to_string(),
             timeout: REQUEST_TIMEOUT_SEC,
@@ -107,15 +114,16 @@ pub enum ARCH {
 }
 
 impl ARCH {
-    pub fn to_str(&self) -> &str {
+    pub fn to_str_vector(&self) -> Vec<&str> {
         match self {
-            ARCH::X32 => "x86",
-            ARCH::X64 => "x86_64",
-            ARCH::ARM64 => "aarch64",
+            ARCH::X32 => vec!["x86", "i386"],
+            ARCH::X64 => vec!["x86_64", "x64", "i686", "amd64", "ia64"],
+            ARCH::ARM64 => vec!["aarch64", "arm64", "arm"],
         }
     }
 
     pub fn is(&self, arch: &str) -> bool {
-        self.to_str().eq_ignore_ascii_case(arch)
+        self.to_str_vector()
+            .contains(&arch.to_ascii_lowercase().as_str())
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -75,7 +75,7 @@ pub const WHERE_COMMAND: &str = "where {}";
 pub const WHICH_COMMAND: &str = "which {}";
 pub const TTL_BROWSERS_SEC: u64 = 0;
 pub const TTL_DRIVERS_SEC: u64 = 86400;
-pub const UNAME_COMMAND: &str = "uname -m";
+pub const UNAME_COMMAND: &str = "uname -{}";
 
 pub trait SeleniumManager {
     // ----------------------------------------------------------
@@ -173,13 +173,11 @@ pub trait SeleniumManager {
                     break;
                 }
                 if !self.is_safari() {
-                    metadata
-                        .browsers
-                        .push(create_browser_metadata(
-                            browser_name,
-                            &browser_version,
-                            browser_ttl,
-                        ));
+                    metadata.browsers.push(create_browser_metadata(
+                        browser_name,
+                        &browser_version,
+                        browser_ttl,
+                    ));
                     write_metadata(&metadata, self.get_logger());
                 }
                 if !browser_version.is_empty() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -69,11 +69,13 @@ pub const DASH_DASH_VERSION: &str = "{} --version";
 pub const ENV_PROGRAM_FILES: &str = "PROGRAMFILES";
 pub const ENV_PROGRAM_FILES_X86: &str = "PROGRAMFILES(X86)";
 pub const ENV_LOCALAPPDATA: &str = "LOCALAPPDATA";
+pub const ENV_PROCESSOR_ARCHITECTURE: &str = "PROCESSOR_ARCHITECTURE";
 pub const FALLBACK_RETRIES: u32 = 5;
 pub const WHERE_COMMAND: &str = "where {}";
 pub const WHICH_COMMAND: &str = "which {}";
 pub const TTL_BROWSERS_SEC: u64 = 0;
 pub const TTL_DRIVERS_SEC: u64 = 86400;
+pub const UNAME_COMMAND: &str = "uname -m";
 
 pub trait SeleniumManager {
     // ----------------------------------------------------------

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,8 +25,8 @@ use exitcode::{DATAERR, UNAVAILABLE};
 
 use selenium_manager::logger::Logger;
 use selenium_manager::REQUEST_TIMEOUT_SEC;
-use selenium_manager::TTL_DRIVERS_SEC;
 use selenium_manager::TTL_BROWSERS_SEC;
+use selenium_manager::TTL_DRIVERS_SEC;
 use selenium_manager::{
     clear_cache, get_manager_by_browser, get_manager_by_driver, SeleniumManager,
 };


### PR DESCRIPTION
### Description
This PR fixes a bug reported in #11517, related to the architecture discovery (e.g., `arm64`, `x86_64`) in Selenium Manager.

### Motivation and Context
So far, the Selenium Manager logic relied on a Rust standard constant called `std::env::consts::ARCH` for the architecture discovery. According to its doc, this constant is _"A string describing the architecture of the CPU that is currently in use"_. Nevertheless, when compiled for a `x86_64`, like in CI (for instance, for macOS, using `cargo build --release --target x86_64-apple-darwin`), that constant is always `x86_64` (even when executed in a macOS M1). The solution I found to fix this issue is to rely on the command `uname` (in UNIX/Linux) and the environment variable (`PROCESSOR_ARCHITECTURE`) in Windows for the automatic discovery of the underlying architecture.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
