### PR TITLE
[java] Filter related fixed in the NettyClient and the JdkHttpClient

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriverBuilder.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriverBuilder.java
@@ -101,31 +101,7 @@ public class RemoteWebDriverBuilder {
       config -> {
         HttpClient.Factory factory = HttpClient.Factory.createDefault();
         HttpClient client = factory.createClient(config);
-        return client.with(
-            next ->
-                req -> {
-                  try {
-                    return client.execute(req);
-                  } finally {
-                    if (req.getMethod() == DELETE) {
-                      HttpSessionId.getSessionId(req.getUri())
-                          .ifPresent(
-                              id -> {
-                                if (("/session/" + id).equals(req.getUri())) {
-                                  try {
-                                    client.close();
-                                  } catch (UncheckedIOException e) {
-                                    LOG.log(
-                                        WARNING,
-                                        "Swallowing exception while closing http client",
-                                        e);
-                                  }
-                                  factory.cleanupIdleClients();
-                                }
-                              });
-                    }
-                  }
-                });
+        return client.with(new CloseHttpClientFilter(factory, client));
       };
   private ClientConfig clientConfig = ClientConfig.defaultConfig();
   private URI remoteHost = null;
@@ -412,8 +388,7 @@ public class RemoteWebDriverBuilder {
     HttpHandler handler =
         Require.nonNull("Http handler", client)
             .with(
-                new CloseHttpClientFilter(client)
-                    .andThen(new AddWebDriverSpecHeaders())
+                new AddWebDriverSpecHeaders()
                     .andThen(new ErrorFilter())
                     .andThen(new DumpHttpExchangeFilter()));
 
@@ -531,9 +506,11 @@ public class RemoteWebDriverBuilder {
 
   private static class CloseHttpClientFilter implements Filter {
 
-    private final HttpHandler client;
+    private final HttpClient.Factory factory;
+    private final HttpClient client;
 
-    CloseHttpClientFilter(HttpHandler client) {
+    CloseHttpClientFilter(HttpClient.Factory factory, HttpClient client) {
+      this.factory = Require.nonNull("Http client factory", factory);
       this.client = Require.nonNull("Http client", client);
     }
 
@@ -543,16 +520,17 @@ public class RemoteWebDriverBuilder {
         try {
           return next.execute(req);
         } finally {
-          if (req.getMethod() == DELETE && client instanceof Closeable) {
+          if (req.getMethod() == DELETE) {
             HttpSessionId.getSessionId(req.getUri())
                 .ifPresent(
                     id -> {
                       if (("/session/" + id).equals(req.getUri())) {
                         try {
-                          ((Closeable) client).close();
-                        } catch (IOException e) {
+                          client.close();
+                        } catch (Exception e) {
                           LOG.log(WARNING, "Exception swallowed while closing http client", e);
                         }
+                        factory.cleanupIdleClients();
                       }
                     });
           }

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
@@ -74,10 +75,9 @@ public class W3CHttpResponseCodec extends AbstractHttpResponseCodec {
   @Override
   public Response decode(HttpResponse encodedResponse) {
     String content = string(encodedResponse).trim();
-    LOG.fine(
-        String.format(
-            "Decoding response. Response code was: %d and content: %s",
-            encodedResponse.getStatus(), content));
+    LOG.log(Level.FINE,
+          "Decoding response. Response code was: {0} and content: {1}",
+          new Object[] { encodedResponse.getStatus(), content });
     String contentType = nullToEmpty(encodedResponse.getHeader(CONTENT_TYPE));
 
     Response response = new Response();

--- a/java/src/org/openqa/selenium/remote/http/Contents.java
+++ b/java/src/org/openqa/selenium/remote/http/Contents.java
@@ -136,6 +136,9 @@ public class Contents {
   }
 
   public static Supplier<InputStream> memoize(Supplier<InputStream> delegate) {
+    if (delegate instanceof MemoizedSupplier) {
+      return delegate;
+    }
     return new MemoizedSupplier(delegate);
   }
 

--- a/java/src/org/openqa/selenium/remote/http/netty/NettyClient.java
+++ b/java/src/org/openqa/selenium/remote/http/netty/NettyClient.java
@@ -59,7 +59,7 @@ public class NettyClient implements HttpClient {
 
   private NettyClient(ClientConfig config) {
     this.config = Require.nonNull("HTTP client config", config);
-    this.handler = new NettyHttpHandler(config, client).with(config.filter());
+    this.handler = new NettyHttpHandler(config, client);
     this.toWebSocket = NettyWebSocket.create(config, client);
   }
 
@@ -103,14 +103,6 @@ public class NettyClient implements HttpClient {
     Require.nonNull("WebSocket listener", listener);
 
     return toWebSocket.apply(request, listener);
-  }
-
-  @Override
-  public HttpClient with(Filter filter) {
-    Require.nonNull("Filter", filter);
-
-    // TODO: We should probably ensure that websocket requests are run through the filter.
-    return new NettyClient(config.withFilter(filter));
   }
 
   @Override


### PR DESCRIPTION
### Description
The NettyClient had a `with` implementation different to the default implementation of the interface. A caller would propably expect the interface behaviour. The PR will fix this and also fix the filters are applied twice for the NettyClient and not applied for the JdkHttpClient.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
