### PR TITLE
[rust] Filter multiple driver occurence from PATH in selenium-manager (#11745)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "975cfe0afdf301c11891272a6f298d0691c00bec625e20980b79749ecec15077",
+  "checksum": "303005c11a6cb82610d545a5a937804a4eb1cba785cd4106762cbefdfe44bb0e",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -231,11 +231,11 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.93",
+              "id": "serde_json 1.0.94",
               "target": "serde_json"
             }
           ],
@@ -359,7 +359,7 @@
               "target": "event_listener"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             }
           ],
@@ -370,13 +370,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-trait 0.1.64": {
+    "async-trait 0.1.66": {
       "name": "async-trait",
-      "version": "0.1.64",
+      "version": "0.1.66",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-trait/0.1.64/download",
-          "sha256": "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+          "url": "https://crates.io/api/v1/crates/async-trait/0.1.66/download",
+          "sha256": "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
         }
       },
       "targets": [
@@ -413,15 +413,15 @@
         "deps": {
           "common": [
             {
-              "id": "async-trait 0.1.64",
+              "id": "async-trait 0.1.66",
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -432,7 +432,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.64"
+        "version": "0.1.66"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -617,13 +617,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "block-buffer 0.10.3": {
+    "block-buffer 0.10.4": {
       "name": "block-buffer",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.3/download",
-          "sha256": "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.4/download",
+          "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
         }
       },
       "targets": [
@@ -655,7 +655,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.3"
+        "version": "0.10.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -708,7 +708,7 @@
               "target": "regex_automata"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             }
           ],
@@ -864,7 +864,7 @@
               "target": "bzip2_sys"
             },
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             }
           ],
@@ -922,7 +922,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             }
           ],
@@ -1270,11 +1270,11 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -1443,19 +1443,19 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -1708,7 +1708,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.64",
+              "id": "async-trait 0.1.66",
               "target": "async_trait"
             }
           ],
