### PR TITLE
Fix bug: Missing to load the "net/http" library.

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -23,6 +23,7 @@ require 'date'
 require 'json'
 require 'set'
 require 'uri'
+require 'net/http'
 
 require 'selenium/webdriver/atoms'
 require 'selenium/webdriver/common'

--- a/rb/lib/selenium/webdriver/chrome.rb
+++ b/rb/lib/selenium/webdriver/chrome.rb
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'net/http'
-
 module Selenium
   module WebDriver
     module Chrome

--- a/rb/lib/selenium/webdriver/chromium.rb
+++ b/rb/lib/selenium/webdriver/chromium.rb
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'net/http'
-
 module Selenium
   module WebDriver
     module Chromium

--- a/rb/lib/selenium/webdriver/edge.rb
+++ b/rb/lib/selenium/webdriver/edge.rb
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'net/http'
-
 module Selenium
   module WebDriver
     module Edge

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -20,7 +20,6 @@
 require 'timeout'
 require 'socket'
 require 'rexml/document'
-require 'net/http'
 
 module Selenium
   module WebDriver

--- a/rb/lib/selenium/webdriver/firefox.rb
+++ b/rb/lib/selenium/webdriver/firefox.rb
@@ -20,6 +20,7 @@
 require 'timeout'
 require 'socket'
 require 'rexml/document'
+require 'net/http'
 
 module Selenium
   module WebDriver


### PR DESCRIPTION
## [Fix] Missing to load the "net/http" library.

### Description

Get this error 
```
Using the selenium-webdriver v4.11.0 gem results in the following error: selenium-webdriver-4.11.0/lib/selenium/webdriver/remote/http/default.rb:108:in `new_request_for': uninitialized constant S elenium::WebDriver::Remote::Http::Default::Net (NameError)

             req = Net::HTTP.const_get(verb.to_s.capitalize).new(url.path, headers)
```

### Motivation and Context

Software installed:
* rbenv 1.2.0-48-g6717c62
* ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
* geckodriver v0.33.0
* gem selenium-webdriver (4.11.0)

When running this script:

```
require "selenium-webdriver"

# Initialize webdriver
options = Selenium::WebDriver::Options.firefox
options.page_load_strategy = :normal
driver = Selenium::WebDriver.for :firefox, options: options
driver.manage.timeouts.implicit_wait = 30

# Use webdriver
driver.get "https://www.nba.com"
puts "[Title] #{driver.title}"
driver.quit
```

Obtain this error:

```
selenium-webdriver-4.11.0/lib/selenium/webdriver/remote/http/default.rb:108:in `new_request_for': uninitialized constant S
elenium::WebDriver::Remote::Http::Default::Net (NameError)

            req = Net::HTTP.const_get(verb.to_s.capitalize).new(url.path, headers)
```

###  Solution

Adding `require 'net/https'` to the `lib/selenium/webdriver/firefox.rb` file.

### Types of changes

[X ] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
