### PR TITLE
Selenium Manager & Error things

### DIFF
--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    selenium-devtools (0.113.0)
+    selenium-devtools (0.114.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.9.1)
       rexml (~> 3.2, >= 3.2.5)

--- a/rb/lib/selenium/webdriver/common/driver_finder.rb
+++ b/rb/lib/selenium/webdriver/common/driver_finder.rb
@@ -26,17 +26,20 @@ module Selenium
         path ||= Platform.find_binary(klass::EXECUTABLE)
 
         path ||= begin
-          SeleniumManager.driver_path(options)
+          SeleniumManager.driver_path(options) unless options.is_a?(Remote::Capabilities)
         rescue StandardError => e
-          WebDriver.logger.warn("Unable to obtain driver using Selenium Manager\n #{e.message}",
-                                id: :selenium_manager)
-          nil
+          raise Error::NoSuchDriverError, "Unable to obtain #{klass::EXECUTABLE} using Selenium Manager; #{e.message}"
         end
-        msg = "Unable to locate the #{klass::EXECUTABLE} executable; for more information on how to install drivers, " \
-              'see https://www.selenium.dev/documentation/webdriver/getting_started/install_drivers/'
-        raise Error::WebDriverError, msg unless path
 
-        Platform.assert_executable path
+        begin
+          Platform.assert_file(path)
+          Platform.assert_executable(path)
+        rescue TypeError
+          raise Error::NoSuchDriverError, "Unable to locate or obtain #{klass::EXECUTABLE}"
+        rescue Error::WebDriverError => e
+          raise Error::NoSuchDriverError, "#{klass::EXECUTABLE} located, but: #{e.message}"
+        end
+
         path
       end
     end

--- a/rb/lib/selenium/webdriver/common/error.rb
+++ b/rb/lib/selenium/webdriver/common/error.rb
@@ -34,13 +34,20 @@ module Selenium
         WebDriverError
       end
 
+      SUPPORT_MSG = 'For documentation on this error, please visit:'
+      ERROR_URL = 'https://www.selenium.dev/documentation/webdriver/troubleshooting/errors'
+
       class WebDriverError < StandardError; end
 
       #
       # An element could not be located on the page using the given search parameters.
       #
 
-      class NoSuchElementError < WebDriverError; end
+      class NoSuchElementError < WebDriverError
+        def initialize(msg = '')
+          super("#{msg}; #{SUPPORT_MSG} #{ERROR_URL}#no-such-element-exception")
+        end
+      end
 
       #
       # A command to switch to a frame could not be satisfied because the frame could not be found.
@@ -58,7 +65,11 @@ module Selenium
       # A command failed because the referenced element is no longer attached to the DOM.
       #
 
-      class StaleElementReferenceError < WebDriverError; end
+      class StaleElementReferenceError < WebDriverError
+        def initialize(msg = '')
+          super("#{msg}; #{SUPPORT_MSG} #{ERROR_URL}#stale-element-reference-exception")
+        end
+      end
 
       #
       # A command failed because the referenced shadow root is no longer attached to the DOM.
@@ -132,7 +143,11 @@ module Selenium
       # Argument was an invalid selector.
       #
 
-      class InvalidSelectorError < WebDriverError; end
+      class InvalidSelectorError < WebDriverError
+        def initialize(msg = '')
+          super("#{msg}; #{SUPPORT_MSG} #{ERROR_URL}#invalid-selector-exception")
+        end
+      end
 
       #
       # A new session could not be created.

--- a/rb/lib/selenium/webdriver/common/error.rb
+++ b/rb/lib/selenium/webdriver/common/error.rb
@@ -227,6 +227,16 @@ module Selenium
       #
 
       class UnsupportedOperationError < WebDriverError; end
+
+      #
+      # Indicates that driver was not specified and could not be located.
+      #
+
+      class NoSuchDriverError < WebDriverError
+        def initialize(msg = '')
+          super("#{msg}; #{SUPPORT_MSG} #{ERROR_URL}/driver_location")
+        end
+      end
     end # Error
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -127,13 +127,6 @@ module Selenium
       # @yield see #deprecate
       #
       def info(message, id: [], &block)
