### PR TITLE
Build universal macOS Selenium-Manager on CI

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -61,7 +61,7 @@ jobs:
           retention-days: 6
 
   macos64:
-    name: "[macOS x64] Build selenium-manager"
+    name: "[macOS x64/arm64] Build selenium-manager"
     runs-on: macos-latest
     env:
       RUSTFLAGS: '-Ctarget-feature=+crt-static'
@@ -71,14 +71,17 @@ jobs:
       - name: "Update Rust"
         run: |
           rustup update
+          rustup target add aarch64-apple-darwin
           rustc -vV
       - name: "Build release"
         run: |
+          export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
           cd rust
-          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
       - name: "Tar binary (to keep executable permission)"
         run: |
-          cd rust/target/x86_64-apple-darwin/release
+          cd rust/target/aarch64-apple-darwin/release
           tar -cvf ../../../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -1,4 +1,4 @@
-name: build-selenium-manager
+name: Build selenium-manager
 
 on: workflow_dispatch
 
@@ -75,8 +75,8 @@ jobs:
           rustc -vV
       - name: "Build release"
         run: |
-          export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+          export SDKROOT=$(xcrun -sdk macosx12.0 --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx12.0 --show-sdk-platform-version)
           cd rust
           cargo build --release --target aarch64-apple-darwin
       - name: "Tar binary (to keep executable permission)"

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -83,7 +83,7 @@ jobs:
           cargo build --release --target aarch64-apple-darwin
       - name: "Build universal"
         run: |
-          cd rust/
+          cd rust
           lipo -create \
             -output target/selenium-manager \
             target/aarch64-apple-darwin/release/selenium-manager \
@@ -91,7 +91,7 @@ jobs:
       - name: "Tar binary (to keep executable permission)"
         run: |
           cd rust/target
-          tar -cvf ../../../../selenium-manager.tar selenium-manager
+          tar -cvf ../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -73,19 +73,28 @@ jobs:
           rustup update
           rustup target add aarch64-apple-darwin
           rustc -vV
-      - name: "Build release"
+      - name: "Build x64"
         run: |
-          export SDKROOT=$(xcrun -sdk macosx12.0 --show-sdk-path)
-          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx12.0 --show-sdk-platform-version)
+          cd rust
+          cargo build --release --target x86_64-apple-darwin
+      - name: "Build arm64"
+        run: |
           cd rust
           cargo build --release --target aarch64-apple-darwin
+      - name: "Build universal"
+        run: |
+          cd rust/
+          lipo -create \
+            -output target/selenium-manager \
+            target/aarch64-apple-darwin/release/selenium-manager \
+            target/x86_64-apple-darwin/release/selenium-manager
       - name: "Tar binary (to keep executable permission)"
         run: |
-          cd rust/target/aarch64-apple-darwin/release
+          cd rust/target
           tar -cvf ../../../../selenium-manager.tar selenium-manager
       - name: "Upload binary"
         uses: actions/upload-artifact@v3
         with:
-          name: selenium-manager_macos-x64
+          name: selenium-manager_macos-universal
           path: selenium-manager.tar
           retention-days: 6


### PR DESCRIPTION
Here is an example of a built binary - https://github.com/SeleniumHQ/selenium/actions/runs/5720210958. It's double-size as we'd expect.

```bash
$ lipo -archs ./selenium-manager
x86_64 arm64
$ du -sh selenium-manager
7.3M	selenium-manager
```