### PR TITLE
[java] do not send driver logs to console by default

### DIFF
--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -465,7 +465,9 @@ public class DriverService implements Closeable {
         }
 
         if (logLocation == null) {
-          return System.err;
+          LOG.info("Driver logs no longer sent to console by default; " +
+            "https://www.selenium.dev/documentation/webdriver/drivers/service/#setting-log-output");
+          return ByteStreams.nullOutputStream();
         }
 
         switch (logLocation) {


### PR DESCRIPTION
### Description
* Sends logs to DEVNULL instead of STDERR unless otherwise specified
* Adds a log line to indicate where the logs went (do we need to log something? maybe a better message?)

### Motivation and Context
Fixes #12016 for Java