### PR TITLE
[rb] Initial extensibility points for Appium

### DIFF
--- a/rb/lib/selenium/webdriver/common/search_context.rb
+++ b/rb/lib/selenium/webdriver/common/search_context.rb
@@ -35,6 +35,14 @@ module Selenium
         xpath: 'xpath'
       }.freeze
 
+      class << self
+        attr_accessor :extra_finders
+
+        def finders
+          FINDERS.merge(extra_finders || {})
+        end
+      end
+
       #
       # Find the first element matching the given arguments
       #
@@ -57,7 +65,7 @@ module Selenium
       def find_element(*args)
         how, what = extract_args(args)
 
-        by = FINDERS[how.to_sym]
+        by = SearchContext.finders[how.to_sym]
         raise ArgumentError, "cannot find element by #{how.inspect}" unless by
 
         bridge.find_element_by by, what, ref
@@ -72,7 +80,7 @@ module Selenium
       def find_elements(*args)
         how, what = extract_args(args)
 
-        by = FINDERS[how.to_sym]
+        by = SearchContext.finders[how.to_sym]
         raise ArgumentError, "cannot find elements by #{how.inspect}" unless by
 
         bridge.find_elements_by by, what, ref

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -29,6 +29,16 @@ module Selenium
         attr_accessor :http, :file_detector
         attr_reader :capabilities
 
+        class << self
+          attr_reader :extra_commands
+
+          def add_command(name, verb, url, &block)
+            @extra_commands ||= {}
+            @extra_commands[name] = [verb, url]
+            define_method(name, &block)
+          end
+        end
+
         #
         # Initializes the bridge with the given server URL
         # @param [String, URI] url url for the remote server
@@ -612,7 +622,7 @@ module Selenium
         end
 
         def commands(command)
-          command_list[command]
+          command_list[command]|| Bridge.extra_commands[command]
         end
 
         def unwrap_script_result(arg)

