### PR TITLE
[rust] Download older and unstable version of Chrome for Testing (#11678)

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -160,13 +160,13 @@ impl SeleniumManager for EdgeManager {
     }
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
-        let mut browser_version = self.get_major_browser_version();
+        let mut major_browser_version = self.get_major_browser_version();
         let mut metadata = get_metadata(self.get_logger());
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
             self.driver_name,
-            browser_version.as_str(),
+            major_browser_version.as_str(),
         ) {
             Some(driver_version) => {
                 self.log.trace(format!(
@@ -178,7 +178,7 @@ impl SeleniumManager for EdgeManager {
             _ => {
                 self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
 
-                if browser_version.is_empty() {
+                if major_browser_version.is_empty() {
                     let latest_stable_url = format!("{}{}", DRIVER_URL, LATEST_STABLE);
                     self.log.debug(format!(
                         "Reading {} latest version from {}",
@@ -189,17 +189,18 @@ impl SeleniumManager for EdgeManager {
                         latest_stable_url,
                         self.get_logger(),
                     )?;
-                    browser_version = self.get_major_version(latest_driver_version.as_str())?;
+                    major_browser_version =
+                        self.get_major_version(latest_driver_version.as_str())?;
                     self.log.debug(format!(
                         "Latest {} major version is {}",
-                        &self.driver_name, browser_version
+                        &self.driver_name, major_browser_version
                     ));
                 }
                 let driver_url = format!(
                     "{}{}_{}_{}",
                     DRIVER_URL,
                     LATEST_RELEASE,
-                    browser_version,
+                    major_browser_version,
                     self.get_os().to_uppercase()
                 );
                 self.log.debug(format!(
@@ -210,9 +211,9 @@ impl SeleniumManager for EdgeManager {
                     read_version_from_link(self.get_http_client(), driver_url, self.get_logger())?;
 
                 let driver_ttl = self.get_driver_ttl();
-                if driver_ttl > 0 && !browser_version.is_empty() {
+                if driver_ttl > 0 && !major_browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(
-                        browser_version.as_str(),
+                        major_browser_version.as_str(),
                         self.driver_name,
                         &driver_version,
                         driver_ttl,

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -158,12 +158,15 @@ impl SeleniumManager for FirefoxManager {
     }
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
-        let browser_version_binding = self.get_major_browser_version();
-        let browser_version = browser_version_binding.as_str();
+        let major_browser_version_binding = self.get_major_browser_version();
+        let major_browser_version = major_browser_version_binding.as_str();
         let mut metadata = get_metadata(self.get_logger());
 
-        match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
-        {
+        match get_driver_version_from_metadata(
+            &metadata.drivers,
+            self.driver_name,
+            major_browser_version,
+        ) {
             Some(driver_version) => {
                 self.log.trace(format!(
                     "Driver TTL is valid. Getting {} version from metadata",
@@ -179,9 +182,9 @@ impl SeleniumManager for FirefoxManager {
                     read_redirect_from_link(self.get_http_client(), latest_url, self.get_logger())?;
 
                 let driver_ttl = self.get_driver_ttl();
-                if driver_ttl > 0 && !browser_version.is_empty() {
+                if driver_ttl > 0 && !major_browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(
-                        browser_version,
+                        major_browser_version,
                         self.driver_name,
                         &driver_version,
                         driver_ttl,

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -95,12 +95,15 @@ impl SeleniumManager for GridManager {
     }
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
-        let browser_version_binding = self.get_major_browser_version();
-        let browser_version = browser_version_binding.as_str();
+        let major_browser_version_binding = self.get_major_browser_version();
+        let major_browser_version = major_browser_version_binding.as_str();
         let mut metadata = get_metadata(self.get_logger());
 
-        match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
-        {
+        match get_driver_version_from_metadata(
+            &metadata.drivers,
+            self.driver_name,
+            major_browser_version,
+        ) {
             Some(driver_version) => {
                 self.log.trace(format!(
                     "Driver TTL is valid. Getting {} version from metadata",
@@ -148,7 +151,7 @@ impl SeleniumManager for GridManager {
                     let driver_ttl = self.get_driver_ttl();
                     if driver_ttl > 0 {
                         metadata.drivers.push(create_driver_metadata(
-                            browser_version,
+                            major_browser_version,
                             self.driver_name,
                             &driver_version,
                             driver_ttl,

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -99,12 +99,15 @@ impl SeleniumManager for IExplorerManager {
     }
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
-        let browser_version_binding = self.get_major_browser_version();
-        let browser_version = browser_version_binding.as_str();
+        let major_browser_version_binding = self.get_major_browser_version();
+        let major_browser_version = major_browser_version_binding.as_str();
         let mut metadata = get_metadata(self.get_logger());
 
-        match get_driver_version_from_metadata(&metadata.drivers, self.driver_name, browser_version)
-        {
+        match get_driver_version_from_metadata(
+            &metadata.drivers,
+            self.driver_name,
+            major_browser_version,
+        ) {
             Some(driver_version) => {
                 self.log.trace(format!(
                     "Driver TTL is valid. Getting {} version from metadata",
@@ -146,9 +149,9 @@ impl SeleniumManager for IExplorerManager {
                     )?;
 
                     let driver_ttl = self.get_driver_ttl();
-                    if driver_ttl > 0 && !browser_version.is_empty() {
+                    if driver_ttl > 0 && !major_browser_version.is_empty() {
                         metadata.drivers.push(create_driver_metadata(
-                            browser_version,
+                            major_browser_version,
                             self.driver_name,
                             &driver_version,
                             driver_ttl,

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -31,13 +31,14 @@ const METADATA_FILE: &str = "selenium-manager.json";
 #[derive(Serialize, Deserialize)]
 pub struct Browser {
     pub browser_name: String,
+    pub major_browser_version: String,
     pub browser_version: String,
     pub browser_ttl: u64,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Driver {
-    pub browser_version: String,
+    pub major_browser_version: String,
     pub driver_name: String,
     pub driver_version: String,
     pub driver_ttl: u64,
@@ -92,10 +93,13 @@ pub fn get_metadata(log: &Logger) -> Metadata {
 pub fn get_browser_version_from_metadata(
     browsers_metadata: &[Browser],
     browser_name: &str,
+    major_browser_version: &str,
 ) -> Option<String> {
     let browser: Vec<&Browser> = browsers_metadata
         .iter()
-        .filter(|b| b.browser_name.eq(browser_name))
+        .filter(|b| {
+            b.browser_name.eq(browser_name) && b.major_browser_version.eq(major_browser_version)
+        })
         .collect();
     if browser.is_empty() {
         None
@@ -107,11 +111,13 @@ pub fn get_browser_version_from_metadata(
 pub fn get_driver_version_from_metadata(
     drivers_metadata: &[Driver],
     driver_name: &str,
-    browser_version: &str,
+    major_browser_version: &str,
 ) -> Option<String> {
     let driver: Vec<&Driver> = drivers_metadata
         .iter()
-        .filter(|d| d.driver_name.eq(driver_name) && d.browser_version.eq(browser_version))
+        .filter(|d| {
+            d.driver_name.eq(driver_name) && d.major_browser_version.eq(major_browser_version)
+        })
         .collect();
     if driver.is_empty() {
         None
@@ -122,24 +128,26 @@ pub fn get_driver_version_from_metadata(
 
 pub fn create_browser_metadata(
     browser_name: &str,
-    browser_version: &String,
+    major_browser_version: &str,
+    browser_version: &str,
     browser_ttl: u64,
 ) -> Browser {
     Browser {
         browser_name: browser_name.to_string(),
+        major_browser_version: major_browser_version.to_string(),
         browser_version: browser_version.to_string(),
         browser_ttl: now_unix_timestamp() + browser_ttl,
     }
 }
 
 pub fn create_driver_metadata(
-    browser_version: &str,
+    major_browser_version: &str,
     driver_name: &str,
     driver_version: &str,
     driver_ttl: u64,
 ) -> Driver {
     Driver {
-        browser_version: browser_version.to_string(),
+        major_browser_version: major_browser_version.to_string(),
         driver_name: driver_name.to_string(),
         driver_version: driver_version.to_string(),
         driver_ttl: now_unix_timestamp() + driver_ttl,

--- a/rust/tests/chrome_download_tests.rs
+++ b/rust/tests/chrome_download_tests.rs
@@ -19,11 +19,12 @@ use assert_cmd::Command;
 use std::path::Path;
 
 use is_executable::is_executable;
+use rstest::rstest;
 use selenium_manager::logger::JsonOutput;
 use std::str;
 
 #[test]
-fn chrome_download_test() {
+fn chrome_latest_download_test() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     cmd.args([
         "--browser",
@@ -36,6 +37,30 @@ fn chrome_download_test() {
     .success()
     .code(0);
 
+    assert_driver_and_browser(&mut cmd);
+}
+
+#[rstest]
+#[case("113")]
+#[case("beta")]
+fn chrome_version_download_test(#[case] browser_version: String) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    cmd.args([
+        "--browser",
+        "chrome",
+        "--browser-version",
+        &browser_version,
+        "--output",
+        "json",
+    ])
+    .assert()
+    .success()
+    .code(0);
+
+    assert_driver_and_browser(&mut cmd);
+}
+
+fn assert_driver_and_browser(cmd: &mut Command) {
     let stdout = &cmd.unwrap().stdout;
     let output = str::from_utf8(stdout).unwrap();
     println!("{}", output);

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -22,7 +22,6 @@ use std::str;
 
 #[rstest]
 #[case("chrome", "chromedriver", "", "")]
-#[case("chrome", "chromedriver", "105", "105.0.5195.52")]
 #[case("chrome", "chromedriver", "114", "114.0.5735.90")]
 #[case("chrome", "chromedriver", "115", "115.0.5790")]
 #[case("edge", "msedgedriver", "", "")]


### PR DESCRIPTION
### Description
This PR implements the Rust logic required to manage Chrome for Testing (CfT) binaries: unstable channels (beta/dev/canary) and fixed versions (e.g., 113, 114, 115, etc.).

Here it is some examples of its usage:

**Chrome stable (forced download)**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --force-browser-download
DEBUG   Checking chromedriver in PATH
DEBUG   Running command: chromedriver --version
DEBUG   Output: ""
DEBUG   chromedriver not found in PATH
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json
DEBUG   Required browser: chrome 115.0.5790.102
DEBUG   Downloading chrome 115.0.5790.102 from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.102/win64/chrome-win64.zip
DEBUG   chrome 115.0.5790.102 has been downloaded at C:\Users\boni\.cache\selenium\chrome\win64\115.0.5790.102\chrome.exe
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required driver: chromedriver 115.0.5790.102
DEBUG   Driver URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.102/win64/chromedriver-win64.zip
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\115.0.5790.102\chromedriver.exe
INFO    Browser path: C:\Users\boni\.cache\selenium\chrome\win64\115.0.5790.102\chrome.exe
```

**Chrome beta (already installed)**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --browser-version beta
DEBUG   Checking chromedriver in PATH
DEBUG   Running command: chromedriver --version
DEBUG   Output: ""
DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome Beta\Application\chrome.exe
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome Beta\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=116.0.5845.42\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 116.0.5845.42
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required driver: chromedriver 116.0.5845.42
DEBUG   Driver URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.42/win64/chromedriver-win64.zip
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\116.0.5845.42\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome Beta\Application\chrome.exe
```

**Chrome dev (not available, and so, CfT is downloaded)**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --browser-version dev
DEBUG   Checking chromedriver in PATH
DEBUG   Running command: chromedriver --version
DEBUG   Output: ""
DEBUG   chromedriver not found in PATH
DEBUG   Checking chrome in PATH
DEBUG   Running command: where chrome
DEBUG   Output: ""
DEBUG   chrome not found in PATH
DEBUG   chrome has not been discovered in the system
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json
DEBUG   Required browser: chrome 117.0.5897.3
DEBUG   Downloading chrome 117.0.5897.3 from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5897.3/win64/chrome-win64.zip
DEBUG   chrome 117.0.5897.3 has been downloaded at C:\Users\boni\.cache\selenium\chrome\win64\117.0.5897.3\chrome.exe
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required driver: chromedriver 117.0.5908.0
DEBUG   Driver URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5908.0/win64/chromedriver-win64.zip
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\117.0.5908.0\chromedriver.exe
INFO    Browser path: C:\Users\boni\.cache\selenium\chrome\win64\117.0.5897.3\chrome.exe
```

**Chrome 113 (not available, and so, CfT is downloaded)**
```
C:\Users\boni\Documents\dev\selenium\rust>cargo run -- --browser chrome --debug --browser-version 113
DEBUG   Checking chromedriver in PATH
DEBUG   Running command: chromedriver --version
DEBUG   Output: ""
DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Using shell command to find out chrome version
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=115.0.5790.99\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 115.0.5790.99
DEBUG   Discovered browser version (115) different to specified browser version (113)
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required browser: chrome 113.0.5672.63
DEBUG   Downloading chrome 113.0.5672.63 from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/113.0.5672.63/win64/chrome-win64.zip
DEBUG   chrome 113.0.5672.63 has been downloaded at C:\Users\boni\.cache\selenium\chrome\win64\113.0.5672.63\chrome.exe
DEBUG   Reading chromedriver version from https://chromedriver.storage.googleapis.com/LATEST_RELEASE_113
DEBUG   Required driver: chromedriver 113.0.5672.63
DEBUG   Driver URL: https://chromedriver.storage.googleapis.com/113.0.5672.63/chromedriver_win32.zip
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\113.0.5672.63\chromedriver.exe
INFO    Browser path: C:\Users\boni\.cache\selenium\chrome\win64\113.0.5672.63\chrome.exe
```



### Motivation and Context
This PR is a continuation of #12353 and implements #11678. It allows to download CfT browser binaries, starting on Chrome 113 (the first version released as CfT).

Now, we need to decide if we want to support the management of even older Chromium releases (e.g., 112, 111, etc.). This could be done by mapping these releases (using the info published in the [Chromium Dash](https://chromiumdash.appspot.com/releases)).

@diemol @titusfortner Do we want to manage these Chromium versions (i.e., older than 113)? It is feasible. In fact, this was the original idea before releasing CfT.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
