### PR TITLE
[py+ci] Get closer to getting all the python tests running on EngFlow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -114,6 +114,8 @@ build:remote --incompatible_enable_cc_toolchain_resolution
 build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 test:remote --test_env=DISPLAY=:99.0
 test:remote --test_tag_filters=-edge,-safari,-remote
+# Skip tests that we mark specifically as being unable to run on the rbe
+test:remote --test_tag_filters=-skip-remote
 
 # Env vars we can hard code
 build:remote --action_env=HOME=/home/dev

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -14,6 +14,9 @@ compile_pip_requirements(
     name = "requirements",
     requirements_in = ":requirements.txt",
     requirements_txt = ":requirements_lock.txt",
+    tags = [
+        "skip-remote",
+    ],
 )
 
 SE_VERSION = "4.11.2"
@@ -352,10 +355,13 @@ py_test_suite(
     args = [
         "--instafail",
         "--driver=chrome",
-    ],
+    ] + BROWSERS["chrome"]["args"],
+    data = BROWSERS["chrome"]["data"],
+    env_inherit = ["DISPLAY"],
     tags = [
         "no-sandbox",
-    ],
+        "skip-remote",
+    ] + BROWSERS["chrome"]["tags"],
     deps = [
         ":init-tree",
         ":selenium",
@@ -380,6 +386,7 @@ py_test_suite(
     ],
     tags = [
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -402,6 +409,7 @@ py_test_suite(
     ],
     tags = [
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -422,10 +430,13 @@ py_test_suite(
     args = [
         "--instafail",
         "--driver=firefox",
-    ],
+    ] + BROWSERS["firefox"]["args"],
+    data = BROWSERS["firefox"]["data"],
+    env_inherit = ["DISPLAY"],
     tags = [
         "no-sandbox",
-    ],
+        "skip-remote",
+    ] + BROWSERS["firefox"]["tags"],
     deps = [
         ":init-tree",
         ":selenium",
@@ -449,6 +460,7 @@ py_test_suite(
     ],
     tags = [
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -471,6 +483,7 @@ py_test_suite(
     ],
     tags = [
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -494,6 +507,7 @@ py_test_suite(
     tags = [
         "exclusive-if-local",
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -518,6 +532,7 @@ py_test_suite(
     tags = [
         "exclusive-if-local",
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",
@@ -542,6 +557,7 @@ py_test_suite(
     tags = [
         "exclusive-if-local",
         "no-sandbox",
+        "skip-remote",
     ],
     deps = [
         ":init-tree",

--- a/py/private/browsers.bzl
+++ b/py/private/browsers.bzl
@@ -65,7 +65,7 @@ BROWSERS = {
     "edge": {
         "args": ["--driver=edge"] + edge_args,
         "data": edge_data,
-        "tags": COMMON_TAGS + ["edge"],
+        "tags": COMMON_TAGS + ["edge", "skip-remote"],
     },
     "firefox": {
         "args": ["--driver=firefox"] + firefox_args,
@@ -75,11 +75,11 @@ BROWSERS = {
     "ie": {
         "args": ["--driver=ie"],
         "data": [],
-        "tags": COMMON_TAGS + ["ie"],
+        "tags": COMMON_TAGS + ["ie", "skip-remote"],
     },
     "safari": {
         "args": ["--driver=safari"],
         "data": [],
-        "tags": COMMON_TAGS + ["safari"],
+        "tags": COMMON_TAGS + ["safari", "skip-remote"],
     },
 }


### PR DESCRIPTION
See what happens when we set the tags and data for each of the chrome and firefox tests. Should be a no-op for the existing test runs.