@@ -1824,7 +1824,7 @@
         "deps": {
           "common": [
             {
-              "id": "block-buffer 0.10.3",
+              "id": "block-buffer 0.10.4",
               "target": "block_buffer"
             },
             {
@@ -1924,7 +1924,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -2186,19 +2186,19 @@
             ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -2262,7 +2262,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             }
           ],
@@ -2441,7 +2441,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -2595,13 +2595,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures 0.3.26": {
+    "futures 0.3.27": {
       "name": "futures",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures/0.3.26/download",
-          "sha256": "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+          "url": "https://crates.io/api/v1/crates/futures/0.3.27/download",
+          "sha256": "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
         }
       },
       "targets": [
@@ -2634,48 +2634,48 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.26",
+              "id": "futures-channel 0.3.27",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-executor 0.3.26",
+              "id": "futures-executor 0.3.27",
               "target": "futures_executor"
             },
             {
-              "id": "futures-io 0.3.26",
+              "id": "futures-io 0.3.27",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.26",
+              "id": "futures-sink 0.3.27",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.26",
+              "id": "futures-task 0.3.27",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-channel 0.3.26": {
+    "futures-channel 0.3.27": {
       "name": "futures-channel",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.26/download",
-          "sha256": "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.27/download",
+          "sha256": "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
         }
       },
       "targets": [
@@ -2719,22 +2719,22 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.26",
+              "id": "futures-channel 0.3.27",
               "target": "build_script_build"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.26",
+              "id": "futures-sink 0.3.27",
               "target": "futures_sink"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2743,13 +2743,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-core 0.3.26": {
+    "futures-core 0.3.27": {
       "name": "futures-core",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-core/0.3.26/download",
-          "sha256": "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+          "url": "https://crates.io/api/v1/crates/futures-core/0.3.27/download",
+          "sha256": "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
         }
       },
       "targets": [
@@ -2791,14 +2791,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2807,13 +2807,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-executor 0.3.26": {
+    "futures-executor 0.3.27": {
       "name": "futures-executor",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.26/download",
-          "sha256": "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.27/download",
+          "sha256": "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
         }
       },
       "targets": [
@@ -2841,32 +2841,32 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-task 0.3.26",
+              "id": "futures-task 0.3.27",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-io 0.3.26": {
+    "futures-io 0.3.27": {
       "name": "futures-io",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-io/0.3.26/download",
-          "sha256": "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+          "url": "https://crates.io/api/v1/crates/futures-io/0.3.27/download",
+          "sha256": "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
         }
       },
       "targets": [
@@ -2893,7 +2893,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2942,11 +2942,11 @@
               "target": "fastrand"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.26",
+              "id": "futures-io 0.3.27",
               "target": "futures_io"
             },
             {
@@ -2973,13 +2973,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "futures-macro 0.3.26": {
+    "futures-macro 0.3.27": {
       "name": "futures-macro",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.26/download",
-          "sha256": "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.27/download",
+          "sha256": "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
         }
       },
       "targets": [
@@ -3004,11 +3004,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -3019,17 +3019,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-sink 0.3.26": {
+    "futures-sink 0.3.27": {
       "name": "futures-sink",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.26/download",
-          "sha256": "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.27/download",
+          "sha256": "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
         }
       },
       "targets": [
@@ -3057,17 +3057,17 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-task 0.3.26": {
+    "futures-task 0.3.27": {
       "name": "futures-task",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-task/0.3.26/download",
-          "sha256": "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+          "url": "https://crates.io/api/v1/crates/futures-task/0.3.27/download",
+          "sha256": "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
         }
       },
       "targets": [
@@ -3108,14 +3108,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-task 0.3.26",
+              "id": "futures-task 0.3.27",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3157,13 +3157,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "futures-util 0.3.26": {
+    "futures-util 0.3.27": {
       "name": "futures-util",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-util/0.3.26/download",
-          "sha256": "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+          "url": "https://crates.io/api/v1/crates/futures-util/0.3.27/download",
+          "sha256": "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
         }
       },
       "targets": [
@@ -3215,27 +3215,27 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.26",
+              "id": "futures-channel 0.3.27",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.26",
+              "id": "futures-io 0.3.27",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.26",
+              "id": "futures-sink 0.3.27",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.26",
+              "id": "futures-task 0.3.27",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "build_script_build"
             },
             {
@@ -3261,13 +3261,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "futures-macro 0.3.26",
+              "id": "futures-macro 0.3.27",
               "target": "futures_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.26"
+        "version": "0.3.27"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3414,7 +3414,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -3477,7 +3477,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -3527,15 +3527,15 @@
               "target": "fnv"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.26",
+              "id": "futures-sink 0.3.27",
               "target": "futures_sink"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "futures_util"
             },
             {
@@ -3676,7 +3676,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             }
           ],
@@ -3807,7 +3807,7 @@
               "target": "fnv"
             },
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             }
           ],
@@ -3951,11 +3951,11 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.93",
+              "id": "serde_json 1.0.94",
               "target": "serde_json"
             },
             {
@@ -4112,13 +4112,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "hyper 0.14.24": {
+    "hyper 0.14.25": {
       "name": "hyper",
-      "version": "0.14.24",
+      "version": "0.14.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.24/download",
-          "sha256": "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+          "url": "https://crates.io/api/v1/crates/hyper/0.14.25/download",
+          "sha256": "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
         }
       },
       "targets": [
@@ -4160,15 +4160,15 @@
               "target": "bytes"
             },
             {
-              "id": "futures-channel 0.3.26",
+              "id": "futures-channel 0.3.27",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "futures_util"
             },
             {
@@ -4192,7 +4192,7 @@
               "target": "httpdate"
             },
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             },
             {
@@ -4200,7 +4200,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "socket2 0.4.7",
+              "id": "socket2 0.4.9",
               "target": "socket2"
             },
             {
@@ -4223,7 +4223,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.24"
+        "version": "0.14.25"
       },
       "license": "MIT"
     },
