### PR TITLE
[JS] [atoms] add get-element-from-cache as a fragment

### DIFF
--- a/javascript/atoms/fragments/BUILD.bazel
+++ b/javascript/atoms/fragments/BUILD.bazel
@@ -79,6 +79,16 @@ closure_fragment(
 )
 
 closure_fragment(
+    name = "get-element-from-cache",
+    function = "bot.inject.cache.getElement",
+    module = "bot.inject",
+    visibility = [],
+    deps = [
+        "//javascript/atoms:inject",
+    ],
+)
+
+closure_fragment(
     name = "get-location",
     function = "bot.geolocation.getCurrentPosition",
     module = "bot.geolocation",


### PR DESCRIPTION
While potentially considered an implementation detail this was an essential fragment for Appium. Can we pretty please have it back?