### PR TITLE
Fix wrong number of arguments error

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -96,7 +96,7 @@ module Selenium
 
     def self.logger(**opts)
       level = $DEBUG || ENV.key?('DEBUG') ? :debug : :info
-      @logger ||= WebDriver::Logger.new('Selenium', default_level: level, **opts)
+      @logger ||= WebDriver::Logger.new(progname: 'Selenium', default_level: level, **opts)
     end
   end # WebDriver
 end # Selenium


### PR DESCRIPTION
### Description
I fixed a bug where the initialize bug was called with the wrong number of arguments.

### Motivation and Context
See https://github.com/SeleniumHQ/selenium/issues/12005

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