@@ -4262,7 +4262,7 @@
               "target": "http"
             },
             {
-              "id": "hyper 0.14.24",
+              "id": "hyper 0.14.25",
               "target": "hyper"
             },
             {
@@ -4316,7 +4316,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-bidi 0.3.10",
+              "id": "unicode-bidi 0.3.11",
               "target": "unicode_bidi"
             },
             {
@@ -4529,13 +4529,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "io-lifetimes 1.0.5": {
+    "io-lifetimes 1.0.6": {
       "name": "io-lifetimes",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/io-lifetimes/1.0.5/download",
-          "sha256": "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+          "url": "https://crates.io/api/v1/crates/io-lifetimes/1.0.6/download",
+          "sha256": "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
         }
       },
       "targets": [
@@ -4578,14 +4578,14 @@
         "deps": {
           "common": [
             {
-              "id": "io-lifetimes 1.0.5",
+              "id": "io-lifetimes 1.0.6",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -4598,7 +4598,7 @@
           }
         },
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.0.6"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4674,14 +4674,14 @@
         "deps": {
           "common": [
             {
-              "id": "io-lifetimes 1.0.5",
+              "id": "io-lifetimes 1.0.6",
               "target": "io_lifetimes"
             }
           ],
           "selects": {
             "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
               {
-                "id": "rustix 0.36.8",
+                "id": "rustix 0.36.9",
                 "target": "rustix"
               }
             ],
@@ -4703,6 +4703,50 @@
         "version": "0.4.4"
       },
       "license": "MIT"
+    },
+    "is_executable 1.0.1": {
+      "name": "is_executable",
+      "version": "1.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/is_executable/1.0.1/download",
+          "sha256": "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "is_executable",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "is_executable",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "1.0.1"
+      },
+      "license": "Apache-2.0/MIT"
     },
     "itertools 0.10.5": {
       "name": "itertools",
@@ -4751,13 +4795,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "itoa 1.0.5": {
+    "itoa 1.0.6": {
       "name": "itoa",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itoa/1.0.5/download",
-          "sha256": "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+          "url": "https://crates.io/api/v1/crates/itoa/1.0.6/download",
+          "sha256": "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
         }
       },
       "targets": [
@@ -4780,7 +4824,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.0.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4817,7 +4861,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -4870,13 +4914,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.139": {
+    "libc 0.2.140": {
       "name": "libc",
-      "version": "0.2.139",
+      "version": "0.2.140",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.139/download",
-          "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.140/download",
+          "sha256": "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
         }
       },
       "targets": [
@@ -4918,14 +4962,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.139"
+        "version": "0.2.140"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5224,7 +5268,7 @@
           "selects": {
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               },
               {
@@ -5234,7 +5278,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -5290,7 +5334,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -5913,11 +5957,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -6002,11 +6046,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             }
           ],
@@ -6031,13 +6075,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.51": {
+    "proc-macro2 1.0.52": {
       "name": "proc-macro2",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.51/download",
-          "sha256": "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.52/download",
+          "sha256": "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
         }
       },
       "targets": [
@@ -6078,18 +6122,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.6",
+              "id": "unicode-ident 1.0.8",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.51"
+        "version": "1.0.52"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6098,13 +6142,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.23": {
+    "quote 1.0.26": {
       "name": "quote",
-      "version": "1.0.23",
+      "version": "1.0.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.23/download",
-          "sha256": "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.26/download",
+          "sha256": "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
         }
       },
       "targets": [
@@ -6145,18 +6189,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.23"
+        "version": "1.0.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6228,7 +6272,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -6491,7 +6535,7 @@
               "target": "syscall"
             },
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.39",
               "target": "thiserror"
             }
           ],
