### PR TITLE
[rust] Offline mode in Selenium Manager (#11639)

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -51,6 +51,8 @@ Options:
           Display DEBUG messages
       --trace
           Display TRACE messages
+      --offline
+          Offline mode (i.e., disabling network requests and downloads)
   -h, --help
           Print help
   -V, --version

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -34,7 +34,7 @@ use crate::metadata::{
 use crate::{
     create_http_client, format_one_arg, format_three_args, SeleniumManager, BETA,
     DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY,
-    REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    OFFLINE_REQUEST_ERR_MSG, REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const CHROME_NAME: &str = "chrome";
@@ -319,6 +319,8 @@ impl SeleniumManager for ChromeManager {
                 Ok(driver_version)
             }
             _ => {
+                self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
+
                 let major_browser_version = browser_version.parse::<i32>().unwrap_or_default();
                 let driver_version = if !browser_version.is_empty() && major_browser_version < 115 {
                     // For old versions (chromedriver 114-), the traditional method should work:

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -41,6 +41,7 @@ pub struct ManagerConfig {
     pub timeout: u64,
     pub browser_ttl: u64,
     pub driver_ttl: u64,
+    pub offline: bool,
 }
 
 impl ManagerConfig {
@@ -87,6 +88,7 @@ impl ManagerConfig {
             timeout: IntegerKey("timeout", REQUEST_TIMEOUT_SEC).get_value(),
             browser_ttl: IntegerKey("browser-ttl", TTL_BROWSERS_SEC).get_value(),
             driver_ttl: IntegerKey("driver-ttl", TTL_DRIVERS_SEC).get_value(),
+            offline: BooleanKey("offline", false).get_value(),
         }
     }
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -31,7 +31,7 @@ use crate::metadata::{
 use crate::{
     create_http_client, format_one_arg, format_three_args, Logger, SeleniumManager, BETA,
     DASH_DASH_VERSION, DEV, ENV_LOCALAPPDATA, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY,
-    REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    OFFLINE_REQUEST_ERR_MSG, REG_QUERY, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const EDGE_NAMES: &[&str] = &["edge", "msedge", "microsoftedge"];
@@ -180,6 +180,8 @@ impl SeleniumManager for EdgeManager {
                 Ok(driver_version)
             }
             _ => {
+                self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
+
                 if browser_version.is_empty() {
                     let latest_stable_url = format!("{}{}", DRIVER_URL, LATEST_STABLE);
                     self.log.debug(format!(

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -31,7 +31,7 @@ use crate::metadata::{
 use crate::{
     create_http_client, format_one_arg, format_three_args, format_two_args, Logger,
     SeleniumManager, BETA, DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, NIGHTLY,
-    REG_QUERY_FIND, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
+    OFFLINE_REQUEST_ERR_MSG, REG_QUERY_FIND, REMOVE_X86, STABLE, WMIC_COMMAND, WMIC_COMMAND_ENV,
 };
 
 pub const FIREFOX_NAME: &str = "firefox";
@@ -178,6 +178,8 @@ impl SeleniumManager for FirefoxManager {
                 Ok(driver_version)
             }
             _ => {
+                self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
+
                 let latest_url = format!("{}{}", DRIVER_URL, LATEST_RELEASE);
                 let driver_version =
                     read_redirect_from_link(self.get_http_client(), latest_url, self.get_logger())?;

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -24,7 +24,9 @@ use std::path::PathBuf;
 use crate::files::{get_cache_folder, BrowserPath};
 
 use crate::downloads::parse_json_from_url;
-use crate::{create_http_client, parse_version, Logger, SeleniumManager, SNAPSHOT};
+use crate::{
+    create_http_client, parse_version, Logger, SeleniumManager, OFFLINE_REQUEST_ERR_MSG, SNAPSHOT,
+};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -107,6 +109,8 @@ impl SeleniumManager for GridManager {
                 Ok(driver_version)
             }
             _ => {
+                self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
+
                 let selenium_releases = parse_json_from_url::<Vec<SeleniumRelease>>(
                     self.get_http_client(),
                     MIRROR_URL.to_string(),

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
 
 use crate::downloads::parse_json_from_url;
-use crate::{create_http_client, parse_version, Logger, SeleniumManager};
+use crate::{create_http_client, parse_version, Logger, SeleniumManager, OFFLINE_REQUEST_ERR_MSG};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -110,6 +110,8 @@ impl SeleniumManager for IExplorerManager {
                 Ok(driver_version)
             }
             _ => {
+                self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
+
                 let selenium_releases = parse_json_from_url::<Vec<SeleniumRelease>>(
                     self.get_http_client(),
                     MIRROR_URL.to_string(),

--- a/rust/tests/offline_tests.rs
+++ b/rust/tests/offline_tests.rs
@@ -1,0 +1,39 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use assert_cmd::Command;
+use std::str;
+
+#[test]
+fn offline_test() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    cmd.args([
+        "--clear-cache",
+        "--debug",
+        "--browser",
+        "chrome",
+        "--offline",
+    ])
+    .assert()
+    .success()
+    .code(0);
+
+    let stdout = &cmd.unwrap().stdout;
+    let output = str::from_utf8(stdout).unwrap();
+    println!("{output}");
+    assert!(output.contains("WARN"));
+}


### PR DESCRIPTION
### Description
This PR includes a new flag in Selenium Manager called `--offline` that forbids making any network call from Selenium Manager. This way, Selenium Manager can only execute shell commands to find drivers in PATH (and browser binary paths).

Selenium Manager throws no errors but warnings when the offline mode is enabled. The following snippets showcase its behavior for different cases:

**Offline mode with empty cache**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --clear-cache --offline
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target\debug\selenium-manager.exe --browser chrome --debug --clear-cache --offline`
DEBUG   Clearing cache at: C:\Users\boni\.cache\selenium
DEBUG   Running command: "chromedriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: "set PFILES=%PROGRAMFILES: (x86)=%&& wmic datafile where name='!PFILES:\\=\\\\!\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=114.0.5735.199\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 114.0.5735.199
WARN    Unable to discover proper chromedriver version in offline mode
```

**Offline mode with driver in cache**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --offline
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target\debug\selenium-manager.exe --browser chrome --debug --offline`
DEBUG   Running command: "chromedriver --version"
DEBUG   Output: ""
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: "set PFILES=%PROGRAMFILES: (x86)=%&& wmic datafile where name='!PFILES:\\=\\\\!\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=114.0.5735.199\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 114.0.5735.199
DEBUG   Required driver: chromedriver 114.0.5735.90
DEBUG   chromedriver 114.0.5735.90 already in the cache
INFO    C:\Users\boni\.cache\selenium\chromedriver\win64\114.0.5735.90\chromedriver.exe
```

**Offline mode with driver in PATH**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --offline
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target\debug\selenium-manager.exe --browser chrome --debug --offline`
DEBUG   Running command: "chromedriver --version"
DEBUG   Output: "ChromeDriver 107.0.5304.62 (1eec40d3a5764881c92085aaee66d25075c159aa-refs/branch-heads/5304@{#942})"
DEBUG   Running command: "where chromedriver"
DEBUG   Output: "C:\\Users\\boni\\Documents\\bat\\chromedriver.exe"
DEBUG   Found chromedriver 107.0.5304.62 in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: "set PFILES=%PROGRAMFILES: (x86)=%&& wmic datafile where name='!PFILES:\\=\\\\!\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe' get Version /value"
DEBUG   Output: "\r\r\n\r\r\nVersion=114.0.5735.199\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 114.0.5735.199
WARN    Exception trying to discover chromedriver version: Unable to discover proper chromedriver version in offline mode
INFO    C:\Users\boni\Documents\bat\chromedriver.exe
```

As usual, the flag `--offline` flag is equivalent to using the configuration file (`offline = true`) or an environment variable `SE_OFFLINE=true`.

### Motivation and Context
This PR implements #11639.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
