### PR TITLE
[java] less memory allocation

### DIFF
--- a/java/src/org/openqa/selenium/netty/server/ResponseConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/ResponseConverter.java
@@ -40,6 +40,7 @@ import org.openqa.selenium.remote.http.HttpResponse;
 public class ResponseConverter extends ChannelOutboundHandlerAdapter {
 
   private static final int CHUNK_SIZE = 1024 * 1024;
+  private static final ThreadLocal<byte[]> CHUNK_CACHE = ThreadLocal.withInitial(() -> new byte[CHUNK_SIZE]);
   private final boolean allowCors;
 
   public ResponseConverter(boolean allowCors) {
@@ -57,7 +58,7 @@ public class ResponseConverter extends ChannelOutboundHandlerAdapter {
     HttpResponse seResponse = (HttpResponse) msg;
 
     // We may not know how large the response is, but figure it out if we can.
-    byte[] ary = new byte[CHUNK_SIZE];
+    byte[] ary = CHUNK_CACHE.get();
     InputStream is = seResponse.getContent().get();
     int byteCount = ByteStreams.read(is, ary, 0, ary.length);
     // If there are no bytes left to read, then -1 is returned by read, and this is bad.
@@ -70,7 +71,7 @@ public class ResponseConverter extends ChannelOutboundHandlerAdapter {
           new DefaultFullHttpResponse(
               HTTP_1_1,
               HttpResponseStatus.valueOf(seResponse.getStatus()),
-              Unpooled.wrappedBuffer(ary, 0, byteCount));
+              Unpooled.copiedBuffer(ary, 0, byteCount));
       first.headers().addInt(CONTENT_LENGTH, byteCount);
       copyHeaders(seResponse, first);
       ctx.write(first);
@@ -81,7 +82,7 @@ public class ResponseConverter extends ChannelOutboundHandlerAdapter {
       ctx.write(first);
 
       // We need to write the first response.
-      ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(ary)));
+      ctx.write(new DefaultHttpContent(Unpooled.copiedBuffer(ary)));
 
       HttpChunkedInput writer = new HttpChunkedInput(new ChunkedStream(is, CHUNK_SIZE));
       ChannelFuture future = ctx.write(writer);

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -75,6 +75,7 @@ import static org.openqa.selenium.remote.DriverCommand.UPLOAD_FILE;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -82,6 +83,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.openqa.selenium.InvalidSelectorException;
@@ -95,6 +97,8 @@ import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
  * @see <a href="https://w3.org/tr/webdriver">W3C WebDriver spec</a>
  */
 public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
+
+  private static final ConcurrentHashMap<String, String> ATOM_SCRIPTS = new ConcurrentHashMap<>();
 
   public W3CHttpCommandCodec() {
     String sessionId = "/session/:sessionId";
@@ -338,15 +342,22 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
 
   private Map<String, ?> executeAtom(String atomFileName, Object... args) {
     try {
-      String scriptName = "/org/openqa/selenium/remote/" + atomFileName;
-      URL url = getClass().getResource(scriptName);
-
-      String rawFunction = Resources.toString(url, StandardCharsets.UTF_8);
-      String atomName = atomFileName.replace(".js", "");
-      String script =
-          String.format("/* %s */return (%s).apply(null, arguments);", atomName, rawFunction);
+      String script = ATOM_SCRIPTS.computeIfAbsent(atomFileName, (fileName) -> {
+        String scriptName = "/org/openqa/selenium/remote/" + atomFileName;
+        URL url = getClass().getResource(scriptName);
+        String rawFunction;
+        try {
+          rawFunction = Resources.toString(url, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+        String atomName = fileName.replace(".js", "");
+        return String.format("/* %s */return (%s).apply(null, arguments);", atomName, rawFunction);
+      });
       return toScript(script, args);
-    } catch (IOException | NullPointerException e) {
+    } catch (UncheckedIOException e) {
+      throw new WebDriverException(e.getCause());
+    } catch (NullPointerException e) {
       throw new WebDriverException(e);
     }
   }

--- a/java/src/org/openqa/selenium/remote/tracing/HttpTracing.java
+++ b/java/src/org/openqa/selenium/remote/tracing/HttpTracing.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.remote.tracing;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.HttpRequest;
@@ -56,11 +57,12 @@ public class HttpTracing {
     Require.nonNull("Tracer", tracer);
     Require.nonNull("Request", request);
 
-    StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
-    LOG.fine(
-        String.format(
-            "Injecting %s into %s at %s:%d",
-            request, context, caller.getClassName(), caller.getLineNumber()));
+    if (LOG.isLoggable(Level.FINE)) {
+      StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
+      LOG.log(
+        Level.FINE, "Injecting {0} into {1} at {2}:{3}",
+        new Object[] {request, context, caller.getClassName(), caller.getLineNumber()});
+    }
 
     tracer.getPropagator().inject(context, request, (req, key, value) -> req.setHeader(key, value));
   }


### PR DESCRIPTION
### Description
Optimized atoms and the grid server to create less garbage objects.

### Motivation and Context
Will reduce the gc needed while polling e.g. for an element to get visble. Helps also when a grid server handles alot of sessions, usually returning only some bytes to the client.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
