### PR TITLE
[dotnet] link exceptions to documentation

### DIFF
--- a/dotnet/src/webdriver/DriverFinder.cs
+++ b/dotnet/src/webdriver/DriverFinder.cs
@@ -41,15 +41,18 @@ namespace OpenQA.Selenium
             if (File.Exists(executablePath)) return service;
             try
             {
-                string driverFullPath = SeleniumManager.DriverPath(options);
-                service.DriverServicePath = Path.GetDirectoryName(driverFullPath);
-                service.DriverServiceExecutableName = Path.GetFileName(driverFullPath);
-                return service;
+                executablePath = SeleniumManager.DriverPath(options);
+                service.DriverServicePath = Path.GetDirectoryName(executablePath);
+                service.DriverServiceExecutableName = Path.GetFileName(executablePath);
             }
             catch (Exception e)
             {
-                throw new WebDriverException($"Unable to locate driver with path: {executablePath}, for more information on how to install drivers see https://www.selenium.dev/documentation/webdriver/getting_started/install_drivers/", e);
+                throw new NoSuchDriverException($"Unable to obtain {service.DriverServiceExecutableName} using Selenium Manager", e);
             }
+
+            if (File.Exists(executablePath)) return service;
+
+            throw new NoSuchDriverException($"Unable to locate or obtain {service.DriverServiceExecutableName}");
         }
     }
 }

--- a/dotnet/src/webdriver/InvalidSelectorException.cs
+++ b/dotnet/src/webdriver/InvalidSelectorException.cs
@@ -28,10 +28,15 @@ namespace OpenQA.Selenium
     public class InvalidSelectorException : WebDriverException
     {
         /// <summary>
+        /// Link to the documentation for this error
+        /// </summary>
+        private static string supportUrl = baseSupportUrl + "#invalid-selector-exception";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InvalidSelectorException"/> class.
         /// </summary>
         public InvalidSelectorException()
-            : base()
+            : base(GetMessage(""))
         {
         }
 
@@ -41,7 +46,7 @@ namespace OpenQA.Selenium
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public InvalidSelectorException(string message)
-            : base(message)
+            : base(GetMessage(message))
         {
         }
 
@@ -54,7 +59,7 @@ namespace OpenQA.Selenium
         /// <param name="innerException">The exception that is the cause of the current exception,
         /// or <see langword="null"/> if no inner exception is specified.</param>
         public InvalidSelectorException(string message, Exception innerException)
-            : base(message, innerException)
+            : base(GetMessage(message), innerException)
         {
         }
 
@@ -68,6 +73,16 @@ namespace OpenQA.Selenium
         protected InvalidSelectorException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+        }
+
+        /// <summary>
+        /// Add information about obtaining additional support from documentation to this exception.
+        /// </summary>
+        /// <param name="message">The original message for exception</param>
+        /// <returns>The final message for exception</returns>
+        protected static string GetMessage(string message)
+        {
+            return message + "; " + supportMsg + supportUrl;
         }
     }
 }

--- a/dotnet/src/webdriver/NoSuchDriverException.cs
+++ b/dotnet/src/webdriver/NoSuchDriverException.cs
@@ -1,0 +1,89 @@
+// <copyright file="NoSuchDriverException.cs" company="WebDriver Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Runtime.Serialization;
+
+namespace OpenQA.Selenium
+{
+    /// <summary>
+    /// The exception that is thrown when a driver is not found.
+    /// </summary>
+    [Serializable]
+    public class NoSuchDriverException : NotFoundException
+    {
+
+        /// <summary>
+        /// Link to the documentation for this error
+        /// </summary>
+        private static string supportUrl = baseSupportUrl + "/driver_location";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoSuchDriverException"/> class.
+        /// </summary>
+        public NoSuchDriverException()
+            : base(GetMessage(""))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoSuchDriverException"/> class with
+        /// a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public NoSuchDriverException(string message)
+            : base(GetMessage(message))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoSuchDriverException"/> class with
+        /// a specified error message and a reference to the inner exception that is the
+        /// cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception,
+        /// or <see langword="null"/> if no inner exception is specified.</param>
+        public NoSuchDriverException(string message, Exception innerException)
+            : base(GetMessage(message), innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoSuchDriverException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized
+        /// object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual
+        /// information about the source or destination.</param>
+        protected NoSuchDriverException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        /// <summary>
+        /// Add information about obtaining additional support from documentation to this exception.
+        /// </summary>
+        /// <param name="message">The original message for exception</param>
+        /// <returns>The final message for exception</returns>
+        protected static string GetMessage(string message)
+        {
+            return message + "; " + supportMsg + supportUrl;
+        }
+    }
+}

--- a/dotnet/src/webdriver/NoSuchElementException.cs
+++ b/dotnet/src/webdriver/NoSuchElementException.cs
@@ -27,11 +27,17 @@ namespace OpenQA.Selenium
     [Serializable]
     public class NoSuchElementException : NotFoundException
     {
+
+        /// <summary>
+        /// Link to the documentation for this error
+        /// </summary>
+        private static string supportUrl = baseSupportUrl + "#no-such-element-exception";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSuchElementException"/> class.
         /// </summary>
         public NoSuchElementException()
-            : base()
+            : base(GetMessage(""))
         {
         }
 
@@ -41,7 +47,7 @@ namespace OpenQA.Selenium
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public NoSuchElementException(string message)
-            : base(message)
+            : base(GetMessage(message))
         {
         }
 
@@ -54,7 +60,7 @@ namespace OpenQA.Selenium
         /// <param name="innerException">The exception that is the cause of the current exception,
         /// or <see langword="null"/> if no inner exception is specified.</param>
         public NoSuchElementException(string message, Exception innerException)
-            : base(message, innerException)
+            : base(GetMessage(message), innerException)
         {
         }
 
@@ -68,6 +74,16 @@ namespace OpenQA.Selenium
         protected NoSuchElementException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+        }
+
+        /// <summary>
+        /// Add information about obtaining additional support from documentation to this exception.
+        /// </summary>
+        /// <param name="message">The original message for exception</param>
+        /// <returns>The final message for exception</returns>
+        protected static string GetMessage(string message)
+        {
+            return message + "; " + supportMsg + supportUrl;
         }
     }
 }

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -72,12 +72,17 @@ namespace OpenQA.Selenium
 #endif
 
             binaryFullPath = Path.Combine(currentDirectory, binary);