-        unless @first_warning
-          @first_warning = true
-          info("Details on how to use and modify Selenium logger:\n", id: [:logger_info]) do
-            "https://selenium.dev/documentation/webdriver/troubleshooting/logging\n"
-          end
-        end
-
         discard_or_log(:info, message, id, &block)
       end
 
@@ -202,6 +195,15 @@ module Selenium
         id = Array(id)
         return if (@ignored & id).any?
         return if @allowed.any? && (@allowed & id).none?
+
+        return if ::Logger::Severity.const_get(level.upcase) < @logger.level
+
+        unless @first_warning
+          @first_warning = true
+          info("Details on how to use and modify Selenium logger:\n", id: [:logger_info]) do
+            "https://selenium.dev/documentation/webdriver/troubleshooting/logging\n"
+          end
+        end
 
         msg = id.empty? ? message : "[#{id.map(&:inspect).join(', ')}] #{message} "
         msg += " #{yield}" if block_given?

--- a/rb/lib/selenium/webdriver/common/proxy.rb
+++ b/rb/lib/selenium/webdriver/common/proxy.rb
@@ -152,7 +152,7 @@ module Selenium
           'socksUsername' => socks_username,
           'socksPassword' => socks_password,
           'socksVersion' => socks_version
-        }.delete_if { |_k, v| v.nil? }
+        }.compact
 
         json_result if json_result.length > 1
       end

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -139,6 +139,20 @@ module Selenium
           expect(driver[:id1]).to be_a(WebDriver::Element)
           expect(driver[xpath: '//h1']).to be_a(WebDriver::Element)
         end
+
+        it 'raises if element not found' do
+          driver.navigate.to url_for('xhtmlTest.html')
+          expect {
+            driver.find_element(id: 'not-there')
+          }.to raise_error(Error::NoSuchElementError, /errors#no-such-element-exception/)
+        end
+
+        it 'raises if invalid locator' do
+          driver.navigate.to url_for('xhtmlTest.html')
+          expect {
+            driver.find_element(xpath: '*?//-')
+          }.to raise_error(Error::InvalidSelectorError, /errors#invalid-selector-exception/)
+        end
       end
 
       describe 'many elements' do

--- a/rb/spec/integration/selenium/webdriver/element_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/element_spec.rb
@@ -40,6 +40,17 @@ module Selenium
         expect { driver.find_element(id: 'other_contents').click }.to raise_error(Error::ElementClickInterceptedError)
       end
 
+      it 'raises if element stale' do
+        driver.navigate.to url_for('formPage.html')
+        button = driver.find_element(id: 'imageButton')
+        driver.navigate.refresh
+
+        expect { button.click }.to raise_exception(Error::StaleElementReferenceError,
+                                                   /errors#stale-element-reference-exception/)
+
+        reset_driver!(time: 1) if %i[safari safari_preview].include? GlobalTestEnv.browser
+      end
+
       describe '#submit' do
         it 'valid submit button' do
           driver.navigate.to url_for('formPage.html')

--- a/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/driver_spec.rb
@@ -64,6 +64,7 @@ module Selenium
 
         it 'does not require any parameters' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           expect_request
@@ -73,6 +74,7 @@ module Selenium
 
         it 'accepts provided Options as sole parameter' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           opts = {args: ['-f']}

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -27,7 +27,7 @@ module Selenium
           let(:service_path) { "/path/to/#{Service::EXECUTABLE}" }
 
           before do
-            allow(Platform).to receive(:assert_executable).and_return(true)
+            allow(Platform).to receive(:assert_executable)
           end
 
           after { described_class.driver_path = nil }
@@ -113,6 +113,7 @@ module Selenium
 
           it 'is created when :url is not provided' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
 
@@ -122,6 +123,7 @@ module Selenium
 
           it 'accepts :service without creating a new instance' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)
 

--- a/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
@@ -31,6 +31,7 @@ module Selenium
 
         it 'accepts path set on class as String' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = 'path'
@@ -42,6 +43,7 @@ module Selenium
 
         it 'accepts path set on class as proc' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = proc { 'path' }
@@ -54,6 +56,7 @@ module Selenium
 
         it 'uses path from PATH' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           allow(Platform).to receive(:find_binary).and_return('path')
 
@@ -68,11 +71,8 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            expect {
-              described_class.path(options, service)
-            }.to raise_error(WebDriver::Error::WebDriverError,
-                             /Unable to locate the #{driver} executable; for more information on how to install/)
-          }.to have_warning(:selenium_manager)
+            described_class.path(options, service)
+          }.to raise_error(WebDriver::Error::NoSuchDriverError, %r{errors/driver_location})
         end
       end
 
@@ -85,6 +85,7 @@ module Selenium
 
         it 'accepts path set on class as String' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = 'path'
@@ -96,6 +97,7 @@ module Selenium
 
         it 'accepts path set on class as proc' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = proc { 'path' }
@@ -108,6 +110,7 @@ module Selenium
 
         it 'uses path from PATH' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           allow(Platform).to receive(:find_binary).and_return('path')
 
@@ -122,11 +125,8 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            expect {
-              described_class.path(options, service)
-            }.to raise_error(WebDriver::Error::WebDriverError,
-                             /Unable to locate the #{driver} executable; for more information on how to install/)
-          }.to have_warning(:selenium_manager)
+            described_class.path(options, service)
+          }.to raise_error(WebDriver::Error::NoSuchDriverError, %r{errors/driver_location})
         end
       end
 
