### PR TITLE
Change Ruby Logging

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -42,6 +42,7 @@ Metrics/CyclomaticComplexity:
   Max: 9
   Exclude:
     - 'lib/selenium/webdriver/support/color.rb'
+    - 'lib/selenium/webdriver/common/logger.rb'
 
 Metrics/MethodLength:
   CountComments: false
@@ -62,6 +63,7 @@ Metrics/PerceivedComplexity:
   Max: 9
   Exclude:
     - 'lib/selenium/webdriver/common/local_driver.rb'
+    - 'lib/selenium/webdriver/common/logger.rb'
 
 Naming/FileName:
   Exclude:

--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -98,4 +98,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.2.33
+   2.2.34

--- a/rb/lib/selenium/devtools.rb
+++ b/rb/lib/selenium/devtools.rb
@@ -25,7 +25,8 @@ module Selenium
       def load_version
         require "selenium/devtools/v#{@version}"
       rescue LoadError
-        Kernel.warn "Could not load selenium-devtools v#{@version}. Trying older versions."
+        WebDriver.logger.warn "Could not load selenium-devtools v#{@version}. Trying older versions.",
+                              id: :devtools
         load_older_version
       end
 
@@ -35,13 +36,19 @@ module Selenium
       def load_older_version
         load_old_version(@version - 1)
       rescue LoadError
-        load_old_version(@version - 2)
+        begin
+          load_old_version(@version - 2)
+        rescue LoadError
+          raise WebDriver::Error::WebDriverError,
+                'Could not find a valid devtools version; use a more recent version of selenium-devtools gem'
+        end
       end
 
       def load_old_version(version)
         require "selenium/devtools/v#{version}"
         self.version = version
-        Kernel.warn "Using selenium-devtools version v#{version}, some features may not work as expected."
+        msg = "Using selenium-devtools version v#{version}, some features may not work as expected."
+        WebDriver.logger.warn msg, id: :devtools
       end
     end
   end # DevTools

--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -254,7 +254,7 @@ module Selenium
         args = ['-jar', @jar, @role, '--port', @port.to_s]
         server_command = ['java'] + properties + args + @additional_args
         cp = WebDriver::ChildProcess.build(*server_command)
-        WebDriver.logger.debug("Executing Process #{server_command}")
+        WebDriver.logger.debug("Executing Process #{server_command}", id: :server)
 
         if @log.is_a?(String)
           cp.io = @log

--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -95,7 +95,8 @@ module Selenium
     #
 
     def self.logger(**opts)
-      @logger ||= WebDriver::Logger.new('Selenium', **opts)
+      level = $DEBUG || ENV.key?('DEBUG') ? :debug : :info
+      @logger ||= WebDriver::Logger.new('Selenium', default_level: level, **opts)
     end
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/common/action_builder.rb
+++ b/rb/lib/selenium/webdriver/common/action_builder.rb
@@ -250,14 +250,6 @@ module Selenium
         @devices << device
         device
       end
-
-      def deprecate_method(device = nil, duration = nil, number = nil, method: :pause)
-        return unless device || number || duration
-
-        WebDriver.logger.deprecate "ActionBuilder##{method} with ordered parameters",
-                                   ':device, :duration, :number keywords',
-                                   id: method
-      end
     end # ActionBuilder
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/common/child_process.rb
+++ b/rb/lib/selenium/webdriver/common/child_process.rb
@@ -53,9 +53,9 @@ module Selenium
         options = {%i[out err] => io}
         options[:pgroup] = true unless Platform.windows? # NOTE: this is a bug only in Windows 7
 
-        WebDriver.logger.debug("Starting process: #{@command} with #{options}")
+        WebDriver.logger.debug("Starting process: #{@command} with #{options}", id: :process)
         @pid = Process.spawn(*@command, options)
-        WebDriver.logger.debug("  -> pid: #{@pid}")
+        WebDriver.logger.debug("  -> pid: #{@pid}", id: :process)
 
         Process.detach(@pid) if detach
       end
@@ -64,16 +64,16 @@ module Selenium
         return unless @pid
         return if exited?
 
-        WebDriver.logger.debug("Sending TERM to process: #{@pid}")
+        WebDriver.logger.debug("Sending TERM to process: #{@pid}", id: :process)
         terminate(@pid)
         poll_for_exit(timeout)
 
-        WebDriver.logger.debug("  -> stopped #{@pid}")
+        WebDriver.logger.debug("  -> stopped #{@pid}", id: :process)
       rescue TimeoutError, Errno::EINVAL
