### PR TITLE
[py] removed `start_error_message` param from common/service.py

### DIFF
--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -31,8 +31,6 @@ class ChromiumService(service.Service):
     :param service_args: (Optional) List of args to be passed to the subprocess when launching the executable.
     :param log_path: (Optional) String to be passed to the executable as `--log-path`.
     :param env: (Optional) Mapping of environment variables for the new process, defaults to `os.environ`.
-    :param start_error_message: (Optional) Error message that forms part of the error when problems occur
-    launching the subprocess.
     """
 
     def __init__(

--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -218,7 +218,5 @@ class Service(ABC):
             raise
         except OSError as err:
             if err.errno == errno.EACCES:
-                raise WebDriverException(
-                    f"'{os.path.basename(self._path)}' executable may have wrong permissions. {self.start_error_message}"
-                )
+                raise WebDriverException(f"'{os.path.basename(self._path)}' executable may have wrong permissions.")
             raise


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Since `start_error_message` is no more used in `Service` object, I have removed if from `common/service.py` and `chromium/service.py` 

### Motivation and Context
Since `start_error_message` is no more used in `Service` object, I have removed if from `common/service.py` and `chromium/service.py` 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
