### PR TITLE
[dotnet] options do not belong in the service class

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeDriver.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriver.cs
@@ -83,7 +83,7 @@ namespace OpenQA.Selenium.Chrome
         /// </summary>
         /// <param name="options">The <see cref="ChromeOptions"/> to be used with the Chrome driver.</param>
         public ChromeDriver(ChromeOptions options)
-            : this(ChromeDriverService.CreateDefaultService(options), options, RemoteWebDriver.DefaultCommandTimeout)
+            : this(ChromeDriverService.CreateDefaultService(), options, RemoteWebDriver.DefaultCommandTimeout)
         {
         }
 

--- a/dotnet/src/webdriver/Chrome/ChromeDriverService.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriverService.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.IO;
 using OpenQA.Selenium.Chromium;
 using OpenQA.Selenium.Internal;
@@ -46,7 +47,7 @@ namespace OpenQA.Selenium.Chrome
         /// <returns>A ChromeDriverService that implements default settings.</returns>
         public static ChromeDriverService CreateDefaultService()
         {
-            return CreateDefaultService(new ChromeOptions());
+            return new ChromeDriverService(null, null, PortUtilities.FindFreePort());
         }
 
         /// <summary>
@@ -54,6 +55,7 @@ namespace OpenQA.Selenium.Chrome
         /// </summary>
         /// /// <param name="options">Browser options used to find the correct ChromeDriver binary.</param>
         /// <returns>A ChromeDriverService that implements default settings.</returns>
