### PR TITLE
[java] Synchronize method to get Selenium Manager binary (fix #11620)

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -117,7 +117,7 @@ public class SeleniumManager {
    * Determines the correct Selenium Manager binary to use.
    * @return the path to the Selenium Manager binary.
    */
-    private File getBinary() {
+    private synchronized File getBinary() {
         if (binary == null) {
             try {
                 Platform current = Platform.getCurrent();


### PR DESCRIPTION
### Description
The method to get the Selenium Manager binary in the Java bindings is not synchronized, which leading to concurrent problems to get Selenium Manager in Java, as reported in #11620. I have confirmed the bug using the provided [example repo](https://github.com/attila-fazekas/selenium-manager-parallel-run). I used that repo as well to test the fix.

### Motivation and Context
This PR fixes #11620.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
