### PR TITLE
[grid] Return stereotype as array in GraphQl

### DIFF
--- a/java/src/org/openqa/selenium/grid/graphql/Node.java
+++ b/java/src/org/openqa/selenium/grid/graphql/Node.java
@@ -19,8 +19,6 @@ package org.openqa.selenium.grid.graphql;
 
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.openqa.selenium.Capabilities;
@@ -97,17 +95,10 @@ public class Node {
         .collect(ImmutableList.toImmutableList());
   }
 
-  public String getStereotypes() {
-    List<Map<String, Object>> toReturn = new ArrayList<>();
-
-    for (Map.Entry<Capabilities, Integer> entry : stereotypes.entrySet()) {
-      Map<String, Object> details = new HashMap<>();
-      details.put("stereotype", entry.getKey());
-      details.put("slots", entry.getValue());
-      toReturn.add(details);
-    }
-
-    return JSON.toJson(toReturn);
+  public List<Stereotype> getStereotypes() {
+    return stereotypes.entrySet().stream()
+      .map(stereotype -> new Stereotype(stereotype.getKey(), stereotype.getValue()))
+      .collect(ImmutableList.toImmutableList());
   }
 
   public Availability getStatus() {

--- a/java/src/org/openqa/selenium/grid/graphql/Stereotype.java
+++ b/java/src/org/openqa/selenium/grid/graphql/Stereotype.java
@@ -1,0 +1,38 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.graphql;
+
+import org.openqa.selenium.Capabilities;
+
+public class Stereotype {
+  private Capabilities stereotype;
+  private int slots;
+
+  public Stereotype(Capabilities stereotype, int slots) {
+    this.stereotype = stereotype;
+    this.slots = slots;
+  }
+
+  public Capabilities getStereotype() {
+    return stereotype;
+  }
+
+  public int getSlots() {
+    return slots;
+  }
+}


### PR DESCRIPTION
### Description
Created the `org.openqa.selenium.grid.graphql.Stereotype` class and use it in the `Node.getStereotypes()`. 

### Motivation and Context
Fixes #11896

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