-        WebDriver.logger.debug("    -> sending KILL to process: #{@pid}")
+        WebDriver.logger.debug("    -> sending KILL to process: #{@pid}", id: :process)
         kill(@pid)
         wait
-        WebDriver.logger.debug("      -> killed #{@pid}")
+        WebDriver.logger.debug("      -> killed #{@pid}", id: :process)
       end
 
       def alive?
@@ -83,18 +83,18 @@ module Selenium
       def exited?
         return unless @pid
 
-        WebDriver.logger.debug("Checking if #{@pid} is exited:")
+        WebDriver.logger.debug("Checking if #{@pid} is exited:", id: :process)
         _, @status = Process.waitpid2(@pid, Process::WNOHANG | Process::WUNTRACED) if @status.nil?
         return if @status.nil?
 
         exit_code = @status.exitstatus || @status.termsig
-        WebDriver.logger.debug("  -> exit code is #{exit_code.inspect}")
+        WebDriver.logger.debug("  -> exit code is #{exit_code.inspect}", id: :process)
 
         !!exit_code
       end
 
       def poll_for_exit(timeout)
-        WebDriver.logger.debug("Polling #{timeout} seconds for exit of #{@pid}")
+        WebDriver.logger.debug("Polling #{timeout} seconds for exit of #{@pid}", id: :process)
 
         end_time = Time.now + timeout
         sleep POLL_INTERVAL until exited? || Time.now > end_time

--- a/rb/lib/selenium/webdriver/common/driver_finder.rb
+++ b/rb/lib/selenium/webdriver/common/driver_finder.rb
@@ -28,7 +28,8 @@ module Selenium
         path ||= begin
           SeleniumManager.driver_path(options)
         rescue StandardError => e
-          WebDriver.logger.warn("Unable obtain driver using Selenium Manager\n #{e.message}")
+          WebDriver.logger.warn("Unable to obtain driver using Selenium Manager\n #{e.message}",
+                                id: :selenium_manager)
           nil
         end
         msg = "Unable to locate the #{klass::EXECUTABLE} executable; for more information on how to install drivers, " \

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -48,8 +48,10 @@ module Selenium
       #
       # @param [String] progname Allow child projects to use Selenium's Logger pattern
       #
-      def initialize(progname = 'Selenium', ignored: nil, allowed: nil)
-        @logger = create_logger(progname)
+      def initialize(progname = 'Selenium', default_level: nil, ignored: nil, allowed: nil)
+        default_level ||= $DEBUG || ENV.key?('DEBUG') ? :debug : :warn
+
+        @logger = create_logger(progname, level: default_level)
         @ignored = Array(ignored)
         @allowed = Array(allowed)
         @first_warning = false
@@ -174,19 +176,15 @@ module Selenium
 
       private
 
-      def create_logger(name)
+      def create_logger(name, level:)
         logger = ::Logger.new($stdout)
         logger.progname = name
-        logger.level = default_level
+        logger.level = level
         logger.formatter = proc do |severity, time, progname, msg|
           "#{time.strftime('%F %T')} #{severity} #{progname} #{msg}\n"
         end
 
         logger
-      end
-
-      def default_level
-        $DEBUG || ENV.key?('DEBUG') ? :debug : :info
       end
 
       def discard_or_log(level, message, id)

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -128,7 +128,7 @@ module Selenium
 
         unless options.empty?
           msg = 'These options are not w3c compliant and will result in failures in a future release'
-          WebDriver.logger.warn("#{msg}: #{options}")
+          WebDriver.logger.warn("#{msg}: #{options}", id: :w3c_options)
           browser_options.merge!(options)
         end
 

--- a/rb/lib/selenium/webdriver/common/port_prober.rb
+++ b/rb/lib/selenium/webdriver/common/port_prober.rb
@@ -34,7 +34,7 @@ module Selenium
         Platform.interfaces.each do |host|
           TCPServer.new(host, port).close
         rescue *IGNORED_ERRORS => e
-          WebDriver.logger.debug("port prober could not bind to #{host}:#{port} (#{e.message})")
+          WebDriver.logger.debug("port prober could not bind to #{host}:#{port} (#{e.message})", id: :driver_service)
           # ignored - some machines appear unable to bind to some of their interfaces
         end
 

--- a/rb/lib/selenium/webdriver/common/selenium_manager.rb
+++ b/rb/lib/selenium/webdriver/common/selenium_manager.rb
@@ -33,8 +33,8 @@ module Selenium
         # @param [Options] options browser options.
         # @return [String] the path to the correct driver.
         def driver_path(options)
