### PR TITLE
Fix NPE regression in 4.8.0

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
+++ b/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
@@ -57,6 +57,9 @@ public class SessionCapabilitiesMutator implements Function<Capabilities, Capabi
     }
 
     String browserName = capabilities.getBrowserName().toLowerCase();
+    if (!BROWSER_OPTIONS.containsKey(browserName)) {
+      return capabilities;
+    }
     String options = BROWSER_OPTIONS.get(browserName);
     if (slotStereotype.asMap().containsKey(options) && capabilities.asMap().containsKey(options)) {
 

--- a/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
@@ -289,4 +289,19 @@ public class SessionCapabilitiesMutatorTest {
     assertThat(modifiedCapabilities.get("unhandledPromptBehavior")).isEqualTo("accept");
     assertThat(modifiedCapabilities.get("pageLoadStrategy")).isEqualTo("normal");
   }
+
+  @Test
+  void shouldAllowUnknownBrowserNames() {
+    stereotype = new ImmutableCapabilities(
+            "browserName", "safari");
+
+    sessionCapabilitiesMutator = new SessionCapabilitiesMutator(stereotype);
+
+    capabilities = new ImmutableCapabilities(
+            "browserName", "safari");
+
+    Map<String, Object> modifiedCapabilities = sessionCapabilitiesMutator.apply(capabilities).asMap();
+
+    assertThat(modifiedCapabilities.get("browserName")).isEqualTo("safari");
+  }
 }


### PR DESCRIPTION
Selenium 4.8.0 introduced a NullPointerException when a node is started with a browserName not in [chrome, firefox, microsoftedge]

### Motivation and Context
We use a custom selenium node to run tests in a Safari browser, but when upgrading to 4.8.0 we could no longer start the node due to this NullPointerException.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
