### PR TITLE
[rb] have Selenium Manager binary locate drivers on PATH

### DIFF
--- a/rb/lib/selenium/webdriver/common/driver_finder.rb
+++ b/rb/lib/selenium/webdriver/common/driver_finder.rb
@@ -23,7 +23,6 @@ module Selenium
       def self.path(options, klass)
         path = klass.driver_path
         path = path.call if path.is_a?(Proc)
-        path ||= Platform.find_binary(klass::EXECUTABLE)
 
         path ||= begin
           SeleniumManager.driver_path(options) unless options.is_a?(Remote::Capabilities)

--- a/rb/lib/selenium/webdriver/common/platform.rb
+++ b/rb/lib/selenium/webdriver/common/platform.rb
@@ -62,18 +62,6 @@ module Selenium
         end
       end
 
-      def bitsize
-        @bitsize ||= if defined?(FFI::Platform::ADDRESS_SIZE)
-                       FFI::Platform::ADDRESS_SIZE
-                     elsif defined?(FFI)
-                       FFI.type_size(:pointer) == 4 ? 32 : 64
-                     elsif jruby?
-                       Integer(ENV_JAVA['sun.arch.data.model'])
-                     else
-                       1.size == 4 ? 32 : 64
-                     end
-      end
-
       def jruby?
         engine == :jruby
       end
@@ -156,43 +144,6 @@ module Selenium
         pid = Process.pid
 
         at_exit { yield if Process.pid == pid }
-      end
-
-      def find_binary(*binary_names)
-        paths = ENV['PATH'].split(File::PATH_SEPARATOR)
-
-        if windows?
-          binary_names.map! { |n| "#{n}.exe" }
-          binary_names.dup.each { |n| binary_names << n.gsub('exe', 'bat') }
-        end
-
-        binary_names.each do |binary_name|
-          paths.each do |path|
-            full_path = File.join(path, binary_name)
-            full_path = unix_path(full_path) if windows?
-            exe = Dir.glob(full_path).find { |f| File.executable?(f) }
-            return exe if exe
-          end
-        end
-
-        nil
-      end
-
-      def find_in_program_files(*binary_names)
-        paths = [
-          ENV.fetch('PROGRAMFILES', '\\Program Files'),
-          ENV.fetch('ProgramFiles(x86)', '\\Program Files (x86)'),
-          ENV.fetch('ProgramW6432', '\\Program Files')
-        ]
-
-        paths.each do |root|
-          binary_names.each do |name|
-            exe = File.join(root, name)
-            return exe if File.executable?(exe)
-          end
-        end
-
-        nil
       end
 
       def localhost

--- a/rb/lib/selenium/webdriver/remote/server_error.rb
+++ b/rb/lib/selenium/webdriver/remote/server_error.rb
@@ -25,7 +25,7 @@ module Selenium
           if response.is_a? String
             super(response)
           else
-            super("status code #{response.code}; payload #{response.payload.to_s}")
+            super("status code #{response.code}; payload #{response.payload}")
           end
         end
       end # ServerError

--- a/rb/spec/integration/selenium/server_spec.rb
+++ b/rb/spec/integration/selenium/server_spec.rb
@@ -34,11 +34,11 @@ module Selenium
     end
 
     it 'downloads specified version' do
-        @location = described_class.download('4.9.0')
+      @location = described_class.download('4.9.0')
 
-        expect(File.exist?(@location)).to be true
-        expect(@location).to eq('selenium-server-4.9.0.jar')
-      end
+      expect(File.exist?(@location)).to be true
+      expect(@location).to eq('selenium-server-4.9.0.jar')
+    end
 
     it 'starts and stops server' do
       @location = described_class.download

--- a/rb/spec/integration/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/service_spec.rb
@@ -30,7 +30,6 @@ module Selenium
         after { service_manager.stop }
 
         it 'auto uses chromedriver' do
-          allow(Platform).to receive(:find_binary)
           expect(service_manager.uri).to be_a(URI)
         end
       end

--- a/rb/spec/integration/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/edge/service_spec.rb
@@ -30,7 +30,6 @@ module Selenium
         after { service_manager.stop }
 
         it 'auto uses edgedriver' do
-          allow(Platform).to receive(:find_binary)
           expect(service_manager.uri).to be_a(URI)
         end
       end

--- a/rb/spec/integration/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/service_spec.rb
@@ -30,7 +30,6 @@ module Selenium
         after { service_manager.stop }
 
         it 'auto uses geckodriver' do
