### PR TITLE
[bazel] Use a credential helper

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,3 +119,6 @@ test:remote --test_tag_filters=-edge,-safari,-remote
 build:remote --action_env=HOME=/home/dev
 build:remote --action_env=PATH=/bin:/usr/bin:/usr/local/bin
 test:remote --test_env=HOME=/home/dev
+
+# Make sure we sniff credentials properly
+build:remote --experimental_credential_helper=%workspace%/scripts/credential-helper.sh

--- a/scripts/credential-helper.sh
+++ b/scripts/credential-helper.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# We try not to rely on there being anything installed on the
+# local machine so although it would be nice to use `jq` here
+# we don't do so. This means that a selenium build needs very
+# little installed by the user
+
+function emit_headers() {
+  echo "{\"headers\":{\"Authorization\":[\"Bearer ${1}\"]}}"
+  exit 0
+}
+
+function get() {
+  INPUT=$1
+
+  if [ -z "$(echo "$INPUT" | grep "gypsum.cluster")" ]; then
+    exit 0
+  fi
+
+  if [ -n "$GITHUB_TOKEN" ]; then
+    emit_headers "$GITHUB_TOKEN"
+  fi
+
+  if [ -n "$ENGFLOW_GITHUB_TOKEN" ]; then
+    emit_headers "${ENGFLOW_GITHUB_TOKEN}"
+  fi
+
+  KEYCHAIN="$(security find-generic-password -a selenium -s 'Selenium EngFlow' -w )"
+  if [ -n "$KEYCHAIN" ]; then
+    emit_headers "${KEYCHAIN}"
+  fi
+
+  "{\"headers\":{}"
+  exit 0
+}
+
+function set() {
+    security add-generic-password -a selenium -s 'Selenium EngFlow' -w "$1"
+    exit 0
+}
+
+cmd=$1
+
+case $cmd in
+"get")
+  get "$(</dev/stdin)"
+  ;;
+
+"set")
+  set "$(</dev/stdin)"
+  ;;
+
+"test")
+  get '{"uri":"https://gypsum.cluster.engflow.com/google.devtools.build.v1.PublishBuildEvent"}'
+  ;;
+
+*)
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Bazel allows us to use a "credential helper" to supply authentication tokens to a remote build environment.

This PR adds a simple helper written as a bash script (so it _should_ work just fine everywhere) that pulls the credential from one of three places: the `GITHUB_TOKEN` env var, a custom `ENGFLOW_GITHUB_TOKEN` (which a user can set), or from the macOS Keychain.

To set the value in the keychain, use `./scripts/credential-helper.sh set` and enter the GitHub token via `stdin`. This will store the value in the keychain, so you can use it elsewhere.