### PR TITLE
[py] Removing browser filter when checking shadow root.

### DIFF
--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -236,7 +236,6 @@ class WebElement(BaseWebElement):
     def shadow_root(self) -> ShadowRoot:
         """Returns a shadow root of the element if there is one or an error.
         Only works from Chromium 96, Firefox 96, and Safari 16.4 onwards.
-        Previous versions of browsers will throw an assertion exception.
 
         :Returns:
           - ShadowRoot object or

--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -235,20 +235,13 @@ class WebElement(BaseWebElement):
     @property
     def shadow_root(self) -> ShadowRoot:
         """Returns a shadow root of the element if there is one or an error.
-        Only works from Chromium 96 and Firefox 96 onwards. Previous versions
-        of browsers will throw an assertion exception.
+        Only works from Chromium 96, Firefox 96, and Safari 16.4 onwards.
+        Previous versions of browsers will throw an assertion exception.
 
         :Returns:
           - ShadowRoot object or
           - NoSuchShadowRoot - if no shadow root was attached to element
         """
-        browser_main_version = int(self._parent.caps["browserVersion"].split(".")[0])
-        assert (
-            self._parent.caps["browserName"].lower() != "safari"
-        ), "This only currently works in Firefox and Chromium based browsers"
-        assert (
-            browser_main_version > 95
-        ), f"Please use Firefox or Chromium based browsers with version 96 or later. Version used {self._parent.caps['browserVersion']}"
         return self._execute(Command.GET_SHADOW_ROOT)["value"]
 
     # RenderedWebElement Items


### PR DESCRIPTION
Only Python had it, fixes #11893

During the meeting on [25.05.2023](https://www.selenium.dev/meetings/2023/tlc-05-25/) it was decided add support for everything in spec and let the drivers error when things do not work.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
