### PR TITLE
[py] add links to documentation for errors

### DIFF
--- a/py/selenium/common/__init__.py
+++ b/py/selenium/common/__init__.py
@@ -34,12 +34,12 @@ from .exceptions import MoveTargetOutOfBoundsException
 from .exceptions import NoAlertPresentException
 from .exceptions import NoSuchAttributeException
 from .exceptions import NoSuchCookieException
+from .exceptions import NoSuchDriverException
 from .exceptions import NoSuchElementException
 from .exceptions import NoSuchFrameException
 from .exceptions import NoSuchShadowRootException
 from .exceptions import NoSuchWindowException
 from .exceptions import ScreenshotException
-from .exceptions import SeleniumManagerException
 from .exceptions import SessionNotCreatedException
 from .exceptions import StaleElementReferenceException
 from .exceptions import TimeoutException
@@ -56,6 +56,7 @@ __all__ = [
     "NoSuchWindowException",
     "NoSuchElementException",
     "NoSuchAttributeException",
+    "NoSuchDriverException",
     "NoSuchShadowRootException",
     "StaleElementReferenceException",
     "InvalidElementStateException",
@@ -82,5 +83,4 @@ __all__ = [
     "InvalidSessionIdException",
     "SessionNotCreatedException",
     "UnknownMethodException",
-    "SeleniumManagerException",
 ]

--- a/py/selenium/common/exceptions.py
+++ b/py/selenium/common/exceptions.py
@@ -20,8 +20,9 @@
 from typing import Optional
 from typing import Sequence
 
-SUPPORT_MSG = 'For documentation on this error, please visit:'
-ERROR_URL = 'https://www.selenium.dev/documentation/webdriver/troubleshooting/errors'
+SUPPORT_MSG = "For documentation on this error, please visit:"
+ERROR_URL = "https://www.selenium.dev/documentation/webdriver/troubleshooting/errors"
+
 
 class WebDriverException(Exception):
     """Base webdriver exception."""
@@ -71,10 +72,11 @@ class NoSuchElementException(WebDriverException):
           (webpage is still loading) see selenium.webdriver.support.wait.WebDriverWait()
           for how to write a wait wrapper to wait for an element to appear.
     """
+
     def __init__(
         self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
     ) -> None:
-        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#no-such-element-exception'
+        with_support = f"{msg}; {SUPPORT_MSG} {ERROR_URL}#no-such-element-exception"
 
         super().__init__(with_support, screen, stacktrace)
 
@@ -109,10 +111,11 @@ class StaleElementReferenceException(WebDriverException):
           node is rebuilt.
         * Element may have been inside an iframe or another context which was refreshed.
     """
+
     def __init__(
         self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
     ) -> None:
-        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#stale-element-reference-exception'
+        with_support = f"{msg}; {SUPPORT_MSG} {ERROR_URL}#stale-element-reference-exception"
 
         super().__init__(with_support, screen, stacktrace)
 
@@ -207,10 +210,11 @@ class InvalidSelectorException(WebDriverException):
     expression) or the expression does not select WebElements (e.g.
     "count(//input)").
     """
+
     def __init__(
         self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
     ) -> None:
-        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#invalid-selector-exception'
+        with_support = f"{msg}; {SUPPORT_MSG} {ERROR_URL}#invalid-selector-exception"
 
         super().__init__(with_support, screen, stacktrace)
 
@@ -273,5 +277,12 @@ class UnknownMethodException(WebDriverException):
     for that URL."""
 
 
-class SeleniumManagerException(WebDriverException):
-    """Raised when an issue interacting with selenium manager occurs."""
+class NoSuchDriverException(WebDriverException):
+    """Raised when driver is not specified and cannot be located."""
+
+    def __init__(
+        self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
+    ) -> None:
+        with_support = f"{msg}; {SUPPORT_MSG} {ERROR_URL}/driver_location"
+
+        super().__init__(with_support, screen, stacktrace)

--- a/py/selenium/common/exceptions.py
+++ b/py/selenium/common/exceptions.py
@@ -20,6 +20,8 @@
 from typing import Optional
 from typing import Sequence
 
+SUPPORT_MSG = 'For documentation on this error, please visit:'
+ERROR_URL = 'https://www.selenium.dev/documentation/webdriver/troubleshooting/errors'
 
 class WebDriverException(Exception):
     """Base webdriver exception."""
@@ -69,6 +71,12 @@ class NoSuchElementException(WebDriverException):
           (webpage is still loading) see selenium.webdriver.support.wait.WebDriverWait()
           for how to write a wait wrapper to wait for an element to appear.
     """
+    def __init__(
+        self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
+    ) -> None:
+        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#no-such-element-exception'
+
+        super().__init__(with_support, screen, stacktrace)
 
 
 class NoSuchAttributeException(WebDriverException):
@@ -101,6 +109,12 @@ class StaleElementReferenceException(WebDriverException):
           node is rebuilt.
         * Element may have been inside an iframe or another context which was refreshed.
     """
+    def __init__(
+        self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
+    ) -> None:
+        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#stale-element-reference-exception'
+
+        super().__init__(with_support, screen, stacktrace)
 
 
 class InvalidElementStateException(WebDriverException):
