### PR TITLE
[rust] Unify browser_ttl and driver_ttl in a single config key

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -43,10 +43,8 @@ Options:
           HTTP proxy for network connection (e.g., https://myproxy.net:8080)
       --timeout <TIMEOUT>
           Timeout for network requests (in seconds) [default: 300]
-      --driver-ttl <DRIVER_TTL>
-          Driver TTL (time-to-live) [default: 3600]
-      --browser-ttl <BROWSER_TTL>
-          Browser TTL (time-to-live) [default: 3600]
+      --ttl <TTL>
+          TTL (time-to-live) for discovered versions (online) of drivers and browsers [default: 3600]
       --cache-path <CACHE_PATH>
           Local folder used to store downloaded assets (drivers and browsers), local metadata, and configuration file [default: ~/.cache/selenium]
       --clear-cache

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -436,7 +436,7 @@ impl SeleniumManager for ChromeManager {
                         self.request_good_driver_version_from_cft()?
                     };
 
-                let driver_ttl = self.get_driver_ttl();
+                let driver_ttl = self.get_ttl();
                 if driver_ttl > 0 && !major_browser_version.is_empty() && !driver_version.is_empty()
                 {
                     metadata.drivers.push(create_driver_metadata(
@@ -476,7 +476,7 @@ impl SeleniumManager for ChromeManager {
                 // If not in metadata, discover version using Chrome for Testing (CfT) endpoints
                 browser_version = self.request_latest_browser_version_from_cft()?;
 
-                let browser_ttl = self.get_browser_ttl();
+                let browser_ttl = self.get_ttl();
                 if browser_ttl > 0 {
                     metadata.browsers.push(create_browser_metadata(
                         browser_name,
@@ -611,7 +611,7 @@ impl SeleniumManager for ChromeManager {
                 }
                 self.set_browser_version(browser_version.clone());
 
-                let browser_ttl = self.get_browser_ttl();
+                let browser_ttl = self.get_ttl();
                 if browser_ttl > 0
                     && !self.is_browser_version_empty()
                     && !self.is_browser_version_stable()

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -21,7 +21,7 @@ use crate::{
     default_cache_folder, format_one_arg, path_buf_to_string, Command, REQUEST_TIMEOUT_SEC,
     UNAME_COMMAND,
 };
-use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, TTL_BROWSERS_SEC, TTL_DRIVERS_SEC, WMIC_COMMAND_OS};
+use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, TTL_SEC, WMIC_COMMAND_OS};
 use std::cell::RefCell;
 use std::env;
 use std::env::consts::OS;
@@ -47,8 +47,7 @@ pub struct ManagerConfig {
     pub arch: String,
     pub proxy: String,
     pub timeout: u64,
-    pub browser_ttl: u64,
-    pub driver_ttl: u64,
+    pub ttl: u64,
     pub offline: bool,
     pub force_browser_download: bool,
 }
@@ -97,8 +96,7 @@ impl ManagerConfig {
             arch: StringKey(vec!["arch"], self_arch.as_str()).get_value(),
             proxy: StringKey(vec!["proxy"], "").get_value(),
             timeout: IntegerKey("timeout", REQUEST_TIMEOUT_SEC).get_value(),
-            browser_ttl: IntegerKey("browser-ttl", TTL_BROWSERS_SEC).get_value(),
-            driver_ttl: IntegerKey("driver-ttl", TTL_DRIVERS_SEC).get_value(),
+            ttl: IntegerKey("ttl", TTL_SEC).get_value(),
             offline: BooleanKey("offline", false).get_value(),
             force_browser_download: BooleanKey("force-browser-download", false).get_value(),
         }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -183,7 +183,7 @@ impl SeleniumManager for EdgeManager {
                 let driver_version =
                     read_version_from_link(self.get_http_client(), driver_url, self.get_logger())?;
 
-                let driver_ttl = self.get_driver_ttl();
+                let driver_ttl = self.get_ttl();
                 if driver_ttl > 0 && !major_browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(
                         major_browser_version.as_str(),

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -153,7 +153,7 @@ impl SeleniumManager for FirefoxManager {
                 let driver_version =
                     read_redirect_from_link(self.get_http_client(), latest_url, self.get_logger())?;
 
-                let driver_ttl = self.get_driver_ttl();
+                let driver_ttl = self.get_ttl();
                 if driver_ttl > 0 && !major_browser_version.is_empty() {
                     metadata.drivers.push(create_driver_metadata(
                         major_browser_version,

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -148,7 +148,7 @@ impl SeleniumManager for GridManager {
                         self.get_logger(),
                     )?;
 
-                    let driver_ttl = self.get_driver_ttl();
+                    let driver_ttl = self.get_ttl();
                     if driver_ttl > 0 {
                         metadata.drivers.push(create_driver_metadata(
                             major_browser_version,

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -156,7 +156,7 @@ impl SeleniumManager for IExplorerManager {
                         self.get_logger(),
                     )?;
 
-                    let driver_ttl = self.get_driver_ttl();
+                    let driver_ttl = self.get_ttl();
                     if driver_ttl > 0 {
                         metadata.drivers.push(create_driver_metadata(
                             major_browser_version,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -86,8 +86,7 @@ pub const ARCH_ARM64: &str = "arm64";
 pub const ENV_PROCESSOR_ARCHITECTURE: &str = "PROCESSOR_ARCHITECTURE";
 pub const WHERE_COMMAND: &str = "where {}";
 pub const WHICH_COMMAND: &str = "which {}";
-pub const TTL_BROWSERS_SEC: u64 = 3600;
-pub const TTL_DRIVERS_SEC: u64 = 3600;
+pub const TTL_SEC: u64 = 3600;
 pub const UNAME_COMMAND: &str = "uname -{}";
 pub const ESCAPE_COMMAND: &str = "printf %q \"{}\"";
 pub const SNAPSHOT: &str = "SNAPSHOT";
@@ -822,20 +821,12 @@ pub trait SeleniumManager {
         Ok(())
     }
 
-    fn get_driver_ttl(&self) -> u64 {
-        self.get_config().driver_ttl
+    fn get_ttl(&self) -> u64 {
+        self.get_config().ttl
     }
 
-    fn set_driver_ttl(&mut self, driver_ttl: u64) {
-        self.get_config_mut().driver_ttl = driver_ttl;
-    }
-
-    fn get_browser_ttl(&self) -> u64 {
-        self.get_config().browser_ttl
-    }
-
-    fn set_browser_ttl(&mut self, browser_ttl: u64) {
-        self.get_config_mut().browser_ttl = browser_ttl;
+    fn set_ttl(&mut self, ttl: u64) {
+        self.get_config_mut().ttl = ttl;
     }
 
     fn is_offline(&self) -> bool {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -26,8 +26,7 @@ use selenium_manager::config::{BooleanKey, StringKey, CACHE_PATH_KEY};
 use selenium_manager::grid::GridManager;
 use selenium_manager::logger::{Logger, BROWSER_PATH, DRIVER_PATH};
 use selenium_manager::REQUEST_TIMEOUT_SEC;
-use selenium_manager::TTL_BROWSERS_SEC;
-use selenium_manager::TTL_DRIVERS_SEC;
+use selenium_manager::TTL_SEC;
 use selenium_manager::{
     clear_cache, get_manager_by_browser, get_manager_by_driver, SeleniumManager,
 };
@@ -88,13 +87,9 @@ struct Cli {
     #[clap(long, value_parser, default_value_t = REQUEST_TIMEOUT_SEC)]
     timeout: u64,
 
-    /// Driver TTL (time-to-live)
-    #[clap(long, value_parser, default_value_t = TTL_DRIVERS_SEC)]
-    driver_ttl: u64,
-
-    /// Browser TTL (time-to-live)
-    #[clap(long, value_parser, default_value_t = TTL_BROWSERS_SEC)]
-    browser_ttl: u64,
+    /// TTL (time-to-live) for discovered versions (online) of drivers and browsers
+    #[clap(long, value_parser, default_value_t = TTL_SEC)]
+    ttl: u64,
 
     /// Local folder used to store downloaded assets (drivers and browsers), local metadata,
     /// and configuration file [default: ~/.cache/selenium]
@@ -164,8 +159,7 @@ fn main() {
     selenium_manager.set_browser_path(cli.browser_path.unwrap_or_default());
     selenium_manager.set_os(cli.os.unwrap_or_default());
     selenium_manager.set_arch(cli.arch.unwrap_or_default());
-    selenium_manager.set_driver_ttl(cli.driver_ttl);
-    selenium_manager.set_browser_ttl(cli.browser_ttl);
+    selenium_manager.set_ttl(cli.ttl);
     selenium_manager.set_offline(cli.offline);
     selenium_manager.set_force_browser_download(cli.force_browser_download);
     selenium_manager.set_cache_path(cache_path.clone());


### PR DESCRIPTION
### Description
This PR unifies the two existing configuration keys in SM related to time-to-live (i.e., `driver-ttl` and `browser-ttl`) in a single one called `ttl`.

### Motivation and Context
As of PR [#12353](https://github.com/SeleniumHQ/selenium/pull/12353), `browser-ttl` refers to the browser version discovered by making network requests to CfT, not by finding browser versions by doing shell commands. As of this change, that value is 3600 seconds (1 hour).

As of PR [#12394](https://github.com/SeleniumHQ/selenium/pull/12394), `driver-ttl` is 1 hour (and not 1 day, as previously) since we detected that the rate change of chromedriver is quicker than it used to be.

All in all, `browser-ttl` and `driver-ttl` now refer to the same concept (i.e., the discovered versions using network requests, and their value is the same. Therefore, I propose to unify both configuration keys in a single one.

The context of this PR is the [documentation](https://github.com/SeleniumHQ/selenium/issues/11695), to simplify a bit the explanation of the concept of TTL on the Selenium Manager page.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
