### PR TITLE
Adding ignore process match for IE Mode across bindings

### DIFF
--- a/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
@@ -92,6 +92,7 @@ namespace OpenQA.Selenium.IE
         private const string EdgeExecutablePathCapability = "ie.edgepath";
         private const string LegacyFileUploadDialogHandlingCapability = "ie.useLegacyFileUploadDialogHandling";
         private const string AttachToEdgeChromeCapability = "ie.edgechromium";
+        private const string IgnoreProcessMatchCapability = "ie.ignoreprocessmatch";
 
         private bool ignoreProtectedModeSettings;
         private bool ignoreZoomLevel;
@@ -105,6 +106,7 @@ namespace OpenQA.Selenium.IE
         private bool enableFullPageScreenshot = true;
         private bool legacyFileUploadDialogHandling;
         private bool attachToEdgeChrome;
+        private bool ignoreProcessMatch;
         private TimeSpan browserAttachTimeout = TimeSpan.MinValue;
         private TimeSpan fileUploadDialogTimeout = TimeSpan.MinValue;
         private string initialBrowserUrl = string.Empty;
@@ -140,6 +142,7 @@ namespace OpenQA.Selenium.IE
             this.AddKnownCapabilityName(LegacyFileUploadDialogHandlingCapability, "LegacyFileUploadDialogHanlding property");
             this.AddKnownCapabilityName(AttachToEdgeChromeCapability, "AttachToEdgeChrome property");
             this.AddKnownCapabilityName(EdgeExecutablePathCapability, "EdgeExecutablePath property");
+            this.AddKnownCapabilityName(IgnoreProcessMatchCapability, "IgnoreProcessMatch property");
         }
 
         /// <summary>
@@ -310,6 +313,15 @@ namespace OpenQA.Selenium.IE
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to ignore process id match with IE Mode on Edge.
+        /// </summary>
+        public bool IgnoreProcessMatch
+        {
+            get { return this.ignoreProcessMatch; }
+            set { this.ignoreProcessMatch = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the path to the Edge Browser Executable.
         /// </summary>
         public string EdgeExecutablePath
@@ -440,6 +452,11 @@ namespace OpenQA.Selenium.IE
             if (this.attachToEdgeChrome)
             {
                 internetExplorerOptionsDictionary[AttachToEdgeChromeCapability] = true;
+            }
+
+            if (this.ignoreProcessMatch)
+            {
+                internetExplorerOptionsDictionary[IgnoreProcessMatchCapability] = true;
             }
 
             if (!string.IsNullOrEmpty(this.edgeExecutablePath))

--- a/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
+++ b/java/src/org/openqa/selenium/ie/InternetExplorerOptions.java
@@ -67,6 +67,7 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
       "ie.useLegacyFileUploadDialogHandling";
   private static final String ATTACH_TO_EDGE_CHROME = "ie.edgechromium";
   private static final String EDGE_EXECUTABLE_PATH = "ie.edgepath";
+  private static final String IGNORE_PROCESS_MATCH = "ie.ignoreprocessmatch";
 
   private static final List<String> CAPABILITY_NAMES =
       Arrays.asList(
@@ -87,7 +88,8 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
           NATIVE_EVENTS,
           LEGACY_FILE_UPLOAD_DIALOG_HANDLING,
           ATTACH_TO_EDGE_CHROME,
-          EDGE_EXECUTABLE_PATH);
+          EDGE_EXECUTABLE_PATH,
+          IGNORE_PROCESS_MATCH);
 
   private final Map<String, Object> ieOptions = new HashMap<>();
 
@@ -218,6 +220,10 @@ public class InternetExplorerOptions extends AbstractDriverOptions<InternetExplo
 
   public InternetExplorerOptions attachToEdgeChrome() {
     return amend(ATTACH_TO_EDGE_CHROME, true);
+  }
+
+  public InternetExplorerOptions ignoreProcessMatch() {
+    return amend(IGNORE_PROCESS_MATCH, true);
   }
 
   public InternetExplorerOptions withEdgeExecutablePath(String path) {

--- a/javascript/node/selenium-webdriver/ie.js
+++ b/javascript/node/selenium-webdriver/ie.js
@@ -83,6 +83,7 @@ const Key = {
   FILE_UPLOAD_DIALOG_TIMEOUT: 'ie.fileUploadDialogTimeout',
   ATTACH_TO_EDGE_CHROMIUM: 'ie.edgechromium',
   EDGE_EXECUTABLE_PATH: 'ie.edgepath',
+  IGNORE_PROCESS_MATCH: 'ie.ignoreprocessmatch',
 }
 
 /**

--- a/py/selenium/webdriver/ie/options.py
+++ b/py/selenium/webdriver/ie/options.py
@@ -46,6 +46,7 @@ class Options(ArgOptions):
     USE_LEGACY_FILE_UPLOAD_DIALOG_HANDLING = "ie.useLegacyFileUploadDialogHandling"
     ATTACH_TO_EDGE_CHROME = "ie.edgechromium"
     EDGE_EXECUTABLE_PATH = "ie.edgepath"
+    IGNORE_PROCESS_MATCH = "ie.ignoreprocessmatch"
 
     def __init__(self) -> None:
         super().__init__()
@@ -288,6 +289,20 @@ class Options(ArgOptions):
          - value: boolean value
         """
         self._options[self.ATTACH_TO_EDGE_CHROME] = value
+
+    @property
+    def ignore_process_match(self) -> bool:
+        """:Returns: The options ignore process match when using IE Mode value"""
+        return self._options.get(self.IGNORE_PROCESS_MATCH)
+
+    @ignore_process_match.setter
+    def ignore_process_match(self, value: bool) -> None:
+        """Sets the options ignore process match when using IE Mode value.
+
+        :Args:
+         - value: boolean value
+        """
+        self._options[self.IGNORE_PROCESS_MATCH] = value
 
     @property
     def edge_executable_path(self) -> str:

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -41,7 +41,8 @@ module Selenium
           use_per_process_proxy: 'ie.usePerProcessProxy',
           use_legacy_file_upload_dialog_handling: 'ie.useLegacyFileUploadDialogHandling',
           attach_to_edge_chrome: 'ie.edgechromium',
-          edge_executable_path: 'ie.edgepath'
+          edge_executable_path: 'ie.edgepath',
+          ignore_process_match: 'ie.ignoreprocessmatch',
         }.freeze
         BROWSER = 'internet explorer'
 


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Useful when IE Mode on Edge is launched from
and admin window. The caveat is that only
one Edge browser should be running on the
host.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
