### PR TITLE
[rust] Allow to change default folder for Selenium Manager cache (#11688)

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -47,6 +47,8 @@ Options:
           Driver TTL (time-to-live) [default: 3600]
       --browser-ttl <BROWSER_TTL>
           Browser TTL (time-to-live) [default: 3600]
+      --cache-path <CACHE_PATH>
+          Local folder used to store downloaded assets (drivers and browsers), local metadata, and configuration file [default: ~/.cache/selenium]
       --clear-cache
           Clear cache folder (~/.cache/selenium)
       --clear-metadata

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -134,7 +134,7 @@ impl SeleniumManager for EdgeManager {
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let mut major_browser_version = self.get_major_browser_version();
-        let mut metadata = get_metadata(self.get_logger());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -191,7 +191,7 @@ impl SeleniumManager for EdgeManager {
                         &driver_version,
                         driver_ttl,
                     ));
-                    write_metadata(&metadata, self.get_logger());
+                    write_metadata(&metadata, self.get_logger(), self.get_cache_path());
                 }
 
                 Ok(driver_version)
@@ -251,7 +251,13 @@ impl SeleniumManager for EdgeManager {
         } else {
             "linux64"
         };
-        compose_driver_path_in_cache(self.driver_name, os, arch_folder, driver_version)
+        compose_driver_path_in_cache(
+            self.get_cache_path(),
+            self.driver_name,
+            os,
+            arch_folder,
+            driver_version,
+        )
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -134,7 +134,7 @@ impl SeleniumManager for EdgeManager {
 
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let mut major_browser_version = self.get_major_browser_version();
-        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path()?);
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -191,7 +191,7 @@ impl SeleniumManager for EdgeManager {
                         &driver_version,
                         driver_ttl,
                     ));
-                    write_metadata(&metadata, self.get_logger(), self.get_cache_path());
+                    write_metadata(&metadata, self.get_logger(), self.get_cache_path()?);
                 }
 
                 Ok(driver_version)
@@ -230,7 +230,7 @@ impl SeleniumManager for EdgeManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
         let driver_version = self.get_driver_version();
         let os = self.get_os();
         let arch = self.get_arch();
@@ -251,13 +251,13 @@ impl SeleniumManager for EdgeManager {
         } else {
             "linux64"
         };
-        compose_driver_path_in_cache(
-            self.get_cache_path(),
+        Ok(compose_driver_path_in_cache(
+            self.get_cache_path()?,
             self.driver_name,
             os,
             arch_folder,
             driver_version,
-        )
+        ))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -54,16 +54,18 @@ impl BrowserPath {
     }
 }
 
