### PR TITLE
[py] Remove unsupported safari parameters from Options

### DIFF
--- a/py/selenium/webdriver/safari/options.py
+++ b/py/selenium/webdriver/safari/options.py
@@ -20,68 +20,12 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.options import ArgOptions
 
 
-class Log:
-    def __init__(self) -> None:
-        self.level = None
-
-    def to_capabilities(self) -> dict:
-        if self.level:
-            return {"log": {"level": self.level}}
-        return {}
-
-
 class Options(ArgOptions):
-    KEY = "safari.options"
-
     # @see https://developer.apple.com/documentation/webkit/about_webdriver_for_safari
     AUTOMATIC_INSPECTION = "safari:automaticInspection"
     AUTOMATIC_PROFILING = "safari:automaticProfiling"
 
     SAFARI_TECH_PREVIEW = "Safari Technology Preview"
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._binary_location = None
-        self._preferences: dict = {}
-        self.log = Log()
-
-    @property
-    def binary_location(self) -> str:
-        """
-        :Returns: The location of the browser binary otherwise an empty string
-        """
-        return self._binary_location
-
-    @binary_location.setter
-    def binary_location(self, value: str) -> None:
-        """Allows you to set the browser binary to launch.
-
-        :Args:
-         - value : path to the browser binary
-        """
-        if not isinstance(value, str):
-            raise TypeError(self.BINARY_LOCATION_ERROR)
-        self._binary_location = value
-
-    def to_capabilities(self) -> dict:
-        """Marshals the  options to an desired capabilities object."""
-        # This intentionally looks at the internal properties
-        # so if a binary or profile has _not_ been set,
-        # it will defer to geckodriver to find the system Firefox
-        # and generate a fresh profile.
-        caps = self._caps
-        opts = {}
-
-        if self._arguments:
-            opts["args"] = self._arguments
-        if self._binary_location:
-            opts["binary"] = self._binary_location
-        opts.update(self.log.to_capabilities())
-
-        if opts:
-            caps[Options.KEY] = opts
-
-        return caps
 
     @property
     def default_capabilities(self) -> typing.Dict[str, str]:

--- a/py/test/unit/selenium/webdriver/safari/safari_options_tests.py
+++ b/py/test/unit/selenium/webdriver/safari/safari_options_tests.py
@@ -25,26 +25,6 @@ def options():
     return Options()
 
 
-def test_set_binary_location(options):
-    options.binary_location = "/foo/bar"
-    assert options._binary_location == "/foo/bar"
-
-
-def test_get_binary_location(options):
-    options._binary_location = "/foo/bar"
-    assert options.binary_location == "/foo/bar"
-
-
-def test_creates_capabilities(options):
-    options._arguments = ["foo"]
-    options._binary_location = "/bar"
-    caps = options.to_capabilities()
-    opts = caps.get(Options.KEY)
-    assert opts
-    assert "foo" in opts["args"]
-    assert opts["binary"] == "/bar"
-
-
 def test_starts_with_default_capabilities(options):
     from selenium.webdriver import DesiredCapabilities
 


### PR DESCRIPTION
### Description
This is all that is supported in Safari: https://developer.apple.com/documentation/webkit/about_webdriver_for_safari 
* Remove logging level
* Remove arguments
* Remove binary_location
* There is no` safari.options`
* Superclass has correct behaviors for constructor, to_capabilities

### Motivation and Context
* All Safari support for Selenium 4.11.0 is broken when using Selenium Manager
* Safari actually errors when you try to pass these things to the driver so no need to deprecate, they *can't be getting used
* Selenium Manager incorrectly assumed the binary_location method was not implemented


**Note**: it also needed this - 2ee529edb61913b6f57b87c7ffa04bab0bcab70f