### PR TITLE
[py] marked all pdf printing tests as xfail for safari

### DIFF
--- a/py/test/selenium/webdriver/common/print_pdf_tests.py
+++ b/py/test/selenium/webdriver/common/print_pdf_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from selenium.webdriver.common.print_page_options import PrintOptions
 
@@ -22,6 +23,7 @@ END_INDEX = 5
 PDF_MAGIC_NUMBER = "JVBER"
 
 
+@pytest.mark.xfail_safari(reason="no endpoint for print in safari")
 def test_pdf_with_2_pages(driver, pages):
     print_options = PrintOptions()
     print_options.page_ranges = ["1-2"]
@@ -33,6 +35,7 @@ def test_pdf_with_2_pages(driver, pages):
     assert base64code[START_INDEX:END_INDEX] == PDF_MAGIC_NUMBER
 
 
+@pytest.mark.xfail_safari(reason="no endpoint for print in safari")
 def test_pdf_with_all_pages(driver, pages):
     pages.load("printPage.html")
     base64code = driver.print_page()
@@ -40,6 +43,7 @@ def test_pdf_with_all_pages(driver, pages):
     assert base64code[START_INDEX:END_INDEX] == PDF_MAGIC_NUMBER
 
 
+@pytest.mark.xfail_safari(reason="no endpoint for print in safari")
 def test_valid_params(driver, pages):
     print_options = PrintOptions()
 
@@ -53,6 +57,7 @@ def test_valid_params(driver, pages):
     assert base64code[START_INDEX:END_INDEX] == PDF_MAGIC_NUMBER
 
 
+@pytest.mark.xfail_safari(reason="no endpoint for print in safari")
 def test_session_id_is_not_preserved_after_page_is_printed(driver, pages):
     print_options = PrintOptions()
     print_options.margin_bottom = print_options.margin_top = print_options.margin_left = print_options.margin_right = 0


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Marked all pdf printing tests in `common/print_pdf_tests.py` as `xfail` for safari browser.

### Motivation and Context
Since there is no endpoint in Safari driver for printing validation, all tests in  `print_pdf_tests.py` were failing. I have marked it as `xfail`.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
