### PR TITLE
[rust] Change default type (arch, os) for binaries downloaded by Selenium Manager (#11685)

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -35,6 +35,10 @@ Options:
           Browser path (absolute) for browser version detection (e.g., /usr/bin/google-chrome, "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", "C:\Program Files\Google\Chrome\Application\chrome.exe")
       --output <OUTPUT>
           Output type: LOGGER (using INFO, WARN, etc.), JSON (custom JSON notation), or SHELL (Unix-like) [default: LOGGER]
+      --os <OS>
+          Operating system (i.e., windows, linux, or macos)
+      --arch <ARCH>
+          System architecture (i.e., x32, x64, or arm64)
       --proxy <PROXY>
           HTTP proxy for network connection (e.g., https://myproxy.net:8080)
       --timeout <TIMEOUT>

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -387,7 +387,7 @@ impl SeleniumManager for ChromeManager {
         ])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_general_browser_version(
             r#"HKCU\Software\Google\Chrome\BLBeacon"#,
             REG_VERSION_ARG,

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -106,26 +106,29 @@ pub enum OS {
 }
 
 impl OS {
-    pub fn to_str(&self) -> &str {
+    pub fn to_str_vector(&self) -> Vec<&str> {
         match self {
-            WINDOWS => "windows",
-            MACOS => "macos",
-            LINUX => "linux",
+            WINDOWS => vec!["windows", "win"],
+            MACOS => vec!["macos", "mac"],
+            LINUX => vec!["linux", "gnu/linux"],
         }
     }
 
     pub fn is(&self, os: &str) -> bool {
-        self.to_str().eq_ignore_ascii_case(os)
+        self.to_str_vector()
+            .contains(&os.to_ascii_lowercase().as_str())
     }
 }
 
-pub fn str_to_os(os: &str) -> OS {
+pub fn str_to_os(os: &str) -> Result<OS, Box<dyn Error>> {
     if WINDOWS.is(os) {
-        WINDOWS
+        Ok(WINDOWS)
     } else if MACOS.is(os) {
-        MACOS
+        Ok(MACOS)
+    } else if LINUX.is(os) {
+        Ok(LINUX)
     } else {
-        LINUX
+        Err(format!("Invalid operating system: {os}").into())
     }
 }
 
@@ -140,9 +143,9 @@ pub enum ARCH {
 impl ARCH {
     pub fn to_str_vector(&self) -> Vec<&str> {
         match self {
-            ARCH::X32 => vec![ARCH_X86, "i386"],
+            ARCH::X32 => vec![ARCH_X86, "i386", "x32"],
             ARCH::X64 => vec![ARCH_AMD64, "x86_64", "x64", "i686", "ia64"],
-            ARCH::ARM64 => vec![ARCH_ARM64, "aarch64", "arm"],
+            ARCH::ARM64 => vec![ARCH_ARM64, "aarch64", "arm", "arm64"],
         }
     }
 

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -120,7 +120,7 @@ impl SeleniumManager for EdgeManager {
         ])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_general_browser_version(
             r#"HKCU\Software\Microsoft\Edge\BLBeacon"#,
             REG_VERSION_ARG,

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -117,7 +117,7 @@ impl SeleniumManager for FirefoxManager {
         ])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_general_browser_version(
             r#"HKCU\Software\Mozilla\Mozilla Firefox"#,
             REG_CURRENT_VERSION_ARG,

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -86,8 +86,8 @@ impl SeleniumManager for GridManager {
         HashMap::new()
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
-        None
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+        Ok(None)
     }
 
     fn get_driver_name(&self) -> &str {

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -62,7 +62,7 @@ impl IExplorerManager {
         let mut config = ManagerConfig::default(browser_name, driver_name);
         let default_timeout = config.timeout.to_owned();
         let default_proxy = &config.proxy;
-        config.os = WINDOWS.to_str().to_string();
+        config.os = WINDOWS.to_str_vector().first().unwrap().to_string();
         Ok(Box::new(IExplorerManager {
             browser_name,
             driver_name,

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -94,7 +94,7 @@ impl SeleniumManager for IExplorerManager {
         )])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_general_browser_version(
             r#"HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer"#,
             REG_VERSION_ARG,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -108,7 +108,7 @@ pub trait SeleniumManager {
 
     fn get_browser_path_map(&self) -> HashMap<BrowserPath, &str>;
 
-    fn discover_browser_version(&mut self) -> Option<String>;
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>>;
 
     fn get_driver_name(&self) -> &str;
 
@@ -169,7 +169,10 @@ pub trait SeleniumManager {
 
         let browser_path = self
             .get_browser_path_map()
-            .get(&BrowserPath::new(str_to_os(self.get_os()), browser_version))
+            .get(&BrowserPath::new(
+                str_to_os(self.get_os()).unwrap(),
+                browser_version,
+            ))
             .cloned()
             .unwrap_or_default();
 
@@ -261,7 +264,7 @@ pub trait SeleniumManager {
 
         // First, we try to discover the browser version
         if !download_browser {
-            match self.discover_browser_version() {
+            match self.discover_browser_version()? {
                 Some(discovered_version) => {
                     if !self.is_safari() {
                         self.get_logger().debug(format!(
@@ -676,7 +679,9 @@ pub trait SeleniumManager {
     }
 
     fn set_os(&mut self, os: String) {
-        self.get_config_mut().os = os;
+        if !os.is_empty() {
+            self.get_config_mut().os = os;
+        }
     }
 
     fn get_arch(&self) -> &str {
@@ -684,7 +689,9 @@ pub trait SeleniumManager {
     }
 
     fn set_arch(&mut self, arch: String) {
-        self.get_config_mut().arch = arch;
+        if !arch.is_empty() {
+            self.get_config_mut().arch = arch;
+        }
     }
 
     fn get_browser_version(&self) -> &str {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -599,7 +599,7 @@ pub trait SeleniumManager {
         reg_key: &'static str,
         reg_version_arg: &'static str,
         cmd_version_arg: &str,
-    ) -> Option<String> {
+    ) -> Result<Option<String>, Box<dyn Error>> {
         let mut browser_path = self.get_browser_path().to_string();
         let mut escaped_browser_path = self.get_escaped_path(browser_path.to_string());
         if browser_path.is_empty() {
@@ -646,10 +646,13 @@ pub trait SeleniumManager {
             )));
         }
 
-        self.detect_browser_version(commands)
+        Ok(self.detect_browser_version(commands))
     }
 
-    fn discover_safari_version(&mut self, safari_path: String) -> Option<String> {
+    fn discover_safari_version(
+        &mut self,
+        safari_path: String,
+    ) -> Result<Option<String>, Box<dyn Error>> {
         let mut browser_path = self.get_browser_path().to_string();
         let mut commands = Vec::new();
         if browser_path.is_empty() {
@@ -657,17 +660,17 @@ pub trait SeleniumManager {
                 Some(path) => {
                     browser_path = self.get_escaped_path(path_buf_to_string(path));
                 }
-                _ => return None,
+                _ => return Ok(None),
             }
         }
         if MACOS.is(self.get_os()) {
             let plist_command = Command::new_single(format_one_arg(PLIST_COMMAND, &browser_path));
             commands.push(plist_command);
         } else {
-            return None;
+            return Ok(None);
         }
         self.set_browser_path(safari_path);
-        self.detect_browser_version(commands)
+        Ok(self.detect_browser_version(commands))
     }
 
     // ----------------------------------------------------------

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -72,6 +72,14 @@ struct Cli {
     #[clap(long, value_parser, default_value = "LOGGER")]
     output: String,
 
+    /// Operating system (i.e., windows, linux, or macos)
+    #[clap(long, value_parser)]
+    os: Option<String>,
+
+    /// System architecture (i.e., x32, x64, or arm64)
+    #[clap(long, value_parser)]
+    arch: Option<String>,
+
     /// HTTP proxy for network connection (e.g., https://myproxy.net:8080)
     #[clap(long, value_parser)]
     proxy: Option<String>,
@@ -155,6 +163,8 @@ fn main() {
     selenium_manager.set_browser_version(cli.browser_version.unwrap_or_default());
     selenium_manager.set_driver_version(cli.driver_version.unwrap_or_default());
     selenium_manager.set_browser_path(cli.browser_path.unwrap_or_default());
+    selenium_manager.set_os(cli.os.unwrap_or_default());
+    selenium_manager.set_arch(cli.arch.unwrap_or_default());
     selenium_manager.set_driver_ttl(cli.driver_ttl);
     selenium_manager.set_browser_ttl(cli.browser_ttl);
     selenium_manager.set_offline(cli.offline);

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -74,7 +74,7 @@ impl SeleniumManager for SafariManager {
         HashMap::from([(BrowserPath::new(MACOS, STABLE), SAFARI_PATH)])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_safari_version(SAFARI_FULL_PATH.to_string())
     }
 

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -80,7 +80,7 @@ impl SeleniumManager for SafariTPManager {
         HashMap::from([(BrowserPath::new(MACOS, STABLE), SAFARITP_PATH)])
     }
 
-    fn discover_browser_version(&mut self) -> Option<String> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
         self.discover_safari_version(SAFARITP_FULL_PATH.to_string())
     }
 


### PR DESCRIPTION
### Description
This PR allows to change the default architecture and operating system for the browser/drivers managed by Selenium Manager. This configuration, as usual, can be done in three ways:

1. CLI flags (`--os OS` and `--arch ARCH`)
2. Configuration file (`os = "OS"` and `arch = "ARCH"`)
3. Environment variables (`SE_OS=OS` and `SE_ARCH=ARCH`)

### Motivation and Context
This PR implements #11685. Also, it allows to give consistency to the configuration table published in the [Selenium Manager page](https://www.selenium.dev/documentation/selenium_manager/).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
