### PR TITLE
[rb] have RubyMine to use artifacts built by bazel if exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,8 @@ If you want to use RubyMine for development, a bit of extra configuration is nec
 
 1. Run `bazel build @bundle//:bundle //rb:selenium-devtools //rb:selenium-webdriver` before configuring IDE.
 2. Open `rb/` as a main project directory.
-3. In <kbd>Settings / Lanugages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-selenium/external/ruby_rules_dist/dist/bin/ruby`.
-4. In <kbd>Run / Edit Configurations... / Edit configuration templates... / RSpec</kbd> add `-I ../bazel-bin/rb/lib` to <kbd>Ruby arguments</kbd>.
-5. You should now be able to run and debug any spec. It uses Chrome by default, but you can alter it using environment variables above.
+3. In <kbd>Settings / Languages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-selenium/external/rules_ruby_dist/dist/bin/ruby`.
+4. You should now be able to run and debug any spec. It uses Chrome by default, but you can alter it using environment variables above.
 
 </details>
 

--- a/rb/lib/selenium/webdriver/common/selenium_manager.rb
+++ b/rb/lib/selenium/webdriver/common/selenium_manager.rb
@@ -27,9 +27,13 @@ module Selenium
     # @api private
     #
     class SeleniumManager
-      BIN_PATH = '../../../../../bin'
-
       class << self
+        attr_writer :bin_path
+
+        def bin_path
+          @bin_path ||= '../../../../../bin'
+        end
+
         # @param [Options] options browser options.
         # @return [String] the path to the correct driver.
         def driver_path(options)
@@ -72,7 +76,7 @@ module Selenium
         # @return [String] the path to the correct selenium manager
         def binary
           @binary ||= begin
-            path = File.expand_path(BIN_PATH, __FILE__)
+            path = File.expand_path(bin_path, __FILE__)
             path << if Platform.windows?
                       '/windows/selenium-manager.exe'
                     elsif Platform.mac?

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -27,7 +27,9 @@ module Selenium
           @create_driver_error = nil
           @create_driver_error_count = 0
 
+          $LOAD_PATH.insert(0, root.join('bazel-bin/rb/lib').to_s) if File.exist?(root.join('bazel-bin/rb/lib'))
           WebDriver.logger.ignore(%i[logger_info selenium_manager])
+          SeleniumManager.bin_path = root.join('bazel-bin/rb/bin').to_s if File.exist?(root.join('bazel-bin/rb/bin'))
 
           @driver = ENV.fetch('WD_SPEC_DRIVER', 'chrome').tr('-', '_').to_sym
           @driver_instance = nil


### PR DESCRIPTION
### Description
This has RubyMine look in `bazel-bin` directories first. This will use artifacts in that directory even if the same files exist in `selenium/rb`.

### Motivation and Context
Can't easily use Selenium Manager with RubyMine

@p0deje 
1. ~Is this a bad use of `$LOAD_PATH`?~
2. ~This should work in a gem? I think? Do we need to test it?~
3. ~Should we check in the `selenium/rb/selenium.iml` file into git which should cause RubyMine to default to the ruby binary in bazel-bin?~
4. ~Should we go one step further and have `test_environment.rb` run the bazel command in shell?~

Ok, take 2... 
This PR will find the selenium manager binaries that were generated by bazel when running tests in RubyMine...

The question remains...
I think adding `bazel-bin/rb/lib` to `$LOAD_PATH` is the same as adding `-I ../bazel-bin/rb/lib` to config arguments? And I think there's no down side to having it there, even when bazel is running the tests and not RubyMine?

