### PR TITLE
[py] Update Remote Connection creation in driver classes

### DIFF
--- a/py/selenium/webdriver/chrome/remote_connection.py
+++ b/py/selenium/webdriver/chrome/remote_connection.py
@@ -1,0 +1,29 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import typing
+
+from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+
+
+class ChromeRemoteConnection(ChromiumRemoteConnection):
+    def __init__(
+        self,
+        remote_server_addr: str,
+        keep_alive: bool = True,
+        ignore_proxy: typing.Optional[bool] = False,
+    ) -> None:
+        super().__init__(remote_server_addr, 'goog', keep_alive, ignore_proxy=ignore_proxy)

--- a/py/selenium/webdriver/chrome/remote_connection.py
+++ b/py/selenium/webdriver/chrome/remote_connection.py
@@ -16,14 +16,23 @@
 # under the License.
 import typing
 
+from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 
 
 class ChromeRemoteConnection(ChromiumRemoteConnection):
+    browser_name = DesiredCapabilities.CHROME["browserName"]
+
     def __init__(
         self,
         remote_server_addr: str,
         keep_alive: bool = True,
         ignore_proxy: typing.Optional[bool] = False,
     ) -> None:
-        super().__init__(remote_server_addr, 'goog', keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(
+            remote_server_addr=remote_server_addr,
+            vendor_prefix="goog",
+            browser_name="chrome",
+            keep_alive=keep_alive,
+            ignore_proxy=ignore_proxy,
+        )

--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from .options import Options
 from .service import Service
@@ -42,10 +41,4 @@ class WebDriver(ChromiumDriver):
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(
-            DesiredCapabilities.CHROME["browserName"],
-            "goog",
-            options,
-            service,
-            keep_alive,
-        )
+        super().__init__(options=options, service=service, keep_alive=keep_alive)

--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -16,14 +16,23 @@
 # under the License.
 import typing
 
+from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 
 
 class EdgeRemoteConnection(ChromiumRemoteConnection):
+    browser_name = DesiredCapabilities.EDGE["browserName"]
+
     def __init__(
         self,
         remote_server_addr: str,
         keep_alive: bool = True,
         ignore_proxy: typing.Optional[bool] = False,
     ) -> None:
-        super().__init__(remote_server_addr, 'ms', keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(
+            remote_server_addr=remote_server_addr,
+            vendor_prefix="goog",
+            browser_name="MicrosoftEdge",
+            keep_alive=keep_alive,
+            ignore_proxy=ignore_proxy,
+        )

--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -1,0 +1,29 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import typing
+
+from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+
+
+class EdgeRemoteConnection(ChromiumRemoteConnection):
+    def __init__(
+        self,
+        remote_server_addr: str,
+        keep_alive: bool = True,
+        ignore_proxy: typing.Optional[bool] = False,
+    ) -> None:
+        super().__init__(remote_server_addr, 'ms', keep_alive, ignore_proxy=ignore_proxy)

--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from .options import Options
 from .service import Service
@@ -29,7 +28,7 @@ class WebDriver(ChromiumDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive=True,
+        keep_alive: bool = True,
     ) -> None:
         """Creates a new instance of the edge driver. Starts the service and
         then creates new instance of edge driver.
@@ -42,10 +41,4 @@ class WebDriver(ChromiumDriver):
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(
-            DesiredCapabilities.EDGE["browserName"],
-            "ms",
-            options,
-            service,
-            keep_alive,
-        )
+        super().__init__(options=options, service=service, keep_alive=keep_alive)

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -93,11 +93,12 @@ def _create_caps(caps):
 
 
 def get_remote_connection(capabilities, command_executor, keep_alive, ignore_local_proxy=False):
-    from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+    from selenium.webdriver.chrome.remote_connection import ChromeRemoteConnection
+    from selenium.webdriver.edge.remote_connection import EdgeRemoteConnection
     from selenium.webdriver.firefox.remote_connection import FirefoxRemoteConnection
     from selenium.webdriver.safari.remote_connection import SafariRemoteConnection
 
-    candidates = [RemoteConnection, ChromiumRemoteConnection, SafariRemoteConnection, FirefoxRemoteConnection]
+    candidates = [ChromeRemoteConnection, EdgeRemoteConnection, SafariRemoteConnection, FirefoxRemoteConnection]
     handler = next((c for c in candidates if c.browser_name == capabilities.get("browserName")), RemoteConnection)
 
     return handler(command_executor, keep_alive=keep_alive, ignore_proxy=ignore_local_proxy)


### PR DESCRIPTION
### Description
* Current code does not allow chrome or edge remote connections in remote webdriver because chromium class will not match on the browser name
* If the remote webdriver class has code for creating the handler, the subclasses do not need to
* There is extra code in chromium class (and a deprecation) that will only matter if someone is subclassing Chromium class with a different browser.
* Made all the quit methods the same
* Have all driver constructors call the quit method to stop the driver if there is an exception when starting session

### Motivation and Context
Tidying some things up in preparation for another change

### Considerations
* Do we actually need the extra Chromium class code, or can we safely assume there aren't additional implementations with separate vendor_code that we need to worry about? Would be nice to just remove those parameters.
* Should we put the try/except/quit code in the remote webdriver constructor instead of all the subclasses?
* Should we get rid of the subclass `quit()` methods and put `self.service.stop()` in the currently unused `stop_client()` method (https://github.com/SeleniumHQ/selenium/blob/selenium-4.10.0/py/selenium/webdriver/remote/webdriver.py#L467-L471)
