### PR TITLE
[rust] Rename metadata file to selenium-manager-metadata.json

### DIFF
--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -25,7 +25,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::Logger;
 
-const METADATA_FILE: &str = "selenium-manager.json";
+const METADATA_FILE_OLD: &str = "selenium-manager.json";
+const METADATA_FILE: &str = "selenium-manager-metadata.json";
 
 #[derive(Serialize, Deserialize)]
 pub struct Browser {
@@ -50,6 +51,10 @@ pub struct Metadata {
 }
 
 fn get_metadata_path(cache_path: PathBuf) -> PathBuf {
+    let old_metadata = cache_path.join(METADATA_FILE_OLD);
+    if old_metadata.exists() {
+        fs::remove_file(old_metadata).unwrap_or_default();
+    }
     cache_path.join(METADATA_FILE)
 }
 

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use crate::Logger;
 
 const METADATA_FILE_OLD: &str = "selenium-manager.json";
-const METADATA_FILE: &str = "selenium-manager-metadata.json";
+const METADATA_FILE: &str = "se-metadata.json";
 
 #[derive(Serialize, Deserialize)]
 pub struct Browser {


### PR DESCRIPTION
### Description
This PR changes the metadata file handled by SM from `selenium-manager.json` to `selenium-manager-metadata.json`.

### Motivation and Context
In addition to the metadata file, the SM cache (`~/.cache/selenium`) can store another file, named `selenium-manager-config.toml`. When having these two files, the current metadata file name (`selenium-manager.json`) is not very expressive. Thus, I think `selenium-manager-metadata.json` is a bit better.

The context of this PR is the [documentation](https://github.com/SeleniumHQ/selenium/issues/11695).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
