### PR TITLE
[rb] add browser output from selenium manager to options

### DIFF
--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    selenium-devtools (0.114.0)
+    selenium-devtools (0.115.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -78,18 +78,18 @@ module Selenium
 
       describe 'self.driver_path' do
         it 'determines browser name by default' do
-          allow(described_class).to receive(:run)
+          allow(described_class).to receive(:run).and_return('browser_path' => '', 'driver_path' => '')
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
 
           described_class.driver_path(Options.chrome)
 
           expect(described_class).to have_received(:run)
-            .with('selenium-manager', '--browser', 'chrome', '--output', 'json')
+            .with('selenium-manager', '--browser', 'chrome')
         end
 
         it 'uses browser version if specified' do
-          allow(described_class).to receive(:run)
+          allow(described_class).to receive(:run).and_return('browser_path' => '', 'driver_path' => '')
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(browser_version: 1)
@@ -99,13 +99,12 @@ module Selenium
           expect(described_class).to have_received(:run)
             .with('selenium-manager',
                   '--browser', 'chrome',
-                  '--output', 'json',
                   '--browser-version', 1)
         end
 
         it 'uses proxy if specified' do
           proxy = Selenium::WebDriver::Proxy.new(ssl: 'proxy')
-          allow(described_class).to receive(:run)
+          allow(described_class).to receive(:run).and_return('browser_path' => '', 'driver_path' => '')
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(proxy: proxy)
@@ -115,12 +114,11 @@ module Selenium
           expect(described_class).to have_received(:run)
             .with('selenium-manager',
                   '--browser', 'chrome',
-                  '--output', 'json',
                   '--proxy', 'proxy')
         end
 
         it 'uses browser location if specified' do
-          allow(described_class).to receive(:run)
+          allow(described_class).to receive(:run).and_return('browser_path' => '', 'driver_path' => '')
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(binary: '/path/to/browser')
@@ -128,11 +126,11 @@ module Selenium
           described_class.driver_path(options)
 
           expect(described_class).to have_received(:run)
-            .with('selenium-manager', '--browser', 'chrome', '--output', 'json', '--browser-path', '/path/to/browser')
+            .with('selenium-manager', '--browser', 'chrome', '--browser-path', '/path/to/browser')
         end
 
         it 'properly escapes plain spaces in browser location' do
-          allow(described_class).to receive(:run)
+          allow(described_class).to receive(:run).and_return('browser_path' => 'a', 'driver_path' => '')
           allow(described_class).to receive(:binary).and_return('selenium-manager')
           allow(Platform).to receive(:assert_executable)
           options = Options.chrome(binary: '/path to/the/browser')
@@ -140,8 +138,18 @@ module Selenium
           described_class.driver_path(options)
 
           expect(described_class).to have_received(:run)
-            .with('selenium-manager', '--browser', 'chrome', '--output', 'json',
+            .with('selenium-manager', '--browser', 'chrome',
                   '--browser-path', '/path to/the/browser')
+        end
+
+        it 'sets binary location on options' do
+          allow(described_class).to receive(:run).and_return('browser_path' => 'foo', 'driver_path' => '')
+          allow(described_class).to receive(:binary).and_return('selenium-manager')
+          allow(Platform).to receive(:assert_executable)
+          options = Options.chrome
+
+          described_class.driver_path(options)
+          expect(options.binary).to eq 'foo'
         end
       end
     end


### PR DESCRIPTION
### Status
Draft because:
* ~proof of concept — looks like it'll be relatively easy to wire these in if we want to try to do it before 4.11?~
* ~waiting on #12353~
* ~waiting on binaries getting committed to trunk - https://github.com/SeleniumHQ/selenium/actions/runs/5646633604~
* ~This corrects for what looks to be a change in how SM binary escapes characters, not sure we want that~
* ~needs tests~

### Description
Sets browser location on Options class if supported (Chrome, Edge, Firefox only)
* Errors on Chrome & Edge if browser version invalid (Not backwards compatible, but GOOD!)
* Uses Dev/Beta/Canary/Nightly if found on system and specified by name as `browser_version`
* Downloads Stable Chrome For Testing if Chrome not installed on System.

### Motivation and Context
* This ensures that the browser Selenium Manager is checking against is the one actually getting used by the driver




