### PR TITLE
Upgrade minimum Ruby version to 3.0 since 2.7 is EOL

### DIFF
--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby-version: 2.7.6
+          - ruby-version: 3.0.6
             os: ubuntu
-          - ruby-version: 2.7.6
+          - ruby-version: 3.0.6
             os: windows
           - ruby-version: 3.2.0
             os: ubuntu

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,9 +322,9 @@ pin_browsers()
 
 http_archive(
     name = "rules_ruby",
-    sha256 = "5228950029d57476a4903db35cd8ce6a4526e30fba08a01af9d7a9b8ebaf63ae",
-    strip_prefix = "rules_ruby-9e6e07ed5d7e02f8bb1c77ce543072d5548bbd86",
-    url = "https://github.com/p0deje/rules_ruby/archive/9e6e07ed5d7e02f8bb1c77ce543072d5548bbd86.zip",
+    sha256 = "dddae0f5bf2c2aa95e20923a6f9f746b0457b956e43e8bd6874d09d88795b40d",
+    strip_prefix = "rules_ruby-be44e324165c617210f9d22e4cdf661c9e330ca2",
+    url = "https://github.com/p0deje/rules_ruby/archive/be44e324165c617210f9d22e4cdf661c9e330ca2.zip",
 )
 
 load("//rb:ruby_version.bzl", "RUBY_VERSION")

--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - !ruby/regexp /lib\/selenium\/devtools\/v\d+/

--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
 PLATFORMS
   java
   ruby
+  universal-java-18
   x64-mingw32
 
 DEPENDENCIES
@@ -101,4 +102,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/rb/lib/selenium/support/nightly_version_generator.rb
+++ b/rb/lib/selenium/support/nightly_version_generator.rb
@@ -30,7 +30,7 @@ module Selenium
     #
 
     class NightlyVersionGenerator
-      REGEXP = /VERSION = ['"]([\d.]+)['"]/.freeze
+      REGEXP = /VERSION = ['"]([\d.]+)['"]/
 
       def self.call(version_file, version_suffix)
         version_suffix ||= Date.today.strftime('%Y%m%d')

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -682,7 +682,7 @@ module Selenium
           [how, what]
         end
 
-        ESCAPE_CSS_REGEXP = /(['"\\#.:;,!?+<>=~*^$|%&@`{}\-\[\]()])/.freeze
+        ESCAPE_CSS_REGEXP = /(['"\\#.:;,!?+<>=~*^$|%&@`{}\-\[\]()])/
         UNICODE_CODE_POINT = 30
 
         # Escapes invalid characters in CSS selector.

--- a/rb/lib/selenium/webdriver/support/color.rb
+++ b/rb/lib/selenium/webdriver/support/color.rb
@@ -23,27 +23,27 @@ module Selenium
       class Color
         RGB_PATTERN = /^\s*rgb\(\s*(\d{1,3})\s*,
                           \s*(\d{1,3})\s*,
-                          \s*(\d{1,3})\s*\)\s*$/x.freeze
+                          \s*(\d{1,3})\s*\)\s*$/x
         RGB_PCT_PATTERN = /^\s*rgb\(\s*(\d{1,3}|\d{1,2}\.\d+)%\s*,
                               \s*(\d{1,3}|\d{1,2}\.\d+)%\s*,
-                              \s*(\d{1,3}|\d{1,2}\.\d+)%\s*\)\s*$/x.freeze
+                              \s*(\d{1,3}|\d{1,2}\.\d+)%\s*\)\s*$/x
         RGBA_PATTERN = /^\s*rgba\(\s*(\d{1,3})\s*,
                           \s*(\d{1,3})\s*,
                           \s*(\d{1,3})\s*,
-                          \s*(0|1|0\.\d+)\s*\)\s*$/x.freeze
+                          \s*(0|1|0\.\d+)\s*\)\s*$/x
         RGBA_PCT_PATTERN = /^\s*rgba\(\s*(\d{1,3}|\d{1,2}\.\d+)
                               %\s*,\s*(\d{1,3}|\d{1,2}\.\d+)
                               %\s*,\s*(\d{1,3}|\d{1,2}\.\d+)
-                              %\s*,\s*(0|1|0\.\d+)\s*\)\s*$/x.freeze
-        HEX_PATTERN = /#(\h{2})(\h{2})(\h{2})/.freeze
-        HEX3_PATTERN = /#(\h)(\h)(\h)/.freeze
+                              %\s*,\s*(0|1|0\.\d+)\s*\)\s*$/x
+        HEX_PATTERN = /#(\h{2})(\h{2})(\h{2})/
+        HEX3_PATTERN = /#(\h)(\h)(\h)/
         HSL_PATTERN = /^\s*hsl\(\s*(\d{1,3})\s*,
                          \s*(\d{1,3})%\s*,
-                         \s*(\d{1,3})%\s*\)\s*$/x.freeze
+                         \s*(\d{1,3})%\s*\)\s*$/x
         HSLA_PATTERN = /^\s*hsla\(\s*(\d{1,3})\s*,
                           \s*(\d{1,3})%\s*,
                           \s*(\d{1,3})%\s*,
-                          \s*(0|1|0\.\d+)\s*\)\s*$/x.freeze
+                          \s*(0|1|0\.\d+)\s*\)\s*$/x
 
         attr_reader :red, :green, :blue, :alpha
 

--- a/rb/ruby_version.bzl
+++ b/rb/ruby_version.bzl
@@ -1,1 +1,1 @@
-RUBY_VERSION = "2.7.6"
+RUBY_VERSION = "3.0.6"

--- a/rb/selenium-devtools.gemspec
+++ b/rb/selenium-devtools.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_rubygems_version = Gem::Requirement.new('> 1.3.1') if s.respond_to? :required_rubygems_version=
-  s.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  s.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   s.files = [
     'LICENSE',

--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_rubygems_version = Gem::Requirement.new('> 1.3.1') if s.respond_to? :required_rubygems_version=
-  s.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  s.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   s.files = [
     'CHANGES',


### PR DESCRIPTION
Since Ruby 2.7 is EOL, upgrade the minimum required Ruby version to 3.0 in Ruby bindings.