-pub fn create_parent_path_if_not_exists(path: &Path) {
+pub fn create_parent_path_if_not_exists(path: &Path) -> Result<(), Box<dyn Error>> {
     if let Some(p) = path.parent() {
-        create_path_if_not_exists(p);
+        create_path_if_not_exists(p)?;
     }
+    Ok(())
 }
 
-pub fn create_path_if_not_exists(path: &Path) {
+pub fn create_path_if_not_exists(path: &Path) -> Result<(), Box<dyn Error>> {
     if !path.exists() {
-        fs::create_dir_all(path).unwrap();
+        fs::create_dir_all(path)?;
     }
+    Ok(())
 }
 
 pub fn uncompress(
@@ -132,7 +134,7 @@ pub fn unzip(
             None => continue,
         };
         if single_file.is_none() {
-            create_path_if_not_exists(target);
+            create_path_if_not_exists(target)?;
             out_path = target.join(path);
         }
 
@@ -148,7 +150,7 @@ pub fn unzip(
                 out_path.display(),
                 file.size()
             ));
-            create_parent_path_if_not_exists(out_path.as_path());
+            create_parent_path_if_not_exists(out_path.as_path())?;
 
             let mut outfile = File::create(&out_path)?;
             io::copy(&mut file, &mut outfile)?;

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -186,7 +186,7 @@ pub fn get_raw_file_name(file_name: &str) -> &str {
     raw_file_name
 }
 
-pub fn compose_cache_folder() -> PathBuf {
+pub fn default_cache_folder() -> PathBuf {
     if let Some(base_dirs) = BaseDirs::new() {
         return Path::new(base_dirs.home_dir())
             .join(String::from(CACHE_FOLDER).replace('/', std::path::MAIN_SEPARATOR_STR));
@@ -194,19 +194,14 @@ pub fn compose_cache_folder() -> PathBuf {
     PathBuf::new()
 }
 
-pub fn get_cache_folder() -> PathBuf {
-    let cache_path = compose_cache_folder();
-    create_path_if_not_exists(&cache_path);
-    cache_path
-}
-
 pub fn compose_driver_path_in_cache(
+    driver_path: PathBuf,
     driver_name: &str,
     os: &str,
     arch_folder: &str,
     driver_version: &str,
 ) -> PathBuf {
-    get_cache_folder()
+    driver_path
         .join(driver_name)
         .join(arch_folder)
         .join(driver_version)

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -132,7 +132,7 @@ impl SeleniumManager for FirefoxManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -161,7 +161,7 @@ impl SeleniumManager for FirefoxManager {
                         &driver_version,
                         driver_ttl,
                     ));
-                    write_metadata(&metadata, self.get_logger());
+                    write_metadata(&metadata, self.get_logger(), self.get_cache_path());
                 }
 
                 Ok(driver_version)
@@ -241,7 +241,13 @@ impl SeleniumManager for FirefoxManager {
         } else {
             "linux64"
         };
-        compose_driver_path_in_cache(self.driver_name, os, arch_folder, driver_version)
+        compose_driver_path_in_cache(
+            self.get_cache_path(),
+            self.driver_name,
+            os,
+            arch_folder,
+            driver_version,
+        )
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -132,7 +132,7 @@ impl SeleniumManager for FirefoxManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path()?);
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -161,7 +161,7 @@ impl SeleniumManager for FirefoxManager {
                         &driver_version,
                         driver_ttl,
                     ));
-                    write_metadata(&metadata, self.get_logger(), self.get_cache_path());
+                    write_metadata(&metadata, self.get_logger(), self.get_cache_path()?);
                 }
 
                 Ok(driver_version)
@@ -211,7 +211,7 @@ impl SeleniumManager for FirefoxManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
         let driver_version = self.get_driver_version();
         let os = self.get_os();
         let arch = self.get_arch();
@@ -241,13 +241,13 @@ impl SeleniumManager for FirefoxManager {
         } else {
             "linux64"
         };
-        compose_driver_path_in_cache(
-            self.get_cache_path(),
+        Ok(compose_driver_path_in_cache(
+            self.get_cache_path()?,
             self.driver_name,
             os,
             arch_folder,
             driver_version,
-        )
+        ))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -97,7 +97,7 @@ impl SeleniumManager for GridManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path()?);
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -156,7 +156,7 @@ impl SeleniumManager for GridManager {
                             &driver_version,
                             driver_ttl,
                         ));
-                        write_metadata(&metadata, self.get_logger(), self.get_cache_path());
+                        write_metadata(&metadata, self.get_logger(), self.get_cache_path()?);
                     }
 
                     Ok(driver_version)
@@ -187,14 +187,15 @@ impl SeleniumManager for GridManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
         let browser_name = self.get_browser_name();
         let driver_name = self.get_driver_name();
         let driver_version = self.get_driver_version();
-        self.get_cache_path()
+        Ok(self
+            .get_cache_path()?
             .join(browser_name)
             .join(driver_version)
-            .join(format!("{driver_name}-{driver_version}.{GRID_EXTENSION}"))
+            .join(format!("{driver_name}-{driver_version}.{GRID_EXTENSION}")))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
 
-use crate::files::{get_cache_folder, BrowserPath};
+use crate::files::BrowserPath;
 
 use crate::downloads::parse_json_from_url;
 use crate::{
@@ -97,7 +97,7 @@ impl SeleniumManager for GridManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -156,7 +156,7 @@ impl SeleniumManager for GridManager {
                             &driver_version,
                             driver_ttl,
                         ));
-                        write_metadata(&metadata, self.get_logger());
+                        write_metadata(&metadata, self.get_logger(), self.get_cache_path());
                     }
 
                     Ok(driver_version)
@@ -191,7 +191,7 @@ impl SeleniumManager for GridManager {
         let browser_name = self.get_browser_name();
         let driver_name = self.get_driver_name();
         let driver_version = self.get_driver_version();
-        get_cache_folder()
+        self.get_cache_path()
             .join(browser_name)
             .join(driver_version)
             .join(format!("{driver_name}-{driver_version}.{GRID_EXTENSION}"))

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -109,7 +109,7 @@ impl SeleniumManager for IExplorerManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path()?);
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -164,7 +164,7 @@ impl SeleniumManager for IExplorerManager {
                             &driver_version,
                             driver_ttl,
                         ));
