### PR TITLE
[rust] Use static linking using cross-compiling to target x86_64-unknown-linux-musl in GH Actions

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -38,6 +38,9 @@ jobs:
         run: |
           rustup update
           rustc -vV
+      - name: "Install zig"
+        run: |
+          sudo snap install zig --beta --classic
       - name: "Build release"
         run: |
           cd rust

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -30,7 +30,7 @@ jobs:
     name: "[Linux] Build selenium-manager"
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-Ctarget-feature=-crt-static -Clink-args=-Wl,--copy-dt-needed-entries'
+      RUSTFLAGS: '-Ctarget-feature=-crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -41,8 +41,9 @@ jobs:
       - name: "Build release"
         run: |
           cd rust
+          cargo install cargo-zigbuild
           rustup target add x86_64-unknown-linux-musl
-          cargo build --release --target x86_64-unknown-linux-musl
+          cargo zigbuild --release --target x86_64-unknown-linux-musl
       - name: "Tar binary (to keep executable permission)"
         run: |
           cd rust/target/x86_64-unknown-linux-musl/release

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -30,7 +30,7 @@ jobs:
     name: "[Linux] Build selenium-manager"
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static'
+      RUSTFLAGS: '-Ctarget-feature=+crt-static  -Clink-args=-Wl,--copy-dt-needed-entries'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
       - name: "Build release"
         run: |
           cd rust
-          cargo install cargo-zigbuild
+          pip3 install ziglang
           rustup target add x86_64-unknown-linux-musl
           cargo zigbuild --release --target x86_64-unknown-linux-musl
       - name: "Tar binary (to keep executable permission)"
@@ -59,7 +59,7 @@ jobs:
     name: "[macOS] Build selenium-manager"
     runs-on: macos-latest
     env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static -Clink-args=-Wl,--copy-dt-needed-entries'
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -30,7 +30,7 @@ jobs:
     name: "[Linux] Build selenium-manager"
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static  -Clink-args=-Wl,--copy-dt-needed-entries'
+      RUSTFLAGS: '-Ctarget-feature=-crt-static -Clink-args=-Wl,--copy-dt-needed-entries'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -7,7 +7,7 @@ jobs:
     name: "[Windows] Build selenium-manager"
     runs-on: windows-latest
     env:
-      RUSTFLAGS: '-C target-feature=+crt-static'
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
     name: "[Linux] Build selenium-manager"
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-C target-feature=+crt-static'
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3
@@ -41,10 +41,12 @@ jobs:
       - name: "Build release"
         run: |
           cd rust
-          cargo build --release --target x86_64-unknown-linux-gnu
+          cargo install cargo-zigbuild
+          rustup target add x86_64-unknown-linux-musl
+          cargo zigbuild --release --target x86_64-unknown-linux-musl
       - name: "Tar binary (to keep executable permission)"
         run: |
-          cd rust/target/x86_64-unknown-linux-gnu/release
+          cd rust/target/x86_64-unknown-linux-musl/release
           tar -cvf ../../../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
@@ -57,7 +59,7 @@ jobs:
     name: "[macOS] Build selenium-manager"
     runs-on: macos-latest
     env:
-      RUSTFLAGS: '-C target-feature=+crt-static'
+      RUSTFLAGS: '-Ctarget-feature=+crt-static -Clink-args=-Wl,--copy-dt-needed-entries'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v3

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -41,9 +41,8 @@ jobs:
       - name: "Build release"
         run: |
           cd rust
-          pip3 install ziglang
           rustup target add x86_64-unknown-linux-musl
-          cargo zigbuild --release --target x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl
       - name: "Tar binary (to keep executable permission)"
         run: |
           cd rust/target/x86_64-unknown-linux-musl/release

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,3 +39,4 @@ lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
 panic = 'abort'     # Abort on panic
 strip = true        # Strip symbols from binary*
+debug = true        # Include debugging symbols

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,4 +39,3 @@ lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
 panic = 'abort'     # Abort on panic
 strip = true        # Strip symbols from binary*
-debug = true        # Include debugging symbols


### PR DESCRIPTION
### Description
This PR changes the default cargo target on GH Actions for Linux, from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl`. This target should ensure static linking in selenium-manager binaries for Linux. Cross-compiling in GH Actions is done through [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild).

### Motivation and Context
This PR should prevent issues like #11717.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