@@ -6698,11 +6742,11 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.26",
+              "id": "futures-util 0.3.27",
               "target": "futures_util"
             },
             {
@@ -6710,7 +6754,7 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
@@ -6741,7 +6785,7 @@
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.24",
+                "id": "hyper 0.14.25",
                 "target": "hyper"
               },
               {
@@ -6799,7 +6843,7 @@
                 "target": "js_sys"
               },
               {
-                "id": "serde_json 1.0.93",
+                "id": "serde_json 1.0.94",
                 "target": "serde_json"
               },
               {
@@ -6933,7 +6977,7 @@
             ],
             "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               },
               {
@@ -7010,7 +7054,7 @@
         "deps": {
           "common": [
             {
-              "id": "futures 0.3.26",
+              "id": "futures 0.3.27",
               "target": "futures"
             },
             {
@@ -7084,11 +7128,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -7100,7 +7144,7 @@
               "target": "syn"
             },
             {
-              "id": "unicode-ident 1.0.6",
+              "id": "unicode-ident 1.0.8",
               "target": "unicode_ident"
             }
           ],
@@ -7156,7 +7200,7 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.16",
+              "id": "semver 1.0.17",
               "target": "semver"
             }
           ],
@@ -7167,13 +7211,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rustix 0.36.8": {
+    "rustix 0.36.9": {
       "name": "rustix",
-      "version": "0.36.8",
+      "version": "0.36.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustix/0.36.8/download",
-          "sha256": "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+          "url": "https://crates.io/api/v1/crates/rustix/0.36.9/download",
+          "sha256": "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
         }
       },
       "targets": [
@@ -7223,11 +7267,11 @@
               "target": "bitflags"
             },
             {
-              "id": "io-lifetimes 1.0.5",
+              "id": "io-lifetimes 1.0.6",
               "target": "io_lifetimes"
             },
             {
-              "id": "rustix 0.36.8",
+              "id": "rustix 0.36.9",
               "target": "build_script_build"
             }
           ],
@@ -7240,7 +7284,7 @@
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               },
               {
@@ -7255,7 +7299,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -7268,7 +7312,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.36.8"
+        "version": "0.36.9"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7401,13 +7445,13 @@
       },
       "license": "Apache-2.0 OR ISC OR MIT"
     },
-    "ryu 1.0.12": {
+    "ryu 1.0.13": {
       "name": "ryu",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ryu/1.0.12/download",
-          "sha256": "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+          "url": "https://crates.io/api/v1/crates/ryu/1.0.13/download",
+          "sha256": "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
         }
       },
       "targets": [
@@ -7430,7 +7474,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.12"
+        "version": "1.0.13"
       },
       "license": "Apache-2.0 OR BSL-1.0"
     },
@@ -7542,6 +7586,10 @@
               "target": "infer"
             },
             {
+              "id": "is_executable 1.0.1",
+              "target": "is_executable"
+            },
+            {
               "id": "log 0.4.17",
               "target": "log"
             },
@@ -7554,11 +7602,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.93",
+              "id": "serde_json 1.0.94",
               "target": "serde_json"
             },
             {
@@ -7602,13 +7650,13 @@
       },
       "license": "Apache-2.0"
     },
-    "semver 1.0.16": {
+    "semver 1.0.17": {
       "name": "semver",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/semver/1.0.16/download",
-          "sha256": "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+          "url": "https://crates.io/api/v1/crates/semver/1.0.17/download",
+          "sha256": "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
         }
       },
       "targets": [
@@ -7649,14 +7697,14 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.16",
+              "id": "semver 1.0.17",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.16"
+        "version": "1.0.17"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7665,13 +7713,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.152": {
+    "serde 1.0.156": {
       "name": "serde",
-      "version": "1.0.152",
+      "version": "1.0.156",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.152/download",
-          "sha256": "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.156/download",
+          "sha256": "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
         }
       },
       "targets": [
@@ -7715,7 +7763,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "build_script_build"
             }
           ],