-          message = 'applicable driver not found; attempting to install with Selenium Manager'
-          WebDriver.logger.warn(message)
+          message = 'applicable driver not found; attempting to install with Selenium Manager (Beta)'
+          WebDriver.logger.info(message, id: :selenium_manager)
 
           unless options.is_a?(Options)
             raise ArgumentError, "SeleniumManager requires a WebDriver::Options instance, not #{options.inspect}"
@@ -52,7 +52,7 @@ module Selenium
           command << '--debug' if WebDriver.logger.debug?
 
           location = run(*command)
-          WebDriver.logger.debug("Driver found at #{location}")
+          WebDriver.logger.debug("Driver found at #{location}", id: :selenium_manager)
           Platform.assert_executable location
 
           location
@@ -76,13 +76,13 @@ module Selenium
               raise Error::WebDriverError, 'Unable to obtain Selenium Manager'
             end
 
-            WebDriver.logger.debug("Selenium Manager found at #{location}")
+            WebDriver.logger.debug("Selenium Manager found at #{location}", id: :selenium_manager)
             location
           end
         end
 
         def run(*command)
-          WebDriver.logger.debug("Executing Process #{command}")
+          WebDriver.logger.debug("Executing Process #{command}", id: :selenium_manager)
 
           begin
             stdout, stderr, status = Open3.capture3(*command)
@@ -97,7 +97,7 @@ module Selenium
           end
 
           json_output['logs'].each do |log|
-            WebDriver.logger.send(log['level'].downcase, log['message'])
+            WebDriver.logger.send(log['level'].downcase, log['message'], id: :selenium_manager)
           end
 
           result

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -80,8 +80,8 @@ module Selenium
       def build_process(*command)
         WebDriver.logger.debug("Executing Process #{command}", id: :driver_service)
         @process = ChildProcess.build(*command)
-        @process.io = @io
-        @process.io ||= WebDriver.logger.io if WebDriver.logger.debug?
+        @io ||= WebDriver.logger.io if WebDriver.logger.debug?
+        @process.io = @io if @io
 
         @process
       end

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -78,7 +78,7 @@ module Selenium
       private
 
       def build_process(*command)
-        WebDriver.logger.debug("Executing Process #{command}")
+        WebDriver.logger.debug("Executing Process #{command}", id: :driver_service)
         @process = ChildProcess.build(*command)
         @process.io = @io
         @process.io ||= WebDriver.logger.io if WebDriver.logger.debug?

--- a/rb/lib/selenium/webdriver/common/socket_lock.rb
+++ b/rb/lib/selenium/webdriver/common/socket_lock.rb
@@ -70,7 +70,7 @@ module Selenium
         @server.close_on_exec = true
         true
       rescue SocketError, Errno::EADDRINUSE, Errno::EBADF => e
-        WebDriver.logger.debug("#{self}: #{e.message}")
+        WebDriver.logger.debug("#{self}: #{e.message}", id: :driver_service)
         false
       end
 

--- a/rb/lib/selenium/webdriver/common/socket_poller.rb
+++ b/rb/lib/selenium/webdriver/common/socket_poller.rb
@@ -93,7 +93,7 @@ module Selenium
           true
         rescue *NOT_CONNECTED_ERRORS
           sock&.close
-          WebDriver.logger.debug("polling for socket on #{[@host, @port].inspect}")
+          WebDriver.logger.debug("polling for socket on #{[@host, @port].inspect}", id: :driver_service)
           false
         end
       end

--- a/rb/lib/selenium/webdriver/common/websocket_connection.rb
+++ b/rb/lib/selenium/webdriver/common/websocket_connection.rb
@@ -55,7 +55,7 @@ module Selenium
       def send_cmd(**payload)
         id = next_id
         data = payload.merge(id: id)
-        WebDriver.logger.debug "WebSocket -> #{data}"[...MAX_LOG_MESSAGE_SIZE]
+        WebDriver.logger.debug "WebSocket -> #{data}"[...MAX_LOG_MESSAGE_SIZE], id: :bidi
         data = JSON.generate(data)
         out_frame = WebSocket::Frame::Outgoing::Client.new(version: ws.version, data: data, type: 'text')
         socket.write(out_frame.to_s)
@@ -112,7 +112,7 @@ module Selenium
 
         message = JSON.parse(message)
         messages[message['id']] = message
-        WebDriver.logger.debug "WebSocket <- #{message}"[...MAX_LOG_MESSAGE_SIZE]
+        WebDriver.logger.debug "WebSocket <- #{message}"[...MAX_LOG_MESSAGE_SIZE], id: :bidi
 
         message
       end

