### PR TITLE
Undo a bug fix that caused a worse bug.

### DIFF
--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -74,7 +74,7 @@ class ChromiumDriver(RemoteWebDriver):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        if keep_alive != DEFAULT_KEEP_ALIVE and isinstance(self, __class__):
+        if keep_alive != DEFAULT_KEEP_ALIVE and type(self) == __class__:
             warnings.warn(
                 "keep_alive has been deprecated, please pass in a Service object", DeprecationWarning, stacklevel=2
             )


### PR DESCRIPTION
### Undo a bug fix that caused a worse bug.

Do to https://github.com/SeleniumHQ/selenium/commit/3f6717df6407180f8fae81a85702e7eec5a81093#diff-10fa59c3fd96a0c31762373ca8d7373c0ab669a437ae957b1a17ea1377b20608 a worse bug was allowed to appear that caused deprecation warnings for everyone using ``selenium`` ``4.8.1`` with unittest / pytest. ``DeprecationWarning: keep_alive has been deprecated, please pass in a Service object``, even if not setting ``keep_alive``.

This temporary fix will allow the Selenium Team more time to deal with the proper fix for both bugs. (Caused by duplicate calls in Chrome / Chromium ``__init__()`` methods.

--------

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.

