### PR TITLE
[py] add browser output from selenium manager to options

### DIFF
--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -70,7 +70,7 @@ class SeleniumManager:
 
         browser = options.capabilities["browserName"]
 
-        args = [str(self.get_binary()), "--browser", browser, "--output", "json"]
+        args = [str(self.get_binary()), "--browser", browser]
 
         if options.browser_version:
             args.append("--browser-version")
@@ -87,22 +87,33 @@ class SeleniumManager:
             value = proxy.ssl_proxy if proxy.ssl_proxy else proxy.http_proxy
             args.append(value)
 
-        if logger.getEffectiveLevel() == logging.DEBUG:
-            args.append("--debug")
+        output = self.run(args)
 
-        result = self.run(args)
-        executable = result.split("\t")[-1].strip()
-        logger.debug(f"Using driver at: {executable}")
-        return executable
+        browser_path = output["browser_path"]
+        driver_path = output["driver_path"]
+        logger.debug(f"Using driver at: {driver_path}")
+
+        try:
+            options.binary_location = browser_path
+            options.browser_version = None  # geckodriver complains if this dev / nightly, etc
+        except AttributeError:
+            pass  # do not set on options classes that do not support it
+
+        return driver_path
 
     @staticmethod
-    def run(args: List[str]) -> str:
+    def run(args: List[str]) -> dict:
         """
         Executes the Selenium Manager Binary.
         :Args:
          - args: the components of the command being executed.
         :Returns: The log string containing the driver location.
         """
+        if logger.getEffectiveLevel() == logging.DEBUG:
+            args.append("--debug")
+        args.append("--output")
+        args.append("json")
+
         command = " ".join(args)
         logger.debug(f"Executing process: {command}")
         try:
@@ -110,7 +121,7 @@ class SeleniumManager:
             stdout = completed_proc.stdout.decode("utf-8").rstrip("\n")
             stderr = completed_proc.stderr.decode("utf-8").rstrip("\n")
             output = json.loads(stdout)
-            result = output["result"]["message"]
+            result = output["result"]
         except Exception as err:
             raise WebDriverException(f"Unsuccessful command executed: {command}; {err}")
 

--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -33,7 +33,10 @@ def test_browser_version_is_used_for_sm(mocker):
     mock_run = mocker.patch("subprocess.run")
     mocked_result = Mock()
     mocked_result.configure_mock(
-        **{"stdout.decode.return_value": '{"result": {"message": "driver"}, "logs": []}', "returncode": 0}
+        **{
+            "stdout.decode.return_value": '{"result": {"driver_path": "driver", "browser_path": "browser"}, "logs": []}',
+            "returncode": 0,
+        }
     )
     mock_run.return_value = mocked_result
     options = Options()
@@ -52,7 +55,10 @@ def test_browser_path_is_used_for_sm(mocker):
     mock_run = mocker.patch("subprocess.run")
     mocked_result = Mock()
     mocked_result.configure_mock(
-        **{"stdout.decode.return_value": '{"result": {"message": "driver"}, "logs": []}', "returncode": 0}
+        **{
+            "stdout.decode.return_value": '{"result": {"driver_path": "driver", "browser_path": "browser"}, "logs": []}',
+            "returncode": 0,
+        }
     )
     mock_run.return_value = mocked_result
     options = Options()
@@ -71,7 +77,10 @@ def test_proxy_is_used_for_sm(mocker):
     mock_run = mocker.patch("subprocess.run")
     mocked_result = Mock()
     mocked_result.configure_mock(
-        **{"stdout.decode.return_value": '{"result": {"message": "driver"}, "logs": []}', "returncode": 0}
+        **{
+            "stdout.decode.return_value": '{"result": {"driver_path": "driver", "browser_path": "browser"}, "logs": []}',
+            "returncode": 0,
+        }
     )
     mock_run.return_value = mocked_result
     options = Options()
@@ -87,11 +96,11 @@ def test_proxy_is_used_for_sm(mocker):
 
 
 def test_stderr_is_propagated_to_exception_messages():
-    msg = r"Unsuccessful command executed:.* --browser foo --output json\.\nInvalid browser name: foo\n"
+    msg = r"Unsuccessful command executed:.*\n.* 'Invalid browser name: foo'.*"
     with pytest.raises(WebDriverException, match=msg):
         manager = SeleniumManager()
         binary = manager.get_binary()
-        _ = manager.run([str(binary), "--browser", "foo", "--output", "json"])
+        _ = manager.run([str(binary), "--browser", "foo"])
 
 
 def test_driver_finder_error(mocker):


### PR DESCRIPTION
### Status
Draft because:
* ~waiting on #12353~

### Description
Sets browser location on Options class if supported (Chrome, Edge, Firefox only)
* Errors on Chrome & Edge if browser version invalid (Not backwards compatible, but GOOD!)
* Uses Dev/Beta/Canary/Nightly if found on system and specified by name as `browser_version`
* Downloads Stable Chrome For Testing if Chrome not installed on System.

### Motivation and Context
* This ensures that the browser Selenium Manager is checking against is the one actually getting used by the driver




