### PR TITLE
Use prebuilt Selenium Manager when stamping, otherwise try and build

### DIFF
--- a/common/manager/BUILD.bazel
+++ b/common/manager/BUILD.bazel
@@ -1,16 +1,35 @@
-filegroup(
-    name = "manager",
-    srcs = glob([
-        "*",
-        "**/*",
-    ]),
-    visibility = [
-        "//java/test/org/openqa/selenium/chrome:__pkg__",
-        "//java/test/org/openqa/selenium/edge:__pkg__",
-        "//java/test/org/openqa/selenium/firefox:__pkg__",
+package(
+    default_visibility = [
+        "//dotnet/src/webdriver:__pkg__",
+        "//java/src/org/openqa/selenium/manager:__pkg__",
+        "//javascript/node/selenium-webdriver:__pkg__",
         "//py:__pkg__",
         "//rb:__pkg__",
     ],
+)
+
+alias(
+    name = "selenium-manager-linux",
+    actual = select({
+        "//common:stamp": "linux/selenium-manager",
+        "//conditions:default": "//rust:selenium-manager-linux",
+    }),
+)
+
+alias(
+    name = "selenium-manager-macos",
+    actual = select({
+        "//common:stamp": "macos/selenium-manager",
+        "//conditions:default": "//rust:selenium-manager-macos",
+    }),
+)
+
+alias(
+    name = "selenium-manager-windows",
+    actual = select({
+        "//common:stamp": "windows/selenium-manager.exe",
+        "//conditions:default": "//rust:selenium-manager-windows",
+    }),
 )
 
 exports_files(
@@ -20,13 +39,6 @@ exports_files(
         "windows/selenium-manager.exe",
     ],
     visibility = [
-        "//dotnet/src/webdriver:__pkg__",
-        "//java/src/org/openqa/selenium/manager:__pkg__",
-        "//java/test/org/openqa/selenium/chrome:__pkg__",
-        "//java/test/org/openqa/selenium/edge:__pkg__",
-        "//java/test/org/openqa/selenium/firefox:__pkg__",
-        "//javascript/node/selenium-webdriver:__pkg__",
-        "//py:__pkg__",
-        "//rb:__pkg__",
+        "//rust:__pkg__",
     ],
 )

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -248,19 +248,19 @@ copy_file(
 
 copy_file(
     name = "manager-linux",
-    src = "//common/manager:linux/selenium-manager",
+    src = "//common/manager:selenium-manager-linux",
     out = "manager/linux/selenium-manager",
 )
 
 copy_file(
     name = "manager-macos",
-    src = "//common/manager:macos/selenium-manager",
+    src = "//common/manager:selenium-manager-macos",
     out = "manager/macos/selenium-manager",
 )
 
 copy_file(
     name = "manager-windows",
-    src = "//common/manager:windows/selenium-manager.exe",
+    src = "//common/manager:selenium-manager-windows",
     out = "manager/windows/selenium-manager.exe",
 )
 

--- a/java/src/org/openqa/selenium/manager/BUILD.bazel
+++ b/java/src/org/openqa/selenium/manager/BUILD.bazel
@@ -25,18 +25,18 @@ java_export(
 
 copy_file(
     name = "manager-linux",
-    src = "//common/manager:linux/selenium-manager",
+    src = "//common/manager:selenium-manager-linux",
     out = "linux/selenium-manager",
 )
 
 copy_file(
-    name = "manager-windows",
-    src = "//common/manager:windows/selenium-manager.exe",
-    out = "windows/selenium-manager.exe",
+    name = "manager-macos",
+    src = "//common/manager:selenium-manager-macos",
+    out = "macos/selenium-manager",
 )
 
 copy_file(
-    name = "manager-macos",
-    src = "//common/manager:macos/selenium-manager",
-    out = "macos/selenium-manager",
+    name = "manager-windows",
+    src = "//common/manager:selenium-manager-windows",
+    out = "windows/selenium-manager.exe",
 )

--- a/javascript/node/selenium-webdriver/BUILD.bazel
+++ b/javascript/node/selenium-webdriver/BUILD.bazel
@@ -152,18 +152,18 @@ genrule(
 
 copy_file(
     name = "manager-linux",
-    src = "//common/manager:linux/selenium-manager",
+    src = "//common/manager:selenium-manager-linux",
     out = "bin/linux/selenium-manager",
 )
 
 copy_file(
-    name = "manager-windows",
-    src = "//common/manager:windows/selenium-manager.exe",
-    out = "bin/windows/selenium-manager.exe",
+    name = "manager-macos",
+    src = "//common/manager:selenium-manager-macos",
+    out = "bin/macos/selenium-manager",
 )
 
 copy_file(
-    name = "manager-macos",
-    src = "//common/manager:macos/selenium-manager",
-    out = "bin/macos/selenium-manager",
+    name = "manager-windows",
+    src = "//common/manager:selenium-manager-windows",
+    out = "bin/windows/selenium-manager.exe",
 )

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -47,20 +47,20 @@ TEST_DEPS = [
 ]
 
 copy_file(
-    name = "manager-macos",
-    src = "//common/manager:macos/selenium-manager",
-    out = "selenium/webdriver/common/macos/selenium-manager",
-)
-
-copy_file(
     name = "manager-linux",
-    src = "//common/manager:linux/selenium-manager",
+    src = "//common/manager:selenium-manager-linux",
     out = "selenium/webdriver/common/linux/selenium-manager",
 )
 
 copy_file(
+    name = "manager-macos",
+    src = "//common/manager:selenium-manager-macos",
+    out = "selenium/webdriver/common/macos/selenium-manager",
+)
+
+copy_file(
     name = "manager-windows",
-    src = "//common/manager:windows/selenium-manager.exe",
+    src = "//common/manager:selenium-manager-windows",
     out = "selenium/webdriver/common/windows/selenium-manager.exe",
 )
 

--- a/rb/BUILD.bazel
+++ b/rb/BUILD.bazel
@@ -16,20 +16,20 @@ exports_files(["ruby_version.bzl"])
 
 copy_file(
     name = "manager-linux",
-    src = "//common/manager:linux/selenium-manager",
+    src = "//common/manager:selenium-manager-linux",
     out = "bin/linux/selenium-manager",
 )
 
 copy_file(
-    name = "manager-windows",
-    src = "//common/manager:windows/selenium-manager.exe",
-    out = "bin/windows/selenium-manager.exe",
+    name = "manager-macos",
+    src = "//common/manager:selenium-manager-macos",
+    out = "bin/macos/selenium-manager",
 )
 
 copy_file(
-    name = "manager-macos",
-    src = "//common/manager:macos/selenium-manager",
-    out = "bin/macos/selenium-manager",
+    name = "manager-windows",
+    src = "//common/manager:selenium-manager-windows",
+    out = "bin/windows/selenium-manager.exe",
 )
 
 select_file(

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -1,6 +1,72 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
+# We want the release versions of Selenium to include the prebuilt
+# binaries, but if we're doing day-to-day dev work, then we should
+# use a local build, unless on we're on Windows, where for some
+# reason we're not able to build locally.
+#
+# We tag the compiled versions as `manual` so that when we do a
+# `bazel build //...` we don't do any additional work
+
+# Start with the variants for each platform
+alias(
+    name = "selenium-manager-windows",
+    actual = select({
+        "//common:windows": ":selenium-manager",
+        "//conditions:default": "//common/manager:windows/selenium-manager.exe",
+    }),
+    tags = [
+        "manual",
+    ],
+    visibility = [
+        "//common/manager:__pkg__",
+    ],
+)
+
+alias(
+    name = "selenium-manager-macos",
+    actual = select({
+        "//common:macos": ":selenium-manager",
+        "//conditions:default": "//common/manager:macos/selenium-manager",
+    }),
+    tags = [
+        "manual",
+    ],
+    visibility = [
+        "//common/manager:__pkg__",
+    ],
+)
+
+alias(
+    name = "selenium-manager-linux",
+    actual = select({
+        "//common:linux": ":selenium-manager",
+        "//conditions:default": "//common/manager:linux/selenium-manager",
+    }),
+    tags = [
+        "manual",
+    ],
+    visibility = [
+        "//common/manager:__pkg__",
+    ],
+)
+
+filegroup(
+    name = "selenium-manager-dev",
+    srcs = [
+        ":selenium-manager-linux",
+        ":selenium-manager-macos",
+        ":selenium-manager-windows",
+    ],
+    tags = [
+        "manual",
+    ],
+    visibility = [
+        "//common/manager:__subpackages__",
+    ],
+)
+
 rust_binary(
     # Yes, this name is very similar to the library. Note the dash
     # instead of an underscore


### PR DESCRIPTION
We only try and build for the current platform we're running on: everything else gets the pre-built binaries too. This avoids cross-compiling, but does allow us to test the latest Selenium Manager without checking in the binaries.
