### PR TITLE
[rust] Use escaped browser path (required by wmic commands) in Selenium Manager

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -32,7 +32,7 @@ Options:
       --browser-version <BROWSER_VERSION>
           Major browser version (e.g., 105, 106, etc. Also: beta, dev, canary -or nightly- is accepted)
       --browser-path <BROWSER_PATH>
-          Browser path (absolute) for browser version detection (e.g., /usr/bin/google-chrome, "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe")
+          Browser path (absolute) for browser version detection (e.g., /usr/bin/google-chrome, "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", "C:\Program Files\Google\Chrome\Application\chrome.exe")
       --output <OUTPUT>
           Output type: LOGGER (using INFO, WARN, etc.), JSON (custom JSON notation), or SHELL (Unix-like) [default: LOGGER]
       --proxy <PROXY>

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -261,7 +261,8 @@ impl SeleniumManager for ChromeManager {
 
     fn discover_browser_version(&self) -> Option<String> {
         let mut commands;
-        let mut browser_path = self.get_browser_path();
+        let escaped_browser_path = self.get_escaped_browser_path();
+        let mut browser_path = escaped_browser_path.as_str();
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -120,7 +120,8 @@ impl SeleniumManager for EdgeManager {
 
     fn discover_browser_version(&self) -> Option<String> {
         let mut commands;
-        let mut browser_path = self.get_browser_path();
+        let escaped_browser_path = self.get_escaped_browser_path();
+        let mut browser_path = escaped_browser_path.as_str();
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -120,7 +120,8 @@ impl SeleniumManager for FirefoxManager {
 
     fn discover_browser_version(&self) -> Option<String> {
         let mut commands;
-        let mut browser_path = self.get_browser_path();
+        let escaped_browser_path = self.get_escaped_browser_path();
+        let mut browser_path = escaped_browser_path.as_str();
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -482,6 +482,22 @@ pub trait SeleniumManager {
         self.get_config().browser_path.as_str()
     }
 
+    fn get_escaped_browser_path(&self) -> String {
+        let mut browser_path = self.get_browser_path().to_string();
+        let path = Path::new(&browser_path);
+        if path.exists() && WINDOWS.is(self.get_os()) {
+            browser_path = Path::new(path)
+                .canonicalize()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+                .replace("\\\\?\\", "")
+                .replace("\\", "\\\\");
+        }
+        browser_path
+    }
+
     fn set_browser_path(&mut self, browser_path: String) {
         if !browser_path.is_empty() {
             let mut config = self.get_config_mut();

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -64,7 +64,7 @@ struct Cli {
 
     /// Browser path (absolute) for browser version detection (e.g., /usr/bin/google-chrome,
     /// "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
-    /// "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe")
+    /// "C:\Program Files\Google\Chrome\Application\chrome.exe")
     #[clap(long, value_parser)]
     browser_path: Option<String>,
 

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -76,7 +76,8 @@ impl SeleniumManager for SafariManager {
     }
 
     fn discover_browser_version(&self) -> Option<String> {
-        let mut browser_path = self.get_browser_path();
+        let escaped_browser_path = self.get_escaped_browser_path();
+        let mut browser_path = escaped_browser_path.as_str();
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -81,7 +81,8 @@ impl SeleniumManager for SafariTPManager {
     }
 
     fn discover_browser_version(&self) -> Option<String> {
-        let mut browser_path = self.get_browser_path();
+        let escaped_browser_path = self.get_escaped_browser_path();
+        let mut browser_path = escaped_browser_path.as_str();
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -17,6 +17,7 @@
 
 use assert_cmd::Command;
 use rstest::rstest;
+use std::env::consts::OS;
 use std::str;
 
 #[rstest]
@@ -132,15 +133,22 @@ fn beta_test(#[case] browser: String, #[case] driver_name: String) {
 
 #[rstest]
 #[case(
+    "windows",
     "chrome",
     r#"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"#
 )]
-#[case("chrome", "/usr/bin/google-chrome")]
 #[case(
+    "windows",
+    "chrome",
+    r#"C:\Program Files\Google\Chrome\Application\chrome.exe"#
+)]
+#[case("linux", "chrome", "/usr/bin/google-chrome")]
+#[case(
+    "macos",
     "chrome",
     r#"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"#
 )]
-fn path_test(#[case] browser: String, #[case] browser_path: String) {
+fn path_test(#[case] os: String, #[case] browser: String, #[case] browser_path: String) {
     println!(
         "Path test browser={} -- browser_path={}",
         browser, browser_path
@@ -151,4 +159,11 @@ fn path_test(#[case] browser: String, #[case] browser_path: String) {
         .assert()
         .success()
         .code(0);
+
+    if OS.eq(&os) {
+        let stdout = &cmd.unwrap().stdout;
+        let output = str::from_utf8(stdout).unwrap();
+        println!("output {:?}", output);
+        assert!(!output.contains("WARN"));
+    }
 }


### PR DESCRIPTION
### Description
So far, Selenium Manager is very sensitive to using back-slash symbols in Windows paths. This happens since the command to discover the browser version in Windows internally uses WMIC, which has some very restrictive behavior regarding paths.

For instance, if the user specifies a browser path in Windows, it must be double-quoted. Otherwise, the command for browser version discovery does not work correctly. For example

```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser firefox --debug --browser-path "C:\Program Files\Mozilla Firefox\firefox.exe"
   Compiling selenium-manager v1.0.0-M3 (C:\Users\boni\Documents\dev\selenium\rust)
    Finished dev [unoptimized + debuginfo] target(s) in 2.53s
     Running `target\debug\selenium-manager.exe --browser firefox --debug --browser-path "C:\Program Files\Mozilla Firefox/firefox.exe"`
DEBUG   Running command: "geckodriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out firefox version
DEBUG   Running command: "wmic datafile where name='C:\\Program Files\\Mozilla Firefox/firefox.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\n\r"
WARN    The version of firefox cannot be detected. Trying with latest driver version
DEBUG   Required driver: geckodriver 0.33.0
DEBUG   geckodriver 0.33.0 already in the cache
INFO    C:\Users\boni\.cache\selenium\geckodriver\win64\0.33.0\geckodriver.exe
```

```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser firefox --debug --browser-path "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target\debug\selenium-manager.exe --browser firefox --debug --browser-path "C:\\Program Files\\Mozilla Firefox\\firefox.exe"`
DEBUG   Running command: "geckodriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out firefox version
DEBUG   Running command: "wmic datafile where name='C:\\\\Program Files\\\\Mozilla Firefox\\\\firefox.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=115.0.0.8569\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: firefox 115.0.0.8569
DEBUG   Required driver: geckodriver 0.33.0
DEBUG   geckodriver 0.33.0 already in the cache
INFO    C:\Users\boni\.cache\selenium\geckodriver\win64\0.33.0\geckodriver.exe
```

This PR enhances the user experience regarding browser paths. In other words, this PR allows using single quotes in Windows for browser paths, as follows:

```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser firefox --debug --browser-path "C:\Program Files\Mozilla Firefox\firefox.exe"
   Compiling selenium-manager v1.0.0-M3 (C:\Users\boni\Documents\dev\selenium\rust)
    Finished dev [unoptimized + debuginfo] target(s) in 3.36s
     Running `target\debug\selenium-manager.exe --browser firefox --debug --browser-path "C:\Program Files\Mozilla Firefox\firefox.exe"`
DEBUG   Running command: "geckodriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out firefox version
DEBUG   Running command: "wmic datafile where name='C:\\\\Program Files\\\\Mozilla Firefox\\\\firefox.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=115.0.0.8569\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: firefox 115.0.0.8569
DEBUG   Required driver: geckodriver 0.33.0
DEBUG   geckodriver 0.33.0 already in the cache
INFO    C:\Users\boni\.cache\selenium\geckodriver\win64\0.33.0\geckodriver.exe
```

```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser firefox --debug --browser-path "C:/Program Files/Mozilla Firefox/firefox.exe"
    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
     Running `target\debug\selenium-manager.exe --browser firefox --debug --browser-path "C:/Program Files/Mozilla Firefox/firefox.exe"`
DEBUG   Running command: "geckodriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out firefox version
DEBUG   Running command: "wmic datafile where name='C:\\\\Program Files\\\\Mozilla Firefox\\\\firefox.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=115.0.0.8569\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: firefox 115.0.0.8569
DEBUG   Required driver: geckodriver 0.33.0
DEBUG   geckodriver 0.33.0 already in the cache
INFO    C:\Users\boni\.cache\selenium\geckodriver\win64\0.33.0\geckodriver.exe
```

### Motivation and Context
This PR will allow us to prevent issues like #12300.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
