### PR TITLE
Fix docstring for removed arg (browser_profile)

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -284,7 +284,6 @@ class WebDriver(BaseWebDriver):
 
         :Args:
          - capabilities - a capabilities dict to start the session with.
-         - browser_profile - A selenium.webdriver.firefox.firefox_profile.FirefoxProfile object. Only used if Firefox is requested.
         """
 
         caps = _create_caps(capabilities)


### PR DESCRIPTION
``browser_profile`` was removed from ``start_session()`` args in ``remote/webdriver.py``, but it's still in the docstring.
It should be removed from the docstring to match the remaining args.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fix docstring

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change is to the documentation / docstrings.
- [X] I have updated the documentation accordingly.
<!--- Provide a general summary of your changes in the Title above -->
