### PR TITLE
[dotnet] Use ChangeType method to convert any object to boolean in WebElement propoerties

### DIFF
--- a/dotnet/src/webdriver/WebElement.cs
+++ b/dotnet/src/webdriver/WebElement.cs
@@ -107,7 +107,7 @@ namespace OpenQA.Selenium
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 parameters.Add("id", this.elementId);
                 Response commandResponse = this.Execute(DriverCommand.IsElementEnabled, parameters);
-                return (bool)commandResponse.Value;
+                return (bool)Convert.ChangeType(commandResponse.Value, typeof(bool));
             }
         }
 
@@ -124,7 +124,7 @@ namespace OpenQA.Selenium
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 parameters.Add("id", this.elementId);
                 Response commandResponse = this.Execute(DriverCommand.IsElementSelected, parameters);
-                return (bool)commandResponse.Value;
+                return (bool)Convert.ChangeType(commandResponse.Value, typeof(bool));
             }
         }
 
@@ -185,7 +185,7 @@ namespace OpenQA.Selenium
                 parameters.Add("args", new object[] { this.ToElementReference().ToDictionary() });
                 commandResponse = this.Execute(DriverCommand.ExecuteScript, parameters);
 
-                return (bool)commandResponse.Value;
+                return (bool)Convert.ChangeType(commandResponse.Value, typeof(bool));
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This approach brings us a possibility to track what exactly we try to convert.

### Description
```csharp
var a = (object)"true";
var b = (bool)a;
```
It always throws `InvalidCastException`.

There is safer method:
```csharp
var a = (object)"true";
var b = (bool)Convert.ChageType(a, typeof(bool));
```

Even if input is not formatted well to be boolean, then we will get more clear exception:
```
System.FormatException: String 'false 66' was not recognized as a valid Boolean.
```
where `false 66` is incorrect input.

### Motivation and Context
Just to get more clear understanding what is going wrong, and highlight a value returned from server side.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