@@ -7725,13 +7773,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.152",
+              "id": "serde_derive 1.0.156",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.152"
+        "version": "1.0.156"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7740,13 +7788,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.152": {
+    "serde_derive 1.0.156": {
       "name": "serde_derive",
-      "version": "1.0.152",
+      "version": "1.0.156",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.152/download",
-          "sha256": "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.156/download",
+          "sha256": "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
         }
       },
       "targets": [
@@ -7786,15 +7834,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.152",
+              "id": "serde_derive 1.0.156",
               "target": "build_script_build"
             },
             {
@@ -7805,7 +7853,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.152"
+        "version": "1.0.156"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7814,13 +7862,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.93": {
+    "serde_json 1.0.94": {
       "name": "serde_json",
-      "version": "1.0.93",
+      "version": "1.0.94",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.93/download",
-          "sha256": "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.94/download",
+          "sha256": "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
         }
       },
       "targets": [
@@ -7861,26 +7909,26 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.12",
+              "id": "ryu 1.0.13",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.93",
+              "id": "serde_json 1.0.94",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.93"
+        "version": "1.0.94"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7927,11 +7975,11 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.39",
               "target": "thiserror"
             }
           ],
@@ -7977,15 +8025,15 @@
               "target": "form_urlencoded"
             },
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.12",
+              "id": "ryu 1.0.13",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             }
           ],
@@ -8178,13 +8226,13 @@
       },
       "license": "MIT"
     },
-    "socket2 0.4.7": {
+    "socket2 0.4.9": {
       "name": "socket2",
-      "version": "0.4.7",
+      "version": "0.4.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/socket2/0.4.7/download",
-          "sha256": "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+          "url": "https://crates.io/api/v1/crates/socket2/0.4.9/download",
+          "sha256": "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
         }
       },
       "targets": [
@@ -8214,7 +8262,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -8227,7 +8275,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.4.7"
+        "version": "0.4.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8386,11 +8434,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -8398,7 +8446,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.6",
+              "id": "unicode-ident 1.0.8",
               "target": "unicode_ident"
             }
           ],
@@ -8456,7 +8504,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               },
               {
@@ -8513,7 +8561,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "rustix 0.36.8",
+                "id": "rustix 0.36.9",
                 "target": "rustix"
               }
             ],
@@ -8613,13 +8661,13 @@
       },
       "license": "MIT"
     },
-    "thiserror 1.0.38": {
+    "thiserror 1.0.39": {
       "name": "thiserror",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.38/download",
-          "sha256": "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+          "url": "https://crates.io/api/v1/crates/thiserror/1.0.39/download",
+          "sha256": "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
         }
       },
       "targets": [
@@ -8656,7 +8704,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.39",
               "target": "build_script_build"
             }
           ],
@@ -8666,13 +8714,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.38",
+              "id": "thiserror-impl 1.0.39",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.38"
+        "version": "1.0.39"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8681,13 +8729,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thiserror-impl 1.0.38": {
+    "thiserror-impl 1.0.39": {
       "name": "thiserror-impl",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.38/download",
-          "sha256": "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.39/download",
+          "sha256": "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
         }
       },
       "targets": [
@@ -8712,11 +8760,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -8727,7 +8775,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.38"
+        "version": "1.0.39"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8766,7 +8814,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
@@ -8988,13 +9036,13 @@
             ],
             "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
               {
-                "id": "socket2 0.4.7",
+                "id": "socket2 0.4.9",
                 "target": "socket2"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ],
@@ -9065,11 +9113,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -9179,11 +9227,11 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.26",
+              "id": "futures-core 0.3.27",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.26",
+              "id": "futures-sink 0.3.27",
               "target": "futures_sink"
             },
             {
@@ -9430,13 +9478,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-bidi 0.3.10": {
+    "unicode-bidi 0.3.11": {
       "name": "unicode-bidi",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-bidi/0.3.10/download",
-          "sha256": "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+          "url": "https://crates.io/api/v1/crates/unicode-bidi/0.3.11/download",
+          "sha256": "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
         }
       },
       "targets": [
@@ -9464,17 +9512,17 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.10"
+        "version": "0.3.11"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-ident 1.0.6": {
+    "unicode-ident 1.0.8": {
       "name": "unicode-ident",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.6/download",
-          "sha256": "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.8/download",
+          "sha256": "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
         }
       },
       "targets": [
@@ -9497,7 +9545,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.6"
+        "version": "1.0.8"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
     },
@@ -9627,7 +9675,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             }
           ],
@@ -9777,7 +9825,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.140",
                 "target": "libc"
               }
             ]
