### PR TITLE
[py] fix proxy options

### DIFF
--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -28,6 +28,7 @@ class BaseOptions(metaclass=ABCMeta):
     def __init__(self) -> None:
         super().__init__()
         self._caps = self.default_capabilities
+        self._proxy = None
         self.set_capability("pageLoadStrategy", "normal")
         self.mobile_options = None
 
@@ -213,6 +214,7 @@ class BaseOptions(metaclass=ABCMeta):
         if not isinstance(value, Proxy):
             raise InvalidArgumentException("Only Proxy objects can be passed in.")
         self._proxy = value
+        self._caps["proxy"] = value.to_capabilities()
 
     @abstractmethod
     def to_capabilities(self):

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -284,13 +284,8 @@ class Proxy:
                 f"Specified proxy type ({compatible_proxy}) not compatible with current setting ({self.proxyType})"
             )
 
-    def add_to_capabilities(self, capabilities):
-        """Adds proxy information as capability in specified capabilities.
-
-        :Args:
-         - capabilities: The capabilities to which proxy will be added.
-        """
-        proxy_caps = {"proxyType": self.proxyType["string"]}
+    def to_capabilities(self):
+        proxy_caps = {"proxyType": self.proxyType["string"].lower()}
         if self.autodetect:
             proxy_caps["autodetect"] = self.autodetect
         if self.ftpProxy:
@@ -311,4 +306,4 @@ class Proxy:
             proxy_caps["socksPassword"] = self.socksPassword
         if self.socksVersion:
             proxy_caps["socksVersion"] = self.socksVersion
-        capabilities["proxy"] = proxy_caps
+        return proxy_caps

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -42,7 +42,6 @@ class Options(ArgOptions):
         self._binary: typing.Optional[FirefoxBinary] = None
         self._preferences: dict = {}
         self._profile = None
-        self._proxy = None
         self.log = Log()
 
     @property
@@ -144,8 +143,6 @@ class Options(ArgOptions):
             opts["binary"] = self._binary._start_cmd
         if self._preferences:
             opts["prefs"] = self._preferences
-        if self._proxy:
-            self._proxy.add_to_capabilities(caps)
         if self._profile:
             opts["profile"] = self._profile.encoded
         if self._arguments:

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -104,8 +104,6 @@ def _make_w3c_caps(caps):
     caps = copy.deepcopy(caps)
     profile = caps.get("firefox_profile")
     always_match = {}
-    if caps.get("proxy") and caps["proxy"].get("proxyType"):
-        caps["proxy"]["proxyType"] = caps["proxy"]["proxyType"].lower()
     for k, v in caps.items():
         if v and k in _OSS_W3C_CONVERSION:
             # Todo: Remove in 4.7.0 (Deprecated in 4.5.0)

--- a/py/test/selenium/webdriver/common/proxy_tests.py
+++ b/py/test/selenium/webdriver/common/proxy_tests.py
@@ -17,6 +17,7 @@
 
 import pytest
 
+from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.common.proxy import Proxy
 from selenium.webdriver.common.proxy import ProxyType
 
@@ -40,7 +41,7 @@ AUTODETECT_PROXY = {
 }
 
 
-def test_can_add_manual_proxy_to_desired_capabilities():
+def test_can_add_manual_proxy_to_options():
     proxy = Proxy()
     proxy.http_proxy = MANUAL_PROXY["httpProxy"]
     proxy.ftp_proxy = MANUAL_PROXY["ftpProxy"]
@@ -51,39 +52,36 @@ def test_can_add_manual_proxy_to_desired_capabilities():
     proxy.socksPassword = MANUAL_PROXY["socksPassword"]
     proxy.socksVersion = MANUAL_PROXY["socksVersion"]
 
-    desired_capabilities = {}
-    proxy.add_to_capabilities(desired_capabilities)
+    options = ArgOptions()
+    options.proxy = proxy
 
     proxy_capabilities = MANUAL_PROXY.copy()