--- a/rb/lib/selenium/webdriver/firefox/profile.rb
+++ b/rb/lib/selenium/webdriver/firefox/profile.rb
@@ -160,7 +160,7 @@ module Selenium
           destination = File.join(directory, 'extensions')
 
           @extensions.each do |name, extension|
-            WebDriver.logger.debug({extenstion: name}.inspect)
+            WebDriver.logger.debug({extension: name}.inspect, id: :firefox_profile)
             extension.write_to(destination)
           end
         end

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -407,7 +407,8 @@ module Selenium
 
         def upload(local_file)
           unless File.file?(local_file)
-            WebDriver.logger.debug("File detector only works with files. #{local_file.inspect} isn`t a file!")
+            WebDriver.logger.debug("File detector only works with files. #{local_file.inspect} isn`t a file!",
+                                   id: :file_detector)
             raise Error::WebDriverError, "You are trying to work with something that isn't a file."
           end
 
@@ -443,7 +444,7 @@ module Selenium
         end
 
         def element_attribute(element, name)
-          WebDriver.logger.info "Using script for :getAttribute of #{name}"
+          WebDriver.logger.debug "Using script for :getAttribute of #{name}", id: :script
           execute_atom :getAttribute, element, name
         end
 
@@ -503,7 +504,7 @@ module Selenium
         end
 
         def element_displayed?(element)
-          WebDriver.logger.info 'Using script for :isDisplayed'
+          WebDriver.logger.debug 'Using script for :isDisplayed', id: :script
           execute_atom :isDisplayed, element
         end
 
@@ -615,7 +616,7 @@ module Selenium
             raise ArgumentError, "#{opts.inspect} invalid for #{command.inspect}"
           end
 
-          WebDriver.logger.info("-> #{verb.to_s.upcase} #{path}")
+          WebDriver.logger.debug("-> #{verb.to_s.upcase} #{path}", id: :command)
           http.call(verb, path, command_hash)['value']
         end
 

--- a/rb/lib/selenium/webdriver/remote/http/common.rb
+++ b/rb/lib/selenium/webdriver/remote/http/common.rb
@@ -49,8 +49,8 @@ module Selenium
               payload                   = JSON.generate(command_hash)
               headers['Content-Length'] = payload.bytesize.to_s if %i[post put].include?(verb)
 
-              WebDriver.logger.info("   >>> #{url} | #{payload}")
-              WebDriver.logger.debug("     > #{headers.inspect}")
+              WebDriver.logger.debug("   >>> #{url} | #{payload}", id: :command)
+              WebDriver.logger.debug("     > #{headers.inspect}", id: :header)
             elsif verb == :post
               payload = '{}'
               headers['Content-Length'] = '2'
@@ -75,7 +75,7 @@ module Selenium
             code = code.to_i
             body = body.to_s.strip
             content_type = content_type.to_s
-            WebDriver.logger.info("<- #{body}")
+            WebDriver.logger.debug("<- #{body}", id: :command)
 
             if content_type.include? CONTENT_TYPE
               raise Error::WebDriverError, "empty body: #{content_type.inspect} (#{code})\n#{body}" if body.empty?

--- a/rb/lib/selenium/webdriver/remote/http/curb.rb
+++ b/rb/lib/selenium/webdriver/remote/http/curb.rb
@@ -83,7 +83,7 @@ module Selenium
               c.max_redirects   = MAX_REDIRECTS
               c.follow_location = true
               c.timeout         = @timeout if @timeout
-              c.verbose         = WebDriver.logger.info?
+              c.verbose         = WebDriver.logger.debug?
 
               c
             end

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -100,7 +100,7 @@ module Selenium
 
               request(:get, URI.parse(response['Location']), DEFAULT_HEADERS.dup, nil, redirects + 1)
             else
-              WebDriver.logger.debug("   <<<  #{response.instance_variable_get(:@header).inspect}")
+              WebDriver.logger.debug("   <<<  #{response.instance_variable_get(:@header).inspect}", id: :header)
               create_response response.code, response.body, response.content_type
             end
           end

--- a/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
@@ -37,18 +37,22 @@ module Selenium
           expect(browsing_context.id).not_to be_nil
         end
 
-        it 'can create a window with a reference context', except: {browser: %i[chrome edge]} do
+        it 'can create a window with a reference context', except: [{browser: :chrome,
+                                                                     platform: %i[linux macosx]},
+                                                                    {browser: :edge}] do
           browsing_context = described_class.new(driver: driver, type: :window,
                                                  reference_context: driver.window_handle)
           expect(browsing_context.id).not_to be_nil
         end
 
