### PR TITLE
[dotnet] have support proxies for Selenium Manager

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -98,6 +98,15 @@ namespace OpenQA.Selenium
                 argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --browser-path \"{0}\"", browserBinary);
             }
 
+            if (options.Proxy != null)
+            {
+                if (options.Proxy.SslProxy != null) {
+                    argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --proxy \"{0}\"", options.Proxy.SslProxy);
+                } else if (options.Proxy.HttpProxy != null) {
+                    argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --proxy \"{0}\"", options.Proxy.HttpProxy);
+                }
+            }
+
             return RunCommand(binaryFullPath, argsBuilder.ToString());
         }
 


### PR DESCRIPTION
### Description
sends proxy argument to selenium manager if found in options

### Motivation and Context
implements #11294 for .NET