-                        write_metadata(&metadata, self.get_logger(), self.get_cache_path());
+                        write_metadata(&metadata, self.get_logger(), self.get_cache_path()?);
                     }
 
                     Ok(driver_version)
@@ -194,20 +194,20 @@ impl SeleniumManager for IExplorerManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
         let driver_version = self.get_driver_version();
         let _minor_driver_version = self
             .get_minor_version(driver_version)
             .unwrap_or_default()
             .parse::<i32>()
             .unwrap_or_default();
-        compose_driver_path_in_cache(
-            self.get_cache_path(),
+        Ok(compose_driver_path_in_cache(
+            self.get_cache_path()?,
             self.driver_name,
             "Windows",
             "win32",
             driver_version,
-        )
+        ))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -109,7 +109,7 @@ impl SeleniumManager for IExplorerManager {
     fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
-        let mut metadata = get_metadata(self.get_logger());
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path());
 
         match get_driver_version_from_metadata(
             &metadata.drivers,
@@ -164,7 +164,7 @@ impl SeleniumManager for IExplorerManager {
                             &driver_version,
                             driver_ttl,
                         ));
-                        write_metadata(&metadata, self.get_logger());
+                        write_metadata(&metadata, self.get_logger(), self.get_cache_path());
                     }
 
                     Ok(driver_version)
