### PR TITLE
[dotnet] Include targets for projects building transitively

### DIFF
--- a/dotnet/src/webdriver/WebDriver.nuspec
+++ b/dotnet/src/webdriver/WebDriver.nuspec
@@ -54,5 +54,6 @@
     <file src="..\icon.png" target="images" />
     <file src="..\manager\**" target="manager" />
     <file src="..\Selenium.WebDriver.targets" target="build" />
+    <file src="..\Selenium.WebDriver.targets" target="buildTransitive" />
   </files>
 </package>


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

<!--- Provide a general summary of your changes in the Title above -->
Selenium Manager binaries are copied to output if the package is consumed directly. What if we allow copying selenium manager to output even if it is referenced transitively?

### Description
Sometimes `Selenium.WebDriver` package is consumed transitively. Let's say `MyProject.Core` is dependent on selenium, when `MyProject.Tests` is dependent on `MyProject.Core`. Selenium Manager binaries are not copied to output when building `MyProject.Tests`.

### Motivation and Context
Avoiding headache for users, who create projects/packages on top of selenium.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

### Note
I verified, it works. But I didn't create a package. Nuget package should have `buildTransitive` folder with `*.targets` file inside.
