### PR TITLE
fix for conda install of selenium-manager

### DIFF
--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -16,7 +16,7 @@
 # under the License.
 import json
 import logging
-import shutil
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -54,9 +54,10 @@ class SeleniumManager:
 
         path = Path(__file__).parent.joinpath(directory, file)
 
-        if not path.is_file():
-            # conda has a separate package selenium-manager, installs in bin folder
-            path = Path(shutil.which(file))
+        if not path.is_file() and os.environ['CONDA_PREFIX']:
+            # conda has a separate package selenium-manager, installs in bin
+            path = Path(os.path.join(os.environ['CONDA_PREFIX'], 'bin', file))
+            logger.debug(f"Conda environment detected, using `{path}`")
         if not path.is_file():
             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")
 

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -54,9 +54,9 @@ class SeleniumManager:
 
         path = Path(__file__).parent.joinpath(directory, file)
 
-        if not path.is_file() and os.environ['CONDA_PREFIX']:
+        if not path.is_file() and os.environ["CONDA_PREFIX"]:
             # conda has a separate package selenium-manager, installs in bin
-            path = Path(os.path.join(os.environ['CONDA_PREFIX'], 'bin', file))
+            path = Path(os.path.join(os.environ["CONDA_PREFIX"], "bin", file))
             logger.debug(f"Conda environment detected, using `{path}`")
         if not path.is_file():
             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -16,10 +16,10 @@
 # under the License.
 import json
 import logging
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-import shutil
 from typing import List
 
 from selenium.common import WebDriverException

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -19,6 +19,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
+import shutil
 from typing import List
 
 from selenium.common import WebDriverException
@@ -53,6 +54,9 @@ class SeleniumManager:
 
         path = Path(__file__).parent.joinpath(directory, file)
 
+        if not path.is_file():
+            # conda has a separate package selenium-manager, installs in bin folder
+            path = Path(shutil.which(file))
         if not path.is_file():
             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")
 


### PR DESCRIPTION
### Description
conda doesn't seem to properly package selenium-manager, so it needs to be install as a separate package (via conda). But this puts it in the environment's bin folder.

This commit checks the path for the selenium-manager executable if it isn't installed in the package's webdriver/common/<platform>/ folder.


Also, I tried running the existing tests but all of the remote tests failed, and two of the browser tests failed for trunk (only one failed for my branch).


### Motivation and Context
fixes #11234 and #12084

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