-    proxy_capabilities["proxyType"] = "MANUAL"
-    expected_capabilities = {"proxy": proxy_capabilities}
-    assert expected_capabilities == desired_capabilities
+    proxy_capabilities["proxyType"] = "manual"
+    assert proxy_capabilities == options.to_capabilities().get("proxy")
 
 
-def test_can_add_autodetect_proxy_to_desired_capabilities():
+def test_can_add_autodetect_proxy_to_options():
     proxy = Proxy()
     proxy.auto_detect = AUTODETECT_PROXY["autodetect"]
 
-    desired_capabilities = {}
-    proxy.add_to_capabilities(desired_capabilities)
+    options = ArgOptions()
+    options.proxy = proxy
 
     proxy_capabilities = AUTODETECT_PROXY.copy()
-    proxy_capabilities["proxyType"] = "AUTODETECT"
-    expected_capabilities = {"proxy": proxy_capabilities}
-    assert expected_capabilities == desired_capabilities
+    proxy_capabilities["proxyType"] = "autodetect"
+    assert proxy_capabilities == options.to_capabilities().get("proxy")
 
 
-def test_can_add_pacproxy_to_desired_capabilities():
+def test_can_add_pacproxy_to_options():
     proxy = Proxy()
     proxy.proxy_autoconfig_url = PAC_PROXY["proxyAutoconfigUrl"]
 
-    desired_capabilities = {}
-    proxy.add_to_capabilities(desired_capabilities)
+    options = ArgOptions()
+    options.proxy = proxy
 
     proxy_capabilities = PAC_PROXY.copy()
-    proxy_capabilities["proxyType"] = "PAC"
-    expected_capabilities = {"proxy": proxy_capabilities}
-    assert expected_capabilities == desired_capabilities
+    proxy_capabilities["proxyType"] = "pac"
+    assert proxy_capabilities == options.to_capabilities().get("proxy")
 
 
 def test_can_not_change_initialized_proxy_type():
@@ -136,10 +134,9 @@ def test_can_init_empty_proxy():
     assert "" == proxy.proxy_autoconfig_url
     assert proxy.socks_version is None
 
-    desired_capabilities = {}
-    proxy.add_to_capabilities(desired_capabilities)
+    options = ArgOptions()
+    options.proxy = proxy
 
     proxy_capabilities = {}
-    proxy_capabilities["proxyType"] = "UNSPECIFIED"
-    expected_capabilities = {"proxy": proxy_capabilities}
-    assert expected_capabilities == desired_capabilities
+    proxy_capabilities["proxyType"] = "unspecified"
+    assert proxy_capabilities == options.to_capabilities().get("proxy")

--- a/py/test/unit/selenium/webdriver/common/common_options_tests.py
+++ b/py/test/unit/selenium/webdriver/common/common_options_tests.py
@@ -17,7 +17,9 @@
 
 import pytest
 
+from selenium.webdriver import Proxy
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.common.proxy import ProxyType
 
 
 @pytest.fixture
@@ -62,3 +64,14 @@ def test_missing_capabilities_return_false_rather_than_none():
     assert options.strict_file_interactability is False
     assert options.set_window_rect is False
     assert options.accept_insecure_certs is False
+
+
+def test_add_proxy():
+    options = ArgOptions()
+    proxy = Proxy({"proxyType": ProxyType.MANUAL})
+    proxy.http_proxy = "http://user:password@http_proxy.com:8080"
+    options.proxy = proxy
+    caps = options.to_capabilities()
+
+    assert options.proxy == proxy
+    assert caps.get("proxy") == proxy.to_capabilities()

--- a/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
+++ b/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
@@ -77,7 +77,7 @@ def test_set_proxy_isnt_in_moz_prefix(options):
     options.proxy = proxy
 
     caps = options.to_capabilities()
