### PR TITLE
[java] Selenium Manager use binary from browser options (#11351)

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -110,10 +110,12 @@ public class ChromeDriverService extends DriverService {
     File executable,
     int port,
     List<String> args,
-    Map<String, String> environment) throws IOException {
+    Map<String, String> environment,
+    List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, DEFAULT_TIMEOUT,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -129,10 +131,12 @@ public class ChromeDriverService extends DriverService {
       int port,
       Duration timeout,
       List<String> args,
-      Map<String, String> environment) throws IOException {
+      Map<String, String> environment,
+      List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, timeout,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -160,9 +164,12 @@ public class ChromeDriverService extends DriverService {
   public static ChromeDriverService createServiceWithConfig(ChromeOptions options) {
     ChromeDriverLogLevel oldLevel = options.getLogLevel();
     ChromiumDriverLogLevel level = (oldLevel == null) ? null : ChromiumDriverLogLevel.fromString(oldLevel.toString());
-    return new Builder()
-      .withLogLevel(level)
-      .build();
+    Builder builder = new Builder().withLogLevel(level);
+    String binary = options.getBinary();
+    if (binary != null && !binary.isEmpty()) {
+      builder.withSeleniumManagerArgs(new String[]{"--browser-path", binary});
+    }
+    return builder.build();
   }
 
   /**
@@ -311,11 +318,11 @@ public class ChromeDriverService extends DriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       return findExecutable(
         "chromedriver", CHROME_DRIVER_EXE_PROPERTY,
         "https://chromedriver.chromium.org/",
-        "https://chromedriver.chromium.org/downloads");
+        "https://chromedriver.chromium.org/downloads", seleniumManagerArgs);
     }
 
     @Override
@@ -367,9 +374,10 @@ public class ChromeDriverService extends DriverService {
         int port,
         Duration timeout,
         List<String> args,
-        Map<String, String> environment) {
+        Map<String, String> environment,
+        List<String> seleniumManagerArgs) {
       try {
-        return new ChromeDriverService(exe, port, timeout, args, environment);
+        return new ChromeDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
       } catch (IOException e) {
         throw new WebDriverException(e);
       }

--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -100,6 +100,10 @@ public class ChromiumOptions<T extends ChromiumOptions<?>> extends AbstractDrive
     return (T) this;
   }
 
+  public String getBinary() {
+    return binary;
+  }
+
   /**
    * @param arguments The arguments to use when starting Chrome.
    * @see #addArguments(List)

--- a/java/src/org/openqa/selenium/edge/EdgeDriver.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriver.java
@@ -43,7 +43,7 @@ public class EdgeDriver extends ChromiumDriver {
   }
 
   public EdgeDriver(EdgeOptions options) {
-    this(new EdgeDriverService.Builder().build(), options);
+    this(EdgeDriverService.createServiceWithConfig(options), options);
   }
 
   public EdgeDriver(EdgeDriverService service) {

--- a/java/src/org/openqa/selenium/edge/EdgeDriverService.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverService.java
@@ -104,10 +104,12 @@ public class EdgeDriverService extends DriverService {
     int port,
     Duration timeout,
     List<String> args,
-    Map<String, String> environment) throws IOException {
-    super(executable, port, timeout,
-          unmodifiableList(new ArrayList<>(args)),
-          unmodifiableMap(new HashMap<>(environment)));
+    Map<String, String> environment,
+    List<String> seleniumManagerArgs) throws IOException {
+    super(executable, port, DEFAULT_TIMEOUT,
+            unmodifiableList(new ArrayList<>(args)),
+            unmodifiableMap(new HashMap<>(environment)),
+            unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -121,6 +123,16 @@ public class EdgeDriverService extends DriverService {
   public static EdgeDriverService createDefaultService() {
     return new Builder().build();
   }
+
+  public static EdgeDriverService createServiceWithConfig(EdgeOptions options) {
+    EdgeDriverService.Builder builder = new EdgeDriverService.Builder();
+    String binary = options.getBinary();
+    if (binary != null && !binary.isEmpty()) {
+      builder.withSeleniumManagerArgs(new String[]{"--browser-path", binary});
+    }
+    return builder.build();
+  }
+
 
   /**
    * Builder used to configure new {@link EdgeDriverService} instances.
@@ -253,11 +265,11 @@ public class EdgeDriverService extends DriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       return findExecutable(
         "msedgedriver", EDGE_DRIVER_EXE_PROPERTY,
         "https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/",
-        "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/");
+        "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/", seleniumManagerArgs);
     }
 
     @Override
@@ -309,9 +321,10 @@ public class EdgeDriverService extends DriverService {
         int port,
         Duration timeout,
         List<String> args,
-        Map<String, String> environment) {
+        Map<String, String> environment,
+        List<String> seleniumManagerArgs) {
       try {
-        return new EdgeDriverService(exe, port, timeout, args, environment);
+        return new EdgeDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
       } catch (IOException e) {
         throw new WebDriverException(e);
       }

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -108,7 +108,7 @@ public class FirefoxDriver extends RemoteWebDriver
    * @see #FirefoxDriver(FirefoxDriverService, FirefoxOptions)
    */
   public FirefoxDriver(FirefoxOptions options) {
-    this(new FirefoxDriverCommandExecutor(GeckoDriverService.createDefaultService()), options);
+    this(new FirefoxDriverCommandExecutor(GeckoDriverService.createServiceWithConfig(options)), options);
   }
 
   /**

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriverService.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriverService.java
@@ -40,8 +40,9 @@ public abstract class FirefoxDriverService extends DriverService {
       int port,
       Duration timeout,
       List<String> args,
-      Map<String, String> environment) throws IOException {
-    super(executable, port, timeout, args, environment);
+      Map<String, String> environment,
+      List<String> seleniumManagerArgs) throws IOException {
+    super(executable, port, timeout, args, environment, seleniumManagerArgs);
   }
 
   public static abstract class Builder<DS extends FirefoxDriverService, B extends FirefoxDriverService.Builder<?, ?>>

--- a/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
+++ b/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
@@ -63,10 +63,11 @@ public class GeckoDriverService extends FirefoxDriverService {
       File executable,
       int port,
       List<String> args,
-      Map<String, String> environment) throws IOException {
+      Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, DEFAULT_TIMEOUT,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -82,10 +83,11 @@ public class GeckoDriverService extends FirefoxDriverService {
       int port,
       Duration timeout,
       List<String> args,
-      Map<String, String> environment) throws IOException {
+      Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, timeout,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -98,6 +100,15 @@ public class GeckoDriverService extends FirefoxDriverService {
    */
   public static GeckoDriverService createDefaultService() {
     return new Builder().build();
+  }
+
+  public static GeckoDriverService createServiceWithConfig(FirefoxOptions options) {
+    Builder builder = new Builder();
+    String binary = options.getBinary().getPath();
+    if (binary != null && !binary.isEmpty()) {
+      builder.withSeleniumManagerArgs(new String[]{"--browser-path", binary});
+    }
+    return builder.build();
   }
 
   /**
@@ -160,11 +171,11 @@ public class GeckoDriverService extends FirefoxDriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       return findExecutable(
         "geckodriver", GECKO_DRIVER_EXE_PROPERTY,
         "https://github.com/mozilla/geckodriver",
-        "https://github.com/mozilla/geckodriver/releases");
+        "https://github.com/mozilla/geckodriver/releases", seleniumManagerArgs);
     }
 
     @Override
@@ -197,9 +208,9 @@ public class GeckoDriverService extends FirefoxDriverService {
     protected GeckoDriverService createDriverService(File exe, int port,
                                                      Duration timeout,
                                                      List<String> args,
-                                                     Map<String, String> environment) {
+                                                     Map<String, String> environment, List<String> seleniumManagerArgs) {
       try {
-        GeckoDriverService service = new GeckoDriverService(exe, port, timeout, args, environment);
+        GeckoDriverService service = new GeckoDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
         String firefoxLogFile = System.getProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE);
         if (firefoxLogFile != null) { // System property has higher precedence
           switch (firefoxLogFile) {

--- a/java/src/org/openqa/selenium/ie/InternetExplorerDriverService.java
+++ b/java/src/org/openqa/selenium/ie/InternetExplorerDriverService.java
@@ -81,10 +81,11 @@ public class InternetExplorerDriverService extends DriverService {
    * @throws IOException If an I/O error occurs.
    */
   private InternetExplorerDriverService(File executable, int port, Duration timeout, List<String> args,
-                                        Map<String, String> environment) throws IOException {
+                                        Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, timeout,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   /**
@@ -171,10 +172,10 @@ public class InternetExplorerDriverService extends DriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       return findExecutable("IEDriverServer", IE_DRIVER_EXE_PROPERTY,
                             "https://www.selenium.dev/documentation/ie_driver_server/",
-                            "https://www.selenium.dev/downloads/");
+                            "https://www.selenium.dev/downloads/", seleniumManagerArgs);
     }
 
     @Override
@@ -235,9 +236,10 @@ public class InternetExplorerDriverService extends DriverService {
     protected InternetExplorerDriverService createDriverService(File exe, int port,
                                                                 Duration timeout,
                                                                 List<String> args,
-                                                                Map<String, String> environment) {
+                                                                Map<String, String> environment,
+                                                                List<String> seleniumManagerArgs) {
       try {
-        return new InternetExplorerDriverService(exe, port, timeout, args, environment);
+        return new InternetExplorerDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
       } catch (IOException e) {
         throw new WebDriverException(e);
       }

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -29,7 +29,9 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Logger;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -153,7 +155,7 @@ public class SeleniumManager {
      * @param driverName which driver the service needs.
      * @return the location of the driver.
      */
-    public String getDriverPath(String driverName) {
+    public String getDriverPath(String driverName, List<String> arguments) {
         if (!ImmutableList.of("geckodriver", "chromedriver", "msedgedriver", "IEDriverServer").contains(driverName)) {
             throw new WebDriverException("Unable to locate driver with name: " + driverName);
         }
@@ -161,8 +163,10 @@ public class SeleniumManager {
         String driverPath = null;
         File binaryFile = getBinary();
         if (binaryFile != null) {
-            driverPath = runCommand(binaryFile.getAbsolutePath(),
-                    "--driver", driverName.replaceAll(EXE, ""));
+            arguments.add(0, binaryFile.getAbsolutePath());
+            arguments.add("--driver");
+            arguments.add(driverName.replaceAll(EXE, ""));
+            driverPath = runCommand(arguments.toArray(new String[0]));
         }
         return driverPath;
     }

--- a/java/src/org/openqa/selenium/safari/SafariDriverService.java
+++ b/java/src/org/openqa/selenium/safari/SafariDriverService.java
@@ -54,10 +54,11 @@ public class SafariDriverService extends DriverService {
     File executable,
     int port,
     List<String> args,
-    Map<String, String> environment) throws IOException {
+    Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, DEFAULT_TIMEOUT,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   public SafariDriverService(
@@ -65,10 +66,11 @@ public class SafariDriverService extends DriverService {
     int port,
     Duration timeout,
     List<String> args,
-    Map<String, String> environment) throws IOException {
+    Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, timeout,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   public static SafariDriverService createDefaultService() {
@@ -100,7 +102,7 @@ public class SafariDriverService extends DriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       File exe;
       if (System.getProperty(SAFARI_DRIVER_EXE_PROPERTY) != null) {
         exe = new File(System.getProperty(SAFARI_DRIVER_EXE_PROPERTY));
@@ -147,9 +149,9 @@ public class SafariDriverService extends DriverService {
         int port,
         Duration timeout,
         List<String> args,
-        Map<String, String> environment) {
+        Map<String, String> environment, List<String> seleniumManagerArgs) {
       try {
-        return new SafariDriverService(exe, port, timeout, args, environment);
+        return new SafariDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
       } catch (IOException e) {
         throw new WebDriverException(e);
       }

--- a/java/src/org/openqa/selenium/safari/SafariTechPreviewDriverService.java
+++ b/java/src/org/openqa/selenium/safari/SafariTechPreviewDriverService.java
@@ -53,10 +53,11 @@ public class SafariTechPreviewDriverService extends DriverService {
     File executable,
     int port,
     List<String> args,
-    Map<String, String> environment) throws IOException {
+    Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, DEFAULT_TIMEOUT,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   public SafariTechPreviewDriverService(
@@ -64,10 +65,11 @@ public class SafariTechPreviewDriverService extends DriverService {
     int port,
     Duration timeout,
     List<String> args,
-    Map<String, String> environment) throws IOException {
+    Map<String, String> environment, List<String> seleniumManagerArgs) throws IOException {
     super(executable, port, timeout,
       unmodifiableList(new ArrayList<>(args)),
-      unmodifiableMap(new HashMap<>(environment)));
+      unmodifiableMap(new HashMap<>(environment)),
+      unmodifiableList(new ArrayList<>(seleniumManagerArgs)));
   }
 
   public static SafariTechPreviewDriverService createDefaultService() {
@@ -99,7 +101,7 @@ public class SafariTechPreviewDriverService extends DriverService {
     }
 
     @Override
-    protected File findDefaultExecutable() {
+    protected File findDefaultExecutable(List<String> seleniumManagerArgs) {
       File exe;
       if (System.getProperty(TP_SAFARI_DRIVER_EXE_PROPERTY) != null) {
         exe = new File(System.getProperty(TP_SAFARI_DRIVER_EXE_PROPERTY));
@@ -125,9 +127,9 @@ public class SafariTechPreviewDriverService extends DriverService {
       int port,
       Duration timeout,
       List<String> args,
-      Map<String, String> environment) {
+      Map<String, String> environment, List<String> seleniumManagerArgs) {
       try {
-        return new SafariTechPreviewDriverService(exe, port, timeout, args, environment);
+        return new SafariTechPreviewDriverService(exe, port, timeout, args, environment, seleniumManagerArgs);
       } catch (IOException e) {
         throw new WebDriverException(e);
       }

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverServiceTest.java
@@ -46,11 +46,11 @@ class ChromeDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 
   // Alternate behavior is throwing an error, but have to at least be consistent
@@ -63,19 +63,19 @@ class ChromeDriverServiceTest {
 
     List<String> silentLast = Arrays.asList("--port=1", "--log-level=OFF");
     builderMock.withLogLevel(ChromiumDriverLogLevel.ALL).usingPort(1).withSilent(true).build();
-    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(silentLast), any());
+    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(silentLast), any(), any());
 
     List<String> silentFirst = Arrays.asList("--port=1", "--log-level=DEBUG");
     builderMock.withSilent(true).withLogLevel(ChromiumDriverLogLevel.DEBUG).usingPort(1).build();
-    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(silentFirst), any());
+    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(silentFirst), any(), any());
 
     List<String> verboseLast = Arrays.asList("--port=1", "--log-level=ALL");
     builderMock.withLogLevel(ChromiumDriverLogLevel.OFF).usingPort(1).withVerbose(true).build();
-    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(verboseLast), any());
+    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(verboseLast), any(), any());
 
     List<String> verboseFirst = Arrays.asList("--port=1", "--log-level=INFO");
     builderMock.withVerbose(true).withLogLevel(ChromiumDriverLogLevel.INFO).usingPort(1).build();
-    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(verboseFirst), any());
+    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(verboseFirst), any(), any());
   }
 
   // Setting these to false makes no sense; we're just going to ignore it.
@@ -88,6 +88,6 @@ class ChromeDriverServiceTest {
 
     List<String> falseSilent = Arrays.asList("--port=1", "--log-level=DEBUG");
     builderMock.withLogLevel(ChromiumDriverLogLevel.DEBUG).usingPort(1).withSilent(false).build();
-    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(falseSilent), any());
+    verify(builderMock).createDriverService(any(), anyInt(), any(), eq(falseSilent), any(), any());
   }
 }

--- a/java/test/org/openqa/selenium/edge/EdgeDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverServiceTest.java
@@ -44,11 +44,11 @@ class EdgeDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 
   @Test

--- a/java/test/org/openqa/selenium/firefox/GeckoDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/firefox/GeckoDriverServiceTest.java
@@ -43,10 +43,10 @@ class GeckoDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 }

--- a/java/test/org/openqa/selenium/ie/InternetExplorerDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/ie/InternetExplorerDriverServiceTest.java
@@ -44,10 +44,10 @@ class InternetExplorerDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 }

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverBuilderTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverBuilderTest.java
@@ -467,7 +467,7 @@ class RemoteWebDriverBuilderTest {
     private boolean started;
 
     FakeDriverService() throws IOException {
-      super(new File("."), 0, DEFAULT_TIMEOUT, null, null);
+      super(new File("."), 0, DEFAULT_TIMEOUT, null, null, null);
     }
 
     @Override

--- a/java/test/org/openqa/selenium/safari/SafariDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/safari/SafariDriverServiceTest.java
@@ -43,11 +43,11 @@ class SafariDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 
   public static class MockSafariDriverServiceBuilder extends SafariDriverService.Builder {

--- a/java/test/org/openqa/selenium/safari/SafariTechPreviewDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/safari/SafariTechPreviewDriverServiceTest.java
@@ -44,11 +44,11 @@ class SafariTechPreviewDriverServiceTest {
     doReturn(exe).when(builderMock).findDefaultExecutable();
     builderMock.build();
 
-    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any(), any());
 
     builderMock.withTimeout(customTimeout);
     builderMock.build();
-    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
+    verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any(), any());
   }
 
   public static class MockSafariTechPreviewDriverServiceBuilder


### PR DESCRIPTION
### Description
This PR updates the Java binding to reuse the browser binary path from options (e.g. `ChromeOptions`) to call Selenium Manager using the flag `--browser-path`.

### Motivation and Context
This PR is the Java implementation of #11351.

NOTE: To test this feature, the Selenium Manager binary (located in `common\manager` should be updated).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
