### PR TITLE
[py] removed un-necessary call to `text` property in `remote/switch_to.py`

### DIFF
--- a/py/selenium/webdriver/remote/switch_to.py
+++ b/py/selenium/webdriver/remote/switch_to.py
@@ -52,7 +52,6 @@ class SwitchTo:
                 alert = driver.switch_to.alert
         """
         alert = Alert(self._driver)
-        _ = alert.text
         return alert
 
     def default_content(self) -> None:


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
There is an un-necessary call to `text` property in the `alert` method in `remote/switch_to.py`. I have removed it as we are not doing anything with the text of alert. 

### Motivation and Context
There is an un-necessary call to `text` property in the `alert` method in `remote/switch_to.py`. I have removed it as we are not doing anything with the text of alert. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
