### PR TITLE
[java] Copy SM binary to cache folder and use it from there (#11359)

### DIFF
--- a/java/src/org/openqa/selenium/manager/BUILD.bazel
+++ b/java/src/org/openqa/selenium/manager/BUILD.bazel
@@ -21,7 +21,6 @@ java_export(
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/os",
         artifact("com.google.guava:guava"),
-        artifact("io.ous:jtoml"),
     ],
 )
 

--- a/java/src/org/openqa/selenium/manager/BUILD.bazel
+++ b/java/src/org/openqa/selenium/manager/BUILD.bazel
@@ -21,6 +21,7 @@ java_export(
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/os",
         artifact("com.google.guava:guava"),
+        artifact("io.ous:jtoml"),
     ],
 )
 

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -19,9 +19,7 @@ package org.openqa.selenium.manager;
 import static org.openqa.selenium.Platform.MAC;
 import static org.openqa.selenium.Platform.WINDOWS;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,9 +41,6 @@ import org.openqa.selenium.json.Json;
 import org.openqa.selenium.json.JsonException;
 import org.openqa.selenium.manager.SeleniumManagerOutput.Result;
 import org.openqa.selenium.os.ExternalProcess;
-
-import io.ous.jtoml.JToml;
-import io.ous.jtoml.Toml;
 
 /**
  * This implementation is still in beta, and may change.
@@ -72,8 +67,6 @@ public class SeleniumManager {
   private static final String DEFAULT_CACHE_PATH = "~/.cache/selenium";
   private static final String BINARY_PATH_FORMAT = "/manager/%s/%s";
   private static final String HOME = "~";
-  private static final String SE_CONFIG_FILE = "/se-config.toml";
-  private static final String CACHE_PATH_KEY = "cache-path";
   private static final String CACHE_PATH_ENV = "SE_CACHE_PATH";
 
   private static final String EXE = ".exe";
@@ -298,25 +291,10 @@ public class SeleniumManager {
   private Path getBinaryInCache(String binaryName) {
     String cachePath = DEFAULT_CACHE_PATH.replace(HOME, System.getProperty("user.home"));
 
-    // 1. Look for cache path in config file
-    Path configFile = Paths.get(cachePath + SE_CONFIG_FILE);
-    if (configFile.toFile().exists()) {
-      try (Reader reader = Files.newBufferedReader(configFile)) {
-        Toml toml = JToml.parse(reader);
-        Object cachePathToml = toml.get(CACHE_PATH_KEY);
-        if (cachePathToml != null) {
-          cachePath = cachePathToml.toString();
-        }
-      } catch (IOException e) {
-        // Nothing
-      }
-    }
-    else {
-      // 2. Look for cache path as env
-      String cachePathEnv = System.getenv(CACHE_PATH_ENV);
-      if (cachePathEnv != null) {
-        cachePath = cachePathEnv;
-      }
+    // Look for cache path as env
+    String cachePathEnv = System.getenv(CACHE_PATH_ENV);
+    if (cachePathEnv != null) {
+      cachePath = cachePathEnv;
     }
 
     return Paths.get(cachePath + String.format(BINARY_PATH_FORMAT, SELENIUM_MANAGER_VERSION, binaryName));

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -16,18 +16,13 @@
 // under the License.
 package org.openqa.selenium.manager;
 
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.openqa.selenium.Platform.MAC;
 import static org.openqa.selenium.Platform.WINDOWS;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
@@ -62,7 +58,20 @@ public class SeleniumManager {
 
   private static final Logger LOG = Logger.getLogger(SeleniumManager.class.getName());
 
+
+  // IMPORTANT: This version needs to be synchronized before each release.
+  // Alternatively, we can try to use Bazel to automate this task
+  private static final String SELENIUM_MANAGER_VERSION = "0.4.12";
+
   private static final String SELENIUM_MANAGER = "selenium-manager";
+  private static final String DEFAULT_CACHE_PATH = "~/.cache/selenium";
+  private static final String BINARY_PATH_FORMAT = "/manager/%s/%s";
+  private static final String HOME = "~";
+
+  private static final String EXE = ".exe";
+  private static final String INFO = "INFO";
+  private static final String WARN = "WARN";
+  private static final String DEBUG = "DEBUG";
 
   private static volatile SeleniumManager manager;
 
@@ -71,23 +80,6 @@ public class SeleniumManager {
 
   /** Wrapper for the Selenium Manager binary. */
   private SeleniumManager() {
-    if (managerPath == null) {
-      Runtime.getRuntime()
-          .addShutdownHook(
-              new Thread(
-                  () -> {
-                    if (binary != null && Files.exists(binary)) {
-                      try {
-                        Files.delete(binary);
-                      } catch (IOException e) {
-                        LOG.warning(
-                            String.format(
-                                "%s deleting temporal file: %s",
-                                e.getClass().getSimpleName(), e.getMessage()));
-                      }
-                    }
-                  }));
-    }
   }
 
   public static SeleniumManager getInstance() {
@@ -161,23 +153,27 @@ public class SeleniumManager {
    */
   private synchronized Path getBinary() {
     if (binary == null) {
-      Platform current = Platform.getCurrent();
-      String folder = "linux";
-      String extension = "";
-      if (current.is(WINDOWS)) {
-        extension = ".exe";
-        folder = "windows";
-      } else if (current.is(MAC)) {
-        folder = "macos";
-      }
-      String binaryPath = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
-      try (InputStream inputStream = this.getClass().getResourceAsStream(binaryPath)) {
-        Path tmpPath = Files.createTempDirectory(SELENIUM_MANAGER + System.nanoTime());
+      try {
+        Platform current = Platform.getCurrent();
+        String folder = "linux";
+        String extension = "";
+        if (current.is(WINDOWS)) {
+          extension = EXE;
+          folder = "windows";
+        } else if (current.is(MAC)) {
+          folder = "macos";
+        }
 
-        deleteOnExit(tmpPath);
+        binary = getBinaryInCache(SELENIUM_MANAGER + extension);
+        if (!binary.toFile().exists()) {
+          String binaryPathInJar = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
+          try (InputStream inputStream = this.getClass().getResourceAsStream(binaryPathInJar)) {
+            binary.getParent().toFile().mkdirs();
+            Files.copy(inputStream, binary);
+          }
+          binary.toFile().setExecutable(true);
+        }
 
-        binary = tmpPath.resolve(SELENIUM_MANAGER + extension);
-        Files.copy(inputStream, binary, REPLACE_EXISTING);
       } catch (Exception e) {
         throw new WebDriverException("Unable to obtain Selenium Manager Binary", e);
       }
@@ -190,35 +186,6 @@ public class SeleniumManager {
     LOG.fine(String.format("Selenium Manager binary found at: %s", binary));
 
     return binary;
-  }
-
-  private void deleteOnExit(Path tmpPath) {
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  try {
-                    Files.walkFileTree(
-                        tmpPath,
-                        new SimpleFileVisitor<Path>() {
-                          @Override
-                          public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-                              throws IOException {
-                            Files.delete(dir);
-                            return FileVisitResult.CONTINUE;
-                          }
-
-                          @Override
-                          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                              throws IOException {
-                            Files.delete(file);
-                            return FileVisitResult.CONTINUE;
-                          }
-                        });
-                  } catch (IOException e) {
-                    // Do nothing. We're just tidying up.
-                  }
-                }));
   }
 
   /**
@@ -318,5 +285,10 @@ public class SeleniumManager {
       return Level.INFO;
     }
     return level;
+  }
+
+  private Path getBinaryInCache(String binaryName) {
+    String cachePath = DEFAULT_CACHE_PATH.replace(HOME, System.getProperty("user.home"));
+    return Paths.get(cachePath + String.format(BINARY_PATH_FORMAT, SELENIUM_MANAGER_VERSION, binaryName));
   }
 }

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -32,6 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openqa.selenium.Beta;
+import org.openqa.selenium.BuildInfo;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Platform;
@@ -59,15 +60,12 @@ public class SeleniumManager {
   private static final Logger LOG = Logger.getLogger(SeleniumManager.class.getName());
 
 
-  // IMPORTANT: This version needs to be synchronized before each release.
-  // Alternatively, we can try to use Bazel to automate this task
-  private static final String SELENIUM_MANAGER_VERSION = "0.4.12";
-
   private static final String SELENIUM_MANAGER = "selenium-manager";
   private static final String DEFAULT_CACHE_PATH = "~/.cache/selenium";
   private static final String BINARY_PATH_FORMAT = "/manager/%s/%s";
   private static final String HOME = "~";
   private static final String CACHE_PATH_ENV = "SE_CACHE_PATH";
+  private static final String BETA_PREFIX = "0.";
 
   private static final String EXE = ".exe";
   private static final String INFO = "INFO";
@@ -75,12 +73,16 @@ public class SeleniumManager {
   private static final String DEBUG = "DEBUG";
 
   private static volatile SeleniumManager manager;
-
   private final String managerPath = System.getenv("SE_MANAGER_PATH");
   private Path binary = managerPath == null ? null : Paths.get(managerPath);
+  private String seleniumManagerVersion;
 
   /** Wrapper for the Selenium Manager binary. */
   private SeleniumManager() {
+    BuildInfo info = new BuildInfo();
+    String releaseLabel = info.getReleaseLabel();
+    int lastDot = releaseLabel.lastIndexOf(".");
+    seleniumManagerVersion = BETA_PREFIX + releaseLabel.substring(0, lastDot);
   }
 
   public static SeleniumManager getInstance() {
@@ -297,6 +299,6 @@ public class SeleniumManager {
       cachePath = cachePathEnv;
     }
 
-    return Paths.get(cachePath + String.format(BINARY_PATH_FORMAT, SELENIUM_MANAGER_VERSION, binaryName));
+    return Paths.get(cachePath + String.format(BINARY_PATH_FORMAT, seleniumManagerVersion, binaryName));
   }
 }

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -19,7 +19,9 @@ package org.openqa.selenium.manager;
 import static org.openqa.selenium.Platform.MAC;
 import static org.openqa.selenium.Platform.WINDOWS;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +43,9 @@ import org.openqa.selenium.json.Json;
 import org.openqa.selenium.json.JsonException;
 import org.openqa.selenium.manager.SeleniumManagerOutput.Result;
 import org.openqa.selenium.os.ExternalProcess;
+
+import io.ous.jtoml.JToml;
+import io.ous.jtoml.Toml;
 
 /**
  * This implementation is still in beta, and may change.
@@ -67,6 +72,9 @@ public class SeleniumManager {
   private static final String DEFAULT_CACHE_PATH = "~/.cache/selenium";
   private static final String BINARY_PATH_FORMAT = "/manager/%s/%s";
   private static final String HOME = "~";
+  private static final String SE_CONFIG_FILE = "/se-config.toml";
+  private static final String CACHE_PATH_KEY = "cache-path";
+  private static final String CACHE_PATH_ENV = "SE_CACHE_PATH";
 
   private static final String EXE = ".exe";
   private static final String INFO = "INFO";
@@ -289,6 +297,28 @@ public class SeleniumManager {
 
   private Path getBinaryInCache(String binaryName) {
     String cachePath = DEFAULT_CACHE_PATH.replace(HOME, System.getProperty("user.home"));
+
+    // 1. Look for cache path in config file
+    Path configFile = Paths.get(cachePath + SE_CONFIG_FILE);
+    if (configFile.toFile().exists()) {
+      try (Reader reader = Files.newBufferedReader(configFile)) {
+        Toml toml = JToml.parse(reader);
+        Object cachePathToml = toml.get(CACHE_PATH_KEY);
+        if (cachePathToml != null) {
+          cachePath = cachePathToml.toString();
+        }
+      } catch (IOException e) {
+        // Nothing
+      }
+    }
+    else {
+      // 2. Look for cache path as env
+      String cachePathEnv = System.getenv(CACHE_PATH_ENV);
+      if (cachePathEnv != null) {
+        cachePath = cachePathEnv;
+      }
+    }
+
     return Paths.get(cachePath + String.format(BINARY_PATH_FORMAT, SELENIUM_MANAGER_VERSION, binaryName));
   }
 }


### PR DESCRIPTION
### Description
This PR copies the SM binary from the distribution (jar) to the cache folder (`~/.cache/selenium), which is invoked from then.

This PR has two commits:

1. The first commit assumes that the cache path is always the path (`~/.cache/selenium), which makes things easier.
2. The "problem" is that the cache folder can be configured in Selenium Manager with other mechanisms: the configuration file (`se-config.toml` -if we finally renamed that way-) or environmental variables (in particular, `SE_CACHE_PATH` is the one for the cache path). The second commit allows to read also the cache path from the configuration file (first) and the env (second).

### Motivation and Context
Resolves #11359.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
