### PR TITLE
Remove newline to enable hyperlink in VS Code

### DIFF
--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -31,8 +31,7 @@ class WebDriver(ChromiumDriver):
     """Controls the Microsoft Edge driver and allows you to drive the browser.
 
     You will need to download the MSEdgeDriver (Chromium) executable
-    from https://developer.microsoft.com/en-us/microsoft-
-    edge/tools/webdriver/
+    from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
     """
 
     def __init__(


### PR DESCRIPTION
### Description

When inspecting/hovering over the Edge class in VS Code, the link for the MSEdgedriver executable does not correctly display as a hyperlink, as seen in the picture below.

![Hyperlink_fail](https://user-images.githubusercontent.com/124664589/222082874-339dc650-9d86-481a-9ce6-656e8467e601.png)

Removing the newline here should fix the problem.

I only have the Python VS code extenstion is installed.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
