### PR TITLE
[py] fixed Enum issue in ie/options

### DIFF
--- a/py/selenium/webdriver/ie/options.py
+++ b/py/selenium/webdriver/ie/options.py
@@ -105,7 +105,7 @@ class Options(ArgOptions):
     `value`: `int` (Timeout) in milliseconds
     """
 
-    element_scroll_behavior = _IeOptionsDescriptor(ELEMENT_SCROLL_BEHAVIOR, int)
+    element_scroll_behavior = _IeOptionsDescriptor(ELEMENT_SCROLL_BEHAVIOR, Enum)
     """Gets and Sets `element_scroll_behavior`
 
     Usage


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Changed Expected Type of `ElementScrollBehavior` to `Enum` in `ie/options`

### Motivation and Context
The descriptor was validating `ElementScrollBehavior`  to incorrect type which was `int`. But this was supposed to be of type `Enum`. I have fixed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