@@ -10064,11 +10112,11 @@
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -10178,7 +10226,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -10227,11 +10275,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.51",
+              "id": "proc-macro2 1.0.52",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -10785,73 +10833,73 @@
           "selects": {
             "aarch64-pc-windows-gnullvm": [
               {
-                "id": "windows_aarch64_gnullvm 0.42.1",
+                "id": "windows_aarch64_gnullvm 0.42.2",
                 "target": "windows_aarch64_gnullvm"
               }
             ],
             "aarch64-pc-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.1",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "aarch64-uwp-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.1",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "i686-pc-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.1",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.1",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "i686-uwp-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.1",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-uwp-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.1",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "x86_64-pc-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.1",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-pc-windows-gnullvm": [
               {
-                "id": "windows_x86_64_gnullvm 0.42.1",
+                "id": "windows_x86_64_gnullvm 0.42.2",
                 "target": "windows_x86_64_gnullvm"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.1",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ],
             "x86_64-uwp-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.1",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-uwp-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.1",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ]
@@ -10915,7 +10963,7 @@
           "selects": {
             "cfg(not(windows_raw_dylib))": [
               {
-                "id": "windows-targets 0.42.1",
+                "id": "windows-targets 0.42.2",
                 "target": "windows_targets"
               }
             ]
@@ -10926,13 +10974,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows-targets 0.42.1": {
+    "windows-targets 0.42.2": {
       "name": "windows-targets",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-targets/0.42.1/download",
-          "sha256": "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+          "url": "https://crates.io/api/v1/crates/windows-targets/0.42.2/download",
+          "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
         }
       },
       "targets": [
@@ -10959,90 +11007,90 @@
           "selects": {
             "aarch64-pc-windows-gnullvm": [
               {
-                "id": "windows_aarch64_gnullvm 0.42.1",
+                "id": "windows_aarch64_gnullvm 0.42.2",
                 "target": "windows_aarch64_gnullvm"
               }
             ],
             "aarch64-pc-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.1",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "aarch64-uwp-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.1",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "i686-pc-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.1",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.1",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "i686-uwp-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.1",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-uwp-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.1",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "x86_64-pc-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.1",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-pc-windows-gnullvm": [
               {
-                "id": "windows_x86_64_gnullvm 0.42.1",
+                "id": "windows_x86_64_gnullvm 0.42.2",
                 "target": "windows_x86_64_gnullvm"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.1",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ],
             "x86_64-uwp-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.1",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-uwp-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.1",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_aarch64_gnullvm 0.42.1": {
+    "windows_aarch64_gnullvm 0.42.2": {
       "name": "windows_aarch64_gnullvm",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.42.1/download",
-          "sha256": "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.42.2/download",
+          "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
         }
       },
       "targets": [
@@ -11079,14 +11127,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_gnullvm 0.42.1",
+              "id": "windows_aarch64_gnullvm 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11095,13 +11143,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_aarch64_msvc 0.42.1": {
+    "windows_aarch64_msvc 0.42.2": {
       "name": "windows_aarch64_msvc",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.42.1/download",
-          "sha256": "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.42.2/download",
+          "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
         }
       },
       "targets": [
@@ -11138,14 +11186,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_msvc 0.42.1",
+              "id": "windows_aarch64_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11154,13 +11202,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_i686_gnu 0.42.1": {
+    "windows_i686_gnu 0.42.2": {
       "name": "windows_i686_gnu",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.42.1/download",
-          "sha256": "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.42.2/download",
+          "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
         }
       },
       "targets": [
@@ -11197,14 +11245,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_gnu 0.42.1",
+              "id": "windows_i686_gnu 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11213,13 +11261,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_i686_msvc 0.42.1": {
+    "windows_i686_msvc 0.42.2": {
       "name": "windows_i686_msvc",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.42.1/download",
-          "sha256": "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.42.2/download",
+          "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
         }
       },
       "targets": [
@@ -11256,14 +11304,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_msvc 0.42.1",
+              "id": "windows_i686_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11272,13 +11320,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_gnu 0.42.1": {
+    "windows_x86_64_gnu 0.42.2": {
       "name": "windows_x86_64_gnu",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.42.1/download",
-          "sha256": "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.42.2/download",
+          "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
         }
       },
       "targets": [
@@ -11315,14 +11363,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnu 0.42.1",
+              "id": "windows_x86_64_gnu 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11331,13 +11379,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_gnullvm 0.42.1": {
+    "windows_x86_64_gnullvm 0.42.2": {
       "name": "windows_x86_64_gnullvm",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.42.1/download",
-          "sha256": "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.42.2/download",
+          "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
         }
       },
       "targets": [
@@ -11374,14 +11422,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnullvm 0.42.1",
+              "id": "windows_x86_64_gnullvm 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11390,13 +11438,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_msvc 0.42.1": {
+    "windows_x86_64_msvc 0.42.2": {
       "name": "windows_x86_64_msvc",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.42.1/download",
-          "sha256": "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.42.2/download",
+          "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
         }
       },
       "targets": [
@@ -11433,14 +11481,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_msvc 0.42.1",
+              "id": "windows_x86_64_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.1"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11555,7 +11603,7 @@
               "target": "deadpool"
             },
             {
-              "id": "futures 0.3.26",
+              "id": "futures 0.3.27",
               "target": "futures"
             },
             {
@@ -11567,7 +11615,7 @@
               "target": "http_types"
             },
             {
-              "id": "hyper 0.14.24",
+              "id": "hyper 0.14.25",
               "target": "hyper"
             },
             {
@@ -11583,11 +11631,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.156",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.93",
+              "id": "serde_json 1.0.94",
               "target": "serde_json"
             },
             {
@@ -11601,7 +11649,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.64",
+              "id": "async-trait 0.1.66",
               "target": "async_trait"
             }
           ],
@@ -11646,7 +11694,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             }
           ],
@@ -11857,7 +11905,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             },
             {
@@ -11929,7 +11977,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.140",
               "target": "libc"
             },
             {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -113,9 +113,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -491,15 +491,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -540,15 +540,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -558,9 +558,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -724,9 +724,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -832,6 +832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -866,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1058,18 +1067,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1261,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -1296,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "sct"
@@ -1321,6 +1330,7 @@ dependencies = [
  "exitcode",
  "flate2",
  "infer 0.13.0",
+ "is_executable",
  "log",
  "regex",
  "reqwest",
@@ -1336,24 +1346,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -1427,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -1505,18 +1515,18 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1648,15 +1658,15 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -1886,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1901,45 +1911,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ flate2 = "1.0.25"
 tar = "0.4.38"
 infer = "0.13.0"
 exitcode = "1.1.2"
+is_executable = "1.0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -24,7 +24,7 @@ use crate::{
     UNAME_COMMAND,
 };
 use std::env;
-use std::env::consts::{OS};
+use std::env::consts::OS;
 
 pub const ARM64_ARCH: &str = "arm64";
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,10 +25,11 @@ use std::fs;
 
 use crate::config::OS::WINDOWS;
 use crate::config::{str_to_os, ManagerConfig};
+use is_executable::IsExecutable;
 use reqwest::{Client, ClientBuilder, Proxy};
 use std::collections::HashMap;
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -76,6 +77,8 @@ pub const WHICH_COMMAND: &str = "which {}";
 pub const TTL_BROWSERS_SEC: u64 = 0;
 pub const TTL_DRIVERS_SEC: u64 = 86400;
 pub const UNAME_COMMAND: &str = "uname -{}";
+pub const CRLF: &str = "\r\n";
+pub const LF: &str = "\n";
 
 pub trait SeleniumManager {
     // ----------------------------------------------------------
@@ -253,7 +256,22 @@ pub trait SeleniumManager {
                         which_command,
                         self.get_driver_name(),
                     )) {
-                        Ok(path) => Some(path),
+                        Ok(path) => {
+                            let path_vector = split_lines(path.as_str());
+                            if path_vector.len() == 1 {
+                                Some(path_vector.first().unwrap().to_string())
+                            } else {
+                                let exec_paths: Vec<&str> = path_vector
+                                    .into_iter()
+                                    .filter(|p| Path::new(p).is_executable())
+                                    .collect();
+                                if exec_paths.is_empty() {
+                                    None
+                                } else {
+                                    Some(exec_paths.first().unwrap().to_string())
+                                }
+                            }
+                        }
                         Err(_) => None,
                     };
                     return (Some(parsed_version), driver_path);
@@ -517,8 +535,8 @@ pub fn http_client_builder() -> ClientBuilder {
 
 fn strip_trailing_newline(input: &str) -> &str {
     input
-        .strip_suffix("\r\n")
-        .or_else(|| input.strip_suffix('\n'))
+        .strip_suffix(CRLF)
+        .or_else(|| input.strip_suffix(LF))
         .unwrap_or(input)
 }
 
@@ -543,4 +561,12 @@ pub fn format_one_arg(string: &str, arg1: &str) -> String {
 
 pub fn format_two_args(string: &str, arg1: &str, arg2: &str) -> String {
     string.replacen("{}", arg1, 1).replacen("{}", arg2, 2)
+}
+
+fn split_lines(string: &str) -> Vec<&str> {
+    if string.contains(CRLF) {
+        string.split(CRLF).collect()
+    } else {
+        string.split(LF).collect()
+    }
 }


### PR DESCRIPTION
### Description
As reported in #11745, currently Selenium Manager returns several lines when chromedriver is installed through npm. This PR includes some logic to filter these lines by selecting only the first of the executables files (if available).

The following output has been generated in Windows and Linux respectively, in both cases with chromedriver installed with npm:

```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug
    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
     Running `target\debug\selenium-manager.exe --browser chrome --debug`
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: "wmic datafile where name='%PROGRAMFILES:\\=\\\\%\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=111.0.5563.65\r\r\n\r\r\n\r\r\n\r"
DEBUG   The version of chrome is 111.0.5563.65
DEBUG   Detected browser: chrome 111
DEBUG   Required driver: chromedriver 111.0.5563.64
DEBUG   Running command: "chromedriver --version"
DEBUG   Output: "ChromeDriver 111.0.5563.64 (c710e93d5b63b7095afe8c2c17df34408078439d-refs/branch-heads/5563@{#995})"
DEBUG   Running command: "where chromedriver"
DEBUG   Output: "C:\\Users\\boni\\AppData\\Roaming\\npm\\chromedriver\r\nC:\\Users\\boni\\AppData\\Roaming\\npm\\chromedriver.cmd"
DEBUG   Found chromedriver 111.0.5563.64 in PATH: C:\Users\boni\AppData\Roaming\npm\chromedriver.cmd
INFO    C:\Users\boni\AppData\Roaming\npm\chromedriver.cmd
```

NOTE: I also tested that chromedriver.cmd can be used as a driver in a Selenium test.

```
boni@slimbook:~/dev/selenium/rust$ cargo run -- --browser chrome --debug
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/selenium-manager --browser chrome --debug`
DEBUG	Using shell command to find out chrome version
DEBUG	Running command: "google-chrome --version"
DEBUG	Output: "Google Chrome 111.0.5563.64 "
DEBUG	The version of chrome is 111.0.5563.64
DEBUG	Detected browser: chrome 111
DEBUG	Reading chromedriver version from https://chromedriver.storage.googleapis.com/LATEST_RELEASE_111
DEBUG	Required driver: chromedriver 111.0.5563.64
DEBUG	Running command: "chromedriver --version"
DEBUG	Output: "ChromeDriver 111.0.5563.64 (c710e93d5b63b7095afe8c2c17df34408078439d-refs/branch-heads/5563@{#995})"
DEBUG	Running command: "which chromedriver"
DEBUG	Output: "/usr/local/bin/chromedriver"
DEBUG	Found chromedriver 111.0.5563.64 in PATH: /usr/local/bin/chromedriver
INFO	/usr/local/bin/chromedriver
```


### Motivation and Context
This PR fixes #11745.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
