### PR TITLE
[py] Use Config class for http client settings

### DIFF
--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -20,13 +20,13 @@ from selenium.webdriver.chromium.webdriver import ChromiumDriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.driver_finder import DriverFinder
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import DEFAULT_EXECUTABLE_PATH
 from .service import Service
 
 DEFAULT_PORT = 0
 DEFAULT_SERVICE_LOG_PATH = None
-DEFAULT_KEEP_ALIVE = None
 
 
 class WebDriver(ChromiumDriver):
@@ -46,7 +46,8 @@ class WebDriver(ChromiumDriver):
         service_log_path=DEFAULT_SERVICE_LOG_PATH,
         chrome_options=None,
         service: Service = None,
-        keep_alive=DEFAULT_KEEP_ALIVE,
+        keep_alive=None,
+        client_config: ClientConfig = ClientConfig(),
     ) -> None:
         """Creates a new instance of the chrome driver. Starts the service and
         then creates new instance of chrome driver.
@@ -69,12 +70,6 @@ class WebDriver(ChromiumDriver):
         if chrome_options:
             warnings.warn("use options instead of chrome_options", DeprecationWarning, stacklevel=2)
             options = chrome_options
-        if keep_alive != DEFAULT_KEEP_ALIVE:
-            warnings.warn(
-                "keep_alive has been deprecated, please pass in a Service object", DeprecationWarning, stacklevel=2
-            )
-        else:
-            keep_alive = True
         if not options:
             options = self.create_options()
         if not service:
@@ -91,6 +86,7 @@ class WebDriver(ChromiumDriver):
             service_log_path,
             service,
             keep_alive,
+            client_config,
         )
 
     def create_options(self) -> Options:

--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import typing
 
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
@@ -25,10 +25,9 @@ class ChromiumRemoteConnection(RemoteConnection):
         remote_server_addr: str,
         vendor_prefix: str,
         browser_name: str,
-        keep_alive: bool = True,
-        ignore_proxy: typing.Optional[bool] = False,
+        client_config: ClientConfig = ClientConfig(),
     ) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(remote_server_addr, client_config=client_config)
         self.browser_name = browser_name
         self._commands["launchApp"] = ("POST", "/session/$sessionId/chromium/launch_app")
         self._commands["setPermissions"] = ("POST", "/session/$sessionId/permissions")

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -101,16 +101,7 @@ class ChromiumDriver(RemoteWebDriver):
         self.service.start()
 
         try:
-            super().__init__(
-                command_executor=ChromiumRemoteConnection(
-                    remote_server_addr=self.service.service_url,
-                    browser_name=browser_name,
-                    vendor_prefix=vendor_prefix,
-                    keep_alive=keep_alive,
-                    ignore_proxy=_ignore_proxy,
-                ),
-                options=options,
-            )
+            super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive,)
         except Exception:
             self.quit()
             raise

--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import typing
+import warnings
 from abc import ABCMeta
 from abc import abstractmethod
 
@@ -30,6 +31,7 @@ class BaseOptions(metaclass=ABCMeta):
         self._caps = self.default_capabilities
         self.set_capability("pageLoadStrategy", "normal")
         self.mobile_options = None
+        self._ignore_local_proxy = False
 
     @property
     def capabilities(self):
@@ -223,12 +225,22 @@ class BaseOptions(metaclass=ABCMeta):
     def default_capabilities(self):
         """Return minimal capabilities necessary as a dictionary."""
 
+    def ignore_local_proxy_environment_variables(self) -> None:
+        """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
+        being picked up and used."""
+        warnings.warn(
+            "setting ignore proxy in Options has been deprecated, "
+            "set ProxyType.DIRECT in ClientConfig and pass to WebDriver constructor instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._ignore_local_proxy = True
+
 
 class ArgOptions(BaseOptions):
     def __init__(self) -> None:
         super().__init__()
         self._arguments = []
-        self._ignore_local_proxy = False
 
     @property
     def arguments(self):
@@ -247,11 +259,6 @@ class ArgOptions(BaseOptions):
             self._arguments.append(argument)
         else:
             raise ValueError("argument can not be null")
-
-    def ignore_local_proxy_environment_variables(self) -> None:
-        """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
-        being picked up and used."""
-        self._ignore_local_proxy = True
 
     def to_capabilities(self):
         return self._caps

--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -20,6 +20,7 @@ from selenium.webdriver.chromium.webdriver import ChromiumDriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.driver_finder import DriverFinder
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import DEFAULT_EXECUTABLE_PATH
 from .service import Service
@@ -44,7 +45,8 @@ class WebDriver(ChromiumDriver):
         capabilities=None,
         service_log_path=DEFAULT_SERVICE_LOG_PATH,
         service: Service = None,
-        keep_alive=False,
+        keep_alive=None,
+        client_config: ClientConfig = ClientConfig(),
         verbose=False,  # Todo: Why is this now unused?
     ) -> None:
         """Creates a new instance of the edge driver. Starts the service and