@@ -139,6 +139,7 @@ module Selenium
 
         it 'accepts path set on class as String' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = 'path'
@@ -150,6 +151,7 @@ module Selenium
 
         it 'accepts path set on class as proc' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = proc { 'path' }
@@ -162,6 +164,7 @@ module Selenium
 
         it 'uses path from PATH' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           allow(Platform).to receive(:find_binary).and_return('path')
 
@@ -176,11 +179,8 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            expect {
-              described_class.path(options, service)
-            }.to raise_error(WebDriver::Error::WebDriverError,
-                             /Unable to locate the #{driver} executable; for more information on how to install/)
-          }.to have_warning(:selenium_manager)
+            described_class.path(options, service)
+          }.to raise_error(WebDriver::Error::NoSuchDriverError, %r{errors/driver_location})
         end
       end
 
@@ -193,6 +193,7 @@ module Selenium
 
         it 'accepts path set on class as String' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = 'path'
@@ -204,6 +205,7 @@ module Selenium
 
         it 'accepts path set on class as proc' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = proc { 'path' }
@@ -216,6 +218,7 @@ module Selenium
 
         it 'uses path from PATH' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           allow(Platform).to receive(:find_binary).and_return('path')
 
@@ -230,11 +233,8 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            expect {
-              described_class.path(options, service)
-            }.to raise_error(WebDriver::Error::WebDriverError,
-                             /Unable to locate the #{driver} executable; for more information on how to install/)
-          }.to have_warning(:selenium_manager)
+            described_class.path(options, service)
+          }.to raise_error(WebDriver::Error::NoSuchDriverError, %r{errors/driver_location})
         end
       end
 
@@ -247,6 +247,7 @@ module Selenium
 
         it 'accepts path set on class as String' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = 'path'
@@ -258,6 +259,7 @@ module Selenium
 
         it 'accepts path set on class as proc' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           service.driver_path = proc { 'path' }
@@ -270,6 +272,7 @@ module Selenium
 
         it 'uses path from PATH' do
           allow(SeleniumManager).to receive(:driver_path)
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           allow(Platform).to receive(:find_binary).and_return('path')
 