+
+            if (!File.Exists(binaryFullPath))
+            {
+                throw new WebDriverException($"Unable to locate or obtain Selenium Manager binary at {binaryFullPath}");
+            }
         }
 
         /// <summary>
         /// Determines the location of the correct driver.
         /// </summary>
-        /// <param name="driverName">Which driver the service needs.</param>
+        /// <param name="options">The correct path depends on which options are being used.</param>
         /// <returns>
         /// The location of the driver.
         /// </returns>

--- a/dotnet/src/webdriver/StaleElementReferenceException.cs
+++ b/dotnet/src/webdriver/StaleElementReferenceException.cs
@@ -28,10 +28,15 @@ namespace OpenQA.Selenium
     public class StaleElementReferenceException : WebDriverException
     {
         /// <summary>
+        /// Link to the documentation for this error
+        /// </summary>
+        private static string supportUrl = baseSupportUrl + "#stale-element-reference-exception";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StaleElementReferenceException"/> class.
         /// </summary>
         public StaleElementReferenceException()
-            : base()
+            : base(GetMessage(""))
         {
         }
 
@@ -41,7 +46,7 @@ namespace OpenQA.Selenium
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public StaleElementReferenceException(string message)
-            : base(message)
+            : base(GetMessage(message))
         {
         }
 
@@ -54,7 +59,7 @@ namespace OpenQA.Selenium
         /// <param name="innerException">The exception that is the cause of the current exception,
         /// or <see langword="null"/> if no inner exception is specified.</param>
         public StaleElementReferenceException(string message, Exception innerException)
-            : base(message, innerException)
+            : base(GetMessage(message), innerException)
         {
         }
 
@@ -68,6 +73,16 @@ namespace OpenQA.Selenium
         protected StaleElementReferenceException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+        }
+
+        /// <summary>
+        /// Add information about obtaining additional support from documentation to this exception.
+        /// </summary>
+        /// <param name="message">The original message for exception</param>
+        /// <returns>The final message for exception</returns>
+        protected static string GetMessage(string message)
+        {
+            return message + "; " + supportMsg + supportUrl;
         }
     }
 }

--- a/dotnet/src/webdriver/WebDriverException.cs
+++ b/dotnet/src/webdriver/WebDriverException.cs
@@ -28,6 +28,16 @@ namespace OpenQA.Selenium
     public class WebDriverException : Exception
     {
         /// <summary>
+        /// Intro comment for pointing to documentation
+        /// </summary>
+        protected static string supportMsg = "For documentation on this error, please visit: ";
+
+        /// <summary>
+        /// Location of errors in documentation
+        /// </summary>
+        protected static string baseSupportUrl = "https://www.selenium.dev/documentation/webdriver/troubleshooting/errors";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WebDriverException"/> class.
         /// </summary>
         public WebDriverException()


### PR DESCRIPTION
### Description
Adds links to our documentation for the relevant exceptions

### Motivation and Context
This brings .NET in alignment with Java, Ruby & Python (soon #12156)


@nvborisenko Java has a more clever way of doing this, but I think this is the best we can do in C# since the methods need to be static?