-        it 'can create a tab' do
+        it 'can create a tab without a reference context' do
           browsing_context = described_class.new(driver: driver, type: :tab)
           expect(browsing_context.id).not_to be_nil
         end
 
-        it 'can create a tab with a reference context', except: {browser: %i[chrome edge]} do
+        it 'can create a tab with a reference context', except: [{browser: :chrome,
+                                                                  platform: %i[linux macosx]},
+                                                                 {browser: :edge}] do
           browsing_context = described_class.new(driver: driver, type: :tab, reference_context: driver.window_handle)
           expect(browsing_context.id).not_to be_nil
         end

--- a/rb/spec/integration/selenium/webdriver/manager_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/manager_spec.rb
@@ -81,14 +81,6 @@ module Selenium
           expect(driver.manage.cookie_named('domain')[:domain]).to eq('.saucelabs.com')
         end
 
-        it 'does not allow domain to be set for localhost', except: {browser: %i[safari safari_preview]} do
-          expect {
-            driver.manage.add_cookie name: 'domain',
-                                     value: 'localhost',
-                                     domain: 'localhost'
-          }.to raise_error(Error::UnableToSetCookieError)
-        end
-
         it 'does not allow setting on a different domain', except: {browser: %i[safari safari_preview]} do
           expect {
             driver.manage.add_cookie name: 'domain',

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -27,7 +27,7 @@ module Selenium
           @create_driver_error = nil
           @create_driver_error_count = 0
 
-          WebDriver.logger.ignore(:logger_info)
+          WebDriver.logger.ignore(%i[logger_info selenium_manager])
 
           @driver = ENV.fetch('WD_SPEC_DRIVER', 'chrome').tr('-', '_').to_sym
           @driver_instance = nil

--- a/rb/spec/rspec_matchers.rb
+++ b/rb/spec/rspec_matchers.rb
@@ -17,35 +17,44 @@
 # specific language governing permissions and limitations
 # under the License.
 
-RSpec::Matchers.define :have_deprecated do |deprecation|
-  match do |actual|
-    # Suppresses logging output to stdout while ensuring that it is still happening
-    default_output = Selenium::WebDriver.logger.io
-    io = StringIO.new
-    Selenium::WebDriver.logger.output = io
+LEVELS = %w[warning info deprecated].freeze
 
-    actual.call
+LEVELS.each do |level|
+  RSpec::Matchers.define "have_#{level}" do |entry|
+    match do |actual|
+      # Suppresses logging output to stdout while ensuring that it is still happening
+      default_output = Selenium::WebDriver.logger.io
+      io = StringIO.new
+      Selenium::WebDriver.logger.output = io
 
-    Selenium::WebDriver.logger.output = default_output
-    @deprecations_found = (io.rewind && io.read).scan(/DEPRECATION\] \[:([^\]]*)\]/).flatten.map(&:to_sym)
-    expect(Array(deprecation).sort).to eq(@deprecations_found.sort)
-  end
+      begin
+        actual.call
+      rescue StandardError => e
+        raise e, 'Can not evaluate output when statement raises an exception'
+      ensure
+        Selenium::WebDriver.logger.output = default_output
+      end
 
-  failure_message do
-    but_message = if @deprecations_found.nil? || @deprecations_found.empty?
-                    'no deprecations were found'
-                  else
-                    "instead these deprecations were found: [#{@deprecations_found.join(', ')}]"
-                  end
-    "expected :#{deprecation} to have been deprecated, but #{but_message}"
-  end
+      @entries_found = (io.rewind && io.read).scan(/\[:([^\]]*)\]/).flatten.map(&:to_sym)
+      expect(Array(entry).sort).to eq(@entries_found.sort)
+    end
 
-  failure_message_when_negated do
-    but_message = "it was found among these deprecations: [#{@deprecations_found.join(', ')}]"
-    "expected :#{deprecation} not to have been deprecated, but #{but_message}"
-  end
+    failure_message do
+      but_message = if @entries_found.nil? || @entries_found.empty?
+                      "no #{entry} entries were reported"
+                    else
+                      "instead these entries were found: [#{@entries_found.join(', ')}]"
+                    end
+      "expected :#{entry} to have been logged, but #{but_message}"
+    end
 
-  def supports_block_expectations?
-    true
+    failure_message_when_negated do
+      but_message = "it was found among these entries: [#{@entries_found.join(', ')}]"
+      "expected :#{entry} not to have been logged, but #{but_message}"
+    end
+
+    def supports_block_expectations?
+      true
+    end
   end
 end

