### PR TITLE
[py] fixed safari tests

### DIFF
--- a/py/test/selenium/webdriver/common/select_class_tests.py
+++ b/py/test/selenium/webdriver/common/select_class_tests.py
@@ -48,7 +48,7 @@ def test_select_by_index_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_index_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -65,7 +65,7 @@ def test_select_by_value_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_value_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -84,7 +84,7 @@ def test_select_by_visible_text_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_text_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -106,7 +106,7 @@ def test_select_by_index_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_index_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 
@@ -129,7 +129,7 @@ def test_select_by_value_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_value_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 
@@ -152,7 +152,7 @@ def test_select_by_visible_text_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
-@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
+@pytest.mark.xfail_safari(reason="options incorrectly reported as enabled")
 def test_raises_exception_select_by_text_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 

--- a/py/test/selenium/webdriver/common/select_class_tests.py
+++ b/py/test/selenium/webdriver/common/select_class_tests.py
@@ -48,6 +48,7 @@ def test_select_by_index_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_index_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -64,6 +65,7 @@ def test_select_by_value_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_value_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -82,6 +84,7 @@ def test_select_by_visible_text_single(driver, pages):
             assert sel.first_selected_option.text == select["values"][x]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_text_single_disabled(driver, pages):
     pages.load("formPage.html")
     sel = Select(driver.find_element(By.NAME, disabledSingleSelect["name"]))
@@ -103,6 +106,7 @@ def test_select_by_index_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_index_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 
@@ -125,6 +129,7 @@ def test_select_by_value_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_value_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 
@@ -147,6 +152,7 @@ def test_select_by_visible_text_multiple(driver, pages):
                 assert selected[j].text == select["values"][j]
 
 
+@pytest.mark.xfail_safari(reason="Unlike chrome, safari does not raise NotImplemented error")
 def test_raises_exception_select_by_text_multiple_disabled(driver, pages):
     pages.load("formPage.html")
 

--- a/py/test/selenium/webdriver/safari/launcher_tests.py
+++ b/py/test/selenium/webdriver/safari/launcher_tests.py
@@ -19,6 +19,9 @@ import os
 
 import pytest
 
+from selenium.common.exceptions import NoSuchDriverException
+from selenium.webdriver.safari.service import Service
+
 
 def test_launch(driver):
     assert driver.capabilities["browserName"] == "Safari"
@@ -27,9 +30,9 @@ def test_launch(driver):
 def test_launch_with_invalid_executable_path_raises_exception(driver_class):
     path = "/this/path/should/never/exist"
     assert not os.path.exists(path)
-    with pytest.raises(Exception) as e:
-        driver_class(executable_path=path)
-    assert "are you running Safari 10 or later?" in str(e)
+    service = Service(executable_path=path)
+    with pytest.raises(NoSuchDriverException):
+        driver_class(service=service)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixed Select class and Launcher tests for Safari.

### Motivation and Context
- Chrome raises `NotImplementedError` while trying to select item from a list box which is disabled. But Safari doesn't. I have marked all those tests as `xfail_safari`.
- Fixed Safari launcher test by passing `service` object to `WebDriver`
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