--- a/rb/lib/selenium/webdriver/remote/bridge/locator_converter.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge/locator_converter.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Selenium
+  module WebDriver
+    module Remote
+      class Bridge
+        class LocatorConverter
+          ESCAPE_CSS_REGEXP = /(['"\\#.:;,!?+<>=~*^$|%&@`{}\-\[\]()])/
+          UNICODE_CODE_POINT = 30
+
+          #
+          # Converts a locator to a specification compatible one.
+          # @param [String, Symbol] how
+          # @param [String] what
+          #
+
+          def convert(how, what)
+            how = SearchContext.finders[how.to_sym] || how
+
+            case how
+            when 'class name'
+              how = 'css selector'
+              what = ".#{escape_css(what.to_s)}"
+            when 'id'
+              how = 'css selector'
+              what = "##{escape_css(what.to_s)}"
+            when 'name'
+              how = 'css selector'
+              what = "*[name='#{escape_css(what.to_s)}']"
+            end
+
+            if what.is_a?(Hash)
+              what = what.each_with_object({}) do |(h, w), hash|
+                h, w = convert(h.to_s, w)
+                hash[h] = w
+              end
+            end
+
+            [how, what]
+          end
+
+          private
+
+          #
+          # Escapes invalid characters in CSS selector.
+          # @see https://mathiasbynens.be/notes/css-escapes
+          #
+
+          def escape_css(string)
+            string = string.gsub(ESCAPE_CSS_REGEXP) { |match| "\\#{match}" }
+            string = "\\#{UNICODE_CODE_POINT + Integer(string[0])} #{string[1..]}" if string[0]&.match?(/[[:digit:]]/)
+
+            string
+          end
+        end # LocatorConverter
+      end # Bridge
+    end # Remote
+  end # WebDriver
+end # Selenium

--- a/rb/lib/selenium/webdriver/remote/http/common.rb
+++ b/rb/lib/selenium/webdriver/remote/http/common.rb
@@ -30,6 +30,10 @@ module Selenium
             'User-Agent' => "selenium/#{WebDriver::VERSION} (ruby #{Platform.os})"
           }.freeze
 
+          class << self
+            attr_accessor :extra_headers
+          end
+
           attr_writer :server_url
 
           def quit_errors
@@ -42,7 +46,7 @@ module Selenium
 
           def call(verb, url, command_hash)
             url      = server_url.merge(url) unless url.is_a?(URI)
-            headers  = DEFAULT_HEADERS.dup
+            headers  = DEFAULT_HEADERS.merge(Common.extra_headers || {}).dup
             headers['Cache-Control'] = 'no-cache' if verb == :get
 
             if command_hash

--- a/rb/lib/selenium/webdriver/remote/http/common.rb
+++ b/rb/lib/selenium/webdriver/remote/http/common.rb
@@ -26,12 +26,16 @@ module Selenium
           CONTENT_TYPE    = 'application/json'
           DEFAULT_HEADERS = {
             'Accept' => CONTENT_TYPE,
-            'Content-Type' => "#{CONTENT_TYPE}; charset=UTF-8",
-            'User-Agent' => "selenium/#{WebDriver::VERSION} (ruby #{Platform.os})"
+            'Content-Type' => "#{CONTENT_TYPE}; charset=UTF-8"
           }.freeze
 
           class << self
             attr_accessor :extra_headers
+            attr_writer :user_agent
+
+            def user_agent
+              @user_agent ||= "selenium/#{WebDriver::VERSION} (ruby #{Platform.os})"
+            end
           end
 
           attr_writer :server_url
@@ -46,7 +50,7 @@ module Selenium
 
           def call(verb, url, command_hash)
             url      = server_url.merge(url) unless url.is_a?(URI)
-            headers  = DEFAULT_HEADERS.merge(Common.extra_headers || {}).dup
+            headers  = common_headers.dup
             headers['Cache-Control'] = 'no-cache' if verb == :get
 
             if command_hash
@@ -64,6 +68,16 @@ module Selenium
           end
 
           private
+
+          def common_headers
+            @common_headers ||= begin
+              headers = DEFAULT_HEADERS.dup
+              headers['User-Agent'] = Common.user_agent
+              headers = headers.merge(Common.extra_headers || {})
+
+              headers
+            end
+          end
 
           def server_url
             return @server_url if @server_url

--- a/rb/spec/unit/selenium/webdriver/remote/http/common_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/common_spec.rb
@@ -33,7 +33,8 @@ module Selenium
           end
 
           after do
-            described_class.extra_headers = {}
+            described_class.extra_headers = nil
+            described_class.user_agent = nil
           end
 
           it 'sends non-empty body header for POST requests without command data' do
@@ -62,6 +63,16 @@ module Selenium
             expect(common).to have_received(:request)
               .with(:post, URI.parse('http://server/session'),
                     hash_including('Foo' => 'bar'), '{}')
+          end
+
+          it 'allows overriding default User-Agent' do
+            described_class.user_agent = 'rspec/1.0 (ruby 3.2)'
+
+            common.call(:post, 'session', nil)
+
+            expect(common).to have_received(:request)
+              .with(:post, URI.parse('http://server/session'),
+                    hash_including('User-Agent' => 'rspec/1.0 (ruby 3.2)'), '{}')
           end
         end
       end # Http

--- a/rb/spec/unit/selenium/webdriver/remote/http/common_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/common_spec.rb
@@ -24,11 +24,19 @@ module Selenium
     module Remote
       module Http
         describe Common do
-          it 'sends non-empty body header for POST requests without command data' do
+          subject(:common) do
             common = described_class.new
             common.server_url = URI.parse('http://server')
             allow(common).to receive(:request)
 
+            common
+          end
+
+          after do
+            described_class.extra_headers = {}
+          end
+
+          it 'sends non-empty body header for POST requests without command data' do
             common.call(:post, 'clear', nil)
 
             expect(common).to have_received(:request)
@@ -37,16 +45,23 @@ module Selenium
           end
 
           it 'sends a standard User-Agent by default' do
-            common = described_class.new
-            common.server_url = URI.parse('http://server')
             user_agent_regexp = %r{\Aselenium/#{WebDriver::VERSION} \(ruby #{Platform.os}\)\z}
-            allow(common).to receive(:request)
 
             common.call(:post, 'session', nil)
 
             expect(common).to have_received(:request)
               .with(:post, URI.parse('http://server/session'),
                     hash_including('User-Agent' => a_string_matching(user_agent_regexp)), '{}')
+          end
+
+          it 'allows registering extra headers' do
+            described_class.extra_headers = {'Foo' => 'bar'}
+
+            common.call(:post, 'session', nil)
+
+            expect(common).to have_received(:request)
+              .with(:post, URI.parse('http://server/session'),
+                    hash_including('Foo' => 'bar'), '{}')
           end
         end
       end # Http

--- a/rb/spec/unit/selenium/webdriver/search_context_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/search_context_spec.rb
@@ -89,6 +89,22 @@ module Selenium
           }.to raise_error(ArgumentError, 'cannot find elements by :foo')
         end
       end
+
+      context 'when extra finders are registered' do
+        around do |example|
+          described_class.extra_finders = {accessibility_id: 'accessibility id'}
+          example.call
+        ensure
+          described_class.extra_finders = nil
+        end
+
+        it 'finds element' do
+          allow(bridge).to receive(:find_element_by).with('accessibility id', 'foo', nil).and_return(element)
+
+          expect(search_context.find_element(accessibility_id: 'foo')).to eq(element)
+          expect(bridge).to have_received(:find_element_by).with('accessibility id', 'foo', nil)
+        end
+      end
     end
   end # WebDriver
 end # Selenium


### PR DESCRIPTION
This PR is the first draft that implements extensibility points that would be useful in Appium per appium/ruby_lib_core#429. With this PR, we can try to see if that would be enough to avoid monkey-patching and hopefully make Selenium break Appium less often. If this is enough, we can repeat the same for other bindings too.

@KazuCocoa Please let me know what do you think about these changes.

UPD: The Appium side is complete (https://github.com/appium/ruby_lib_core/pull/480) and greatly simplified with this PR in mind. I propose we merge this and note down what needs to be done in other bindings. Python is likely going to be similar, but I am not sure about other languages.