--- a/rb/spec/unit/selenium/devtools_spec.rb
+++ b/rb/spec/unit/selenium/devtools_spec.rb
@@ -36,13 +36,9 @@ module Selenium
         let(:version) { current_version + 1 }
 
         it 'can fall back to an older devtools if necessary' do
-          expect { described_class.load_version }
-            .to output(
-              a_string_including(<<~MSG)
-                Could not load selenium-devtools v#{version}. Trying older versions.
-                Using selenium-devtools version v#{current_version}, some features may not work as expected.
-              MSG
-            ).to_stderr
+          msg1 = /Could not load selenium-devtools v#{version}. Trying older versions/
+          msg2 = /Using selenium-devtools version v#{current_version}, some features may not work as expected/
+          expect { described_class.load_version }.to output(match(msg1).and(match(msg2))).to_stdout_from_any_process
         end
       end
     end

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -272,7 +272,7 @@ module Selenium
 
             expect {
               options.as_json
-            }.to output(/WARN Selenium These options are not w3c compliant/).to_stdout_from_any_process
+            }.to have_warning(:w3c_options)
           end
 
           it 'returns added options' do

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -265,7 +265,7 @@ module Selenium
             expect(options.as_json).to eq('browserName' => 'chrome', 'goog:chromeOptions' => {})
           end
 
-          it 'errors when unrecognized capability is passed' do
+          it 'warns when unrecognized capability is passed' do
             expect {
               options.add_option(:foo, 'bar')
             }.to have_deprecated(:add_option)

