### PR TITLE
[rb] allow users to direct driver process output

### DIFF
--- a/rb/lib/selenium/webdriver/common/service.rb
+++ b/rb/lib/selenium/webdriver/common/service.rb
@@ -57,7 +57,7 @@ module Selenium
         end
       end
 
-      attr_accessor :host, :executable_path, :port, :args
+      attr_accessor :host, :executable_path, :port, :log, :args
       alias extra_args args
 
       #
@@ -66,13 +66,21 @@ module Selenium
       # @api private
       #
 
-      def initialize(path: nil, port: nil, args: nil)
+      def initialize(path: nil, port: nil, log: nil, args: nil)
         port ||= self.class::DEFAULT_PORT
         args ||= []
 
         @executable_path = path
         @host = Platform.localhost
         @port = Integer(port)
+        @log = case log
+               when :stdout
+                 $stdout
+               when :stderr
+                 $stderr
+               else
+                 log
+               end
 
         @args = args.is_a?(Hash) ? extract_service_args(args) : args
 

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -41,6 +41,7 @@ module Selenium
         @host = Platform.localhost
         @port = config.port
         @extra_args = config.args
+        @io = config.log
         @shutdown_supported = config.shutdown_supported
 
         raise Error::WebDriverError, "invalid port: #{@port}" if @port < 1
@@ -79,7 +80,8 @@ module Selenium
       def build_process(*command)
         WebDriver.logger.debug("Executing Process #{command}")
         @process = ChildProcess.build(*command)
-        @process.io = WebDriver.logger.io if WebDriver.logger.debug?
+        @process.io = @io
+        @process.io ||= WebDriver.logger.io if WebDriver.logger.debug?
 
         @process
       end

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -59,6 +59,18 @@ module Selenium
             expect(service.extra_args).to be_empty
           end
 
+          it 'uses sets log path to stdout' do
+            service = described_class.chrome(log: :stdout)
+
+            expect(service.log).to eq $stdout
+          end
+
+          it 'uses sets log path to stderr' do
+            service = described_class.chrome(log: :stderr)
+
+            expect(service.log).to eq $stderr
+          end
+
           it 'uses provided args' do
             allow(Platform).to receive(:find_binary).and_return(service_path)
 


### PR DESCRIPTION
### Description

Allow users to specify where driver log output goes

### Motivation and Context
Currently output is discarded unless the logger level is set to :debug, then all the driver logs are included in the all the Selenium logs

### Examples:

```ruby
Selenium::WebDriver::Service.chrome(log: '/path/to/chromedriver.log')
```

```ruby
Selenium::WebDriver::Service.chrome(log: :stdout)
```

```ruby
Selenium::WebDriver::Service.chrome(log: :stderr, args: ['--verbose'])
```

