### PR TITLE
[grid] no need for CDP version dependencies in the server

### DIFF
--- a/java/src/org/openqa/selenium/grid/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/BUILD.bazel
@@ -154,9 +154,10 @@ java_export(
         "//java/src/org/openqa/selenium/grid/sessionmap/httpd",
         "//java/src/org/openqa/selenium/grid/sessionqueue/httpd",
         "//java/src/org/openqa/selenium/ie",
+        "//java/src/org/openqa/selenium/remote",
         "//java/src/org/openqa/selenium/safari",
         "//javascript/grid-ui:react_jar",
-    ] + CDP_DEPS,
+    ],
     deps = [
         ":base-command",
         "//java/src/org/openqa/selenium/cli",


### PR DESCRIPTION
### Description
This PR will remove the CDP version dependencies from the grid and only keep the devtools dependency.
The grid is only interested in the WebDriverInfo implementations of all the browsers, they do not rely on the concrete versions. If this would be the case the server version would be strong bound to the browser version. I think this is a not desired behavior and should be avoided in any case.

Or am i wrong and the CDP version dependencies are somewhere needed in the server?

### Motivation and Context
Reduces the size of the standalone server by ~3 mb

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
