### PR TITLE
[java] Implements binding volumes for dynamic nodes.

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
@@ -85,6 +85,21 @@ public class DockerFlags implements HasRoles {
   private List<String> devices;
 
   @Parameter(
+    names = {"--docker-volumes"},
+    description =
+      "Exposes volumes to a container. Each volume mapping declaration must have the"
+      + " path of the volume in both host and container separated by a colon like in this"
+      + " example: /path/in/host:/path/in/container",
+    arity = 1,
+    variableArity = true,
+    splitter = NonSplittingSplitter.class)
+  @ConfigValue(
+    section = DockerOptions.DOCKER_SECTION,
+    name = "volumes",
+    example = "[\"/mnt/disk:/mnt/custom-files\"]")
+  private List<String> volumes;
+
+  @Parameter(
       names = {"--docker-video-image"},
       description = "Docker image to be used when video recording is enabled")
   @ConfigValue(

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -98,6 +98,7 @@ public class DockerSessionFactory implements SessionFactory {
   private final Image browserImage;
   private final Capabilities stereotype;
   private final List<Device> devices;
+  private final Map<String, String> volumes;
   private final Image videoImage;
   private final DockerAssetsPath assetsPath;
   private final String networkName;
@@ -113,6 +114,7 @@ public class DockerSessionFactory implements SessionFactory {
       Image browserImage,
       Capabilities stereotype,
       List<Device> devices,
+      Map<String, String> volumes,
       Image videoImage,
       DockerAssetsPath assetsPath,
       String networkName,
@@ -126,6 +128,7 @@ public class DockerSessionFactory implements SessionFactory {
     this.networkName = Require.nonNull("Docker network name", networkName);
     this.stereotype = ImmutableCapabilities.copyOf(Require.nonNull("Stereotype", stereotype));
     this.devices = Require.nonNull("Container devices", devices);
+    this.volumes = Require.nonNull("Container volumes", volumes);
     this.videoImage = videoImage;
     this.assetsPath = assetsPath;
     this.runningInDocker = runningInDocker;
@@ -292,7 +295,8 @@ public class DockerSessionFactory implements SessionFactory {
             .env(browserContainerEnvVars)
             .shmMemorySize(browserContainerShmMemorySize)
             .network(networkName)
-            .devices(devices);
+            .devices(devices)
+            .bind(volumes);
     if (!runningInDocker) {
       containerConfig = containerConfig.map(Port.tcp(4444), Port.tcp(port));
     }

--- a/java/test/org/openqa/selenium/grid/node/docker/DockerOptionDevicesTest.java
+++ b/java/test/org/openqa/selenium/grid/node/docker/DockerOptionDevicesTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mockito;
 import org.openqa.selenium.docker.Device;
 import org.openqa.selenium.grid.config.Config;
 
-class DockerOptionsTest {
+class DockerOptionDevicesTest {
 
   public static Stream<Arguments> data() {
     return Arrays.stream(

--- a/java/test/org/openqa/selenium/grid/node/docker/DockerOptionVolumesTest.java
+++ b/java/test/org/openqa/selenium/grid/node/docker/DockerOptionVolumesTest.java
@@ -1,0 +1,71 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.node.docker;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.openqa.selenium.docker.Device;
+import org.openqa.selenium.grid.config.Config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+class DockerOptionVolumesTest {
+
+  public static Stream<Arguments> data() {
+    return Arrays.stream(
+            new Object[][] {
+              {
+                configuredVolumeMapping(List.of("/mnt/diskh:/mnt/diskl")),
+                Map.of("/mnt/diskh", "/mnt/diskl")
+              },
+              {
+                configuredVolumeMapping(asList("/mnt/diskh1:/mnt/diskl1", "/mnt/diskh2:/mnt/diskl2")),
+                Map.of("/mnt/diskh1", "/mnt/diskl1", "/mnt/diskh2", "/mnt/diskl2")
+              },
+              {
+                configuredVolumeMapping(List.of("/mnt/diskh:/mnt/diskl ")),
+                Map.of("/mnt/diskh", "/mnt/diskl")
+              }
+            })
+        .map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  void shouldReturnOnlyExpectedDeviceMappings(Config config, Map<String, String> volumesExpected) {
+    Map<String, String> returnedVolumes = new DockerOptions(config).getVolumesMapping();
+    assertThat(volumesExpected.equals(returnedVolumes))
+        .describedAs("Expected %s but was %s", volumesExpected, returnedVolumes)
+        .isTrue();
+  }
+
+  private static Config configuredVolumeMapping(List<String> volumeMapping) {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.getAll("docker", "volumes")).thenReturn(Optional.of(volumeMapping));
+    return config;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds option to mount volumes for dynamically loaded nodes. Fixes SeleniumHQ/docker-selenium#1642. 
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While testing a webrtc app we need to provide audio and video files to be used as mic and camera source for chrome via `--use-file-for-fake-audio-capture` and `--use-file-for-fake-video-capture`.

### Types of changes
Adding array of volumes to bind. Changes based on the existing devices functionality. 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
