### PR TITLE
[java] minimize overhead of regex compilation

### DIFF
--- a/java/src/org/openqa/selenium/By.java
+++ b/java/src/org/openqa/selenium/By.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
+
 import org.openqa.selenium.internal.Require;
 
 /**
@@ -414,6 +416,7 @@ public abstract class By {
   }
 
   private abstract static class PreW3CLocator extends By implements Remotable {
+    private static final Pattern CSS_ESCAPE = Pattern.compile("([\\s'\"\\\\#.:;,!?+<>=~*^$|%&@`{}\\-\\/\\[\\]\\(\\)])");
     private final Parameters remoteParams;
     private final ByCssSelector fallback;
 
@@ -442,7 +445,7 @@ public abstract class By {
     }
 
     private String cssEscape(String using) {
-      using = using.replaceAll("([\\s'\"\\\\#.:;,!?+<>=~*^$|%&@`{}\\-\\/\\[\\]\\(\\)])", "\\\\$1");
+      using = CSS_ESCAPE.matcher(using).replaceAll("\\\\$1");
       if (using.length() > 0 && Character.isDigit(using.charAt(0))) {
         using = "\\" + (30 + Integer.parseInt(using.substring(0, 1))) + " " + using.substring(1);
       }

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -84,6 +84,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.openqa.selenium.InvalidSelectorException;
@@ -99,6 +100,7 @@ import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
 public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
 
   private static final ConcurrentHashMap<String, String> ATOM_SCRIPTS = new ConcurrentHashMap<>();
+  private static final Pattern CSS_ESCAPE = Pattern.compile("([\\s'\"\\\\#.:;,!?+<>=~*^$|%&@`{}\\-\\/\\[\\]\\(\\)])");
 
   public W3CHttpCommandCodec() {
     String sessionId = "/session/:sessionId";
@@ -376,7 +378,7 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
   }
 
   private String cssEscape(String using) {
-    using = using.replaceAll("([\\s'\"\\\\#.:;,!?+<>=~*^$|%&@`{}\\-\\/\\[\\]\\(\\)])", "\\\\$1");
+    using = CSS_ESCAPE.matcher(using).replaceAll("\\\\$1");
     if (using.length() > 0 && Character.isDigit(using.charAt(0))) {
       using = "\\" + (30 + Integer.parseInt(using.substring(0, 1))) + " " + using.substring(1);
     }

--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
@@ -148,7 +148,12 @@ class JdkHttpMessages {
         || uri.startsWith("https://")) {
       rawUrl = uri;
     } else {
-      rawUrl = baseUrl.toString().replaceAll("/$", "") + uri;
+      String base = baseUrl.toString();
+      if (base.endsWith("/")) {
+        rawUrl = base.substring(0, base.length() - 1) + uri;
+      } else {
+        rawUrl = base + uri;
+      }
     }
 
     return URI.create(rawUrl);

--- a/java/src/org/openqa/selenium/remote/http/netty/NettyMessages.java
+++ b/java/src/org/openqa/selenium/remote/http/netty/NettyMessages.java
@@ -138,7 +138,12 @@ class NettyMessages {
     } else if (uri.startsWith("http://") || uri.startsWith("https://")) {
       rawUrl = uri;
     } else {
-      rawUrl = baseUrl.toString().replaceAll("/$", "") + uri;
+      String base = baseUrl.toString();
+      if (base.endsWith("/")) {
+        rawUrl = base.substring(0, base.length() - 1) + uri;
+      } else {
+        rawUrl = base + uri;
+      }
     }
     return rawUrl;
   }


### PR DESCRIPTION
### Description
Use a precompiled regex or replaced the usage of a regex in cases where it is not needed. 

### Motivation and Context
Compiling a regex is the most expensive part of matching a regex, we can do this once and keep the pattern.
This is to further reduce the GC of the grid server and the client.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