@@ -193,6 +207,12 @@ class InvalidSelectorException(WebDriverException):
     expression) or the expression does not select WebElements (e.g.
     "count(//input)").
     """
+    def __init__(
+        self, msg: Optional[str] = None, screen: Optional[str] = None, stacktrace: Optional[Sequence[str]] = None
+    ) -> None:
+        with_support = f'{msg}; {SUPPORT_MSG} {ERROR_URL}#invalid-selector-exception'
+
+        super().__init__(with_support, screen, stacktrace)
 
 
 class ImeNotAvailableException(WebDriverException):

--- a/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -99,6 +99,7 @@ def test_no_such_element_error(driver, pages):
     with pytest.raises(NoSuchElementException, match=msg):
         driver.find_element(By.ID, "non_Existent_Button")
 
+
 # By.name positive
 
 

--- a/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -93,6 +93,12 @@ def test_finding_multiple_elements_by_id_with_space_should_return_empty_list(dri
     assert len(elements) == 0
 
 
+def test_no_such_element_error(driver, pages):
+    pages.load("formPage.html")
+    msg = r"\/errors#no-such-element-exception"
+    with pytest.raises(NoSuchElementException, match=msg):
+        driver.find_element(By.ID, "non_Existent_Button")
+
 # By.name positive
 
 
@@ -268,7 +274,8 @@ def test_should_not_find_element_by_class_when_the_name_queried_is_shorter_than_
 
 def test_finding_asingle_element_by_empty_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
-    with pytest.raises(InvalidSelectorException):
+    msg = r"\/errors#invalid-selector-exception"
+    with pytest.raises(InvalidSelectorException, match=msg):
         driver.find_element(By.CLASS_NAME, "")
 
 

--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -19,8 +19,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from selenium.common.exceptions import SeleniumManagerException
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.common.proxy import Proxy
 from selenium.webdriver.common.selenium_manager import SeleniumManager
 
@@ -85,8 +87,18 @@ def test_proxy_is_used_for_sm(mocker):
 
 
 def test_stderr_is_propagated_to_exception_messages():
-    msg = r"Selenium Manager failed for:.* --browser foo --output json\.\nInvalid browser name: foo\n"
-    with pytest.raises(SeleniumManagerException, match=msg):
+    msg = r"Unsuccessful command executed:.* --browser foo --output json\.\nInvalid browser name: foo\n"
+    with pytest.raises(WebDriverException, match=msg):
         manager = SeleniumManager()
         binary = manager.get_binary()
         _ = manager.run([str(binary), "--browser", "foo", "--output", "json"])
+
+
+def test_driver_finder_error(mocker):
+    mocker.patch("selenium.webdriver.common.selenium_manager.SeleniumManager.driver_location", return_value=None)
+
+    service = Service()
+    options = Options()
+    msg = r"Unable to locate or obtain chromedriver.*errors\/driver_location"
+    with pytest.raises(WebDriverException, match=msg):
+        DriverFinder.get_path(service, options)

--- a/py/test/selenium/webdriver/common/stale_reference_tests.py
+++ b/py/test/selenium/webdriver/common/stale_reference_tests.py
@@ -25,7 +25,8 @@ def test_old_page(driver, pages):
     pages.load("simpleTest.html")
     elem = driver.find_element(by=By.ID, value="links")
     pages.load("xhtmlTest.html")
-    with pytest.raises(StaleElementReferenceException):
+    msg = r"\/errors#stale-element-reference-exception"
+    with pytest.raises(StaleElementReferenceException, match=msg):
         elem.click()
 
 

--- a/py/test/selenium/webdriver/support/relative_by_tests.py
+++ b/py/test/selenium/webdriver/support/relative_by_tests.py
@@ -86,7 +86,7 @@ def test_no_such_element_is_raised_rather_than_index_error(driver, pages):
     with pytest.raises(NoSuchElementException) as exc:
         anchor = driver.find_element(By.ID, "second")
         driver.find_element(locate_with(By.ID, "nonexistentid").above(anchor))
-    assert exc.value.msg == "Cannot locate relative element with: {'id': 'nonexistentid'}"
+    assert "Cannot locate relative element with: {'id': 'nonexistentid'}" in exc.value.msg
 
 
 def test_near_locator_should_find_near_elements(driver, pages):
@@ -105,4 +105,4 @@ def test_near_locator_should_not_find_far_elements(driver, pages):
     with pytest.raises(NoSuchElementException) as exc:
         driver.find_element(locate_with(By.ID, "rect4").near(rect3))
 
-    assert exc.value.msg == "Cannot locate relative element with: {'id': 'rect4'}"
+    assert "Cannot locate relative element with: {'id': 'rect4'}" in exc.value.msg


### PR DESCRIPTION
### Description
* Have exceptions link to documentation
* Create custom Error for Driver Location that links to docs
* Driver Finder gives different error message if Selenium Manager code errors
* SeleniumManager throws WebDriverExceptions, which are caught by DriverFinder & raised as NoSuchDriver exceptions 
* Catches additional potential exceptions in Selenium Manager

### Motivation and Context
* We want to give the user the most accurate info in their error messages when there is a problem and link to more info if necessary
* This brings the logic in line with Java & Ruby
