### PR TITLE
[grid] use a message template when the log message is most likely dropped

### DIFF
--- a/java/src/org/openqa/selenium/bidi/Connection.java
+++ b/java/src/org/openqa/selenium/bidi/Connection.java
@@ -142,7 +142,7 @@ public class Connection implements Closeable {
     try (JsonOutput out = JSON.newOutput(json).writeClassName(false)) {
       out.write(serialized.build());
     }
-    LOG.log(getDebugLogLevel(), () -> String.format("-> %s", json));
+    LOG.log(getDebugLogLevel(), "-> {0}", json);
     socket.sendText(json);
 
     if (!command.getSendsResponse()) {
@@ -245,7 +245,7 @@ public class Connection implements Closeable {
     // TODO: decode once, and once only
 
     String asString = String.valueOf(data);
-    LOG.log(getDebugLogLevel(), () -> String.format("<- %s", asString));
+    LOG.log(getDebugLogLevel(), "<- {0}", asString);
 
     Map<String, Object> raw = JSON.toType(asString, MAP_TYPE);
     if (raw.get("id") instanceof Number
@@ -304,8 +304,8 @@ public class Connection implements Closeable {
               event -> {
                 LOG.log(
                     getDebugLogLevel(),
-                    String.format(
-                        "Matching %s with %s", rawDataMap.get("method"), event.getMethod()));
+                    "Matching {0} with {1}",
+                    new Object[] { rawDataMap.get("method"), event.getMethod() });
                 return rawDataMap.get("method").equals(event.getMethod());
               })
           .forEach(
@@ -326,9 +326,8 @@ public class Connection implements Closeable {
                   Consumer<Object> obj = (Consumer<Object>) action;
                   LOG.log(
                       getDebugLogLevel(),
-                      String.format(
-                          "Calling callback for %s using %s being passed %s",
-                          event, obj, finalValue));
+                      "Calling callback for {0} using {1} being passed {2}",
+                      new Object[] { event, obj, finalValue });
                   obj.accept(finalValue);
                 }
               });

--- a/java/src/org/openqa/selenium/devtools/Connection.java
+++ b/java/src/org/openqa/selenium/devtools/Connection.java
@@ -156,7 +156,7 @@ public class Connection implements Closeable {
     try (JsonOutput out = JSON.newOutput(json).writeClassName(false)) {
       out.write(serialized.build());
     }
-    LOG.log(getDebugLogLevel(), () -> String.format("-> %s", json));
+    LOG.log(getDebugLogLevel(), "-> {0}", json);
     socket.sendText(json);
 
     if (!command.getSendsResponse()) {
@@ -236,7 +236,7 @@ public class Connection implements Closeable {
     // TODO: decode once, and once only
 
     String asString = String.valueOf(data);
-    LOG.log(getDebugLogLevel(), () -> String.format("<- %s", asString));
+    LOG.log(getDebugLogLevel(), "<- {0}", asString);
 
     Map<String, Object> raw = JSON.toType(asString, MAP_TYPE);
     if (raw.get("id") instanceof Number
@@ -270,9 +270,8 @@ public class Connection implements Closeable {
     } else if (raw.get("method") instanceof String && raw.get("params") instanceof Map) {
       LOG.log(
           getDebugLogLevel(),
-          String.format(
-              "Method %s called with %d callbacks available",
-              raw.get("method"), eventCallbacks.keySet().size()));
+          "Method {0} called with {1} callbacks available",
+          new Object[] { raw.get("method"), eventCallbacks.keySet().size() });
       Lock lock = callbacksLock.readLock();
       lock.lock();
       try {
@@ -282,7 +281,8 @@ public class Connection implements Closeable {
                 event ->
                     LOG.log(
                         getDebugLogLevel(),
-                        String.format("Matching %s with %s", raw.get("method"), event.getMethod())))
+                        "Matching {0} with {1}",
+                        new Object[]{ raw.get("method"), event.getMethod()}))
             .filter(event -> raw.get("method").equals(event.getMethod()))
             .forEach(
                 event -> {
@@ -316,9 +316,8 @@ public class Connection implements Closeable {
                       Consumer<Object> obj = (Consumer<Object>) action;
                       LOG.log(
                           getDebugLogLevel(),
-                          String.format(
-                              "Calling callback for %s using %s being passed %s",
-                              event, obj, finalValue));
+                          "Calling callback for {0} using {1} being passed {2}",
+                          new Object[] { event, obj, finalValue });
                       obj.accept(finalValue);
                     }
                   }

--- a/java/src/org/openqa/selenium/grid/distributor/GridModel.java
+++ b/java/src/org/openqa/selenium/grid/distributor/GridModel.java
@@ -97,7 +97,7 @@ public class GridModel {
             && next.getExternalUri().equals(node.getExternalUri())) {
           iterator.remove();
 
-          LOG.log(Debug.getDebugLogLevel(), "Refreshing node with id %s", node.getNodeId());
+          LOG.log(Debug.getDebugLogLevel(), "Refreshing node with id {0}", node.getNodeId());
           NodeStatus refreshed = rewrite(node, next.getAvailability());
           nodes.add(refreshed);
           nodePurgeTimes.put(refreshed.getNodeId(), Instant.now());
@@ -135,8 +135,8 @@ public class GridModel {
       // Nodes are initially added in the "down" state until something changes their availability
       LOG.log(
           Debug.getDebugLogLevel(),
-          String.format(
-              "Adding node with id %s and URI %s", node.getNodeId(), node.getExternalUri()));
+          "Adding node with id {0} and URI {1}",
+          new Object[]{ node.getNodeId(), node.getExternalUri()});
       NodeStatus refreshed = rewrite(node, DOWN);
       nodes.add(refreshed);
       nodePurgeTimes.put(refreshed.getNodeId(), Instant.now());

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -830,7 +830,7 @@ public class LocalDistributor extends Distributor implements AutoCloseable {
           try (Span childSpan = span.createSpan("distributor.retry")) {
             LOG.log(
                 Debug.getDebugLogLevel(),
-                String.format("Retrying %s", sessionRequest.getDesiredCapabilities()));
+                "Retrying {0}", sessionRequest.getDesiredCapabilities());
             boolean retried = sessionQueue.retryAddToQueue(sessionRequest);
 
             attributeMap.put("request.retry_add", EventAttribute.setValue(retried));

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -902,7 +902,7 @@ public class LocalNode extends Node {
       int remainingSessions = this.sessionCount.decrementAndGet();
       LOG.log(
           Debug.getDebugLogLevel(),
-          String.format("%s remaining sessions before draining Node", remainingSessions));
+          "{0} remaining sessions before draining Node", remainingSessions);
       if (remainingSessions <= 0) {
         LOG.info(
             String.format(

--- a/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
@@ -220,7 +220,7 @@ public class RelaySessionFactory implements SessionFactory {
       HttpClient client = clientFactory.createClient(serviceStatusUrl);
       HttpResponse response =
           client.execute(new HttpRequest(HttpMethod.GET, serviceStatusUrl.toString()));
-      LOG.log(Debug.getDebugLogLevel(), Contents.string(response));
+      LOG.log(Debug.getDebugLogLevel(), () -> Contents.string(response));
       return response.getStatus() == 200;
     } catch (Exception e) {
       LOG.log(

--- a/java/src/org/openqa/selenium/netty/server/RequestConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/RequestConverter.java
@@ -59,10 +59,10 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
-    LOG.log(Debug.getDebugLogLevel(), "Incoming message: " + msg);
+    LOG.log(Debug.getDebugLogLevel(), "Incoming message: {0}", msg);
 
     if (msg instanceof io.netty.handler.codec.http.HttpRequest) {
-      LOG.log(Debug.getDebugLogLevel(), "Start of http request: " + msg);
+      LOG.log(Debug.getDebugLogLevel(), "Start of http request: {0}", msg);
 
       io.netty.handler.codec.http.HttpRequest nettyRequest =
           (io.netty.handler.codec.http.HttpRequest) msg;
@@ -110,7 +110,7 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
       }
 
       if (msg instanceof LastHttpContent) {
-        LOG.log(Debug.getDebugLogLevel(), "End of http request: " + msg);
+        LOG.log(Debug.getDebugLogLevel(), "End of http request: {0}", msg);
 
         if (buffer != null) {
           ByteSource source = buffer.asByteSource();

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -636,13 +636,13 @@ public class RemoteWebDriver
     }
     switch (when) {
       case BEFORE:
-        LOG.log(level, "Executing: " + commandName + " " + text);
+        LOG.log(level, "Executing: {0} {1}", new Object[] {commandName, text});
         break;
       case AFTER:
-        LOG.log(level, "Executed: " + commandName + " " + text);
+        LOG.log(level, "Executed: {0} {1}", new Object[] {commandName, text});
         break;
       case EXCEPTION:
-        LOG.log(level, "Exception: " + commandName + " " + text);
+        LOG.log(level, "Exception: {0} {1}", new Object[] {commandName, text});
         break;
       default:
         LOG.log(level, text);


### PR DESCRIPTION
### Description
Using a message template when the log message is most likely dropped will avoid the creation of a string when the message is not logged.

### Motivation and Context
When building the log message string before passing it into the logger there might be some overhead, this can be ignored in most cases. But there are some frequently used areas like the `RequestConverter`, `RemoteWebDriver` or the`Connection` we should avoid this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