@@ -201,7 +201,13 @@ impl SeleniumManager for IExplorerManager {
             .unwrap_or_default()
             .parse::<i32>()
             .unwrap_or_default();
-        compose_driver_path_in_cache(self.driver_name, "Windows", "win32", driver_version)
+        compose_driver_path_in_cache(
+            self.get_cache_path(),
+            self.driver_name,
+            "Windows",
+            "win32",
+            driver_version,
+        )
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -23,6 +23,7 @@ use exitcode::DATAERR;
 use exitcode::OK;
 use exitcode::UNAVAILABLE;
 use selenium_manager::config::{BooleanKey, StringKey, CACHE_PATH_KEY};
+use selenium_manager::files::{default_cache_folder, path_buf_to_string};
 use selenium_manager::grid::GridManager;
 use selenium_manager::logger::{Logger, BROWSER_PATH, DRIVER_PATH};
 use selenium_manager::REQUEST_TIMEOUT_SEC;
@@ -128,8 +129,13 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
-    let cache_path =
-        StringKey(vec![CACHE_PATH_KEY], &cli.cache_path.unwrap_or_default()).get_value();
+
+    let default_cache_path = path_buf_to_string(default_cache_folder());
+    let cache_path = StringKey(
+        vec![CACHE_PATH_KEY],
+        &cli.cache_path.unwrap_or(default_cache_path),
+    )
+    .get_value();
     let debug = cli.debug || BooleanKey("debug", false).get_value();
     let trace = cli.trace || BooleanKey("trace", false).get_value();
     let log = Logger::create(&cli.output, debug, trace);
@@ -170,16 +176,10 @@ fn main() {
     selenium_manager.set_cache_path(cache_path.clone());
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
-        clear_cache(
-            selenium_manager.get_logger(),
-            selenium_manager.get_cache_path(),
-        );
+        clear_cache(selenium_manager.get_logger(), &cache_path);
     }
     if cli.clear_metadata || BooleanKey("clear-metadata", false).get_value() {
-        clear_metadata(
-            selenium_manager.get_logger(),
-            selenium_manager.get_cache_path(),
-        );
+        clear_metadata(selenium_manager.get_logger(), &cache_path);
     }
 
     selenium_manager

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 use exitcode::DATAERR;
 use exitcode::OK;
 use exitcode::UNAVAILABLE;
-use selenium_manager::config::BooleanKey;
+use selenium_manager::config::{BooleanKey, StringKey, CACHE_PATH_KEY};
 use selenium_manager::grid::GridManager;
 use selenium_manager::logger::{Logger, BROWSER_PATH, DRIVER_PATH};
 use selenium_manager::REQUEST_TIMEOUT_SEC;
@@ -96,6 +96,11 @@ struct Cli {
     #[clap(long, value_parser, default_value_t = TTL_BROWSERS_SEC)]
     browser_ttl: u64,
 
+    /// Local folder used to store downloaded assets (drivers and browsers), local metadata,
+    /// and configuration file [default: ~/.cache/selenium]
+    #[clap(long, value_parser)]
+    cache_path: Option<String>,
+
     /// Clear cache folder (~/.cache/selenium)
     #[clap(long)]
     clear_cache: bool,
@@ -123,19 +128,12 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
+    let cache_path =
+        StringKey(vec![CACHE_PATH_KEY], &cli.cache_path.unwrap_or_default()).get_value();
     let debug = cli.debug || BooleanKey("debug", false).get_value();
     let trace = cli.trace || BooleanKey("trace", false).get_value();
     let log = Logger::create(&cli.output, debug, trace);
     let grid = cli.grid;
-
-    if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
-        clear_cache(&log);
-    }
-
-    if cli.clear_metadata || BooleanKey("clear-metadata", false).get_value() {
-        clear_metadata(&log);
-    }
-
     let browser_name: String = cli.browser.unwrap_or_default();
     let driver_name: String = cli.driver.unwrap_or_default();
 
@@ -169,6 +167,20 @@ fn main() {
     selenium_manager.set_browser_ttl(cli.browser_ttl);
     selenium_manager.set_offline(cli.offline);
     selenium_manager.set_force_browser_download(cli.force_browser_download);
+    selenium_manager.set_cache_path(cache_path.clone());
+
+    if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
+        clear_cache(
+            selenium_manager.get_logger(),
+            selenium_manager.get_cache_path(),
+        );
+    }
+    if cli.clear_metadata || BooleanKey("clear-metadata", false).get_value() {
+        clear_metadata(
+            selenium_manager.get_logger(),
+            selenium_manager.get_cache_path(),
+        );
+    }
 
     selenium_manager
         .set_timeout(cli.timeout)

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -18,7 +18,7 @@
 use std::fs;
 use std::fs::File;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -163,7 +163,8 @@ pub fn write_metadata(metadata: &Metadata, log: &Logger, cache_path: PathBuf) {
     .unwrap();
 }
 
-pub fn clear_metadata(log: &Logger, cache_path: PathBuf) {
+pub fn clear_metadata(log: &Logger, path: &str) {
+    let cache_path = Path::new(path).to_path_buf();
     let metadata_path = get_metadata_path(cache_path);
     log.debug(format!(
         "Deleting metadata file {}",

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -23,7 +23,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use crate::files::get_cache_folder;
 use crate::Logger;
 
 const METADATA_FILE: &str = "selenium-manager.json";
@@ -50,8 +49,8 @@ pub struct Metadata {
     pub drivers: Vec<Driver>,
 }
 
-fn get_metadata_path() -> PathBuf {
-    get_cache_folder().join(METADATA_FILE)
+fn get_metadata_path(cache_path: PathBuf) -> PathBuf {
+    cache_path.join(METADATA_FILE)
 }
 
 pub fn now_unix_timestamp() -> u64 {
@@ -69,8 +68,8 @@ fn new_metadata(log: &Logger) -> Metadata {
     }
 }
 
-pub fn get_metadata(log: &Logger) -> Metadata {
-    let metadata_path = get_metadata_path();
+pub fn get_metadata(log: &Logger, cache_path: PathBuf) -> Metadata {
+    let metadata_path = get_metadata_path(cache_path);
     log.trace(format!("Reading metadata from {}", metadata_path.display()));
 
     if metadata_path.exists() {
@@ -154,8 +153,8 @@ pub fn create_driver_metadata(
     }
 }
 
-pub fn write_metadata(metadata: &Metadata, log: &Logger) {
-    let metadata_path = get_metadata_path();
+pub fn write_metadata(metadata: &Metadata, log: &Logger, cache_path: PathBuf) {
+    let metadata_path = get_metadata_path(cache_path);
     log.trace(format!("Writing metadata to {}", metadata_path.display()));
     fs::write(
         metadata_path,
@@ -164,8 +163,8 @@ pub fn write_metadata(metadata: &Metadata, log: &Logger) {
     .unwrap();
 }
 
-pub fn clear_metadata(log: &Logger) {
-    let metadata_path = get_metadata_path();
+pub fn clear_metadata(log: &Logger, cache_path: PathBuf) {
+    let metadata_path = get_metadata_path(cache_path);
     log.debug(format!(
         "Deleting metadata file {}",
         metadata_path.display()

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -94,8 +94,8 @@ impl SeleniumManager for SafariManager {
         Err(format!("{} not available for download", self.get_driver_name()).into())
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
-        PathBuf::from("/usr/bin/safaridriver")
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+        Ok(PathBuf::from("/usr/bin/safaridriver"))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -100,8 +100,10 @@ impl SeleniumManager for SafariTPManager {
         Err(format!("{} not available for download", self.get_driver_name()).into())
     }
 
-    fn get_driver_path_in_cache(&self) -> PathBuf {
-        PathBuf::from("/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver")
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+        Ok(PathBuf::from(
+            "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver",
+        ))
     }
 
     fn get_config(&self) -> &ManagerConfig {

--- a/rust/tests/cache_tests.rs
+++ b/rust/tests/cache_tests.rs
@@ -40,7 +40,7 @@ fn cache_path_test() {
 
     let driver_path = get_driver_path(&mut cmd);
     println!("*** Custom cache path: {}", driver_path);
-    assert!(!driver_path.contains("cache"));
+    assert!(!driver_path.contains(r#"cache\selenium"#));
 
     let tmp_cache_path = Path::new(tmp_cache_folder_name);
     fs::remove_dir_all(&tmp_cache_path).unwrap();

--- a/rust/tests/cache_tests.rs
+++ b/rust/tests/cache_tests.rs
@@ -1,0 +1,48 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::common::get_driver_path;
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+mod common;
+
+#[test]
+fn cache_path_test() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    let tmp_cache_folder_name = "../tmp";
+    cmd.args([
+        "--browser",
+        "chrome",
+        "--cache-path",
+        tmp_cache_folder_name,
+        "--output",
+        "json",
+    ])
+    .assert()
+    .success()
+    .code(0);
+
+    let driver_path = get_driver_path(&mut cmd);
+    println!("*** Custom cache path: {}", driver_path);
+    assert!(!driver_path.contains("cache"));
+
+    let tmp_cache_path = Path::new(tmp_cache_folder_name);
+    fs::remove_dir_all(&tmp_cache_path).unwrap();
+    assert!(!tmp_cache_path.exists());
+}

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -16,14 +16,17 @@
 // under the License.
 
 use assert_cmd::Command;
+use std::borrow::BorrowMut;
 use std::env::consts::OS;
 use std::path::Path;
 
 use is_executable::is_executable;
+use selenium_manager::files::path_buf_to_string;
 use selenium_manager::logger::JsonOutput;
 use selenium_manager::shell;
 use selenium_manager::shell::run_shell_command_by_os;
 
+#[allow(dead_code)]
 pub fn assert_driver(cmd: &mut Command) {
     let stdout = &cmd.unwrap().stdout;
     let output = std::str::from_utf8(stdout).unwrap();
@@ -35,6 +38,7 @@ pub fn assert_driver(cmd: &mut Command) {
     assert!(is_executable(driver_path));
 }
 
+#[allow(dead_code)]
 pub fn assert_browser(cmd: &mut Command) {
     let stdout = &cmd.unwrap().stdout;
     let output = std::str::from_utf8(stdout).unwrap();
@@ -45,14 +49,18 @@ pub fn assert_browser(cmd: &mut Command) {
 }
 
 #[allow(dead_code)]
-pub fn exec_driver(cmd: &mut Command) -> String {
+pub fn get_driver_path(cmd: &mut Command) -> String {
     let stdout = &cmd.unwrap().stdout;
     let output = std::str::from_utf8(stdout).unwrap();
     let json: JsonOutput = serde_json::from_str(output).unwrap();
-    let driver_path = Path::new(&json.result.driver_path);
+    path_buf_to_string(Path::new(&json.result.driver_path).to_path_buf())
+}
 
-    let driver_version_command =
-        shell::Command::new_single(format!("{} --version", driver_path.to_str().unwrap()));
+#[allow(dead_code)]
+pub fn exec_driver(cmd: &mut Command) -> String {
+    let mut cmd_mut = cmd.borrow_mut();
+    let driver_path = get_driver_path(&mut cmd_mut);
+    let driver_version_command = shell::Command::new_single(format!("{} --version", &driver_path));
     let output = run_shell_command_by_os(OS, driver_version_command).unwrap();
     println!("**** EXEC DRIVER: {}", output);
     output


### PR DESCRIPTION
### Description
This PR allows to change the default cache folder for Selenium Manager. For instance:

```
> selenium-manager --browser chrome --debug --cache-path C:\Users\boni\Downloads\se

DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=115.0.5790.111\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 115.0.5790.111
DEBUG   Reading metadata from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required driver: chromedriver 115.0.5790.170
DEBUG   Driver URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/win64/chromedriver-win64.zip
INFO    Driver path: C:\Users\boni\Downloads\se\chromedriver\win64\115.0.5790.170\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

As usual, the new CLI flag (`--cache-path`) can be overridden using the configuration file (key `cache-path`) or using an environment variable (`SE_CACHE_PATH`).

### Motivation and Context
This PR implements #11688.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
