### PR TITLE
Replace GetCallingAssembly with GetExecutingAssembly

### DIFF
--- a/dotnet/src/webdriver/Internal/ResourceUtilities.cs
+++ b/dotnet/src/webdriver/Internal/ResourceUtilities.cs
@@ -43,7 +43,7 @@ namespace OpenQA.Selenium.Internal
             {
                 if (string.IsNullOrEmpty(assemblyVersion))
                 {
-                    Assembly executingAssembly = Assembly.GetCallingAssembly();
+                    Assembly executingAssembly = Assembly.GetExecutingAssembly();
                     Version versionResource = executingAssembly.GetName().Version;
                     assemblyVersion = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", versionResource.Major, versionResource.Minor, versionResource.Revision);
                 }


### PR DESCRIPTION
`GetCallingAssembly` is not supported with .NET 7 PublishAot.

It's not clear why `GetCallingAssembly` was chosen - `GetCallingAssembly` returns the assembly of the method that is calling this method. If two different assemblies were to call `ResourceUtilities.AssemblyVersion`, this code would cache the assembly of the first caller and produce what is essentially an incorrect result for the second caller.

Given the only caller of `ResourceUtilities.AssemblyVersion` is within the same assembly, it's likely `Assembly.GetExecutedAssembly()` was intended (it's also indicated by the name of the local variable).

Fixes dotnet/runtime#86202.
Fixes #8549 (that was won't fixed but it's the same problem).

