### PR TITLE
Add supports for list-of-table options

### DIFF
--- a/java/src/org/openqa/selenium/grid/config/Config.java
+++ b/java/src/org/openqa/selenium/grid/config/Config.java
@@ -17,7 +17,11 @@
 
 package org.openqa.selenium.grid.config;
 
+import com.google.common.collect.ImmutableList;
+import org.openqa.selenium.json.Json;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -54,5 +58,20 @@ public interface Config {
     } catch (ReflectiveOperationException e) {
       throw new IllegalArgumentException("Unable to find class: " + clazz, e);
     }
+  }
+
+  default List<String> toEntryList(Map<String, Object> mapItem) {
+    return mapItem.entrySet().stream()
+      .map(entry -> {
+        return String.format("%s=%s", entry.getKey(), toJson(entry.getValue()));
+      })
+      .sorted()
+      .collect(ImmutableList.toImmutableList());
+  }
+
+  default String toJson(Object value) {
+    StringBuilder jsonStr = new StringBuilder();
+    new Json().newOutput(jsonStr).setPrettyPrint(false).write(value);
+    return jsonStr.toString();
   }
 }

--- a/java/src/org/openqa/selenium/grid/config/MapConfig.java
+++ b/java/src/org/openqa/selenium/grid/config/MapConfig.java
@@ -21,10 +21,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import org.openqa.selenium.internal.Require;
 
 public class MapConfig implements Config {
@@ -65,7 +67,33 @@ public class MapConfig implements Config {
     }
 
     Object value = rawSection.get(option);
-    return value == null ? Optional.empty() : Optional.of(ImmutableList.of(String.valueOf(value)));
+    if (value == null) {
+      return Optional.empty();
+    }
+
+    if (value instanceof Collection) {
+      Collection<?> collection = (Collection<?>) value;
+      // Case when an array of map is used as config
+      if (collection.stream().anyMatch(item -> item instanceof Map)) {
+        return Optional.of(collection.stream()
+          .map(item -> (Map<String, Object>) item)
+          .map(this::toEntryList)
+          .flatMap(Collection::stream)
+          .collect(ImmutableList.toImmutableList()));
+      }
+
+      return Optional.of(
+        collection.stream()
+          .filter(item -> (!(item instanceof Collection)))
+          .map(String::valueOf)
+          .collect(ImmutableList.toImmutableList()));
+    }
+
+    if (value instanceof Map) {
+      return Optional.of(toEntryList((Map<String, Object>) value));
+    }
+
+    return Optional.of(ImmutableList.of(String.valueOf(value)));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/config/TomlConfig.java
+++ b/java/src/org/openqa/selenium/grid/config/TomlConfig.java
@@ -23,16 +23,16 @@ import io.ous.jtoml.JToml;
 import io.ous.jtoml.ParseException;
 import io.ous.jtoml.Toml;
 import io.ous.jtoml.TomlTable;
+import org.openqa.selenium.internal.Require;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.openqa.selenium.internal.Require;
 
 public class TomlConfig implements Config {
 
@@ -87,24 +87,24 @@ public class TomlConfig implements Config {
       // Case when an array of tables is used as config
       // https://toml.io/en/v1.0.0-rc.3#array-of-tables
       if (collection.stream().anyMatch(item -> item instanceof TomlTable)) {
-        List<String> toReturn = new ArrayList<>();
-        collection.stream()
-            .map(item -> (TomlTable) item)
-            .forEach(
-                tomlTable ->
-                    tomlTable.toMap().entrySet().stream()
-                        .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
-                        .sorted()
-                        .forEach(toReturn::add));
-        return Optional.of(toReturn);
-      }
-      List<String> values =
+        return Optional.of(
           collection.stream()
-              .filter(item -> (!(item instanceof Collection)))
-              .map(String::valueOf)
-              .collect(ImmutableList.toImmutableList());
+            .map(item -> (TomlTable) item)
+            .map(TomlTable::toMap)
+            .map(this::toEntryList)
+            .flatMap(Collection::stream)
+            .collect(ImmutableList.toImmutableList()));
+      }
 
-      return Optional.of(values);
+      return Optional.of(
+        collection.stream()
+          .filter(item -> (!(item instanceof Collection)))
+          .map(String::valueOf)
+          .collect(ImmutableList.toImmutableList()));
+    }
+
+    if (value instanceof TomlTable) {
+      return Optional.of(toEntryList(((TomlTable) value).toMap()));
     }
 
     return Optional.of(ImmutableList.of(String.valueOf(value)));

--- a/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.io.File;
+import java.io.StringReader;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
@@ -57,6 +58,7 @@ import org.openqa.selenium.grid.node.Node;
 import org.openqa.selenium.grid.node.SessionFactory;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.Json;
+import org.openqa.selenium.json.JsonInput;
 import org.openqa.selenium.json.JsonOutput;
 import org.openqa.selenium.net.NetworkUtils;
 import org.openqa.selenium.net.Urls;
@@ -390,7 +392,7 @@ public class NodeOptions {
                     .forEach(
                         keyValue -> {
                           String[] values = keyValue.split("=", 2);
-                          configMap.put(values[0], values[1]);
+                          configMap.put(values[0], unquote(values[1]));
                         });
                 driversMap.add(configMap);
               }
@@ -715,5 +717,13 @@ public class NodeOptions {
             caps.toString().replaceAll("\\s+", " "),
             entry.getValue().size(),
             entry.getKey().isPresent() ? "Host" : "SM"));
+  }
+
+  private String unquote(String input) {
+    int len = input.length();
+    if ((input.charAt(0) == '"') && (input.charAt(len - 1) == '"')) {
+      return new Json().newInput(new StringReader(input)).read(Json.OBJECT_TYPE);
+    }
+    return input;
   }
 }

