### PR TITLE
[dotnet] add support for Safari Technology Preview

### DIFF
--- a/dotnet/src/webdriver/Safari/SafariDriverService.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriverService.cs
@@ -32,6 +32,7 @@ namespace OpenQA.Selenium.Safari
     {
         private const string DefaultSafariDriverServiceExecutableName = "safaridriver";
         private const string DefaultSafariDriverServiceExecutablePath = "/usr/bin";
+        private const string DefaultSafariPreviewDriverServiceExecutablePath = "/Applications/Safari Technology Preview.app/Contents/MacOS/";
 
         private static readonly Uri SafariDriverDownloadUrl = new Uri("http://apple.com");
 
@@ -161,6 +162,20 @@ namespace OpenQA.Selenium.Safari
         /// <returns>A SafariDriverService that implements default settings.</returns>
         public static SafariDriverService CreateDefaultService()
         {
+            return CreateDefaultService(DefaultSafariDriverServiceExecutablePath);
+        }
+
+        /// <summary>
+        /// Creates a default instance of the SafariDriverService.
+        /// </summary>
+        /// <returns>A SafariDriverService that implements default settings.</returns>
+        public static SafariDriverService CreateDefaultService(SafariOptions options)
+        {
+            if (options.TechnologyPreview)
+            {
+                return CreateDefaultService(DefaultSafariPreviewDriverServiceExecutablePath);
+            }
+
             return CreateDefaultService(DefaultSafariDriverServiceExecutablePath);
         }
 

--- a/dotnet/src/webdriver/Safari/SafariOptions.cs
+++ b/dotnet/src/webdriver/Safari/SafariOptions.cs
@@ -47,10 +47,11 @@ namespace OpenQA.Selenium.Safari
     {
         private const string BrowserNameValue = "safari";
         private const string EnableAutomaticInspectionSafariOption = "safari:automaticInspection";
-        private const string EnableAutomticProfilingSafariOption = "safari:automaticProfiling";
+        private const string EnableAutomaticProfilingSafariOption = "safari:automaticProfiling";
 
         private bool enableAutomaticInspection = false;
         private bool enableAutomaticProfiling = false;
+        private bool technologyPreview = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SafariOptions"/> class.
@@ -58,8 +59,27 @@ namespace OpenQA.Selenium.Safari
         public SafariOptions() : base()
         {
             this.BrowserName = BrowserNameValue;
+            this.technologyPreview = false;
             this.AddKnownCapabilityName(SafariOptions.EnableAutomaticInspectionSafariOption, "EnableAutomaticInspection property");
-            this.AddKnownCapabilityName(SafariOptions.EnableAutomticProfilingSafariOption, "EnableAutomaticProfiling property");
+            this.AddKnownCapabilityName(SafariOptions.EnableAutomaticProfilingSafariOption, "EnableAutomaticProfiling property");
+        }
+
+        /// <summary>
+        /// Allows the Options class to be used with a Safari Technology Preview driver
+        /// </summary>
+        public void UseTechnologyPreview()
+        {
+            this.technologyPreview = true;
+            this.BrowserName = "Safari Technology Preview";
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to have the driver preload the
+        /// Web Inspector and JavaScript debugger in the background.
+        /// </summary>
+        public bool TechnologyPreview
+        {
+            get { return this.technologyPreview; }
         }
 
         /// <summary>
@@ -98,7 +118,7 @@ namespace OpenQA.Selenium.Safari
 
             if (this.enableAutomaticProfiling)
             {
-                capabilities.SetCapability(EnableAutomticProfilingSafariOption, true);
+                capabilities.SetCapability(EnableAutomaticProfilingSafariOption, true);
             }
 
             return capabilities.AsReadOnly();

--- a/dotnet/test/common/CustomDriverConfigs/SafariTechnologyPreviewDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/SafariTechnologyPreviewDriver.cs
@@ -22,7 +22,12 @@ namespace OpenQA.Selenium.Safari
 
         public static SafariOptions DefaultOptions
         {
-            get { return new SafariOptions(); }
+            get
+            {
+                SafariOptions options = new SafariOptions();
+                options.UseTechnologyPreview();
+                return options;
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
* Creates Options method to set the browser name to one that Technology Preview Driver requires
* Creates Options Getter Parameter to indicate whether Technology Preview has been set
* Creates Service method to toggle default location of driver based on whether Technology Preview has been set
* Updates the test driver config to use it

### Motivation and Context
What is required to use STP changed several times between 3.x and 4.x and looks like .NET missed one of the zigs.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)