@@ -59,7 +61,7 @@ class WebDriver(ChromiumDriver):
            capabilities only, such as "proxy" or "loggingPref".
          - service_log_path - Deprecated: Where to log information from the driver.
          - service - Service object for handling the browser driver if you need to pass extra details
-         - keep_alive - Whether to configure EdgeRemoteConnection to use HTTP keep-alive.
+         - keep_alive - Deprecated: Whether to configure EdgeRemoteConnection to use HTTP keep-alive.
          - verbose - whether to set verbose logging in the service.
         """
         if executable_path != "msedgedriver":
@@ -83,6 +85,7 @@ class WebDriver(ChromiumDriver):
             service_log_path,
             service,
             keep_alive,
+            client_config,
         )
 
     def create_options(self) -> Options:

--- a/py/selenium/webdriver/firefox/remote_connection.py
+++ b/py/selenium/webdriver/firefox/remote_connection.py
@@ -16,14 +16,15 @@
 # under the License.
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
 class FirefoxRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.FIREFOX["browserName"]
 
-    def __init__(self, remote_server_addr, keep_alive=True, ignore_proxy=False) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+    def __init__(self, remote_server_addr: str, client_config: ClientConfig = ClientConfig()) -> None:
+        super().__init__(remote_server_addr, client_config=client_config)
 
         self._commands["GET_CONTEXT"] = ("GET", "/session/$sessionId/moz/context")
         self._commands["SET_CONTEXT"] = ("POST", "/session/$sessionId/moz/context")

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -195,10 +195,7 @@ class WebDriver(RemoteWebDriver):
         self.service.path = DriverFinder.get_path(self.service, options)
         self.service.start()
 
-        executor = FirefoxRemoteConnection(
-            remote_server_addr=self.service.service_url, ignore_proxy=options._ignore_local_proxy
-        )
-        super().__init__(command_executor=executor, options=options, keep_alive=True)
+        super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
 
         self._is_remote = False
 

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -27,10 +27,10 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
+from ..remote.client_config import ClientConfig
 from .firefox_binary import FirefoxBinary
 from .firefox_profile import FirefoxProfile
 from .options import Options
-from .remote_connection import FirefoxRemoteConnection
 from .service import DEFAULT_EXECUTABLE_PATH
 from .service import Service
 
@@ -58,7 +58,8 @@ class WebDriver(RemoteWebDriver):
         service=None,
         desired_capabilities=None,
         log_path=DEFAULT_LOG_PATH,
-        keep_alive=True,  # Todo: Why is this now unused?
+        keep_alive=None,
+        client_config: ClientConfig = ClientConfig(),
     ) -> None:
         """Starts a new local session of Firefox.
 
@@ -106,7 +107,7 @@ class WebDriver(RemoteWebDriver):
         :param desired_capabilities: Deprecated: alias of capabilities. In future
             versions of this library, this will replace 'capabilities'.
             This will make the signature consistent with RemoteWebDriver.