@@ -284,11 +287,8 @@ module Selenium
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
-            expect {
-              described_class.path(options, service)
-            }.to raise_error(WebDriver::Error::WebDriverError,
-                             /Unable to locate the #{driver} executable; for more information on how to install/)
-          }.to have_warning(:selenium_manager)
+            described_class.path(options, service)
+          }.to raise_error(WebDriver::Error::NoSuchDriverError, %r{errors/driver_location})
         end
       end
     end

--- a/rb/spec/unit/selenium/webdriver/common/interactions/pointer_event_prop_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/interactions/pointer_event_prop_spec.rb
@@ -29,6 +29,7 @@ module Selenium
 
             def initialize(opts)
               @opts = opts
+              super
             end
 
             def assert_source(*); end

--- a/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/logger_spec.rb
@@ -105,9 +105,10 @@ module Selenium
       end
 
       describe '#info' do
-        it 'logs info on first info but not second' do
+        it 'logs info on first displayed logging only' do
           logger = described_class.new('Selenium', default_level: :info)
 
+          logger.debug('first')
           expect { logger.info('first') }.to output(/:logger_info/).to_stdout_from_any_process
           expect { logger.info('second') }.not_to output(/:logger_info/).to_stdout_from_any_process
         end

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -34,6 +34,7 @@ module Selenium
 
         it 'detects Windows' do
           stub_binary('/windows/selenium-manager.exe')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:windows?).and_return(true)
 
           expect(described_class.send(:binary)).to match(%r{/windows/selenium-manager\.exe$})
@@ -41,6 +42,7 @@ module Selenium
 
         it 'detects Mac' do
           stub_binary('/macos/selenium-manager')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:windows?).and_return(false)
           allow(Platform).to receive(:mac?).and_return(true)
 
@@ -49,6 +51,7 @@ module Selenium
 
         it 'detects Linux' do
           stub_binary('/linux/selenium-manager')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:windows?).and_return(false)
           allow(Platform).to receive(:mac?).and_return(false)
           allow(Platform).to receive(:linux?).and_return(true)
@@ -61,7 +64,7 @@ module Selenium
 
           expect {
             described_class.send(:binary)
-          }.to raise_error(Error::WebDriverError, /Unable to obtain Selenium Manager/)
+          }.to raise_error(Error::WebDriverError, /Selenium Manager binary located, but not a file/)
         end
       end
 
@@ -74,12 +77,6 @@ module Selenium
       end
 
       describe 'self.driver_path' do
-        it 'errors if not an option' do
-          expect {
-            described_class.driver_path(Remote::Capabilities.new(browser_name: 'chrome'))
-          }.to raise_error(ArgumentError, /SeleniumManager requires a WebDriver::Options instance/)
-        end
-
         it 'determines browser name by default' do
           allow(described_class).to receive(:run)
           allow(described_class).to receive(:binary).and_return('selenium-manager')

--- a/rb/spec/unit/selenium/webdriver/common/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/service_spec.rb
@@ -25,7 +25,7 @@ module Selenium
       let(:service_path) { '/path/to/service' }
 
       before do
-        allow(Platform).to receive(:assert_executable).and_return(true)
+        allow(Platform).to receive(:assert_executable)
         stub_const('Selenium::WebDriver::Service::DEFAULT_PORT', 1234)
         stub_const('Selenium::WebDriver::Service::EXECUTABLE', 'service')
       end

--- a/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/driver_spec.rb
@@ -64,6 +64,7 @@ module Selenium
 
         it 'does not require any parameters' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           expect_request
 
@@ -72,6 +73,7 @@ module Selenium
 
         it 'accepts provided Options as sole parameter' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'MicrosoftEdge', 'ms:edgeOptions': opts}}})
@@ -81,6 +83,7 @@ module Selenium
 
         it 'raises an ArgumentError if parameter is not recognized' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           msg = 'unknown keyword: :invalid'
           expect { described_class.new(invalid: 'foo') }.to raise_error(ArgumentError, msg)

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -27,7 +27,7 @@ module Selenium
           let(:service_path) { "/path/to/#{Service::EXECUTABLE}" }
 
           before do