-    assert caps["proxy"]["proxyType"] == "MANUAL"
+    assert caps["proxy"]["proxyType"] == "manual"
     assert caps.get("moz:firefoxOptions") is None
 
 
@@ -132,7 +132,7 @@ def test_creates_capabilities(options):
     options._arguments = ["foo"]
     options._binary = FirefoxBinary("/bar")
     options._preferences = {"foo": "bar"}
-    options._proxy = Proxy({"proxyType": ProxyType.MANUAL})
+    options.proxy = Proxy({"proxyType": ProxyType.MANUAL})
     options._profile = profile
     options.log.level = "debug"
     caps = options.to_capabilities()
@@ -142,7 +142,7 @@ def test_creates_capabilities(options):
     assert opts["binary"] == "/bar"
     assert opts["prefs"]["foo"] == "bar"
     assert opts["profile"] == profile.encoded
-    assert caps["proxy"]["proxyType"] == ProxyType.MANUAL["string"]
+    assert caps["proxy"]["proxyType"] == "manual"
     assert opts["log"]["level"] == "debug"
 
 

--- a/py/test/unit/selenium/webdriver/remote/new_session_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/new_session_tests.py
@@ -16,24 +16,17 @@
 # under the License.
 
 
-from copy import deepcopy
 from importlib import import_module
 
 import pytest
 
 from selenium.webdriver import DesiredCapabilities
+from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.common.proxy import Proxy
+from selenium.webdriver.common.proxy import ProxyType
 from selenium.webdriver.remote import webdriver
 from selenium.webdriver.remote.command import Command
 from selenium.webdriver.remote.webdriver import WebDriver
-
-
-def test_converts_oss_capabilities_to_w3c(mocker):
-    mock = mocker.patch("selenium.webdriver.remote.webdriver.WebDriver.execute")
-    oss_caps = {"platform": "WINDOWS", "version": "11", "acceptSslCerts": True}
-    w3c_caps = {"platformName": "windows", "browserVersion": "11", "acceptInsecureCerts": True}
-    WebDriver(desired_capabilities=deepcopy(oss_caps))
-    expected_params = {"capabilities": {"firstMatch": [{}], "alwaysMatch": w3c_caps}}
-    mock.assert_called_with(Command.NEW_SESSION, expected_params)
 
 
 @pytest.mark.parametrize(
@@ -54,9 +47,11 @@ def test_non_compliant_w3c_caps_is_deprecated(oss_name, val, w3c_name):
 
 def test_converts_proxy_type_value_to_lowercase_for_w3c(mocker):
     mock = mocker.patch("selenium.webdriver.remote.webdriver.WebDriver.execute")
-    oss_caps = {"proxy": {"proxyType": "MANUAL", "httpProxy": "foo"}}
-    w3c_caps = {"proxy": {"proxyType": "manual", "httpProxy": "foo"}}
-    WebDriver(desired_capabilities=deepcopy(oss_caps))
+    w3c_caps = {"pageLoadStrategy": "normal", "proxy": {"proxyType": "manual", "httpProxy": "foo"}}
+    options = ArgOptions()
+    proxy = Proxy({"proxyType": ProxyType.MANUAL, "httpProxy": "foo"})
+    options.proxy = proxy
+    WebDriver(options=options)
     expected_params = {"capabilities": {"firstMatch": [{}], "alwaysMatch": w3c_caps}}
     mock.assert_called_with(Command.NEW_SESSION, expected_params)
 


### PR DESCRIPTION
### Description
Allow Proxy to be used in any browser

### Motivation and Context
I added proxy property to Base Options class right before Se 4.0, but I didn't add the part that would actually add it to the capabilities. So right now I think proxy only works as intended for Firefox.

I'm removing `add_to_capabilities()` because it's a weird way to serialize a class, and also because capabilities is deprecated so no one should be passing it around. If we're just using options class, then we just need a way to serialize it, so I'm renaming the logic `to_capabilities()`. When we serialize it in options, we don't have to add logic in remote webdriver class.