--- a/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
@@ -68,9 +68,11 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            described_class.path(options, service)
-          }.to raise_error(WebDriver::Error::WebDriverError,
-                           /Unable to locate the #{driver} executable; for more information on how to install drivers/)
+            expect {
+              described_class.path(options, service)
+            }.to raise_error(WebDriver::Error::WebDriverError,
+                             /Unable to locate the #{driver} executable; for more information on how to install/)
+          }.to have_warning(:selenium_manager)
         end
       end
 
@@ -120,9 +122,11 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            described_class.path(options, service)
-          }.to raise_error(WebDriver::Error::WebDriverError,
-                           /Unable to locate the #{driver} executable; for more information on how to install drivers/)
+            expect {
+              described_class.path(options, service)
+            }.to raise_error(WebDriver::Error::WebDriverError,
+                             /Unable to locate the #{driver} executable; for more information on how to install/)
+          }.to have_warning(:selenium_manager)
         end
       end
 
@@ -172,9 +176,11 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            described_class.path(options, service)
-          }.to raise_error(WebDriver::Error::WebDriverError,
-                           /Unable to locate the #{driver} executable; for more information on how to install drivers/)
+            expect {
+              described_class.path(options, service)
+            }.to raise_error(WebDriver::Error::WebDriverError,
+                             /Unable to locate the #{driver} executable; for more information on how to install/)
+          }.to have_warning(:selenium_manager)
         end
       end
 
@@ -224,9 +230,11 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            described_class.path(options, service)
-          }.to raise_error(WebDriver::Error::WebDriverError,
-                           /Unable to locate the #{driver} executable; for more information on how to install drivers/)
+            expect {
+              described_class.path(options, service)
+            }.to raise_error(WebDriver::Error::WebDriverError,
+                             /Unable to locate the #{driver} executable; for more information on how to install/)
+          }.to have_warning(:selenium_manager)
         end
       end
 
@@ -276,9 +284,11 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            described_class.path(options, service)
-          }.to raise_error(WebDriver::Error::WebDriverError,
-                           /Unable to locate the #{driver} executable; for more information on how to install drivers/)
+            expect {
+              described_class.path(options, service)
+            }.to raise_error(WebDriver::Error::WebDriverError,
+                             /Unable to locate the #{driver} executable; for more information on how to install/)
+          }.to have_warning(:selenium_manager)
         end
       end
     end

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -175,7 +175,7 @@ module Selenium
       end
 
       describe '#ignore' do
-        it 'prevents logging when ignoring single id' do
+        it 'prevents logging when id' do
           logger.ignore(:foo)
           expect { logger.deprecate('#old', '#new', id: :foo) }.not_to output.to_stdout_from_any_process
         end
@@ -195,6 +195,28 @@ module Selenium
         it 'prevents logging any deprecation when ignoring :deprecations' do
           logger.ignore(:deprecations)
           expect { logger.deprecate('#old', '#new') }.not_to output.to_stdout_from_any_process
+        end
+      end
+
+      describe '#allow' do
+        it 'logs only allowed ids from method' do
+          logger.allow(:foo)
+          logger.allow(:bar)
+          expect { logger.deprecate('#old', '#new', id: :foo) }.to output(/foo/).to_stdout_from_any_process
+          expect { logger.deprecate('#old', '#new', id: :bar) }.to output(/bar/).to_stdout_from_any_process
+          expect { logger.deprecate('#old', '#new', id: :foobar) }.not_to output.to_stdout_from_any_process
+        end
+
+        it 'logs only allowed ids from Array' do
+          logger.allow(%i[foo bar])
+          expect { logger.deprecate('#old', '#new', id: :foo) }.to output(/foo/).to_stdout_from_any_process
+          expect { logger.deprecate('#old', '#new', id: :bar) }.to output(/bar/).to_stdout_from_any_process
+          expect { logger.deprecate('#old', '#new', id: :foobar) }.not_to output.to_stdout_from_any_process
+        end
+
+        it 'prevents logging any deprecation when ignoring :deprecations' do
+          logger.allow(:deprecations)
+          expect { logger.deprecate('#old', '#new') }.to output(/new/).to_stdout_from_any_process
         end
       end
     end

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -22,7 +22,7 @@ require File.expand_path('../spec_helper', __dir__)
 module Selenium
   module WebDriver
     describe Logger do
-      subject(:logger) { described_class.new('Selenium', ignored: [:logger_info]) }
+      subject(:logger) { described_class.new('Selenium', default_level: :info, ignored: [:logger_info]) }
 
       around do |example|
         debug = $DEBUG
@@ -53,6 +53,8 @@ module Selenium
 
         it 'logs at debug level if $DEBUG is set to true' do
           $DEBUG = true
+          logger = described_class.new('Selenium')
+          $DEBUG = nil
           expect(logger.level).to eq(0)
           expect(logger).to be_debug
         end
@@ -104,7 +106,8 @@ module Selenium
 
       describe '#info' do
         it 'logs info on first info but not second' do
-          logger = described_class.new('Selenium')
+          logger = described_class.new('Selenium', default_level: :info)
+
           expect { logger.info('first') }.to output(/:logger_info/).to_stdout_from_any_process
           expect { logger.info('second') }.not_to output(/:logger_info/).to_stdout_from_any_process
         end

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -46,9 +46,9 @@ module Selenium
       end
 
       describe '#level' do
-        it 'logs at warning level by default' do
-          expect(logger.level).to eq(2)
-          expect(logger).to be_warn
+        it 'logs at warn level by default' do
+          expect(logger.level).to eq(1)
+          expect(logger).to be_info
         end
 
         it 'logs at debug level if $DEBUG is set to true' do
@@ -58,9 +58,9 @@ module Selenium
         end
 
         it 'allows changing level by name during execution' do
-          logger.level = :info
-          expect(logger.level).to eq(1)
-          expect(logger).to be_info
+          logger.level = :error
+          expect(logger.level).to eq(3)
+          expect(logger).to be_error
         end
 
         it 'allows changing level by integer during execution' do
@@ -84,14 +84,48 @@ module Selenium
         end
       end
 
-      describe '#warn' do
-        it 'logs info on first warning but not second' do
-          logger = described_class.new('Selenium')
-          expect { logger.warn('first') }.to output(/:logger_info/).to_stdout_from_any_process
-          expect { logger.warn('second') }.not_to output(/:logger_info/).to_stdout_from_any_process
+      describe '#debug' do
+        before { logger.level = :debug }
+
+        it 'logs message' do
+          expect { logger.debug 'String Value' }.to output(/DEBUG Selenium String Value/).to_stdout_from_any_process
         end
 
-        it 'logs with String' do
+        it 'logs single id when set' do
+          msg = /DEBUG Selenium \[:foo\] debug message/
+          expect { logger.debug('debug message', id: :foo) }.to output(msg).to_stdout_from_any_process
+        end
+
+        it 'logs multiple ids when set' do
+          msg = /DEBUG Selenium \[:foo, :bar\] debug message/
+          expect { logger.debug('debug message', id: %i[foo bar]) }.to output(msg).to_stdout_from_any_process
+        end
+      end
+
+      describe '#info' do
+        it 'logs info on first info but not second' do
+          logger = described_class.new('Selenium')
+          expect { logger.info('first') }.to output(/:logger_info/).to_stdout_from_any_process
+          expect { logger.info('second') }.not_to output(/:logger_info/).to_stdout_from_any_process
+        end
+
+        it 'logs message' do
+          expect { logger.info 'String Value' }.to output(/INFO Selenium String Value/).to_stdout_from_any_process
+        end
+
+        it 'logs single id when set' do
+          msg = /INFO Selenium \[:foo\] info message/
+          expect { logger.info('info message', id: :foo) }.to output(msg).to_stdout_from_any_process
+        end
+
+        it 'logs multiple ids when set' do
+          msg = /INFO Selenium \[:foo, :bar\] info message/
+          expect { logger.info('info message', id: %i[foo bar]) }.to output(msg).to_stdout_from_any_process
+        end
+      end
+
+      describe '#warn' do
+        it 'logs message' do
           expect { logger.warn 'String Value' }.to output(/WARN Selenium String Value/).to_stdout_from_any_process
         end
 

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -76,8 +76,10 @@ module Selenium
       describe 'self.driver_path' do
         it 'errors if not an option' do
           expect {
-            described_class.driver_path(Remote::Capabilities.new(browser_name: 'chrome'))
-          }.to raise_error(ArgumentError, /SeleniumManager requires a WebDriver::Options instance/)
+            expect {
+              described_class.driver_path(Remote::Capabilities.new(browser_name: 'chrome'))
+            }.to raise_error(ArgumentError, /SeleniumManager requires a WebDriver::Options instance/)
+          }.to have_warning(:selenium_manager)
         end
 
         it 'determines browser name by default' do