-            allow(Platform).to receive(:assert_executable).and_return(true)
+            allow(Platform).to receive(:assert_executable)
             described_class.driver_path = nil
           end
 
@@ -105,6 +105,7 @@ module Selenium
 
           it 'is created when :url is not provided' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
 
@@ -114,6 +115,7 @@ module Selenium
 
           it 'accepts :service without creating a new instance' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)
 

--- a/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/driver_spec.rb
@@ -67,6 +67,7 @@ module Selenium
 
         it 'does not require any parameters' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           expect_request
 
@@ -75,6 +76,7 @@ module Selenium
 
         it 'accepts provided Options as sole parameter' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
 
           opts = {args: ['-f']}

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -27,7 +27,7 @@ module Selenium
           let(:service_path) { "/path/to/#{Service::EXECUTABLE}" }
 
           before do
-            allow(Platform).to receive(:assert_executable).and_return(true)
+            allow(Platform).to receive(:assert_executable)
           end
 
           it 'uses default port and nil path' do
@@ -98,6 +98,7 @@ module Selenium
 
           it 'is created when :url is not provided' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
 
@@ -108,6 +109,7 @@ module Selenium
 
           it 'accepts :service without creating a new instance' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)
 

--- a/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/driver_spec.rb
@@ -65,6 +65,7 @@ module Selenium
 
         it 'does not require any parameters' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           expect_request
 
@@ -73,6 +74,7 @@ module Selenium
 
         it 'accepts provided Options as sole parameter' do
           allow(SeleniumManager).to receive(:driver_path).and_return('path')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           opts = {args: ['-f']}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'internet explorer',

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -27,7 +27,7 @@ module Selenium
           let(:service_path) { "/path/to/#{Service::EXECUTABLE}" }
 
           before do
-            allow(Platform).to receive(:assert_executable).and_return(true)
+            allow(Platform).to receive(:assert_executable)
           end
 
           it 'uses default port and nil path' do
@@ -101,6 +101,7 @@ module Selenium
 
           it 'is created when :url is not provided' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
 
@@ -111,6 +112,7 @@ module Selenium
 
           it 'accepts :service without creating a new instance' do
             allow(SeleniumManager).to receive(:driver_path).and_return('path')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)
 

--- a/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
@@ -64,6 +64,7 @@ module Selenium
 
         it 'does not require any parameters' do
           allow(Platform).to receive(:find_binary).and_return('/path/to/safaridriver')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           expect_request
 
@@ -72,6 +73,7 @@ module Selenium
 
         it 'accepts provided Options as sole parameter' do
           allow(Platform).to receive(:find_binary).and_return('path/to/safaridriver')
+          allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           opts = {automatic_inspection: true}
           expect_request(body: {capabilities: {alwaysMatch: {browserName: 'safari',

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -27,7 +27,7 @@ module Selenium
           let(:service_path) { "/path/to/#{Service::EXECUTABLE}" }
 
           before do
-            allow(Platform).to receive(:assert_executable).and_return(true)
+            allow(Platform).to receive(:assert_executable)
           end
 
           it 'does not allow log' do
@@ -102,6 +102,7 @@ module Selenium
 
           it 'is created when :url is not provided' do
             allow(Platform).to receive(:find_binary).and_return('/path/to/safaridriver')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
 
@@ -112,6 +113,7 @@ module Selenium
 
           it 'accepts :service without creating a new instance' do
             allow(Platform).to receive(:find_binary).and_return('path/to/safaridriver')
+            allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)
 


### PR DESCRIPTION
### Description
* Logger logic - `@first_use` should be when anything actually prints to screen
* Error documentation - We log an additional message if one exists for it
* Selenium Manager - Better error management; User has the best info we can give them and is directed to where to go for more info
* Tests had to change because we now check "file exists" which we weren't before

### Motivation and Context
The error stuff all matches Java logic