-          allow(Platform).to receive(:find_binary)
           service_manager = service.launch
           expect(service_manager.uri).to be_a(URI)
         end

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -52,8 +52,6 @@ module Selenium
           end
 
           it 'does not create args by default' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new
 
             expect(service.extra_args).to be_empty
@@ -72,16 +70,12 @@ module Selenium
           end
 
           it 'uses provided args' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.chrome(args: ['--foo', '--bar'])
 
             expect(service.extra_args).to eq ['--foo', '--bar']
           end
 
           it 'uses args when passed in as a Hash' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             expect {
               service = described_class.new(args: {log_path: '/path/to/log',
                                                    verbose: true})

--- a/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/driver_finder_spec.rb
@@ -54,20 +54,7 @@ module Selenium
           expect(Platform).to have_received(:assert_executable).with('path')
         end
 
-        it 'uses path from PATH' do
-          allow(SeleniumManager).to receive(:driver_path)
-          allow(Platform).to receive(:assert_file)
-          allow(Platform).to receive(:assert_executable)
-          allow(Platform).to receive(:find_binary).and_return('path')
-
-          described_class.path(options, service)
-
-          expect(SeleniumManager).not_to have_received(:driver_path)
-          expect(Platform).to have_received(:assert_executable).with('path')
-        end
-
         it 'gives original error if not found by Selenium Manager' do
-          allow(Platform).to receive(:find_binary)
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
@@ -108,20 +95,7 @@ module Selenium
           expect(Platform).to have_received(:assert_executable).with('path')
         end
 
-        it 'uses path from PATH' do
-          allow(SeleniumManager).to receive(:driver_path)
-          allow(Platform).to receive(:assert_file)
-          allow(Platform).to receive(:assert_executable)
-          allow(Platform).to receive(:find_binary).and_return('path')
-
-          described_class.path(options, service)
-
-          expect(SeleniumManager).not_to have_received(:driver_path)
-          expect(Platform).to have_received(:assert_executable).with('path')
-        end
-
         it 'gives original error if not found by Selenium Manager' do
-          allow(Platform).to receive(:find_binary)
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
@@ -162,20 +136,7 @@ module Selenium
           expect(Platform).to have_received(:assert_executable).with('path')
         end
 
-        it 'uses path from PATH' do
-          allow(SeleniumManager).to receive(:driver_path)
-          allow(Platform).to receive(:assert_file)
-          allow(Platform).to receive(:assert_executable)
-          allow(Platform).to receive(:find_binary).and_return('path')
-
-          described_class.path(options, service)
-
-          expect(SeleniumManager).not_to have_received(:driver_path)
-          expect(Platform).to have_received(:assert_executable).with('path')
-        end
-
         it 'gives original error if not found by Selenium Manager' do
-          allow(Platform).to receive(:find_binary)
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
@@ -216,20 +177,7 @@ module Selenium
           expect(Platform).to have_received(:assert_executable).with('path')
         end
 
-        it 'uses path from PATH' do
-          allow(SeleniumManager).to receive(:driver_path)
-          allow(Platform).to receive(:assert_file)
-          allow(Platform).to receive(:assert_executable)
-          allow(Platform).to receive(:find_binary).and_return('path')
-
-          described_class.path(options, service)
-
-          expect(SeleniumManager).not_to have_received(:driver_path)
-          expect(Platform).to have_received(:assert_executable).with('path')
-        end
-
         it 'gives original error if not found by Selenium Manager' do
-          allow(Platform).to receive(:find_binary)
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {
@@ -270,20 +218,7 @@ module Selenium
           expect(Platform).to have_received(:assert_executable).with('path')
         end
 
-        it 'uses path from PATH' do
-          allow(SeleniumManager).to receive(:driver_path)
-          allow(Platform).to receive(:assert_file)
-          allow(Platform).to receive(:assert_executable)
-          allow(Platform).to receive(:find_binary).and_return('path')
-
-          described_class.path(options, service)
-
-          expect(SeleniumManager).not_to have_received(:driver_path)
-          expect(Platform).to have_received(:assert_executable).with('path')
-        end
-
         it 'gives original error if not found by Selenium Manager' do
-          allow(Platform).to receive(:find_binary)
           allow(SeleniumManager).to receive(:driver_path).and_raise(Error::WebDriverError)
 
           expect {

--- a/rb/spec/unit/selenium/webdriver/common/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/service_spec.rb
@@ -31,8 +31,6 @@ module Selenium
       end
 
       describe 'browser shortcuts' do
-        before { allow(Platform).to receive(:find_binary).and_return(service_path) }
-
         let(:args) { %w[--foo --bar] }
 
         it 'creates Chrome instance' do

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -51,16 +51,12 @@ module Selenium
           end
 
           it 'does not create args by default' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new
 
             expect(service.extra_args).to be_empty
           end
 
           it 'uses provided args' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new(args: ['--foo', '--bar'])
 
             expect(service.extra_args).to eq ['--foo', '--bar']
@@ -68,8 +64,6 @@ module Selenium
 
           # This is deprecated behavior
           it 'uses args when passed in as a Hash' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             expect {
               service = described_class.new(args: {log_path: '/path/to/log',
                                                    verbose: true})

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -49,24 +49,18 @@ module Selenium
           end
 
           it 'does not create args by default' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new
 
             expect(service.extra_args).to be_empty
           end
 
           it 'uses provided args' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new(args: ['--foo', '--bar'])
 
             expect(service.extra_args).to eq ['--foo', '--bar']
           end
 
           it 'uses args when passed in as a Hash' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             expect {
               service = described_class.new(args: {log: '/path/to/log',
                                                    marionette_port: 4})

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -50,16 +50,12 @@ module Selenium
           end
 
           it 'does not create args by default' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new
 
             expect(service.extra_args).to be_empty
           end
 
           it 'uses provided args' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new(args: ['--foo', '--bar'])
 
             expect(service.extra_args).to eq ['--foo', '--bar']
@@ -67,8 +63,6 @@ module Selenium
 
           # This is deprecated behavior
           it 'uses args when passed in as a Hash' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             expect {
               service = described_class.new(args: {log_file: '/path/to/log',
                                                    silent: true})

--- a/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/driver_spec.rb
@@ -63,7 +63,7 @@ module Selenium
         end
 
         it 'does not require any parameters' do
-          allow(Platform).to receive(:find_binary).and_return('/path/to/safaridriver')
+          allow(SeleniumManager).to receive(:driver_path).and_return('/path/to/safaridriver')
           allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           expect_request
@@ -72,7 +72,7 @@ module Selenium
         end
 
         it 'accepts provided Options as sole parameter' do
-          allow(Platform).to receive(:find_binary).and_return('path/to/safaridriver')
+          allow(SeleniumManager).to receive(:driver_path).and_return('/path/to/safaridriver')
           allow(Platform).to receive(:assert_file)
           allow(Platform).to receive(:assert_executable)
           opts = {automatic_inspection: true}

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -56,8 +56,6 @@ module Selenium
           end
 
           it 'does not create args by default' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new
 
             expect(service.extra_args).to be_empty
@@ -71,8 +69,6 @@ module Selenium
           end
 
           it 'uses provided args' do
-            allow(Platform).to receive(:find_binary).and_return(service_path)
-
             service = described_class.new(args: ['--foo', '--bar'])
 
             expect(service.extra_args).to eq ['--foo', '--bar']
@@ -101,7 +97,7 @@ module Selenium
           end
 
           it 'is created when :url is not provided' do
-            allow(Platform).to receive(:find_binary).and_return('/path/to/safaridriver')
+            allow(SeleniumManager).to receive(:driver_path).and_return('/path/to/safaridriver')
             allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new).and_return(service)
@@ -112,7 +108,7 @@ module Selenium
           end
 
           it 'accepts :service without creating a new instance' do
-            allow(Platform).to receive(:find_binary).and_return('path/to/safaridriver')
+            allow(SeleniumManager).to receive(:driver_path).and_return('/path/to/safaridriver')
             allow(Platform).to receive(:assert_file)
             allow(Platform).to receive(:assert_executable)
             allow(described_class).to receive(:new)


### PR DESCRIPTION
### Description
* Remove the use of `Platform#find_binary` in `DriverFinder`
* Remove `#find_binary` from `Platform`
* Fixed unit tests

### Motivation and Context
* Ruby implementation of #11356 

### Considerations
* It is possible for this to be a breaking change since the `find_binary` logic may differ slightly from the binary, but it is unlikely and warnings will be thrown in the console.
* Are there any of these methods in this API private class that I'm deleting that we want to keep?