### PR TITLE
Create Client config class for http client values

### DIFF
--- a/py/selenium/webdriver/chrome/remote_connection.py
+++ b/py/selenium/webdriver/chrome/remote_connection.py
@@ -1,0 +1,29 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import typing
+
+from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+
+
+class ChromeRemoteConnection(ChromiumRemoteConnection):
+    def __init__(
+        self,
+        remote_server_addr: str,
+        keep_alive: bool = True,
+        ignore_proxy: typing.Optional[bool] = False,
+    ) -> None:
+        super().__init__(remote_server_addr, 'goog', keep_alive, ignore_proxy=ignore_proxy)

--- a/py/selenium/webdriver/chrome/remote_connection.py
+++ b/py/selenium/webdriver/chrome/remote_connection.py
@@ -16,14 +16,23 @@
 # under the License.
 import typing
 
+from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 
 
 class ChromeRemoteConnection(ChromiumRemoteConnection):
+    browser_name = DesiredCapabilities.CHROME["browserName"]
+
     def __init__(
         self,
         remote_server_addr: str,
         keep_alive: bool = True,
         ignore_proxy: typing.Optional[bool] = False,
     ) -> None:
-        super().__init__(remote_server_addr, 'goog', keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(
+            remote_server_addr=remote_server_addr,
+            vendor_prefix="goog",
+            browser_name="chrome",
+            keep_alive=keep_alive,
+            ignore_proxy=ignore_proxy,
+        )

--- a/py/selenium/webdriver/chrome/remote_connection.py
+++ b/py/selenium/webdriver/chrome/remote_connection.py
@@ -18,6 +18,7 @@ import typing
 
 from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+from selenium.webdriver.remote.client_config import ClientConfig
 
 
 class ChromeRemoteConnection(ChromiumRemoteConnection):
@@ -26,8 +27,9 @@ class ChromeRemoteConnection(ChromiumRemoteConnection):
     def __init__(
         self,
         remote_server_addr: str,
-        keep_alive: bool = True,
-        ignore_proxy: typing.Optional[bool] = False,
+        keep_alive: typing.Optional[bool] = None,
+        ignore_proxy: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         super().__init__(
             remote_server_addr=remote_server_addr,
@@ -35,4 +37,5 @@ class ChromeRemoteConnection(ChromiumRemoteConnection):
             browser_name="chrome",
             keep_alive=keep_alive,
             ignore_proxy=ignore_proxy,
+            client_config=client_config,
         )

--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from .options import Options
 from .service import Service
@@ -42,10 +41,4 @@ class WebDriver(ChromiumDriver):
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(
-            DesiredCapabilities.CHROME["browserName"],
-            "goog",
-            options,
-            service,
-            keep_alive,
-        )
+        super().__init__(options=options, service=service, keep_alive=keep_alive)

--- a/py/selenium/webdriver/chrome/webdriver.py
+++ b/py/selenium/webdriver/chrome/webdriver.py
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import Service
 
@@ -28,7 +30,8 @@ class WebDriver(ChromiumDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive: bool = True,
+        keep_alive: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new instance of the chrome driver. Starts the service and
         then creates new instance of chrome driver.
@@ -36,9 +39,10 @@ class WebDriver(ChromiumDriver):
         :Args:
          - options - this takes an instance of ChromeOptions
          - service - Service object for handling the browser driver if you need to pass extra details
-         - keep_alive - Whether to configure ChromeRemoteConnection to use HTTP keep-alive.
+         - keep_alive - Deprecated: Whether to configure ChromeRemoteConnection to use HTTP keep-alive.
+         - client_config - configuration values for the http client
         """
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(options=options, service=service, keep_alive=keep_alive)
+        super().__init__(options=options, service=service, keep_alive=keep_alive, client_config=client_config)

--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -16,6 +16,7 @@
 # under the License.
 import typing
 
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
@@ -25,10 +26,11 @@ class ChromiumRemoteConnection(RemoteConnection):
         remote_server_addr: str,
         vendor_prefix: str,
         browser_name: str,
-        keep_alive: bool = True,
-        ignore_proxy: typing.Optional[bool] = False,
+        keep_alive: typing.Optional[bool] = None,
+        ignore_proxy: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy, client_config=client_config)
         self.browser_name = browser_name
         self._commands["launchApp"] = ("POST", "/session/$sessionId/chromium/launch_app")
         self._commands["setPermissions"] = ("POST", "/session/$sessionId/permissions")

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 import warnings
 
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.common.service import Service
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 
@@ -31,10 +33,11 @@ class ChromiumDriver(RemoteWebDriver):
         self,
         browser_name: str = None,
         vendor_prefix: str = None,
-        options: ArgOptions = ArgOptions(),
+        options: ArgOptions = None,
         service: Service = None,
-        keep_alive: bool = True,
-        remote_connection: ChromiumRemoteConnection = None,
+        keep_alive: typing.Optional[bool] = None,
+        remote_connection: typing.Optional[ChromiumRemoteConnection] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new WebDriver instance of the ChromiumDriver. Starts the
         service and then creates new WebDriver instance of ChromiumDriver.
@@ -44,7 +47,8 @@ class ChromiumDriver(RemoteWebDriver):
          - vendor_prefix - Company prefix to apply to vendor-specific WebDriver extension commands.
          - options - this takes an instance of ChromiumOptions
          - service - Service object for handling the browser driver if you need to pass extra details
-         - keep_alive - Whether to configure ChromiumRemoteConnection to use HTTP keep-alive.
+         - keep_alive - Deprecated: Whether to configure ChromiumRemoteConnection to use HTTP keep-alive.
+         - client_config - configuration values for the http client
         """
 
         if browser_name:
@@ -73,7 +77,12 @@ class ChromiumDriver(RemoteWebDriver):
         command_executor = remote_connection if remote_connection else self.service.service_url
 
         try:
-            super().__init__(command_executor=command_executor, options=options, keep_alive=keep_alive)
+            super().__init__(
+                command_executor=command_executor,
+                options=options,
+                keep_alive=keep_alive,
+                client_config=client_config,
+            )
         except Exception:
             self.quit()
             raise

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 from selenium.webdriver.common.driver_finder import DriverFinder
@@ -28,11 +29,12 @@ class ChromiumDriver(RemoteWebDriver):
 
     def __init__(
         self,
-        browser_name,
-        vendor_prefix,
-        options: ArgOptions,
-        service: Service,
-        keep_alive=True,
+        browser_name: str = None,
+        vendor_prefix: str = None,
+        options: ArgOptions = ArgOptions(),
+        service: Service = None,
+        keep_alive: bool = True,
+        remote_connection: ChromiumRemoteConnection = None,
     ) -> None:
         """Creates a new WebDriver instance of the ChromiumDriver. Starts the
         service and then creates new WebDriver instance of ChromiumDriver.
@@ -44,25 +46,34 @@ class ChromiumDriver(RemoteWebDriver):
          - service - Service object for handling the browser driver if you need to pass extra details
          - keep_alive - Whether to configure ChromiumRemoteConnection to use HTTP keep-alive.
         """
-        self.vendor_prefix = vendor_prefix
+
+        if browser_name:
+            warnings.warn(
+                "browser_name is not necessary when an Options class is used", DeprecationWarning, stacklevel=2
+            )
 
         self.service = service
-
         self.service.path = DriverFinder.get_path(self.service, options)
-
         self.service.start()
 
-        try:
-            super().__init__(
-                command_executor=ChromiumRemoteConnection(
-                    remote_server_addr=self.service.service_url,
-                    browser_name=browser_name,
-                    vendor_prefix=vendor_prefix,
-                    keep_alive=keep_alive,
-                    ignore_proxy=options._ignore_local_proxy,
-                ),
-                options=options,
+        if vendor_prefix:
+            warnings.warn(
+                "vendor_prefix is deprecated, use a ChromiumRemoteConnection with command_executor instead",
+                DeprecationWarning,
+                stacklevel=2,
             )
+            remote_connection = ChromiumRemoteConnection(
+                remote_server_addr=self.service.service_url,
+                browser_name=browser_name,
+                vendor_prefix=vendor_prefix,
+                keep_alive=keep_alive,
+                ignore_proxy=options._ignore_local_proxy,
+            )
+
+        command_executor = remote_connection if remote_connection else self.service.service_url
+
+        try:
+            super().__init__(command_executor=command_executor, options=options, keep_alive=keep_alive)
         except Exception:
             self.quit()
             raise
@@ -185,8 +196,7 @@ class ChromiumDriver(RemoteWebDriver):
         return self.execute("stopCasting", {"sinkName": sink_name})
 
     def quit(self) -> None:
-        """Closes the browser and shuts down the ChromiumDriver executable that
-        is started when starting the ChromiumDriver."""
+        """Ends the driver session and shuts down the ChromiumDriver executable."""
         try:
             super().quit()
         except Exception:

--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import typing
+import warnings
 from abc import ABCMeta
 from abc import abstractmethod
 
@@ -31,6 +32,7 @@ class BaseOptions(metaclass=ABCMeta):
         self._proxy = None
         self.set_capability("pageLoadStrategy", "normal")
         self.mobile_options = None
+        self._ignore_local_proxy = False
 
     @property
     def capabilities(self):
@@ -225,12 +227,22 @@ class BaseOptions(metaclass=ABCMeta):
     def default_capabilities(self):
         """Return minimal capabilities necessary as a dictionary."""
 
+    def ignore_local_proxy_environment_variables(self) -> None:
+        """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
+        being picked up and used."""
+        warnings.warn(
+            "setting ignore proxy in Options has been deprecated, "
+            "set ProxyType.DIRECT in ClientConfig and pass to WebDriver constructor instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._ignore_local_proxy = True
+
 
 class ArgOptions(BaseOptions):
     def __init__(self) -> None:
         super().__init__()
         self._arguments = []
-        self._ignore_local_proxy = False
 
     @property
     def arguments(self):
@@ -249,11 +261,6 @@ class ArgOptions(BaseOptions):
             self._arguments.append(argument)
         else:
             raise ValueError("argument can not be null")
-
-    def ignore_local_proxy_environment_variables(self) -> None:
-        """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
-        being picked up and used."""
-        self._ignore_local_proxy = True
 
     def to_capabilities(self):
         return self._caps

--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -16,14 +16,23 @@
 # under the License.
 import typing
 
+from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
 
 
 class EdgeRemoteConnection(ChromiumRemoteConnection):
+    browser_name = DesiredCapabilities.EDGE["browserName"]
+
     def __init__(
         self,
         remote_server_addr: str,
         keep_alive: bool = True,
         ignore_proxy: typing.Optional[bool] = False,
     ) -> None:
-        super().__init__(remote_server_addr, 'ms', keep_alive, ignore_proxy=ignore_proxy)
+        super().__init__(
+            remote_server_addr=remote_server_addr,
+            vendor_prefix="goog",
+            browser_name="MicrosoftEdge",
+            keep_alive=keep_alive,
+            ignore_proxy=ignore_proxy,
+        )

--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -1,0 +1,29 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import typing
+
+from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+
+
+class EdgeRemoteConnection(ChromiumRemoteConnection):
+    def __init__(
+        self,
+        remote_server_addr: str,
+        keep_alive: bool = True,
+        ignore_proxy: typing.Optional[bool] = False,
+    ) -> None:
+        super().__init__(remote_server_addr, 'ms', keep_alive, ignore_proxy=ignore_proxy)

--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -18,6 +18,7 @@ import typing
 
 from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+from selenium.webdriver.remote.client_config import ClientConfig
 
 
 class EdgeRemoteConnection(ChromiumRemoteConnection):
@@ -26,8 +27,9 @@ class EdgeRemoteConnection(ChromiumRemoteConnection):
     def __init__(
         self,
         remote_server_addr: str,
-        keep_alive: bool = True,
-        ignore_proxy: typing.Optional[bool] = False,
+        keep_alive: typing.Optional[bool] = None,
+        ignore_proxy: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         super().__init__(
             remote_server_addr=remote_server_addr,
@@ -35,4 +37,5 @@ class EdgeRemoteConnection(ChromiumRemoteConnection):
             browser_name="MicrosoftEdge",
             keep_alive=keep_alive,
             ignore_proxy=ignore_proxy,
+            client_config=client_config,
         )

--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from .options import Options
 from .service import Service
@@ -29,7 +28,7 @@ class WebDriver(ChromiumDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive=True,
+        keep_alive: bool = True,
     ) -> None:
         """Creates a new instance of the edge driver. Starts the service and
         then creates new instance of edge driver.
@@ -42,10 +41,4 @@ class WebDriver(ChromiumDriver):
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(
-            DesiredCapabilities.EDGE["browserName"],
-            "ms",
-            options,
-            service,
-            keep_alive,
-        )
+        super().__init__(options=options, service=service, keep_alive=keep_alive)

--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import Service
 
@@ -28,7 +30,8 @@ class WebDriver(ChromiumDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive: bool = True,
+        keep_alive: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new instance of the edge driver. Starts the service and
         then creates new instance of edge driver.
@@ -37,8 +40,9 @@ class WebDriver(ChromiumDriver):
          - options - this takes an instance of EdgeOptions
          - service - Service object for handling the browser driver if you need to pass extra details
          - keep_alive - Whether to configure EdgeRemoteConnection to use HTTP keep-alive.
+         - client_config - configuration values for the http client
         """
         service = service if service else Service()
         options = options if options else Options()
 
-        super().__init__(options=options, service=service, keep_alive=keep_alive)
+        super().__init__(options=options, service=service, keep_alive=keep_alive, client_config=client_config)

--- a/py/selenium/webdriver/firefox/remote_connection.py
+++ b/py/selenium/webdriver/firefox/remote_connection.py
@@ -14,16 +14,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
 class FirefoxRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.FIREFOX["browserName"]
 
-    def __init__(self, remote_server_addr, keep_alive=True, ignore_proxy=False) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+    def __init__(
+        self,
+        remote_server_addr,
+        keep_alive: typing.Optional[bool] = None,
+        ignore_proxy: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
+    ) -> None:
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy, client_config=client_config)
 
         self._commands["GET_CONTEXT"] = ("GET", "/session/$sessionId/moz/context")
         self._commands["SET_CONTEXT"] = ("POST", "/session/$sessionId/moz/context")

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -17,6 +17,7 @@
 import base64
 import logging
 import os
+import typing
 import warnings
 import zipfile
 from contextlib import contextmanager
@@ -25,6 +26,7 @@ from io import BytesIO
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import Service
 
@@ -41,15 +43,17 @@ class WebDriver(RemoteWebDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive: bool = True,
+        keep_alive: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new instance of the Firefox driver. Starts the service and
         then creates new instance of Firefox driver.
 
         :Args:
-         - options - Instance of ``options.Options``.
+         - options - (Optional) Instance of ``options.Options``.
          - service - (Optional) service instance for managing the starting and stopping of the driver.
-         - keep_alive - Whether to configure remote_connection.RemoteConnection to use HTTP keep-alive.
+         - keep_alive - Deprecated: Whether to configure remote_connection.RemoteConnection to use HTTP keep-alive.
+         - client_config - configuration values for the http client
         """
 
         self.service = service if service else Service()
@@ -59,7 +63,12 @@ class WebDriver(RemoteWebDriver):
         self.service.start()
 
         try:
-            super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+            super().__init__(
+                command_executor=self.service.service_url,
+                options=options,
+                keep_alive=keep_alive,
+                client_config=client_config,
+            )
         except Exception:
             self.quit()
             raise

--- a/py/selenium/webdriver/ie/webdriver.py
+++ b/py/selenium/webdriver/ie/webdriver.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import Service
 
@@ -30,16 +32,18 @@ class WebDriver(RemoteWebDriver):
         self,
         options: Options = None,
         service: Service = None,
-        keep_alive=True,
+        keep_alive: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new instance of the Ie driver.
 
         Starts the service and then creates new instance of Ie driver.
 
         :Args:
-         - options - IE Options instance, providing additional IE options
+         - options - (Optional) IE Options instance, providing additional IE options
          - service - (Optional) service instance for managing the starting and stopping of the driver.
          - keep_alive - Deprecated: Whether to configure RemoteConnection to use HTTP keep-alive.
+         - client_config - configuration values for the http client
         """
 
         self.service = service if service else Service()
@@ -49,7 +53,12 @@ class WebDriver(RemoteWebDriver):
         self.service.start()
 
         try:
-            super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+            super().__init__(
+                command_executor=self.service.service_url,
+                options=options,
+                keep_alive=keep_alive,
+                client_config=client_config,
+            )
         except Exception:
             self.quit()
             raise

--- a/py/selenium/webdriver/remote/client_config.py
+++ b/py/selenium/webdriver/remote/client_config.py
@@ -1,0 +1,57 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from selenium.webdriver.common.proxy import Proxy
+from selenium.webdriver.common.proxy import ProxyType
+
+
+class ClientConfig:
+    def __init__(
+        self,
+        keep_alive: bool = True,
+        proxy: Proxy = Proxy({"proxyType": ProxyType.SYSTEM}),
+    ) -> None:
+        self.keep_alive = keep_alive
+        self.proxy = proxy
+
+    @property
+    def keep_alive(self) -> bool:
+        """:Returns: The keep alive value"""
+        return self._keep_alive
+
+    @keep_alive.setter
+    def keep_alive(self, value: bool) -> None:
+        """Toggles the keep alive value.
+
+        :Args:
+         - value: whether to keep the http connection alive
+        """
+        self._keep_alive = value
+
+    @property
+    def proxy(self) -> Proxy:
+        """:Returns: The proxy used for communicating to the driver/server"""
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, proxy: Proxy) -> None:
+        """Provides the information for communicating with the driver or server.
+
+        :Args:
+         - value: the proxy information to use to communicate with the driver or server
+        """
+        self._proxy = proxy

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -91,11 +91,12 @@ def _create_caps(caps):
 
 
 def get_remote_connection(capabilities, command_executor, keep_alive, ignore_local_proxy=False):
-    from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
+    from selenium.webdriver.chrome.remote_connection import ChromeRemoteConnection
+    from selenium.webdriver.edge.remote_connection import EdgeRemoteConnection
     from selenium.webdriver.firefox.remote_connection import FirefoxRemoteConnection
     from selenium.webdriver.safari.remote_connection import SafariRemoteConnection
 
-    candidates = [RemoteConnection, ChromiumRemoteConnection, SafariRemoteConnection, FirefoxRemoteConnection]
+    candidates = [ChromeRemoteConnection, EdgeRemoteConnection, SafariRemoteConnection, FirefoxRemoteConnection]
     handler = next((c for c in candidates if c.browser_name == capabilities.get("browserName")), RemoteConnection)
 
     return handler(command_executor, keep_alive=keep_alive, ignore_proxy=ignore_local_proxy)

--- a/py/selenium/webdriver/safari/remote_connection.py
+++ b/py/selenium/webdriver/safari/remote_connection.py
@@ -14,16 +14,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import typing
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 
 class SafariRemoteConnection(RemoteConnection):
     browser_name = DesiredCapabilities.SAFARI["browserName"]
 
-    def __init__(self, remote_server_addr: str, keep_alive: bool = True, ignore_proxy: bool = False) -> None:
-        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy)
+    def __init__(
+        self,
+        remote_server_addr: str,
+        keep_alive: typing.Optional[bool] = None,
+        ignore_proxy: typing.Optional[bool] = None,
+        client_config: typing.Optional[ClientConfig] = None,
+    ) -> None:
+        super().__init__(remote_server_addr, keep_alive, ignore_proxy=ignore_proxy, client_config=client_config)
         self._commands["GET_PERMISSIONS"] = ("GET", "/session/$sessionId/apple/permissions")
         self._commands["SET_PERMISSIONS"] = ("POST", "/session/$sessionId/apple/permissions")
         self._commands["ATTACH_DEBUGGER"] = ("POST", "/session/$sessionId/apple/attach_debugger")

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import typing
 import warnings
 
 from selenium.common.exceptions import WebDriverException
@@ -22,6 +22,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from ..common.driver_finder import DriverFinder
+from ..remote.client_config import ClientConfig
 from .options import Options
 from .service import Service
 
@@ -34,19 +35,21 @@ class WebDriver(RemoteWebDriver):
     def __init__(
         self,
         reuse_service=False,
-        keep_alive=True,
+        keep_alive: typing.Optional[bool] = None,
         options: Options = None,
         service: Service = None,
+        client_config: typing.Optional[ClientConfig] = None,
     ) -> None:
         """Creates a new Safari driver instance and launches or finds a running
         safaridriver service.
 
         :Args:
-         - reuse_service - If True, do not spawn a safaridriver instance; instead, connect to an already-running service that was launched externally.
-         - keep_alive - Whether to configure SafariRemoteConnection to use
-             HTTP keep-alive. Defaults to True.
+         - reuse_service - Deprecated: If True, do not spawn a safaridriver instance;
+             instead, connect to an already-running service that was launched externally.
+         - keep_alive - Deprecated: Whether to configure remote_connection.RemoteConnection to use HTTP keep-alive.
          - options - Instance of ``options.Options``.
          - service - Service object for handling the browser driver if you need to pass extra details
+         - client_config - configuration values for the http client
         """
         if reuse_service:
             warnings.warn(
@@ -65,7 +68,12 @@ class WebDriver(RemoteWebDriver):
             self.service.start()
 
         try:
-            super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+            super().__init__(
+                command_executor=self.service.service_url,
+                options=options,
+                keep_alive=keep_alive,
+                client_config=client_config,
+            )
         except Exception:
             self.quit()
             raise

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import http.client as http_client
 import warnings
 
 from selenium.common.exceptions import WebDriverException
@@ -24,7 +23,6 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from ..common.driver_finder import DriverFinder
 from .options import Options
-from .remote_connection import SafariRemoteConnection
 from .service import Service
 
 DEFAULT_SAFARI_CAPS = DesiredCapabilities.SAFARI.copy()
@@ -66,22 +64,20 @@ class WebDriver(RemoteWebDriver):
         if not self._reuse_service:
             self.service.start()
 
-        executor = SafariRemoteConnection(
-            remote_server_addr=self.service.service_url,
-            keep_alive=keep_alive,
-            ignore_proxy=options._ignore_local_proxy,
-        )
-
-        super().__init__(command_executor=executor, options=options)
+        try:
+            super().__init__(command_executor=self.service.service_url, options=options, keep_alive=keep_alive)
+        except Exception:
+            self.quit()
+            raise
 
         self._is_remote = False
 
     def quit(self):
-        """Closes the browser and shuts down the SafariDriver executable that
-        is started when starting the SafariDriver."""
+        """Ends the driver session and shuts down the safaridriver executable if necessary."""
         try:
             super().quit()
-        except http_client.BadStatusLine:
+        except Exception:
+            # We don't care about the message because something probably has gone wrong
             pass
         finally:
             if not self._reuse_service:


### PR DESCRIPTION
### Status

* Dependent on #12364 — putting code here as placeholder; do not need to review until that one is merged.

### Description
* Creates a Client config class like Java has to store configuration values related to Http Client
* Have users set "keep alive" in client config instead of in Options since it is not related to capabilities
* Have users set "ignore proxy" in client config instead of webdriver directly; this is done by creating a proxy of type "Direct" instead of default "System"

Browser subclasses for `RemoteConnection` and `WebDriver` set deprecated value defaults to `None`
Remote superclass for those throw the deprecation warning if they are not `None` so subclasses still need to send them.

@isaulv told me to be careful creating objects in constructor parameters, so I'm just using `None` and setting defaults in first line.

Also, I separated out the code for whether to use a proxy into a new private method 

### Motivation and Context
This is to match what Java is doing and better organize the constructor parameters
also sets us up to make more values configurable in a future PR.