### PR TITLE
[CI] Mirror api.github.com using scheduled job (part of #11672)

### DIFF
--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -3,6 +3,7 @@ name: mirror
 on:
   schedule:
     - cron:  '0 */12 * * *'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -22,9 +22,7 @@ jobs:
       run: |
         export CHANGES=$(git status -s)
         if [ -n "$CHANGES" ]; then
-           git config --local user.email "boni.garcia@uc3m.es"
-           git config --local user.name "Boni Garcia"
-           git add *
+           git add common/mirror/selenium
            git commit -m "Update mirror info" -a
            echo "::set-output name=commit::true"
         fi

--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -23,6 +23,8 @@ jobs:
       run: |
         export CHANGES=$(git status -s)
         if [ -n "$CHANGES" ]; then
+           git config --local user.email "github-actions[bot]@users.noreply.github.com"
+           git config --local user.name "github-actions[bot]"
            git add common/mirror/selenium
            git commit -m "Update mirror info" -a
            echo "::set-output name=commit::true"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,36 @@
+name: mirror
+
+on:
+  schedule:
+    - cron:  '0 */12 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Read api.github.com and filter response
+      run: |
+        cd common/mirror
+        export JQ_FILTER="[.[] | {tag_name: .tag_name, assets: [.assets[] | {browser_download_url: .browser_download_url} ] } ]"
+        curl -H "Authorization: ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/SeleniumHQ/selenium/releases | jq "$JQ_FILTER" > selenium
+    - name: Commit files
+      id: git
+      run: |
+        export CHANGES=$(git status -s)
+        if [ -n "$CHANGES" ]; then
+           git config --local user.email "boni.garcia@uc3m.es"
+           git config --local user.name "Boni Garcia"
+           git add *
+           git commit -m "Update mirror info" -a
+           echo "::set-output name=commit::true"
+        fi
+    - name: Push changes
+      if: steps.git.outputs.commit == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}


### PR DESCRIPTION
### Description
This PR includes a new job in CI for mirroring and filtering the responses of api.github.com for discovering the Selenium releases programmatically. The mirror is required to avoid the error HTTP 403 get requesting the GH API. This error is well known from WebDriverManager (see [job](https://github.com/bonigarcia/webdrivermanager/blob/master/.github/workflows/mirror.yml)).

### Motivation and Context
This PR is the first step for implementing #11672. The second step is to implement the Rust code to read the resulting mirror.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
