### PR TITLE
[ruby] Fix devtools version fallback

### DIFF
--- a/rb/lib/selenium/devtools.rb
+++ b/rb/lib/selenium/devtools.rb
@@ -40,6 +40,7 @@ module Selenium
 
       def load_old_version(version)
         require "selenium/devtools/v#{version}"
+        self.version = version
         Kernel.warn "Using selenium-devtools version v#{version}, some features may not work as expected."
       end
     end

--- a/rb/spec/integration/selenium/webdriver/devtools_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/devtools_spec.rb
@@ -29,6 +29,31 @@ module Selenium
         expect(driver.title).to eq('XHTML Test Page')
       end
 
+      context 'when the devtools version is too high' do
+        let(:existing_devtools_version) { driver.send(:devtools_version) }
+        let(:imaginary_devtools_version) { existing_devtools_version + 1 }
+
+        before do
+          # set the devtools version to a newer one than exists
+          allow(driver).to receive(:devtools_version).and_return(imaginary_devtools_version)
+
+          # forget what the actual version was
+          Selenium::DevTools.remove_instance_variable(:@version)
+        end
+
+        it 'can fall back to an older devtools if necessary' do
+          expect { driver.devtools }
+            .to output(
+              a_string_matching(
+                /
+                  Could\ not\ load\ selenium-devtools\ v#{imaginary_devtools_version}.\ Trying\ older\ versions.\n
+                  Using\ selenium-devtools\ version\ v\d+,\ some\ features\ may\ not\ work\ as\ expected.\n
+                /x
+              )
+            ).to_stderr
+        end
+      end
+
       it 'supports events', except: {browser: :firefox,
                                      reason: 'https://bugzilla.mozilla.org/show_bug.cgi?id=1819965'} do
         expect { |block|


### PR DESCRIPTION
### Description

When using the feature added in #11827 that loads devtools methods possibly a version or two earlier than was necessary asked for, i was seeing this error:

```
NoMethodError: undefined method `get_targets' for nil:NilClass
./rb/lib/selenium/webdriver/devtools.rb:75:in `start_session'
./rb/lib/selenium/webdriver/devtools.rb:34:in `initialize'
./rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb:35:in `new'
./rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb:35:in `devtools'
```
because `target` was nil because it was trying to load a class named:
```
Selenium::DevTools::V#{Selenium::DevTools.version}::#{method.capitalize}
```
which resolved to:
```
Selenium::DevTools::V112::Target
```
even though the falling-back code had already given up on 112 and loaded 111 instead.

The simplest way to fix this seems to be ensure that `Selenium::DevTools.version` matches what was loaded.

Also now there's a test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
