### PR TITLE
[rust] Build selenium-manager for win32 (compatible when executed in win64)

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -3,8 +3,8 @@ name: build-selenium-manager
 on: workflow_dispatch
 
 jobs:
-  windows:
-    name: "[Windows] Build selenium-manager"
+  win64:
+    name: "[Windows x64] Build selenium-manager"
     runs-on: windows-latest
     env:
       RUSTFLAGS: '-Ctarget-feature=+crt-static'
@@ -26,8 +26,8 @@ jobs:
           path: rust/target/x86_64-pc-windows-msvc/release/selenium-manager.exe
           retention-days: 6
 
-  linux:
-    name: "[Linux] Build selenium-manager"
+  linux64:
+    name: "[Linux x64] Build selenium-manager"
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: '-Ctarget-feature=-crt-static'
@@ -58,8 +58,8 @@ jobs:
           path: selenium-manager.tar
           retention-days: 6
 
-  macos:
-    name: "[macOS] Build selenium-manager"
+  macos64:
+    name: "[macOS x64] Build selenium-manager"
     runs-on: macos-latest
     env:
       RUSTFLAGS: '-Ctarget-feature=+crt-static'
@@ -83,4 +83,29 @@ jobs:
         with:
           name: selenium-manager_macos-x64
           path: selenium-manager.tar
+          retention-days: 6
+
+  win32:
+    name: "[Windows x32] Build selenium-manager"
+    runs-on: windows-latest
+    env:
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
+    steps:
+      - name: "Checkout project"
+        uses: actions/checkout@v3
+      - name: "Update Rust"
+        run: |
+          rustup update
+          rustup toolchain install stable-i686-pc-windows-msvc
+          rustup default stable-i686-pc-windows-msvc
+          rustc -vV
+      - name: "Build release"
+        run: |
+          cd rust
+          cargo build --release
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-manager_windows-x32
+          path: rust/target/release/selenium-manager.exe
           retention-days: 6

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -3,8 +3,8 @@ name: build-selenium-manager
 on: workflow_dispatch
 
 jobs:
-  win64:
-    name: "[Windows x64] Build selenium-manager"
+  win32:
+    name: "[Windows x32] Build selenium-manager"
     runs-on: windows-latest
     env:
       RUSTFLAGS: '-Ctarget-feature=+crt-static'
@@ -14,16 +14,18 @@ jobs:
       - name: "Update Rust"
         run: |
           rustup update
+          rustup toolchain install stable-i686-pc-windows-msvc
+          rustup default stable-i686-pc-windows-msvc
           rustc -vV
       - name: "Build release"
         run: |
           cd rust
-          cargo build --release --target x86_64-pc-windows-msvc
+          cargo build --release
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:
-          name: selenium-manager_windows-x64
-          path: rust/target/x86_64-pc-windows-msvc/release/selenium-manager.exe
+          name: selenium-manager_windows-x32
+          path: rust/target/release/selenium-manager.exe
           retention-days: 6
 
   linux64:
@@ -83,29 +85,4 @@ jobs:
         with:
           name: selenium-manager_macos-x64
           path: selenium-manager.tar
