### PR TITLE
[rb] Fix wrongly trying to load a constant

### DIFF
--- a/rb/lib/selenium/webdriver/devtools.rb
+++ b/rb/lib/selenium/webdriver/devtools.rb
@@ -60,7 +60,7 @@ module Selenium
                           "#{namespace}::#{Object.const_get(methods_to_classes)[method]}"
                         else
                           # selenium-devtools 0.112 and older
-                          "#{namespace}::#{method.capitalize}}"
+                          "#{namespace}::#{method.capitalize}"
                         end
 
         return unless Object.const_defined?(desired_class)


### PR DESCRIPTION
### Description
There was one `}` too many.

### Motivation and Context
Otherwise people get:

```
NameError:
       wrong constant name Selenium::DevTools::V112::Target}
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.