+        [Obsolete("CreateDefaultService() now evaluates options in Driver constructor")]
         public static ChromeDriverService CreateDefaultService(ChromeOptions options)
         {
             string fullServicePath = DriverFinder.FullPath(options);

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using OpenQA.Selenium.DevTools;
 using OpenQA.Selenium.Remote;
 
@@ -125,9 +126,26 @@ namespace OpenQA.Selenium.Chromium
         /// <param name="options">The <see cref="ChromiumOptions"/> to be used with the ChromiumDriver.</param>
         /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
         protected ChromiumDriver(ChromiumDriverService service, ChromiumOptions options, TimeSpan commandTimeout)
-            : base(new DriverServiceCommandExecutor(service, commandTimeout), ConvertOptionsToCapabilities(options))
+            : base(GenerateDriverServiceCommandExecutor(service, options, commandTimeout), ConvertOptionsToCapabilities(options))
         {
             this.optionsCapabilityName = options.CapabilityName;
+        }
+
+        /// <summary>
+        /// Uses DriverFinder to set Service attributes if necessary when creating the command executor
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="commandTimeout"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        private static ICommandExecutor GenerateDriverServiceCommandExecutor(DriverService service, DriverOptions options, TimeSpan commandTimeout)
+        {
+            if (service.DriverServicePath == null) {
+                string fullServicePath = DriverFinder.FullPath(options);
+                service.DriverServicePath = Path.GetDirectoryName(fullServicePath);
+                service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
+            }
+            return new DriverServiceCommandExecutor(service, commandTimeout);
         }
 
         protected static IReadOnlyDictionary<string, CommandInfo> ChromiumCustomCommands

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -23,7 +23,6 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using OpenQA.Selenium.Internal;
 using OpenQA.Selenium.Remote;
 
 namespace OpenQA.Selenium

--- a/dotnet/src/webdriver/Edge/EdgeDriver.cs
+++ b/dotnet/src/webdriver/Edge/EdgeDriver.cs
@@ -53,7 +53,7 @@ namespace OpenQA.Selenium.Edge
         /// </summary>
         /// <param name="options">The <see cref="EdgeOptions"/> to be used with the Edge driver.</param>
         public EdgeDriver(EdgeOptions options)
-            : this(EdgeDriverService.CreateDefaultService(options), options)
+            : this(EdgeDriverService.CreateDefaultService(), options)
         {
         }
 

--- a/dotnet/src/webdriver/Edge/EdgeDriverService.cs
+++ b/dotnet/src/webdriver/Edge/EdgeDriverService.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.IO;
 using OpenQA.Selenium.Chromium;
 using OpenQA.Selenium.Internal;
@@ -55,7 +56,7 @@ namespace OpenQA.Selenium.Edge
         /// <returns>A EdgeDriverService that implements default settings.</returns>
         public static EdgeDriverService CreateDefaultService()
         {
-            return CreateDefaultService(new EdgeOptions());
+            return new EdgeDriverService(null, null, PortUtilities.FindFreePort());
         }
 
         /// <summary>
@@ -63,6 +64,7 @@ namespace OpenQA.Selenium.Edge
         /// </summary>
         /// <param name="options">Browser options used to find the correct MSEdgeDriver binary.</param>
         /// <returns>A EdgeDriverService that implements default settings.</returns>
+        [Obsolete("CreateDefaultService() now evaluates options in Driver constructor")]
         public static EdgeDriverService CreateDefaultService(EdgeOptions options)
         {
             string fullServicePath = DriverFinder.FullPath(options);

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -208,7 +208,7 @@ namespace OpenQA.Selenium.Firefox
         /// <returns>A FirefoxDriverService that implements default settings.</returns>
         public static FirefoxDriverService CreateDefaultService()
         {
-            return CreateDefaultService(new FirefoxOptions());
+            return new FirefoxDriverService(null, null, PortUtilities.FindFreePort());
         }
 
 
@@ -217,6 +217,7 @@ namespace OpenQA.Selenium.Firefox
         /// </summary>
         /// <param name="options">Browser options used to find the correct GeckoDriver binary.</param>
         /// <returns>A FirefoxDriverService that implements default settings.</returns>
+        [Obsolete("CreateDefaultService() now evaluates options in Driver constructor")]
         public static FirefoxDriverService CreateDefaultService(FirefoxOptions options)
         {
             string fullServicePath = DriverFinder.FullPath(options);

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -17,6 +17,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using OpenQA.Selenium.Remote;
 
 namespace OpenQA.Selenium.IE
@@ -75,7 +76,7 @@ namespace OpenQA.Selenium.IE
         /// </summary>
         /// <param name="options">The <see cref="InternetExplorerOptions"/> used to initialize the driver.</param>
         public InternetExplorerDriver(InternetExplorerOptions options)
-            : this(InternetExplorerDriverService.CreateDefaultService(options), options)
+            : this(InternetExplorerDriverService.CreateDefaultService(), options)
         {
         }
 
@@ -140,8 +141,25 @@ namespace OpenQA.Selenium.IE
         /// <param name="options">The <see cref="InternetExplorerOptions"/> used to initialize the driver.</param>
         /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
         public InternetExplorerDriver(InternetExplorerDriverService service, InternetExplorerOptions options, TimeSpan commandTimeout)
-            : base(new DriverServiceCommandExecutor(service, commandTimeout), ConvertOptionsToCapabilities(options))
+            : base(GenerateDriverServiceCommandExecutor(service, options, commandTimeout), ConvertOptionsToCapabilities(options))
         {
+        }
+
+        /// <summary>
+        /// Uses DriverFinder to set Service attributes if necessary when creating the command executor
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="commandTimeout"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        private static ICommandExecutor GenerateDriverServiceCommandExecutor(DriverService service, DriverOptions options, TimeSpan commandTimeout)
+        {
+            if (service.DriverServicePath == null) {
+                string fullServicePath = DriverFinder.FullPath(options);
+                service.DriverServicePath = Path.GetDirectoryName(fullServicePath);
+                service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
+            }
+            return new DriverServiceCommandExecutor(service, commandTimeout);
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -148,7 +149,7 @@ namespace OpenQA.Selenium.IE
         /// <returns>A InternetExplorerDriverService that implements default settings.</returns>
         public static InternetExplorerDriverService CreateDefaultService()
         {
-            return CreateDefaultService(new InternetExplorerOptions());
+            return new InternetExplorerDriverService(null, null, PortUtilities.FindFreePort());
         }
 
         /// <summary>
@@ -156,6 +157,7 @@ namespace OpenQA.Selenium.IE
         /// </summary>
         /// <param name="options">Browser options used to find the correct IEDriver binary.</param>
         /// <returns>A InternetExplorerDriverService that implements default settings.</returns>
+        [Obsolete("CreateDefaultService() now evaluates options in Driver constructor")]
         public static InternetExplorerDriverService CreateDefaultService(InternetExplorerOptions options)
         {
             string fullServicePath = DriverFinder.FullPath(options);

--- a/dotnet/src/webdriver/Safari/SafariDriverService.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriverService.cs
@@ -159,7 +159,7 @@ namespace OpenQA.Selenium.Safari
         /// <returns>A SafariDriverService that implements default settings.</returns>
         public static SafariDriverService CreateDefaultService()
         {
-            return CreateDefaultService(new SafariOptions());
+            return new SafariDriverService(null, null, PortUtilities.FindFreePort());
         }
 
         /// <summary>
@@ -167,6 +167,7 @@ namespace OpenQA.Selenium.Safari
         /// </summary>
         /// <param name="options">Browser options used to find the correct GeckoDriver binary.</param>
         /// <returns>A SafariDriverService that implements default settings.</returns>
+        [Obsolete("CreateDefaultService() now evaluates options in Driver constructor")]
         public static SafariDriverService CreateDefaultService(SafariOptions options)
         {
             string fullServicePath = DriverFinder.FullPath(options);

--- a/dotnet/test/common/CustomDriverConfigs/DefaultSafariDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/DefaultSafariDriver.cs
@@ -5,20 +5,15 @@ namespace OpenQA.Selenium.Safari
     // constructor.
     public class DefaultSafariDriver : SafariDriver
     {
-        public DefaultSafariDriver()
-            : base(DefaultOptions)
-        {
-        }
-
         // Required for dynamic setting with `EnvironmentManager.Instance.CreateDriverInstance(options)`
         public DefaultSafariDriver(SafariOptions options)
             : base(options)
         {
         }
 
-        public static SafariOptions DefaultOptions
+        public DefaultSafariDriver(SafariDriverService service, SafariOptions options)
+            : base(service, options)
         {
-            get { return new SafariOptions(); }
         }
     }
 }

--- a/dotnet/test/common/CustomDriverConfigs/DevChannelChromeDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/DevChannelChromeDriver.cs
@@ -13,6 +13,11 @@ namespace OpenQA.Selenium.Chrome
         {
         }
 
+        public DevChannelChromeDriver(ChromeDriverService service, ChromeOptions options)
+            : base(service, options)
+        {
+        }
+
         public static ChromeOptions DefaultOptions
         {
             get { return new ChromeOptions() { BrowserVersion = "dev" }; }

--- a/dotnet/test/common/CustomDriverConfigs/DevChannelEdgeDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/DevChannelEdgeDriver.cs
@@ -13,6 +13,11 @@ namespace OpenQA.Selenium.Edge
         {
         }
 
+        public DevChannelEdgeDriver(EdgeDriverService service, EdgeOptions options)
+            : base(service, options)
+        {
+        }
+
         public static EdgeOptions DefaultOptions
         {
             get { return new EdgeOptions() { BrowserVersion = "dev" }; }

--- a/dotnet/test/common/CustomDriverConfigs/EdgeInternetExplorerModeDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/EdgeInternetExplorerModeDriver.cs
@@ -16,6 +16,11 @@ namespace OpenQA.Selenium.IE
         {
         }
 
+        public EdgeInternetExplorerModeDriver(InternetExplorerDriverService service, InternetExplorerOptions options)
+            : base(service, options)
+        {
+        }
+
         public static InternetExplorerOptions DefaultOptions
         {
             get { return new InternetExplorerOptions() { RequireWindowFocus = true, UsePerProcessProxy = true, AttachToEdgeChrome = true }; }

--- a/dotnet/test/common/CustomDriverConfigs/NightlyChannelFirefoxDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/NightlyChannelFirefoxDriver.cs
@@ -16,6 +16,11 @@ namespace OpenQA.Selenium.Firefox
         {
         }
 
+        public NightlyChannelFirefoxDriver(FirefoxDriverService service, FirefoxOptions options)
+            : base(service, options)
+        {
+        }
+
         public static FirefoxOptions DefaultOptions
         {
             get { return new FirefoxOptions() { BrowserVersion = "nightly" }; }

--- a/dotnet/test/common/CustomDriverConfigs/SafariTechnologyPreviewDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/SafariTechnologyPreviewDriver.cs
@@ -16,6 +16,11 @@ namespace OpenQA.Selenium.Safari
         {
         }
 
+        public SafariTechnologyPreviewDriver(SafariDriverService service, SafariOptions options)
+            : base(service, options)
+        {
+        }
+
         public static SafariOptions DefaultOptions
         {
             get

--- a/dotnet/test/common/CustomDriverConfigs/StableChannelChromeDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/StableChannelChromeDriver.cs
@@ -13,6 +13,11 @@ namespace OpenQA.Selenium.Chrome
         {
         }
 
+        public StableChannelChromeDriver(ChromeDriverService service, ChromeOptions options)
+            : base(service, options)
+        {
+        }
+
         public static ChromeOptions DefaultOptions
         {
             get { return new ChromeOptions() { AcceptInsecureCertificates = true, BrowserVersion = "116" }; }

--- a/dotnet/test/common/CustomDriverConfigs/StableChannelEdgeDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/StableChannelEdgeDriver.cs
@@ -14,9 +14,13 @@ namespace OpenQA.Selenium.Edge
         {
         }
 
+        public StableChannelEdgeDriver(EdgeDriverService service, EdgeOptions options)
+            : base(service, options)
+        {
+        }
         public static EdgeOptions DefaultOptions
         {
-            get { return new EdgeOptions(); }
+            get { return new EdgeOptions() { AcceptInsecureCertificates = true }; }
         }
     }
 }

--- a/dotnet/test/common/CustomDriverConfigs/StableChannelFirefoxDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/StableChannelFirefoxDriver.cs
@@ -1,5 +1,3 @@
-using OpenQA.Selenium.Remote;
-
 namespace OpenQA.Selenium.Firefox
 {
     // This is a simple wrapper class to create a FirefoxDriver that
@@ -15,6 +13,11 @@ namespace OpenQA.Selenium.Firefox
         // Required for dynamic setting with `EnvironmentManager.Instance.CreateDriverInstance(options)`
         public StableChannelFirefoxDriver(FirefoxOptions options)
             : base(options)
+        {
+        }
+
+        public StableChannelFirefoxDriver(FirefoxDriverService service, FirefoxOptions options)
+            : base(service, options)
         {
         }
 

--- a/dotnet/test/common/DriverTestFixture.cs
+++ b/dotnet/test/common/DriverTestFixture.cs
@@ -113,13 +113,7 @@ namespace OpenQA.Selenium
         [OneTimeSetUp]
         public void SetUp()
         {
-            driver = EnvironmentManager.Instance.CreateFreshDriver();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            // EnvironmentManager.Instance.CloseCurrentDriver();
+            driver = EnvironmentManager.Instance.GetCurrentDriver();
         }
 
         [TearDown]

--- a/dotnet/test/common/Environment/DriverFactory.cs
+++ b/dotnet/test/common/Environment/DriverFactory.cs
@@ -11,10 +11,12 @@ namespace OpenQA.Selenium.Environment
 {
     public class DriverFactory
     {
+        private Dictionary<Browser, Type> serviceTypes = new Dictionary<Browser, Type>();
         private Dictionary<Browser, Type> optionsTypes = new Dictionary<Browser, Type>();
 
         public DriverFactory()
         {
+            this.PopulateServiceTypes();
             this.PopulateOptionsTypes();
         }
 
@@ -27,6 +29,15 @@ namespace OpenQA.Selenium.Environment
             this.optionsTypes[Browser.Safari] = typeof(SafariOptions);
         }
 
+        private void PopulateServiceTypes()
+        {
+            this.serviceTypes[Browser.Chrome] = typeof(ChromeDriverService);
+            this.serviceTypes[Browser.Edge] = typeof(EdgeDriverService);
+            this.serviceTypes[Browser.Firefox] = typeof(FirefoxDriverService);
+            this.serviceTypes[Browser.IE] = typeof(InternetExplorerDriverService);
+            this.serviceTypes[Browser.Safari] = typeof(SafariDriverService);
+        }
+
         public event EventHandler<DriverStartingEventArgs> DriverStarting;
 
         public IWebDriver CreateDriver(Type driverType)
@@ -37,6 +48,7 @@ namespace OpenQA.Selenium.Environment
         public IWebDriver CreateDriverWithOptions(Type driverType, DriverOptions driverOptions)
         {
             Browser browser = Browser.All;
+            DriverService service = null;
             DriverOptions options = null;
 
             List<Type> constructorArgTypeList = new List<Type>();
@@ -45,49 +57,55 @@ namespace OpenQA.Selenium.Environment
             {
                 browser = Browser.Chrome;
                 options = GetDriverOptions<ChromeOptions>(driverType, driverOptions);
+                service = CreateService<ChromeDriverService>();
             }
             else if (typeof(EdgeDriver).IsAssignableFrom(driverType))
             {
                 browser = Browser.Edge;
                 options = GetDriverOptions<EdgeOptions>(driverType, driverOptions);
+                service = CreateService<EdgeDriverService>();
             }
             else if (typeof(InternetExplorerDriver).IsAssignableFrom(driverType))
             {
                 browser = Browser.IE;
                 options = GetDriverOptions<InternetExplorerOptions>(driverType, driverOptions);
+                service = CreateService<InternetExplorerDriverService>();
             }
             else if (typeof(FirefoxDriver).IsAssignableFrom(driverType))
             {
                 browser = Browser.Firefox;
                 options = GetDriverOptions<FirefoxOptions>(driverType, driverOptions);
+                service = CreateService<FirefoxDriverService>();
             }
             else if (typeof(SafariDriver).IsAssignableFrom(driverType))
             {
                 browser = Browser.Safari;
                 options = GetDriverOptions<SafariOptions>(driverType, driverOptions);
+                service = CreateService<SafariDriverService>();
             }
 
-            this.OnDriverLaunching(options);
+            this.OnDriverLaunching(service, options);
 
             if (browser != Browser.All)
             {
+                constructorArgTypeList.Add(this.serviceTypes[browser]);
                 constructorArgTypeList.Add(this.optionsTypes[browser]);
                 ConstructorInfo ctorInfo = driverType.GetConstructor(constructorArgTypeList.ToArray());
                 if (ctorInfo != null)
                 {
-                    return (IWebDriver)ctorInfo.Invoke(new object[] { options });
+                    return (IWebDriver)ctorInfo.Invoke(new object[] { service, options });
                 }
             }
 
-            driver = (IWebDriver)Activator.CreateInstance(driverType, options);
+            driver = (IWebDriver)Activator.CreateInstance(driverType);
             return driver;
         }
 
-        protected void OnDriverLaunching(DriverOptions options)
+        protected void OnDriverLaunching(DriverService service, DriverOptions options)
         {
             if (this.DriverStarting != null)
             {
-                DriverStartingEventArgs args = new DriverStartingEventArgs(options);
+                DriverStartingEventArgs args = new DriverStartingEventArgs(service, options);
                 this.DriverStarting(this, args);
             }
         }
@@ -136,16 +154,18 @@ namespace OpenQA.Selenium.Environment
             return mergedOptions;
         }
 
-        private object GetDefaultOptions(Type driverType)
+        private T CreateService<T>() where T:DriverService
         {
-            PropertyInfo info = driverType.GetProperty("DefaultOptions", BindingFlags.Public | BindingFlags.Static);
-            if (info != null)
+            T service = default(T);
+            Type serviceType = typeof(T);
+
+            MethodInfo createDefaultServiceMethod = serviceType.GetMethod("CreateDefaultService", BindingFlags.Public | BindingFlags.Static, null, new Type[] { }, null);
+            if (createDefaultServiceMethod != null && createDefaultServiceMethod.ReturnType == serviceType)
             {
-                object propertyValue = info.GetValue(null, null);
-                return propertyValue;
+                service = (T)createDefaultServiceMethod.Invoke(null, new object[] {});
             }
 
-            return null;
+            return service;
         }
     }
 }

--- a/dotnet/test/common/Environment/DriverStartingEventArgs.cs
+++ b/dotnet/test/common/Environment/DriverStartingEventArgs.cs
@@ -5,8 +5,9 @@ namespace OpenQA.Selenium.Environment
         DriverService service;
         DriverOptions options;
 
-        public DriverStartingEventArgs(DriverOptions options)
+        public DriverStartingEventArgs(DriverService service, DriverOptions options)
         {
+            this.Service = service;
             this.Options = options;
         }
 

--- a/dotnet/test/common/Environment/EnvironmentManager.cs
+++ b/dotnet/test/common/Environment/EnvironmentManager.cs
@@ -204,10 +204,8 @@ namespace OpenQA.Selenium.Environment
             {
                 return driver;
             }
-            else
-            {
-                return CreateFreshDriver();
-            }
+
+            return CreateFreshDriver();
         }
 
         public IWebDriver CreateDriverInstance()
@@ -231,9 +229,15 @@ namespace OpenQA.Selenium.Environment
         {
             if (driver != null)
             {
-                driver.Quit();
+                try
+                {
+                    driver.Quit();
+                }
+                finally
+                {
+                    driver = null;
+                }
             }
-            driver = null;
         }
 
         protected void OnDriverStarting(object sender, DriverStartingEventArgs e)

--- a/dotnet/test/common/Environment/RemoteSeleniumServer.cs
+++ b/dotnet/test/common/Environment/RemoteSeleniumServer.cs
@@ -34,8 +34,7 @@ namespace OpenQA.Selenium.Environment
 
                 webserverProcess = new Process();
                 webserverProcess.StartInfo.FileName = "java.exe";
-                webserverProcess.StartInfo.Arguments = " -jar " + serverJarName
-                                                                + " standalone --port 6000 --selenium-manager true";
+                webserverProcess.StartInfo.Arguments = " -jar " + serverJarName + " standalone --port 6000 --selenium-manager true";
                 webserverProcess.StartInfo.WorkingDirectory = projectRootPath;
                 webserverProcess.Start();
                 DateTime timeout = DateTime.Now.Add(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
### Description
Follow Java approach and use Driver Finder in Driver constructor and not in the Service constructor.

### Motivation and Context
If a user creates the service instance independently it will use DriverFinder for the default options instead of specified options. Generally not an issue since users have no reason to create a Service class in .NET if they aren't going to specify the location of the driver. But users need to be able to toggle things like logging without having options. and let DriverFinder still set location based on actual options.
