### PR TITLE
[py] moved safari options to descriptor class

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -162,8 +162,8 @@ class RemoteConnection:
     def get_certificate_bundle_path(cls):
         """
         :Returns:
-            Paths of the .pem encoded certificate to verify connection to command executor. Defaults 
-            to certifi.where() or REQUESTS_CA_BUNDLE env variable if set.            
+            Paths of the .pem encoded certificate to verify connection to command executor. Defaults
+            to certifi.where() or REQUESTS_CA_BUNDLE env variable if set.
         """
         return cls._ca_certs
 


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Moved all Safari options to descriptor class

### Motivation and Context
- Refactored safari options by moving to descriptor class
- Also, I have fixed linting issue in remote/remote_connection.py. (this was broken in PR 11957) 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
