### PR TITLE
[py]: Adding `LICENSE` to `sdist` & `whl`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,14 +3,22 @@ load("//common:browsers.bzl", "chrome_data", "firefox_data")
 load("//java:browsers.bzl", "chrome_jvm_flags", "firefox_jvm_flags")
 load("//java:defs.bzl", "artifact")
 
+# Can only use this if it returns a single file.
+filegroup(
+    name = "global-license",
+    srcs = ["LICENSE"],
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "license",
     srcs = [
-        "LICENSE",
+        ":global-license",
         "NOTICE",
     ],
     visibility = ["//visibility:public"],
 )
+
 
 alias(
     name = "grid",

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -112,6 +112,12 @@ copy_file(
     out = "test/extensions/webextensions-selenium-example-unsigned.zip",
 )
 
+copy_file(
+    name = "copy-global-license",
+    src = "//:global-license",
+    out = "LICENSE"
+)
+
 py_library(
     name = "selenium",
     srcs = glob(
@@ -161,6 +167,7 @@ pkg_files(
     name = "selenium-sdist-pkg",
     srcs = [
         "CHANGES",
+        ":copy-global-license",
         "MANIFEST.in",
         "README.rst",
         "setup.py",
@@ -178,6 +185,7 @@ pkg_tar(
     package_dir = "selenium-%s" % SE_VERSION,
     package_file_name = "selenium-%s.tar.gz" % SE_VERSION,
 )
+
 
 genrule(
     name = "selenium-pkginfo",
@@ -227,6 +235,7 @@ py_wheel(
     visibility = ["//visibility:public"],
     deps = [
         ":selenium-pkg",
+        "//:global-license",
     ],
 )
 


### PR DESCRIPTION
I'm trying to get the license file into the built `sdist` and `whl` archives, I have the sdist working here, the whl is writing currently to the root folder.

Need some guidance on bazel specifics here;

closes #12166

Bazel is very confusing to me, so this is likely a complete incorrect hack, any advice is greatly appreciated