-        :param keep_alive: Whether to configure remote_connection.RemoteConnection to use
+        :param keep_alive - Deprecated: Whether to configure remote_connection.RemoteConnection to use
              HTTP keep-alive.
         """
 
@@ -195,7 +196,12 @@ class WebDriver(RemoteWebDriver):
         self.service.path = DriverFinder.get_path(self.service, options)
         self.service.start()
 
-        super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+        super().__init__(
+            command_executor=self.service.service_url,
+            options=options,
+            keep_alive=keep_alive,
+            client_config=client_config,
+        )
 
         self._is_remote = False
 

--- a/py/selenium/webdriver/ie/webdriver.py
+++ b/py/selenium/webdriver/ie/webdriver.py
@@ -21,6 +21,7 @@ from selenium.webdriver.common import utils
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import DEFAULT_EXECUTABLE_PATH
 from .service import Service
@@ -30,7 +31,6 @@ DEFAULT_PORT = 0
 DEFAULT_HOST = None
 DEFAULT_LOG_LEVEL = None
 DEFAULT_SERVICE_LOG_PATH = None
-DEFAULT_KEEP_ALIVE = None
 
 
 class WebDriver(RemoteWebDriver):
@@ -49,7 +49,8 @@ class WebDriver(RemoteWebDriver):
         options: Options = None,
         service: Service = None,
         desired_capabilities=None,
-        keep_alive=DEFAULT_KEEP_ALIVE,
+        keep_alive=None,
+        client_config: ClientConfig = ClientConfig(),
     ) -> None:
         """Creates a new instance of the Ie driver.
 
@@ -102,12 +103,6 @@ class WebDriver(RemoteWebDriver):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        if keep_alive != DEFAULT_KEEP_ALIVE:
-            warnings.warn(
-                "keep_alive has been deprecated, please pass in a Service object", DeprecationWarning, stacklevel=2
-            )
-        else:
-            keep_alive = True
 
         self.host = host
         self.port = port
@@ -127,7 +122,12 @@ class WebDriver(RemoteWebDriver):
         self.iedriver.path = DriverFinder.get_path(self.iedriver, options)
         self.iedriver.start()
 
-        super().__init__(command_executor=self.iedriver.service_url, options=options, keep_alive=keep_alive)
+        super().__init__(
+            command_executor=self.iedriver.service_url,
+            options=options,
+            keep_alive=keep_alive,
+            client_config=client_config,
+        )
         self._is_remote = False
 
     def quit(self) -> None:

--- a/py/selenium/webdriver/remote/client_config.py
+++ b/py/selenium/webdriver/remote/client_config.py
@@ -1,0 +1,89 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from selenium.webdriver.common.proxy import Proxy
+from selenium.webdriver.common.proxy import ProxyType
+
+
+class ClientConfig:
+    def __init__(
+        self, keep_alive: bool = True, timeout=None, proxy=Proxy({"proxyType": ProxyType.SYSTEM}), certificate_path=None
+    ) -> None:
+        self._keep_alive = keep_alive
+        self._timeout = timeout
+        self._proxy = proxy
+        self._certificate_path = certificate_path
+
+    @property
+    def keep_alive(self) -> bool:
+        """:Returns: The keep alive value"""
+        return self._keep_alive
+
+    @keep_alive.setter
+    def keep_alive(self, value: bool) -> None:
+        """Toggles the keep alive value.
+
+        :Args:
+         - value: whether to keep the http connection alive
+        """
+        self._keep_alive = value
+
+    @property
+    def timeout(self) -> int:
+        """:Returns: The amount of time to wait for an http response."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, time: int) -> None:
+        """Sets the amount of time to wait for an http response.
+
+        :Args:
+         - value: number of seconds to wait for an http response
+        """
+        self._timeout = time
+
+    @property
+    def proxy(self) -> Proxy:
+        """:Returns: The proxy used for communicating to the driver/server"""
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, proxy: Proxy) -> None:
+        """Provides the information for communicating with the driver or server.
+
+        :Args:
+         - value: the proxy information to use to communicate with the driver or server
+        """
+        self._proxy = proxy
+
+    @property
+    def certificate_path(self) -> bool:
+        """:Returns: The path of the .pem encoded certificate
+        used to verify connection to the driver or server
+        """
+        return self._certificate_path
+
+    @certificate_path.setter
+    def certificate_path(self, path: str) -> None:
+        """Set the path to the certificate bundle to verify connection to
+        command executor. Can also be set to None to disable certificate
+        validation.
+
+        :Args:
+            - path - path of a .pem encoded certificate chain.
+        """
+        self._certificate_path = path

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -130,15 +130,42 @@ def _make_w3c_caps(caps):
     return {"firstMatch": [{}], "alwaysMatch": always_match}
 
 
-def get_remote_connection(capabilities, command_executor, keep_alive, ignore_local_proxy=False):
-    from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
-    from selenium.webdriver.firefox.remote_connection import FirefoxRemoteConnection
-    from selenium.webdriver.safari.remote_connection import SafariRemoteConnection
+def get_remote_connection(browser_name, command_executor, keep_alive, ignore_local_proxy=False):
+    if browser_name == "chrome":
+        from selenium.webdriver.chromium.remote_connection import (
+            ChromiumRemoteConnection
+        )
+        return ChromiumRemoteConnection(command_executor,
+                                        vendor_prefix="goog",
+                                        browser_name=browser_name,
+                                        keep_alive=keep_alive,
+                                        ignore_proxy=ignore_local_proxy)
 
-    candidates = [RemoteConnection, ChromiumRemoteConnection, SafariRemoteConnection, FirefoxRemoteConnection]
-    handler = next((c for c in candidates if c.browser_name == capabilities.get("browserName")), RemoteConnection)
+    elif browser_name == "MicrosoftEdge":
+        from selenium.webdriver.chromium.remote_connection import (
+            ChromiumRemoteConnection
+        )
+        return ChromiumRemoteConnection(command_executor,
+                                        vendor_prefix="ms",
+                                        browser_name=browser_name,
+                                        keep_alive=keep_alive,
+                                        ignore_proxy=ignore_local_proxy)
 
-    return handler(command_executor, keep_alive=keep_alive, ignore_proxy=ignore_local_proxy)
+    elif browser_name == "firefox":
+        from selenium.webdriver.firefox.remote_connection import FirefoxRemoteConnection
+        return FirefoxRemoteConnection(command_executor,
+                                       keep_alive=keep_alive,
+                                       ignore_proxy=ignore_local_proxy)
+
+    elif browser_name == "safari":
+        from selenium.webdriver.safari.remote_connection import SafariRemoteConnection
+        return SafariRemoteConnection(command_executor,
+                                       keep_alive=keep_alive,
+                                       ignore_proxy=ignore_local_proxy)
+    else:
+        return RemoteConnection(command_executor,
+                                keep_alive=keep_alive,
+                                ignore_proxy=ignore_local_proxy)
 
 
 def create_matches(options: List[BaseOptions]) -> Dict:
@@ -268,7 +295,7 @@ class WebDriver(BaseWebDriver):
         self.command_executor = command_executor
         if isinstance(self.command_executor, (str, bytes)):
             self.command_executor = get_remote_connection(
-                capabilities,
+                capabilities.get("browserName"),
                 command_executor=command_executor,
                 keep_alive=keep_alive,
                 ignore_local_proxy=_ignore_local_proxy,

--- a/py/selenium/webdriver/safari/remote_connection.py
+++ b/py/selenium/webdriver/safari/remote_connection.py
@@ -16,14 +16,15 @@
 # under the License.
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
 class SafariRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.SAFARI["browserName"]
 
-    def __init__(self, remote_server_addr: str, keep_alive: bool = True, ignore_proxy: bool = False) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+    def __init__(self, remote_server_addr: str, client_config: ClientConfig) -> None:
+        super().__init__(remote_server_addr, client_config=client_config)
         self._commands["GET_PERMISSIONS"] = ("GET", "/session/$sessionId/apple/permissions")
         self._commands["SET_PERMISSIONS"] = ("POST", "/session/$sessionId/apple/permissions")
         self._commands["ATTACH_DEBUGGER"] = ("POST", "/session/$sessionId/apple/attach_debugger")

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -105,9 +105,7 @@ class WebDriver(RemoteWebDriver):
         if not reuse_service:
             self.service.start()
 
-        executor = SafariRemoteConnection(remote_server_addr=self.service.service_url, keep_alive=keep_alive)
-
-        super().__init__(command_executor=executor, options=options)
+        super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
 
         self._is_remote = False
 

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -22,8 +22,8 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
-from .remote_connection import SafariRemoteConnection
 from .service import DEFAULT_EXECUTABLE_PATH
 from .service import Service
 
@@ -40,10 +40,11 @@ class WebDriver(RemoteWebDriver):
         reuse_service=False,
         desired_capabilities=DEFAULT_SAFARI_CAPS,
         quiet=False,
-        keep_alive=True,
+        keep_alive=None,
         service_args=None,
         options: Options = None,
         service: Service = None,
+        client_config: ClientConfig = ClientConfig(),
     ) -> None:
         """Creates a new Safari driver instance and launches or finds a running
         safaridriver service.