@@ -85,7 +87,9 @@ module Selenium
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
 
-          described_class.driver_path(Options.chrome)
+          expect {
+            described_class.driver_path(Options.chrome)
+          }.to have_warning(:selenium_manager)
 
           expect(described_class).to have_received(:run)
             .with('selenium-manager', '--browser', 'chrome', '--output', 'json')
@@ -97,7 +101,9 @@ module Selenium
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(browser_version: 1)
 
-          described_class.driver_path(options)
+          expect {
+            described_class.driver_path(options)
+          }.to have_warning(:selenium_manager)
 
           expect(described_class).to have_received(:run)
             .with('selenium-manager', '--browser', 'chrome', '--output', 'json', '--browser-version', 1)
@@ -109,7 +115,9 @@ module Selenium
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(binary: '/path/to/browser')
 
-          described_class.driver_path(options)
+          expect {
+            described_class.driver_path(options)
+          }.to have_warning(:selenium_manager)
 
           expect(described_class).to have_received(:run)
             .with('selenium-manager', '--browser', 'chrome', '--output', 'json', '--browser-path', '/path/to/browser')
@@ -121,7 +129,9 @@ module Selenium
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(binary: '/path to/the/browser')
 
-          described_class.driver_path(options)
+          expect {
+            described_class.driver_path(options)
+          }.to have_warning(:selenium_manager)
 
           expect(described_class).to have_received(:run)
             .with('selenium-manager', '--browser', 'chrome', '--output', 'json',

--- a/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/options_spec.rb
@@ -220,14 +220,14 @@ module Selenium
             expect(options.as_json).to eq('browserName' => 'MicrosoftEdge', 'ms:edgeOptions' => {})
           end
 
-          it 'errors when unrecognized capability is passed' do
+          it 'warns when unrecognized capability is passed' do
             expect {
               options.add_option(:foo, 'bar')
             }.to have_deprecated(:add_option)
 
             expect {
               options.as_json
-            }.to output(/WARN Selenium These options are not w3c compliant/).to_stdout_from_any_process
+            }.to have_warning(:w3c_options)
           end
 
           it 'returns added options' do

--- a/rb/spec/unit/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/unit/selenium/webdriver/spec_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |c|
   c.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true
   end
-  Selenium::WebDriver.logger(ignored: [:logger_info])
+  Selenium::WebDriver.logger(ignored: :logger_info)
 
   c.include Selenium::WebDriver::UnitSpecHelper
 


### PR DESCRIPTION
### Description

Change default logging level to `:info` and provide more granular filtering options

### Motivation and Context

I'm looking at how logging is being done in other languages, and as part of putting this documentation together - https://www.selenium.dev/documentation/webdriver/troubleshooting/logging/ I thought we should change our implementation to match the other languages.

### Details:

To better manage the flood of details now in `:debug` mode, I've added `#select` and `#reject` methods where you can opt in or opt out of specific types of logs.

```rb
Selenium::WebDriver.logger.level = :debug
Selenium::WebDriver.logger.select(:selenium_manager)
```

```rb
Selenium::WebDriver.logger.reject(%i[deprecations logger_info])
```

Let me know if all of these choices make sense.