### PR TITLE
Keyword loalization implemention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ java/client/build/
 java/client/log.txt
 java/client/iedriver.log
 java/server/build/
+java/.idea
+**/selenium.iml
 __pycache__
 .tox
 *.pyc

--- a/java/src/org/openqa/selenium/By.java
+++ b/java/src/org/openqa/selenium/By.java
@@ -89,6 +89,14 @@ public abstract class By {
   }
 
   /**
+   * @param keyword The XPath with a keyowrd text in it to use.
+   * @return A By which locates elements via XPath witha  keyword.
+   */
+  public static By keyword(String keyword) {
+    return new ByKeyword(keyword);
+  } 
+
+  /**
    * Find elements based on the value of the "class" attribute. Only one class name should be used.
    * If an element has multiple classes, please use {@link By#cssSelector(String)}.
    *
@@ -292,6 +300,21 @@ public abstract class By {
       return "By.xpath: " + xpathExpression;
     }
   }
+
+    public static class ByKeyword extends BaseW3CLocator {
+      private final String keyword;
+
+      public ByKeyword(String keyword) {
+        super("keyword",
+        Require.argument("Keyword", keyword)
+          .nonNull("Cannot find elements when the Keyword is null"));
+
+        this.keyword = keyword;
+      }
+
+      @Override
+      public String toString() { return "By.keyword: " + keyword; }
+    }
 
   public static class ByClassName extends PreW3CLocator {
 

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -97,8 +97,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -91,8 +91,14 @@ import org.openqa.selenium.virtualauthenticator.Credential;
 import org.openqa.selenium.virtualauthenticator.HasVirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 @Augmentable
 public class RemoteWebDriver
@@ -165,6 +171,43 @@ public class RemoteWebDriver
 
       throw e;
     }
+  }
+
+  public static void addLanguageProperty(String propertiePath) {
+    if(languagesProperties == null) {
+      languagesProperties = new ArrayList<Map<String, String>>();
+    }
+    HashMap<String, String> newMap;
+    try {
+      newMap = RemoteWebDriver.makeHashMap(propertiePath);
+    } catch (IOException e) {
+      if(e.getClass().equals(FileNotFoundException.class)) {
+        System.out.println("File " + propertiePath + " was not found.");
+      } else {
+        System.out.println("File " + propertiePath + " could no be loaded.");
+      }
+      newMap = null;
+    }
+    languagesProperties.add(newMap);
+  }
+
+  private static HashMap<String, String> makeHashMap (String propertiePath) throws IOException {
+    Require.argument("propertiePath", propertiePath).nonNull("propertiePath argument must not have the value equal null");
+
+    Properties languagePropertie = new Properties();
+
+    languagePropertie.load(new FileInputStream(propertiePath));
+
+    Enumeration<Object> keys = languagePropertie.keys();
+
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+
+    while (keys.hasMoreElements()) {
+      String key = (String) keys.nextElement();
+      String value = languagePropertie.getProperty(key);
+      hashMap.put(key, value);
+    }
+    return hashMap;
   }
 
   private static URL getDefaultServerURL() {

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -91,6 +91,8 @@ import org.openqa.selenium.virtualauthenticator.Credential;
 import org.openqa.selenium.virtualauthenticator.HasVirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
+import java.util.List;
+import java.util.Map;
 
 @Augmentable
 public class RemoteWebDriver
@@ -116,6 +118,8 @@ public class RemoteWebDriver
 
   private Logs remoteLogs;
   private LocalLogs localLogs;
+
+  static private List<Map<String, String>> languagesProperties;
 
   // For cglib
   protected RemoteWebDriver() {


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

This Pull Request contains a implementation of a new way to find Elements using XPath and Keywords presents in properties files. I dynamical replace the keyword text for the equivalent translation to find a element using a generic text content for any language covered at the properties file.

### Description
I implemented a new method By.keyword() and a new internal class ByKeyword();
I Also implemented a list of hash maps at the RemoteWebDriver class so I could store the properties files with the translations.
I Added a method to add this properties files
I modified the findElement and findElements methods so it would replace the keyowrd present at the content of the XPath with the available translations.

### Motivation and Context
I wanted to make a new method so I could find elements in pages where the identifiers are not well written and could use the text content, but it be independent of what language it was written.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