--- a/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
@@ -93,11 +93,12 @@ class FirefoxOptionsTest {
 
   @Test
   void shouldKeepRelativePathToBinaryAsIs() {
-    FirefoxOptions options = new FirefoxOptions().setBinary("some/path");
+    String path = String.join(File.separator, "some", "path");
+    FirefoxOptions options = new FirefoxOptions().setBinary(path);
     assertThat(options.getBinary())
         .extracting(FirefoxBinary::getFile)
         .extracting(String::valueOf)
-        .isEqualTo("some/path");
+        .isEqualTo(path);
   }
 
   @Test
@@ -138,11 +139,12 @@ class FirefoxOptionsTest {
 
   @Test
   void pathBasedBinaryRemainsAbsoluteIfSetAsAbsolute() {
+    String path = String.join(File.separator, "", "i", "like", "cheese");
     Map<String, Object> json = new FirefoxOptions().setBinary(Paths.get("/i/like/cheese")).asMap();
 
     assertThat(json.get(FIREFOX_OPTIONS))
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("binary", "/i/like/cheese");
+        .containsEntry("binary", path);
   }
 
   @Test
@@ -311,7 +313,7 @@ class FirefoxOptionsTest {
     Object options2 = options.asMap().get(FirefoxOptions.FIREFOX_OPTIONS);
     assertThat(options2)
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("binary", tempFile.toFile().getPath().replaceAll("\\\\", "/"));
+        .containsEntry("binary", tempFile.toFile().getPath());
   }
 
   @Test

--- a/java/test/org/openqa/selenium/grid/config/BUILD.bazel
+++ b/java/test/org/openqa/selenium/grid/config/BUILD.bazel
@@ -8,6 +8,7 @@ java_test_suite(
     deps = [
         "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/grid/config",
+        "//java/src/org/openqa/selenium/json",
         artifact("com.beust:jcommander"),
         artifact("com.google.guava:guava"),
         artifact("io.ous:jtoml"),

--- a/java/test/org/openqa/selenium/grid/config/JsonConfigTest.java
+++ b/java/test/org/openqa/selenium/grid/config/JsonConfigTest.java
@@ -20,7 +20,11 @@ package org.openqa.selenium.grid.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 class JsonConfigTest {
@@ -31,5 +35,84 @@ class JsonConfigTest {
     Config config = new JsonConfig(new StringReader(raw));
 
     assertThat(config.get("cheeses", "selected")).isEqualTo(Optional.of("brie"));
+  }
+
+  @Test
+  void ensureCanReadListOfStrings() {
+    String raw = String.join("", "",
+      "{",
+        "`relay`: {",
+          "`configs`: [`2`, `{\\`browserName\\`: \\`chrome\\`}`]",
+        "}",
+      "}"
+    ).replace("`", "\"");
+    Config config = new JsonConfig(new StringReader(raw));
+
+    List<String> expected = Arrays.asList(
+      "2",
+      "{\"browserName\": \"chrome\"}"
+    );
+    Optional<List<String>> content = config.getAll("relay", "configs");
+    assertThat(content).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  void shouldContainConfigFromArrayOfTables() {
+    String raw = String.join("", "",
+      "{",
+        "`cheeses`: {",
+          "`default`: `manchego`,",
+          "`type`: [",
+            "{",
+              "`name`: `soft cheese`,",
+              "`default`: `brie`",
+            "},",
+            "{",
+              "`name`: `Medium-hard cheese`,",
+              "`default`: `Emmental`",
+            "}",
+          "]",
+        "}",
+      "}"
+    ).replace("`", "\"");
+    Config config = new JsonConfig(new StringReader(raw));
+
+    assertThat(config.get("cheeses", "default")).isEqualTo(Optional.of("manchego"));
+
+    List<String> expected =
+      Arrays.asList(
+        "default=\"brie\"", "name=\"soft cheese\"",
+        "default=\"Emmental\"", "name=\"Medium-hard cheese\"");
+    assertThat(config.getAll("cheeses", "type").orElse(Collections.emptyList()))
+      .isEqualTo(expected);
+    assertThat(config.getAll("cheeses", "type").orElse(Collections.emptyList()).subList(0, 2))
+      .isEqualTo(expected.subList(0, 2));
+  }
+
+  @Test
+  void ensureCanReadListOfMaps() {
+    String raw = String.join("", "",
+      "{",
+        "`node`: {",
+          "`detect-drivers`: false,",
+          "`driver-configuration`: [",
+            "{",
+              "`display-name`: `htmlunit`,",
+              "`stereotype`: {",
+                "`browserName`: `htmlunit`,",
+                "`browserVersion`: `chrome`",
+              "}",
+            "}",
+          "]",
+        "}",
+      "}"
+    ).replace("`", "\"");
+    Config config = new JsonConfig(new StringReader(raw));
+    List<String> expected = Arrays.asList(
+      "display-name=\"htmlunit\"",
+      "stereotype={\"browserName\": \"htmlunit\",\"browserVersion\": \"chrome\"}"
+    );
+    Optional<List<String>> content = config.getAll("node", "driver-configuration");
+    assertThat(content).isEqualTo(Optional.of(expected));
   }
 }


### PR DESCRIPTION
Currently our json based configurations does not
support List of Maps (this is supported on Toml
format)

Issue details are available in
https://groups.google.com/g/selenium-developers/c/_UYMd3ZjQ0M

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
More details on this issue is available in https://groups.google.com/g/selenium-developers/c/_UYMd3ZjQ0M

### Motivation and Context
To support list of maps when dealing with json config files for Grid.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
