### PR TITLE
[rust] Rename configuration file to se-config.toml

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -32,7 +32,7 @@ use toml::Table;
 
 thread_local!(static CACHE_PATH: RefCell<String> = RefCell::new(path_buf_to_string(default_cache_folder())));
 
-pub const CONFIG_FILE: &str = "selenium-manager-config.toml";
+pub const CONFIG_FILE: &str = "se-config.toml";
 pub const ENV_PREFIX: &str = "SE_";
 pub const VERSION_PREFIX: &str = "-version";
 pub const PATH_PREFIX: &str = "-path";


### PR DESCRIPTION
### Description
This PR renames the Selenium Manager configuration file from `selenium-manager-config.toml` to `se-config.toml`.

### Motivation and Context
This PR is a continuation of #12531 and part of #11695.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