@@ -54,8 +55,7 @@ class WebDriver(RemoteWebDriver):
          - reuse_service - If True, do not spawn a safaridriver instance; instead, connect to an already-running service that was launched externally.
          - desired_capabilities: Dictionary object with desired capabilities (Can be used to provide various Safari switches).
          - quiet - If True, the driver's stdout and stderr is suppressed.
-         - keep_alive - Whether to configure SafariRemoteConnection to use
-             HTTP keep-alive. Defaults to True.
+         - keep_alive - Deprecated: Whether to configure SafariRemoteConnection to use HTTP keep-alive.
          - service_args : List of args to pass to the safaridriver service
          - service - Service object for handling the browser driver if you need to pass extra details
         """
@@ -86,12 +86,6 @@ class WebDriver(RemoteWebDriver):
             warnings.warn(
                 "quiet has been deprecated, please use the Service class to set it", DeprecationWarning, stacklevel=2
             )
-        if not keep_alive:
-            warnings.warn(
-                "keep_alive has been deprecated, please use the Service class to set it",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         if service_args:
             warnings.warn(
@@ -105,7 +99,12 @@ class WebDriver(RemoteWebDriver):
         if not reuse_service:
             self.service.start()
 
-        super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+        super().__init__(
+            command_executor=self.service.service_url,
+            options=options,
+            keep_alive=keep_alive,
+            client_config=client_config,
+        )
 
         self._is_remote = False
 

--- a/py/selenium/webdriver/webkitgtk/webdriver.py
+++ b/py/selenium/webdriver/webkitgtk/webdriver.py
@@ -35,7 +35,7 @@ class WebDriver(RemoteWebDriver):
         options=None,
         desired_capabilities=None,
         service_log_path=None,
-        keep_alive=False,
+        keep_alive=None,
     ):
         """Creates a new instance of the WebKitGTK driver.
 


### PR DESCRIPTION
### Description
* New `ClientConfig` class with:
  * keep-alive
  * proxy
  * timeout
  * certificate path
* `keep_alive` deprecation changed (it was never supported in Service class)
* `ignore_proxy` deprecated in Options (not an option) 

### Motivation and Context
Python implementation of `command_executor` / `RemoteConnection`  is similar to Java. A user can create the class themselves, but can only use it as a parameter for `RemoteWebDriver`. Local drivers are subclassed and have their `RemoteConnection` classes created for them. 

Java addressed this with the `ClientConfig` class. (Ruby has always had a separate http_client, and I haven't looked at what JS or .NET do).

The only way to use a proxy right now is with environment variables. If a user wants to ignore the environment variables they use `ignore_local_proxy()` on `Options` class. `ClientConfig` takes a `Proxy` instance so the user does not need to set environment variables. Instead of having the user pass `ignore_proxy: true`, the user would pass `proxy: Proxy({"ProxyType": ProxyType.DIRECT})`. If that seems too odd, I can add back the ignore_proxy parameter, but only having the "right" proxy object seems more "correct."

Example usage:
```py
proxy = Proxy()
proxy.http = "http://localhost:8080"
client_config = ClientConfig(proxy=proxy, keep_alive=False, timeout=180)
driver = webdriver.Chrome(client_config=client_config)
```