### PR TITLE
[rust] Save to directory

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -25,9 +25,11 @@ use crate::{
 };
 use std::env;
 use std::env::consts::OS;
+use std::path::PathBuf;
 
 pub const ARM64_ARCH: &str = "arm64";
 
+#[derive(Clone)]
 pub struct ManagerConfig {
     pub browser_version: String,
     pub driver_version: String,
@@ -38,7 +40,7 @@ pub struct ManagerConfig {
     pub timeout: u64,
     pub browser_ttl: u64,
     pub driver_ttl: u64,
-    pub custom_save_path: Option<String>,
+    pub custom_save_path: Option<PathBuf>,
 }
 
 impl ManagerConfig {
@@ -72,22 +74,6 @@ impl ManagerConfig {
             custom_save_path: None,
         }
     }
-
-    #[allow(clippy::should_implement_trait)]
-    pub fn clone(config: &ManagerConfig) -> ManagerConfig {
-        ManagerConfig {
-            browser_version: config.browser_version.as_str().to_string(),
-            driver_version: config.driver_version.as_str().to_string(),
-            os: config.os.as_str().to_string(),
-            arch: config.arch.as_str().to_string(),
-            browser_path: config.browser_path.as_str().to_string(),
-            proxy: config.proxy.as_str().to_string(),
-            timeout: config.timeout,
-            browser_ttl: config.browser_ttl,
-            driver_ttl: config.driver_ttl,
-            custom_save_path: config.custom_save_path
-        }
-    }
 }
 
 #[allow(dead_code)]
@@ -114,12 +100,11 @@ impl OS {
 }
 
 pub fn str_to_os(os: &str) -> OS {
-    if WINDOWS.is(os) {
-        WINDOWS
-    } else if MACOS.is(os) {
-        MACOS
-    } else {
-        LINUX
+    match os {
+        "windows" => WINDOWS,
+        "macos" => MACOS,
+        "linux" => LINUX,
+        _ => panic!("Unknown OS: {}", os),
     }
 }
 

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -38,6 +38,7 @@ pub struct ManagerConfig {
     pub timeout: u64,
     pub browser_ttl: u64,
     pub driver_ttl: u64,
+    pub custom_save_path: Option<String>,
 }
 
 impl ManagerConfig {
@@ -68,6 +69,7 @@ impl ManagerConfig {
             timeout: REQUEST_TIMEOUT_SEC,
             browser_ttl: TTL_BROWSERS_SEC,
             driver_ttl: TTL_DRIVERS_SEC,
+            custom_save_path: None,
         }
     }
 
@@ -83,6 +85,7 @@ impl ManagerConfig {
             timeout: config.timeout,
             browser_ttl: config.browser_ttl,
             driver_ttl: config.driver_ttl,
+            custom_save_path: config.custom_save_path
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -453,6 +453,12 @@ pub trait SeleniumManager {
         self.set_http_client(http_client);
         Ok(())
     }
+
+    fn set_save_path(&mut self, save_path: String) {
+        let mut config = ManagerConfig::clone(self.get_config());
+        config.custom_save_path = Some(save_path);
+        self.set_config(config);
+    }
 }
 
 // ----------------------------------------------------------

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -17,6 +17,7 @@
 
 use std::error::Error;
 
+use std::path::PathBuf;
 use std::process::exit;
 
 use clap::Parser;
@@ -98,6 +99,10 @@ struct Cli {
     /// Clear metadata file
     #[clap(long)]
     clear_metadata: bool,
+
+    /// Specifies a custom path to save the driver
+    #[clap(long, value_parser)]
+    save_path: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -137,6 +142,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     selenium_manager.set_browser_version(cli.browser_version.unwrap_or_default());
     selenium_manager.set_driver_version(cli.driver_version.unwrap_or_default());
     selenium_manager.set_browser_path(cli.browser_path.unwrap_or_default());
+    selenium_manager.set_save_path(cli.save_path.map(PathBuf::from));
+
     match selenium_manager.set_timeout(cli.timeout) {
         Ok(_) => {}
         Err(err) => {

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -155,12 +155,14 @@ pub fn write_metadata(metadata: &Metadata, log: &Logger) {
     .unwrap();
 }
 
-pub fn clear_metadata(log: &Logger){
+pub fn clear_metadata(log: &Logger) {
     let metadata_path = get_metadata_path();
-    log.trace(format!("Deleting metadata file {}", metadata_path.display()));
-    match fs::remove_file(metadata_path){
+    log.trace(format!(
+        "Deleting metadata file {}",
+        metadata_path.display()
+    ));
+    match fs::remove_file(metadata_path) {
         Ok(()) => log.trace("Metadata file was deleted".to_string()),
-        Err(err) => log.warn(
-            format!("Metadata file deleting invoked an error: {}",err)),
+        Err(err) => log.warn(format!("Metadata file deleting invoked an error: {}", err)),
     }
 }


### PR DESCRIPTION
Allows the user to download the webdriver to a specific directory.

### Description

Adds the `--save-path` flag, which allows the user to download the selected driver to a folder.

Also a few refactors that I didn't see in the other PR

### Motivation and Context

I had the need for this so I implemented it here.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
