### PR TITLE
[rb] better: allow to use devtools which are all upercase.

### DIFF
--- a/rb/lib/selenium/webdriver/devtools.rb
+++ b/rb/lib/selenium/webdriver/devtools.rb
@@ -52,7 +52,8 @@ module Selenium
       end
 
       def method_missing(method, *_args)
-        desired_class = "Selenium::DevTools::V#{Selenium::DevTools.version}::#{method.capitalize}"
+        name = method[0] == method[0].upcase ? method : method.capitalize
+        desired_class = "Selenium::DevTools::V#{Selenium::DevTools.version}::#{name}"
         return unless Object.const_defined?(desired_class)
 
         self.class.class_eval do

--- a/rb/spec/integration/selenium/webdriver/devtools_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/devtools_spec.rb
@@ -29,6 +29,18 @@ module Selenium
         expect(driver.title).to eq('XHTML Test Page')
       end
 
+      context 'when auto discovering devtools domains' do
+        it 'capitalizes the domain name' do
+          expect(driver.devtools.profiler.class.to_s).to match(/Selenium::DevTools::V[0-9]+::Profiler/)
+        end
+
+        it 'works with uppercase domains' do
+          expect(driver.devtools.CSS.class.to_s).to match(/Selenium::DevTools::V[0-9]+::CSS/)
+          expect(driver.devtools.DOM.class.to_s).to match(/Selenium::DevTools::V[0-9]+::DOM/)
+          expect(driver.devtools.DOMDebugger.class.to_s).to match(/Selenium::DevTools::V[0-9]+::DOMDebugger/)
+        end
+      end
+
       context 'when the devtools version is too high' do
         let(:existing_devtools_version) { driver.send(:devtools_version) }
         let(:imaginary_devtools_version) { existing_devtools_version + 1 }


### PR DESCRIPTION
### Description
This PR allows to get devtools domains which are uppercased (because there is a force capitalize atm)

Before

```rb
[38] pry(main)> driver.devtools.CSS
=> nil
```

Now

```rb
[2] pry(main)> driver.devtools.CSS
=> #<Selenium::DevTools::V112::CSS:0x000055a5cce00458
 @devtools=
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

Couldn't check the tests as I don't have bazel installed