### PR TITLE
[py] added pythonic approach of type checking in `firefox/firefox_profile.py`

### DIFF
--- a/py/selenium/webdriver/firefox/firefox_profile.py
+++ b/py/selenium/webdriver/firefox/firefox_profile.py
@@ -130,7 +130,7 @@ class FirefoxProfile:
 
     @accept_untrusted_certs.setter
     def accept_untrusted_certs(self, value) -> None:
-        if value not in [True, False]:
+        if not isinstance(value, bool):
             raise WebDriverException("Please pass in a Boolean to this call")
         self.set_preference("webdriver_accept_untrusted_certs", value)
 
@@ -140,7 +140,7 @@ class FirefoxProfile:
 
     @assume_untrusted_cert_issuer.setter
     def assume_untrusted_cert_issuer(self, value) -> None:
-        if value not in [True, False]:
+        if not isinstance(value, bool):
             raise WebDriverException("Please pass in a Boolean to this call")
 
         self.set_preference("webdriver_assume_untrusted_issuer", value)


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In `accept_untrusted_certs` and `assume_untrusted_cert_issuer` setter methods, we are checking if the `value` is either `True` or `False` using membership operator, like `value in [True, False]`, which is not a standard way of python type checking. I have changed it to use python's built-in `isinstance`.

### Motivation and Context
Motivation for this change is to make type checking more pythonic.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
