### PR TITLE
[rb] FIX uninitialized constant Net::HTTP when Selenium::WebDriver.fo…

### DIFF
--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -20,6 +20,7 @@
 require 'timeout'
 require 'socket'
 require 'rexml/document'
+require 'net/http'
 
 module Selenium
   module WebDriver


### PR DESCRIPTION

# Load missing library (net/http)

Fix an error due to failure to load the corresponding library.

## Motivation and Context

Software installed:
* rbenv 1.2.0-48-g6717c62
* ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
* geckodriver v0.33.0
* gem selenium-webdriver (4.11.0)

When running this script:

```ruby
require "selenium-webdriver"

# Initialize webdriver
options = Selenium::WebDriver::Options.firefox
options.page_load_strategy = :normal
driver = Selenium::WebDriver.for :firefox, options: options
driver.manage.timeouts.implicit_wait = 30

# Use webdriver
driver.get "https://www.nba.com"
puts "[Title] #{driver.title}"
driver.quit
```

We get this error:

```
selenium-webdriver-4.11.0/lib/selenium/webdriver/remote/http/default.rb:108:in `new_request_for': uninitialized constant S
elenium::WebDriver::Remote::Http::Default::Net (NameError)

            req = Net::HTTP.const_get(verb.to_s.capitalize).new(url.path, headers)
```

### Solution

Add `require 'net/http'` to `lib/selenium/webdriver/firefox.rb` to load Net::HTTP module before use it.

### Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