-          retention-days: 6
-
-  win32:
-    name: "[Windows x32] Build selenium-manager"
-    runs-on: windows-latest
-    env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static'
-    steps:
-      - name: "Checkout project"
-        uses: actions/checkout@v3
-      - name: "Update Rust"
-        run: |
-          rustup update
-          rustup toolchain install stable-i686-pc-windows-msvc
-          rustup default stable-i686-pc-windows-msvc
-          rustc -vV
-      - name: "Build release"
-        run: |
-          cd rust
-          cargo build --release
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: selenium-manager_windows-x32
-          path: rust/target/release/selenium-manager.exe
           retention-days: 6

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -30,9 +30,9 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    create_http_client, format_one_arg, format_two_args, SeleniumManager, BETA, DASH_DASH_VERSION,
-    DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, FALLBACK_RETRIES, NIGHTLY,
-    REG_QUERY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    create_http_client, format_one_arg, format_three_args, SeleniumManager, BETA,
+    DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86,
+    FALLBACK_RETRIES, NIGHTLY, REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const CHROME_NAME: &str = "chrome";
@@ -126,9 +126,19 @@ impl SeleniumManager for ChromeManager {
                 Some(path) => {
                     browser_path = path;
                     commands = vec![
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES, browser_path),
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES_X86, browser_path),
-                        format_two_args(WMIC_COMMAND_ENV, ENV_LOCALAPPDATA, browser_path),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES,
+                            REMOVE_X86,
+                            browser_path,
+                        ),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES_X86,
+                            "",
+                            browser_path,
+                        ),
+                        format_three_args(WMIC_COMMAND_ENV, ENV_LOCALAPPDATA, "", browser_path),
                     ];
                     if !self.is_browser_version_unstable() {
                         commands.push(format_one_arg(

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -29,9 +29,9 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    create_http_client, format_one_arg, format_two_args, Logger, SeleniumManager, BETA,
+    create_http_client, format_one_arg, format_three_args, Logger, SeleniumManager, BETA,
     DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY,
-    REG_QUERY, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const EDGE_NAMES: &[&str] = &["edge", "msedge", "microsoftedge"];
@@ -126,9 +126,19 @@ impl SeleniumManager for EdgeManager {
                 Some(path) => {
                     browser_path = path;
                     commands = vec![
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES_X86, browser_path),
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES, browser_path),
-                        format_two_args(WMIC_COMMAND, ENV_LOCALAPPDATA, browser_path),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES_X86,
+                            "",
+                            browser_path,
+                        ),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES,
+                            REMOVE_X86,
+                            browser_path,
+                        ),
+                        format_three_args(WMIC_COMMAND, ENV_LOCALAPPDATA, "", browser_path),
                     ];
                     if !self.is_browser_version_unstable() {
                         commands.push(format_one_arg(

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -29,9 +29,9 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    create_http_client, format_one_arg, format_two_args, Logger, SeleniumManager, BETA,
-    DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY, STABLE, WMIC_COMMAND,
-    WMIC_COMMAND_ENV,
+    create_http_client, format_one_arg, format_three_args, Logger, SeleniumManager, BETA,
+    DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY, REMOVE_X86, STABLE,
+    WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const FIREFOX_NAME: &str = "firefox";
@@ -126,8 +126,18 @@ impl SeleniumManager for FirefoxManager {
                 Some(path) => {
                     browser_path = path;
                     commands = vec![
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES, browser_path),
-                        format_two_args(WMIC_COMMAND_ENV, ENV_PROGRAM_FILES_X86, browser_path),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES,
+                            REMOVE_X86,
+                            browser_path,
+                        ),
+                        format_three_args(
+                            WMIC_COMMAND_ENV,
+                            ENV_PROGRAM_FILES_X86,
+                            "",
+                            browser_path,
+                        ),
                     ];
                 }
                 _ => return None,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -61,7 +61,9 @@ pub const DEV: &str = "dev";
 pub const CANARY: &str = "canary";
 pub const NIGHTLY: &str = "nightly";
 pub const WMIC_COMMAND: &str = r#"wmic datafile where name='{}' get Version /value"#;
-pub const WMIC_COMMAND_ENV: &str = r#"wmic datafile where name='%{}:\=\\%{}' get Version /value"#;
+pub const WMIC_COMMAND_ENV: &str =
+    r#"set PFILES=%{}{}%&& wmic datafile where name='!PFILES:\=\\!{}' get Version /value"#;
+pub const WMIC_COMMAND_OS: &str = r#"wmic os get osarchitecture"#;
 pub const REG_QUERY: &str = r#"REG QUERY {} /v version"#;
 pub const PLIST_COMMAND: &str =
     r#"/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" {}/Contents/Info.plist"#;
@@ -70,6 +72,10 @@ pub const DASH_DASH_VERSION: &str = "{} --version";
 pub const ENV_PROGRAM_FILES: &str = "PROGRAMFILES";
 pub const ENV_PROGRAM_FILES_X86: &str = "PROGRAMFILES(X86)";
 pub const ENV_LOCALAPPDATA: &str = "LOCALAPPDATA";
+pub const REMOVE_X86: &str = ": (x86)=";
+pub const ARCH_X86: &str = "x86";
+pub const ARCH_AMD64: &str = "amd64";
+pub const ARCH_ARM64: &str = "arm64";
 pub const ENV_PROCESSOR_ARCHITECTURE: &str = "PROCESSOR_ARCHITECTURE";
 pub const FALLBACK_RETRIES: u32 = 5;
 pub const WHERE_COMMAND: &str = "where {}";
@@ -528,7 +534,7 @@ pub fn create_http_client(timeout: u64, proxy: String) -> Result<Client, String>
 
 pub fn run_shell_command(os: &str, command: String) -> Result<String, Box<dyn Error>> {
     let (shell, flag) = if WINDOWS.is(os) {
-        ("cmd", "/C")
+        ("cmd", "/v/c")
     } else {
         ("sh", "-c")
     };
@@ -545,8 +551,11 @@ pub fn format_one_arg(string: &str, arg1: &str) -> String {
     string.replacen("{}", arg1, 1)
 }
 
-pub fn format_two_args(string: &str, arg1: &str, arg2: &str) -> String {
-    string.replacen("{}", arg1, 1).replacen("{}", arg2, 2)
+pub fn format_three_args(string: &str, arg1: &str, arg2: &str, arg3: &str) -> String {
+    string
+        .replacen("{}", arg1, 1)
+        .replacen("{}", arg2, 1)
+        .replacen("{}", arg3, 1)
 }
 
 // ----------------------------------------------------------

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -155,12 +155,14 @@ pub fn write_metadata(metadata: &Metadata, log: &Logger) {
     .unwrap();
 }
 
-pub fn clear_metadata(log: &Logger){
+pub fn clear_metadata(log: &Logger) {
     let metadata_path = get_metadata_path();
-    log.trace(format!("Deleting metadata file {}", metadata_path.display()));
-    match fs::remove_file(metadata_path){
+    log.trace(format!(
+        "Deleting metadata file {}",
+        metadata_path.display()
+    ));
+    match fs::remove_file(metadata_path) {
         Ok(()) => log.trace("Metadata file was deleted".to_string()),
-        Err(err) => log.warn(
-            format!("Metadata file deleting invoked an error: {}",err)),
+        Err(err) => log.warn(format!("Metadata file deleting invoked an error: {}", err)),
     }
 }


### PR DESCRIPTION
### Description
This PR updated the workflow to build Selenium Manager in GH Actions, for building `selenium-manager` for Windows x32. An example execution can be see [here](https://github.com/SeleniumHQ/selenium/actions/runs/4446568310). I tested the resulting binary (e.g. [selenium-manager_windows-x32](https://github.com/SeleniumHQ/selenium/suites/11703832229/artifacts/608889643)) both in Windows x32 and x64. In both cases, it works as expected.

### Motivation and Context
This PR is part of #11599. Since the resulting binary is compatible with win32 and win64, it can be used to replace the selenium-manager binary for windows (in the folder `common/manager/windows`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
