### PR TITLE
Add support for getting logs

### DIFF
--- a/dotnet/src/webdriver/Remote/W3CWireProtocolCommandInfoRepository.cs
+++ b/dotnet/src/webdriver/Remote/W3CWireProtocolCommandInfoRepository.cs
@@ -134,6 +134,8 @@ namespace OpenQA.Selenium.Remote
             this.TryAddCommand(DriverCommand.IsElementDisplayed, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/element/{id}/displayed"));
             this.TryAddCommand(DriverCommand.ElementEquals, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/element/{id}/equals/{other}"));
             this.TryAddCommand(DriverCommand.UploadFile, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/file"));
+            this.TryAddCommand(DriverCommand.GetLog, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log"));
+            this.TryAddCommand(DriverCommand.GetAvailableLogTypes, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log/types"));
         }
     }
 }


### PR DESCRIPTION
### Description
To have consistency with local drivers, add support for getting logs. Unfortunately I was not able to setup dev environment and test these changes locally. But seems to be infra is here.

### Motivation and Context

I was asked in the chat why this snippet does not working. And troubleshooting lead me here.
```
var chromeOptions = new ChromeOptions();
RemoteWebDriver driver = new RemoteWebDriver(new Uri("http://localhost:4444"), chromeOptions);
driver.Navigate().GoToUrl("https://stackoverflow.com/questions/5639473/using-selenium-remotewebdriver-in-c-sharp");
var logs = driver.Manage().Logs;
var av = logs.AvailableLogTypes; // empty
var browserLogs = logs.GetLog(LogType.Browser); // empty
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
