### PR TITLE
[rust] Automated Firefox management (#11680 and #11682)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "411f529aca096bd6f3ebbe47fcbd44f95dc26ac344ae92e24cd2a1dba11c37e0",
+  "checksum": "914b0f717c99d5b8faa2ffe41cdb0d58641d07272c5bb4b4faac79e27c9c1fd1",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -975,6 +975,55 @@
         },
         "edition": "2015",
         "version": "0.4.4"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "bzip2-rs 0.1.2": {
+      "name": "bzip2-rs",
+      "version": "0.1.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/bzip2-rs/0.1.2/download",
+          "sha256": "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bzip2_rs",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "bzip2_rs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "crc32fast 1.3.2",
+              "target": "crc32fast"
+            },
+            {
+              "id": "tinyvec 1.6.0",
+              "target": "tinyvec"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.2"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -7093,6 +7142,10 @@
         ],
         "deps": {
           "common": [
+            {
+              "id": "bzip2-rs 0.1.2",
+              "target": "bzip2_rs"
+            },
             {
               "id": "clap 4.3.19",
               "target": "clap"

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "914b0f717c99d5b8faa2ffe41cdb0d58641d07272c5bb4b4faac79e27c9c1fd1",
+  "checksum": "b50f15009b9d7188b2c56599e319668c3625e3e8f8fdd64797cf1e22f3a73b44",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -166,6 +166,36 @@
         "version": "1.0.2"
       },
       "license": "Unlicense OR MIT"
+    },
+    "android-tzdata 0.1.1": {
+      "name": "android-tzdata",
+      "version": "0.1.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/android-tzdata/0.1.1/download",
+          "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "android_tzdata",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "android_tzdata",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.1.1"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "anstream 0.3.2": {
       "name": "anstream",
@@ -694,6 +724,88 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
+    "bit-set 0.5.3": {
+      "name": "bit-set",
+      "version": "0.5.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/bit-set/0.5.3/download",
+          "sha256": "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bit_set",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "bit_set",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bit-vec 0.6.3",
+              "target": "bit_vec"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.5.3"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "bit-vec 0.6.3": {
+      "name": "bit-vec",
+      "version": "0.6.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/bit-vec/0.6.3/download",
+          "sha256": "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bit_vec",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "bit_vec",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.6.3"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "bitflags 1.3.2": {
       "name": "bitflags",
       "version": "1.3.2",
@@ -766,6 +878,45 @@
         },
         "edition": "2018",
         "version": "0.10.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "block-buffer 0.9.0": {
+      "name": "block-buffer",
+      "version": "0.9.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/block-buffer/0.9.0/download",
+          "sha256": "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "block_buffer",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "block_buffer",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "generic-array 0.14.6",
+              "target": "generic_array"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.9.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1221,6 +1372,52 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "chrono 0.4.26": {
+      "name": "chrono",
+      "version": "0.4.26",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/chrono/0.4.26/download",
+          "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "chrono",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "chrono",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "num-traits 0.2.16",
+              "target": "num_traits"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"android\")": [
+              {
+                "id": "android-tzdata 0.1.1",
+                "target": "android_tzdata"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.4.26"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "cipher 0.4.4": {
       "name": "cipher",
       "version": "0.4.4",
@@ -1591,6 +1788,75 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "crc 3.0.1": {
+      "name": "crc",
+      "version": "3.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/crc/3.0.1/download",
+          "sha256": "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "crc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crc-catalog 2.2.0",
+              "target": "crc_catalog"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "3.0.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "crc-catalog 2.2.0": {
+      "name": "crc-catalog",
+      "version": "2.2.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/crc-catalog/2.2.0/download",
+          "sha256": "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc_catalog",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "crc_catalog",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.2.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "crc32fast 1.3.2": {
       "name": "crc32fast",
       "version": "1.3.2",
@@ -1854,6 +2120,52 @@
         },
         "edition": "2018",
         "version": "0.10.6"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "digest 0.9.0": {
+      "name": "digest",
+      "version": "0.9.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/digest/0.9.0/download",
+          "sha256": "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "digest",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "digest",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "generic-array 0.14.6",
+              "target": "generic_array"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.9.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2451,13 +2763,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "filetime 0.2.20": {
+    "filetime 0.2.22": {
       "name": "filetime",
-      "version": "0.2.20",
+      "version": "0.2.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/filetime/0.2.20/download",
-          "sha256": "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+          "url": "https://crates.io/api/v1/crates/filetime/0.2.22/download",
+          "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
         }
       },
       "targets": [
@@ -2486,7 +2798,7 @@
           "selects": {
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.2.16",
+                "id": "redox_syscall 0.3.5",
                 "target": "syscall"
               }
             ],
@@ -2498,14 +2810,64 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.45.0",
+                "id": "windows-sys 0.48.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.20"
+        "version": "0.2.22"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "filetime_creation 0.1.6": {
+      "name": "filetime_creation",
+      "version": "0.1.6",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/filetime_creation/0.1.6/download",
+          "sha256": "3aea213d5ab4e6cd49f50c0688a4e20e5b75ff3bc07ff63f814778bd9b1dd42d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "filetime_creation",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "filetime_creation",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "filetime 0.2.22",
+              "target": "filetime"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.1.6"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -4897,6 +5259,51 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "lzma-rust 0.1.4": {
+      "name": "lzma-rust",
+      "version": "0.1.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/lzma-rust/0.1.4/download",
+          "sha256": "9d5dadd5fd2bcf0256ff0340310c47851ef4113d2cc803b606804cd26604d0e1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "lzma_rust",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "lzma_rust",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "encoder"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.4.3",
+              "target": "byteorder"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.4"
+      },
+      "license": "Apache-2.0"
+    },
     "memchr 2.5.0": {
       "name": "memchr",
       "version": "2.5.0",
@@ -5141,6 +5548,114 @@
       },
       "license": "MIT"
     },
+    "nt-time 0.5.3": {
+      "name": "nt-time",
+      "version": "0.5.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/nt-time/0.5.3/download",
+          "sha256": "a7388539da3ff64e2ee5f23b310e2d46d78fbabf338bd35d410d59562ed188bd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "nt_time",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "nt_time",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "time 0.3.23",
+              "target": "time"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.3"
+      },
+      "license": "Apache-2.0 OR MIT"
+    },
+    "num-traits 0.2.16": {
+      "name": "num-traits",
+      "version": "0.2.16",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/num-traits/0.2.16/download",
+          "sha256": "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "num_traits",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "num_traits",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "num-traits 0.2.16",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.16"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "num_cpus 1.15.0": {
       "name": "num_cpus",
       "version": "1.15.0",
@@ -5263,6 +5778,36 @@
         },
         "edition": "2021",
         "version": "1.17.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "opaque-debug 0.3.0": {
+      "name": "opaque-debug",
+      "version": "0.3.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/opaque-debug/0.3.0/download",
+          "sha256": "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "opaque_debug",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "opaque_debug",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.3.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7195,6 +7740,10 @@
               "target": "serde_json"
             },
             {
+              "id": "sevenz-rust 0.5.0",
+              "target": "sevenz_rust"
+            },
+            {
               "id": "tar 0.4.39",
               "target": "tar"
             },
@@ -7587,6 +8136,87 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "sevenz-rust 0.5.0": {
+      "name": "sevenz-rust",
+      "version": "0.5.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/sevenz-rust/0.5.0/download",
+          "sha256": "e2b4f55cc8838a27c4717b4bef491e936e31e19510136f31efd8e463343d0c3c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sevenz_rust",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "sevenz_rust",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "compress",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bit-set 0.5.3",
+              "target": "bit_set"
+            },
+            {
+              "id": "byteorder 1.4.3",
+              "target": "byteorder"
+            },
+            {
+              "id": "crc 3.0.1",
+              "target": "crc"
+            },
+            {
+              "id": "filetime_creation 0.1.6",
+              "target": "filetime_creation"
+            },
+            {
+              "id": "lzma-rust 0.1.4",
+              "target": "lzma_rust"
+            },
+            {
+              "id": "nt-time 0.5.3",
+              "target": "nt_time"
+            },
+            {
+              "id": "sha2 0.9.9",
+              "target": "sha2"
+            }
+          ],
+          "selects": {
+            "cfg(target_arch = \"wasm32\")": [
+              {
+                "id": "js-sys 0.3.61",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.84",
+                "target": "wasm_bindgen"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.5.0"
+      },
+      "license": "Apache-2.0"
+    },
     "sha1 0.10.5": {
       "name": "sha1",
       "version": "0.10.5",
@@ -7691,6 +8321,71 @@
         },
         "edition": "2018",
         "version": "0.10.6"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "sha2 0.9.9": {
+      "name": "sha2",
+      "version": "0.9.9",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/sha2/0.9.9/download",
+          "sha256": "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sha2",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "sha2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "block-buffer 0.9.0",
+              "target": "block_buffer"
+            },
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "digest 0.9.0",
+              "target": "digest"
+            },
+            {
+              "id": "opaque-debug 0.3.0",
+              "target": "opaque_debug"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
+              {
+                "id": "cpufeatures 0.2.5",
+                "target": "cpufeatures"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.9.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8082,7 +8777,7 @@
         "deps": {
           "common": [
             {
-              "id": "filetime 0.2.20",
+              "id": "filetime 0.2.22",
               "target": "filetime"
             }
           ],
@@ -8373,13 +9068,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time 0.3.20": {
+    "time 0.3.23": {
       "name": "time",
-      "version": "0.3.20",
+      "version": "0.3.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.3.20/download",
-          "sha256": "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+          "url": "https://crates.io/api/v1/crates/time/0.3.23/download",
+          "sha256": "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
         }
       },
       "targets": [
@@ -8401,6 +9096,7 @@
         "crate_features": {
           "common": [
             "alloc",
+            "macros",
             "std"
           ],
           "selects": {}
@@ -8408,24 +9104,33 @@
         "deps": {
           "common": [
             {
-              "id": "time-core 0.1.0",
+              "id": "time-core 0.1.1",
               "target": "time_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.20"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "time-macros 0.2.10",
+              "target": "time_macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.3.23"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time-core 0.1.0": {
+    "time-core 0.1.1": {
       "name": "time-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-core/0.1.0/download",
-          "sha256": "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+          "url": "https://crates.io/api/v1/crates/time-core/0.1.1/download",
+          "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
         }
       },
       "targets": [
@@ -8445,7 +9150,46 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.1.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "time-macros 0.2.10": {
+      "name": "time-macros",
+      "version": "0.2.10",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/time-macros/0.2.10/download",
+          "sha256": "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "time_macros",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "time_macros",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "time-core 0.1.1",
+              "target": "time_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.10"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11649,7 +12393,7 @@
               "target": "sha1"
             },
             {
-              "id": "time 0.3.20",
+              "id": "time 0.3.23",
               "target": "time"
             },
             {
@@ -12251,6 +12995,12 @@
       "wasm32-wasi"
     ],
     "cfg(target_feature = \"atomics\")": [],
+    "cfg(target_os = \"android\")": [
+      "aarch64-linux-android",
+      "armv7-linux-androideabi",
+      "i686-linux-android",
+      "x86_64-linux-android"
+    ],
     "cfg(target_os = \"dragonfly\")": [],
     "cfg(target_os = \"hermit\")": [],
     "cfg(target_os = \"redox\")": [],

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b50f15009b9d7188b2c56599e319668c3625e3e8f8fdd64797cf1e22f3a73b44",
+  "checksum": "caaba3929b24d3586b1f404473cca35425c3804bee5f3ec0431f8ddef02c1a7e",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -1126,55 +1126,6 @@
         },
         "edition": "2015",
         "version": "0.4.4"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "bzip2-rs 0.1.2": {
-      "name": "bzip2-rs",
-      "version": "0.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bzip2-rs/0.1.2/download",
-          "sha256": "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bzip2_rs",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "bzip2_rs",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "crc32fast 1.3.2",
-              "target": "crc32fast"
-            },
-            {
-              "id": "tinyvec 1.6.0",
-              "target": "tinyvec"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.2"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -7688,8 +7639,8 @@
         "deps": {
           "common": [
             {
-              "id": "bzip2-rs 0.1.2",
-              "target": "bzip2_rs"
+              "id": "bzip2 0.4.4",
+              "target": "bzip2"
             },
             {
               "id": "clap 4.3.19",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,10 +147,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -243,6 +273,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "num-traits",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,11 +405,20 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -469,14 +533,25 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
- "windows-sys 0.45.0",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "filetime_creation"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aea213d5ab4e6cd49f50c0688a4e20e5b75ff3bc07ff63f814778bd9b1dd42d"
+dependencies = [
+ "cfg-if",
+ "filetime",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -684,7 +759,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -917,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "lzma-rust"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5dadd5fd2bcf0256ff0340310c47851ef4113d2cc803b606804cd26604d0e1"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1043,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nt-time"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7388539da3ff64e2ee5f23b310e2d46d78fbabf338bd35d410d59562ed188bd"
+dependencies = [
+ "chrono",
+ "time",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,10 +1115,10 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.6",
  "hmac",
  "password-hash",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -1341,6 +1450,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sevenz-rust",
  "tar",
  "tempfile",
  "tokio",
@@ -1407,6 +1517,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sevenz-rust"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b4f55cc8838a27c4717b4bef491e936e31e19510136f31efd8e463343d0c3c"
+dependencies = [
+ "bit-set",
+ "byteorder",
+ "crc",
+ "filetime_creation",
+ "js-sys",
+ "lzma-rust",
+ "nt-time",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,7 +1541,20 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1425,7 +1565,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1549,19 +1689,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -196,6 +196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
+dependencies = [
+ "crc32fast",
+ "tinyvec",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1327,7 @@ name = "selenium-manager"
 version = "0.4.12"
 dependencies = [
  "assert_cmd",
+ "bzip2-rs",
  "clap",
  "directories",
  "env_logger",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -226,16 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2-rs"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
-dependencies = [
- "crc32fast",
- "tinyvec",
-]
-
-[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,7 +1426,7 @@ name = "selenium-manager"
 version = "0.4.12"
 dependencies = [
  "assert_cmd",
- "bzip2-rs",
+ "bzip2",
  "clap",
  "directories",
  "env_logger",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ exitcode = "1.1.2"
 is_executable = "1.0.1"
 toml = "0.7.6"
 bzip2-rs = "0.1.2"
+sevenz-rust = "0.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ infer = "0.14.0"
 exitcode = "1.1.2"
 is_executable = "1.0.1"
 toml = "0.7.6"
-bzip2-rs = "0.1.2"
+bzip2 = "0.4.4"
 sevenz-rust = "0.5.0"
 
 [dev-dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,7 @@ infer = "0.14.0"
 exitcode = "1.1.2"
 is_executable = "1.0.1"
 toml = "0.7.6"
+bzip2-rs = "0.1.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/rust/README.md
+++ b/rust/README.md
@@ -59,6 +59,8 @@ Options:
           Offline mode (i.e., disabling network requests and downloads)
       --force-browser-download
           Force to download browser. Currently Chrome for Testing (CfT) is supported
+      --avoid-browser-download
+          Avoid to download browser (even when browser-version is specified)
   -h, --help
           Print help
   -V, --version

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -633,6 +633,7 @@ impl SeleniumManager for ChromeManager {
                 &driver_zip_file,
                 &self.get_browser_path_in_cache()?,
                 self.get_logger(),
+                self.get_os(),
                 None,
             )?;
         }

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -296,22 +296,24 @@ impl SeleniumManager for ChromeManager {
 
                 let major_browser_version_int =
                     major_browser_version.parse::<i32>().unwrap_or_default();
-                let driver_version =
-                    if self.is_browser_version_stable() || major_browser_version.is_empty() {
-                        // For discovering the latest driver version, the CfT endpoints are also used
-                        self.request_latest_driver_version_from_online()?
-                    } else if !major_browser_version.is_empty() && major_browser_version_int < 115 {
-                        // For old versions (chromedriver 114-), the traditional method should work:
-                        // https://chromedriver.chromium.org/downloads
-                        self.request_driver_version_from_latest(
-                            self.create_latest_release_with_version_url(),
-                        )?
-                    } else {
-                        // As of chromedriver 115+, the metadata for version discovery are published
-                        // by the "Chrome for Testing" (CfT) JSON endpoints:
-                        // https://googlechromelabs.github.io/chrome-for-testing/
-                        self.request_good_driver_version_from_online()?
-                    };
+                let driver_version = if self.is_browser_version_stable()
+                    || major_browser_version.is_empty()
+                    || self.is_browser_version_unstable()
+                {
+                    // For discovering the latest driver version, the CfT endpoints are also used
+                    self.request_latest_driver_version_from_online()?
+                } else if !major_browser_version.is_empty() && major_browser_version_int < 115 {
+                    // For old versions (chromedriver 114-), the traditional method should work:
+                    // https://chromedriver.chromium.org/downloads
+                    self.request_driver_version_from_latest(
+                        self.create_latest_release_with_version_url(),
+                    )?
+                } else {
+                    // As of chromedriver 115+, the metadata for version discovery are published
+                    // by the "Chrome for Testing" (CfT) JSON endpoints:
+                    // https://googlechromelabs.github.io/chrome-for-testing/
+                    self.request_good_driver_version_from_online()?
+                };
 
                 let driver_ttl = self.get_ttl();
                 if driver_ttl > 0 && !major_browser_version.is_empty() && !driver_version.is_empty()

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -506,6 +506,7 @@ impl SeleniumManager for ChromeManager {
                 self.get_logger(),
                 self.get_os(),
                 None,
+                None,
             )?;
         }
         if browser_binary_path.exists() {

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -507,6 +507,7 @@ impl SeleniumManager for ChromeManager {
                 self.get_os(),
                 None,
                 None,
+                None,
             )?;
         }
         if browser_binary_path.exists() {

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -50,6 +50,7 @@ pub struct ManagerConfig {
     pub ttl: u64,
     pub offline: bool,
     pub force_browser_download: bool,
+    pub avoid_browser_download: bool,
 }
 
 impl ManagerConfig {
@@ -99,6 +100,7 @@ impl ManagerConfig {
             ttl: IntegerKey("ttl", TTL_SEC).get_value(),
             offline: BooleanKey("offline", false).get_value(),
             force_browser_download: BooleanKey("force-browser-download", false).get_value(),
+            avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
         }
     }
 }

--- a/rust/src/downloads.rs
+++ b/rust/src/downloads.rs
@@ -17,6 +17,7 @@
 
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::error::Error;
 use std::fs::File;
 use std::io::copy;
@@ -105,5 +106,14 @@ where
 {
     let content = read_content_from_link(http_client, url)?;
     let response: T = serde_json::from_str(&content)?;
+    Ok(response)
+}
+
+pub fn parse_generic_json_from_url(
+    http_client: &Client,
+    url: String,
+) -> Result<Value, Box<dyn Error>> {
+    let content = read_content_from_link(http_client, url)?;
+    let response: Value = serde_json::from_str(&content)?;
     Ok(response)
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -121,7 +121,7 @@ impl SeleniumManager for EdgeManager {
     }
 
     fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
-        self.discover_general_browser_version(
+        self.general_discover_browser_version(
             r#"HKCU\Software\Microsoft\Edge\BLBeacon"#,
             REG_VERSION_ARG,
             DASH_DASH_VERSION,
@@ -284,5 +284,15 @@ impl SeleniumManager for EdgeManager {
         } else {
             "linux64"
         }
+    }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
     }
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -151,7 +151,10 @@ impl SeleniumManager for EdgeManager {
             _ => {
                 self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
 
-                if self.is_browser_version_stable() || major_browser_version.is_empty() {
+                if self.is_browser_version_stable()
+                    || major_browser_version.is_empty()
+                    || self.is_browser_version_unstable()
+                {
                     let latest_stable_url = format!("{}{}", DRIVER_URL, LATEST_STABLE);
                     self.log.debug(format!(
                         "Reading {} latest version from {}",

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -231,32 +231,12 @@ impl SeleniumManager for EdgeManager {
     }
 
     fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
-        let driver_version = self.get_driver_version();
-        let os = self.get_os();
-        let arch = self.get_arch();
-        let arch_folder = if WINDOWS.is(os) {
-            if ARM64.is(arch) {
-                "win-arm64"
-            } else if X32.is(arch) {
-                "win32"
-            } else {
-                "win64"
-            }
-        } else if MACOS.is(os) {
-            if ARM64.is(arch) {
-                "mac-arm64"
-            } else {
-                "mac64"
-            }
-        } else {
-            "linux64"
-        };
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?,
             self.driver_name,
-            os,
-            arch_folder,
-            driver_version,
+            self.get_os(),
+            self.get_platform_label(),
+            self.get_driver_version(),
         ))
     }
 
@@ -282,5 +262,27 @@ impl SeleniumManager for EdgeManager {
 
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
         Ok(None)
+    }
+
+    fn get_platform_label(&self) -> &str {
+        let os = self.get_os();
+        let arch = self.get_arch();
+        if WINDOWS.is(os) {
+            if ARM64.is(arch) {
+                "win-arm64"
+            } else if X32.is(arch) {
+                "win32"
+            } else {
+                "win64"
+            }
+        } else if MACOS.is(os) {
+            if ARM64.is(arch) {
+                "mac-arm64"
+            } else {
+                "mac64"
+            }
+        } else {
+            "linux64"
+        }
     }
 }

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -290,12 +290,10 @@ impl SeleniumManager for EdgeManager {
     }
 
     fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 }

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -93,7 +93,7 @@ pub fn uncompress(
     let mut extension = match infer::get_from_path(compressed_file)? {
         Some(kind) => kind.extension(),
         _ => {
-            if compressed_file.ends_with(PKG) {
+            if compressed_file.ends_with(PKG) || compressed_file.ends_with(DMG) {
                 if MACOS.is(os) {
                     PKG
                 } else {

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -21,7 +21,7 @@ use std::fs::File;
 use std::io;
 use std::io::{BufReader, Cursor, Read};
 
-use bzip2_rs::DecoderReader;
+use bzip2::read::BzDecoder;
 use std::path::{Path, PathBuf};
 
 use crate::config::OS;
@@ -288,9 +288,10 @@ pub fn uncompress_bz2(
         compressed_file,
         target.display()
     ));
-    let file = File::open(compressed_file)?;
-    let tar = DecoderReader::new(file);
-    let mut archive = Archive::new(tar);
+    let mut bz_decoder = BzDecoder::new(File::open(compressed_file)?);
+    let mut buffer: Vec<u8> = Vec::new();
+    bz_decoder.read_to_end(&mut buffer)?;
+    let mut archive = Archive::new(Cursor::new(buffer));
     if !target.exists() {
         for entry in archive.entries()? {
             let mut entry_decoder = entry?;

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -92,7 +92,7 @@ pub fn uncompress(
                 if MACOS.is(os) {
                     PKG
                 } else {
-                    return Err(format!("PKG files are only supported in macOS").into());
+                    return Err("PKG files are only supported in macOS".into());
                 }
             } else {
                 return Err(
@@ -439,7 +439,7 @@ pub fn read_bytes_from_file(file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> 
     Ok(buffer)
 }
 
-pub fn find_bytes(buffer: &Vec<u8>, bytes: &[u8]) -> Option<usize> {
+pub fn find_bytes(buffer: &[u8], bytes: &[u8]) -> Option<usize> {
     buffer
         .windows(bytes.len())
         .position(|window| window == bytes)

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -442,6 +442,10 @@ impl SeleniumManager for FirefoxManager {
             let (_tmp_folder, driver_zip_file) =
                 download_to_tmp_folder(self.get_http_client(), browser_url, self.get_logger())?;
 
+            let major_browser_version_int = self
+                .get_major_browser_version()
+                .parse::<i32>()
+                .unwrap_or_default();
             uncompress(
                 &driver_zip_file,
                 &self.get_browser_path_in_cache()?,
@@ -449,6 +453,7 @@ impl SeleniumManager for FirefoxManager {
                 self.get_os(),
                 None,
                 Some(FIREFOX_NIGHTLY_VOLUME),
+                Some(major_browser_version_int),
             )?;
         }
         if browser_binary_path.exists() {

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -90,108 +90,10 @@ impl FirefoxManager {
         format!("{}{}", FIREFOX_DETAILS_URL, endpoint)
     }
 
-    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        let browser_name = self.browser_name;
-        self.get_logger().trace(format!(
-            "Using Firefox endpoints to find out latest stable {} version",
-            browser_name
-        ));
-
-        let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
-        let firefox_versions =
-            parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
-        let browser_version = firefox_versions
-            .get(FIREFOX_STABLE_LABEL)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        self.set_browser_version(browser_version.to_string());
-        Ok(browser_version.to_string())
-    }
-
-    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        let browser_name = self.browser_name;
-        let browser_version = self.get_browser_version().to_string();
-        self.get_logger().trace(format!(
-            "Using Firefox endpoints to find out {} {}",
-            browser_name, browser_version
-        ));
-
-        if self.is_browser_version_unstable() {
-            let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
-            let firefox_versions =
-                parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
-            let version_label = if browser_version.eq_ignore_ascii_case(BETA) {
-                FIREFOX_BETA_LABEL
-            } else if browser_version.eq_ignore_ascii_case(DEV) {
-                FIREFOX_DEV_LABEL
-            } else {
-                FIREFOX_CANARY_LABEL
-            };
-            let browser_version = firefox_versions
-                .get(version_label)
-                .unwrap()
-                .as_str()
-                .unwrap();
-            Ok(browser_version.to_string())
-        } else {
-            let os = self.get_os();
-            let major_browser_version = self
-                .get_major_browser_version()
-                .parse::<i32>()
-                .unwrap_or_default();
-
-            let min_downloadable_version = if WINDOWS.is(os) {
-                MIN_DOWNLOADABLE_FIREFOX_VERSION_WIN
-            } else if MACOS.is(os) {
-                MIN_DOWNLOADABLE_FIREFOX_VERSION_MAC
-            } else {
-                MIN_DOWNLOADABLE_FIREFOX_VERSION_LINUX
-            };
-            if major_browser_version < min_downloadable_version {
-                return Err(format_three_args(
-                    UNAVAILABLE_DOWNLOAD_ERROR_MESSAGE,
-                    browser_name,
-                    &browser_version,
-                    &min_downloadable_version.to_string(),
-                )
-                .into());
-            }
-
-            let mut firefox_versions =
-                self.request_versions_from_online(FIREFOX_HISTORY_ENDPOINT)?;
-            if firefox_versions.is_empty() {
-                firefox_versions =
-                    self.request_versions_from_online(FIREFOX_HISTORY_DEV_ENDPOINT)?;
-                if firefox_versions.is_empty() {
-                    return Err(format_two_args(
-                        ONLINE_DISCOVERY_ERROR_MESSAGE,
-                        browser_name,
-                        self.get_browser_version(),
-                    )
-                    .into());
-                }
-            }
-
-            for version in firefox_versions.iter().rev() {
-                let release_url = format_two_args("{}{}/", BROWSER_URL, version);
-                self.get_logger()
-                    .trace(format!("Checking release URL: {}", release_url));
-                let content = read_content_from_link(self.get_http_client(), release_url)?;
-                if !content.contains("Not Found") {
-                    return Ok(version.to_string());
-                }
-            }
-            Err(format_two_args(
-                ONLINE_DISCOVERY_ERROR_MESSAGE,
-                browser_name,
-                self.get_browser_version(),
-            )
-            .into())
-        }
-    }
-
-    fn request_versions_from_online(&self, endpoint: &str) -> Result<Vec<String>, Box<dyn Error>> {
+    fn request_versions_from_online(
+        &mut self,
+        endpoint: &str,
+    ) -> Result<Vec<String>, Box<dyn Error>> {
         let browser_version = self.get_browser_version().to_string();
         let firefox_versions_url = self.create_firefox_details_url(endpoint);
         let firefox_versions =
@@ -242,6 +144,8 @@ impl FirefoxManager {
             artifact_extension = "tar.bz2";
             if X32.is(arch) {
                 platform_label = "linux-i686";
+            } else if self.is_browser_version_nightly() {
+                platform_label = "linux64";
             } else {
                 platform_label = "linux-x86_64";
             }
@@ -336,7 +240,7 @@ impl SeleniumManager for FirefoxManager {
     }
 
     fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
-        self.discover_general_browser_version(
+        self.general_discover_browser_version(
             r#"HKCU\Software\Mozilla\Mozilla Firefox"#,
             REG_CURRENT_VERSION_ARG,
             DASH_VERSION,
@@ -388,7 +292,7 @@ impl SeleniumManager for FirefoxManager {
     }
 
     fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
-        Ok(None)
+        self.general_request_browser_version(self.browser_name)
     }
 
     fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
@@ -574,20 +478,107 @@ impl SeleniumManager for FirefoxManager {
             "linux64"
         }
     }
-}
 
-pub fn request_firefox_beta_version(http_client: &Client) -> Result<String, Box<dyn Error>> {
-    let firefox_versions_url = format!("{}{}", FIREFOX_DETAILS_URL, FIREFOX_VERSIONS_ENDPOINT);
-    let firefox_versions = parse_generic_json_from_url(http_client, firefox_versions_url)?;
-    let firefox_beta_version = firefox_versions
-        .get(FIREFOX_BETA_LABEL)
-        .unwrap()
-        .as_str()
-        .unwrap();
-    let index_b = firefox_beta_version.find('b');
-    let index_or_total = index_b.unwrap_or(firefox_beta_version.len());
-    let trimmed_version = &firefox_beta_version[..index_or_total];
-    Ok(trimmed_version.to_string())
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        let browser_name = self.browser_name;
+        self.get_logger().trace(format!(
+            "Using Firefox endpoints to find out latest stable {} version",
+            browser_name
+        ));
+
+        let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
+        let firefox_versions =
+            parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+        let browser_version = firefox_versions
+            .get(FIREFOX_STABLE_LABEL)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        self.set_browser_version(browser_version.to_string());
+        Ok(browser_version.to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        let browser_name = self.browser_name;
+        let browser_version = self.get_browser_version().to_string();
+        self.get_logger().trace(format!(
+            "Using Firefox endpoints to find out {} {}",
+            browser_name, browser_version
+        ));
+
+        if self.is_browser_version_unstable() {
+            let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
+            let firefox_versions =
+                parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+            let version_label = if browser_version.eq_ignore_ascii_case(BETA) {
+                FIREFOX_BETA_LABEL
+            } else if browser_version.eq_ignore_ascii_case(DEV) {
+                FIREFOX_DEV_LABEL
+            } else {
+                FIREFOX_CANARY_LABEL
+            };
+            let browser_version = firefox_versions
+                .get(version_label)
+                .unwrap()
+                .as_str()
+                .unwrap();
+            Ok(browser_version.to_string())
+        } else {
+            let os = self.get_os();
+            let major_browser_version = self
+                .get_major_browser_version()
+                .parse::<i32>()
+                .unwrap_or_default();
+
+            let min_downloadable_version = if WINDOWS.is(os) {
+                MIN_DOWNLOADABLE_FIREFOX_VERSION_WIN
+            } else if MACOS.is(os) {
+                MIN_DOWNLOADABLE_FIREFOX_VERSION_MAC
+            } else {
+                MIN_DOWNLOADABLE_FIREFOX_VERSION_LINUX
+            };
+            if major_browser_version < min_downloadable_version {
+                return Err(format_three_args(
+                    UNAVAILABLE_DOWNLOAD_ERROR_MESSAGE,
+                    browser_name,
+                    &browser_version,
+                    &min_downloadable_version.to_string(),
+                )
+                .into());
+            }
+
+            let mut firefox_versions =
+                self.request_versions_from_online(FIREFOX_HISTORY_ENDPOINT)?;
+            if firefox_versions.is_empty() {
+                firefox_versions =
+                    self.request_versions_from_online(FIREFOX_HISTORY_DEV_ENDPOINT)?;
+                if firefox_versions.is_empty() {
+                    return Err(format_two_args(
+                        ONLINE_DISCOVERY_ERROR_MESSAGE,
+                        browser_name,
+                        self.get_browser_version(),
+                    )
+                    .into());
+                }
+            }
+
+            for version in firefox_versions.iter().rev() {
+                let release_url = format_two_args("{}{}/", BROWSER_URL, version);
+                self.get_logger()
+                    .trace(format!("Checking release URL: {}", release_url));
+                let content = read_content_from_link(self.get_http_client(), release_url)?;
+                if !content.contains("Not Found") {
+                    return Ok(version.to_string());
+                }
+            }
+            Err(format_two_args(
+                ONLINE_DISCOVERY_ERROR_MESSAGE,
+                browser_name,
+                self.get_browser_version(),
+            )
+            .into())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -40,7 +40,7 @@ const DRIVER_URL: &str = "https://github.com/mozilla/geckodriver/releases/";
 const LATEST_RELEASE: &str = "latest";
 const BROWSER_URL: &str = "https://ftp.mozilla.org/pub/firefox/releases/";
 const FIREFOX_DEFAULT_LANG: &str = "en-US";
-const FIREFOX_MACOS_APP_NAME: &str = "Firefox.app/Contents/MacOS/Firefox";
+const FIREFOX_MACOS_APP_NAME: &str = "Firefox.app/Contents/MacOS/firefox";
 const FIREFOX_DETAILS_URL: &str = "https://product-details.mozilla.org/1.0/";
 const LATEST_FIREFOX_VERSION: &str = "LATEST_FIREFOX_VERSION";
 const FIREFOX_VERSIONS_ENDPOINT: &str = "firefox_versions.json";
@@ -115,8 +115,8 @@ impl FirefoxManager {
                 platform_label = "win64";
             }
         } else if MACOS.is(os) {
-            artifact_name = "Firefox%%20";
-            artifact_extension = "dmg";
+            artifact_name = "Firefox%20";
+            artifact_extension = "pkg";
             platform_label = "mac";
         } else {
             // Linux
@@ -403,6 +403,7 @@ impl SeleniumManager for FirefoxManager {
                 &driver_zip_file,
                 &self.get_browser_path_in_cache()?,
                 self.get_logger(),
+                self.get_os(),
                 None,
             )?;
         }

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -23,20 +23,27 @@ use std::path::PathBuf;
 
 use crate::config::ARCH::{ARM64, X32};
 use crate::config::OS::{LINUX, MACOS, WINDOWS};
-use crate::downloads::read_redirect_from_link;
+use crate::downloads::{parse_generic_json_from_url, read_redirect_from_link};
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    create_http_client, Logger, SeleniumManager, BETA, DASH_VERSION, DEV, NIGHTLY,
-    OFFLINE_REQUEST_ERR_MSG, REG_CURRENT_VERSION_ARG, STABLE,
+    create_browser_metadata, create_http_client, download_to_tmp_folder,
+    get_browser_version_from_metadata, path_buf_to_string, uncompress, Logger, SeleniumManager,
+    BETA, DASH_VERSION, DEV, NIGHTLY, OFFLINE_REQUEST_ERR_MSG, REG_CURRENT_VERSION_ARG, STABLE,
 };
 
 pub const FIREFOX_NAME: &str = "firefox";
 pub const GECKODRIVER_NAME: &str = "geckodriver";
 const DRIVER_URL: &str = "https://github.com/mozilla/geckodriver/releases/";
 const LATEST_RELEASE: &str = "latest";
+const BROWSER_URL: &str = "https://ftp.mozilla.org/pub/firefox/releases/";
+const FIREFOX_DEFAULT_LANG: &str = "en-US";
+const FIREFOX_MACOS_APP_NAME: &str = "Firefox.app/Contents/MacOS/Firefox";
+const FIREFOX_DETAILS_URL: &str = "https://product-details.mozilla.org/1.0/";
+const LATEST_FIREFOX_VERSION: &str = "LATEST_FIREFOX_VERSION";
+const FIREFOX_VERSIONS_ENDPOINT: &str = "firefox_versions.json";
 
 pub struct FirefoxManager {
     pub browser_name: &'static str,
@@ -60,6 +67,89 @@ impl FirefoxManager {
             config,
             log: Logger::new(),
         }))
+    }
+
+    fn create_firefox_details_url(&self, endpoint: &str) -> String {
+        format!("{}{}", FIREFOX_DETAILS_URL, endpoint)
+    }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        let browser_name = self.browser_name;
+        self.get_logger().trace(format!(
+            "Using Firefox endpoints to find out latest stable {} version",
+            browser_name
+        ));
+
+        let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
+        let firefox_versions =
+            parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+        let browser_version = firefox_versions
+            .get(LATEST_FIREFOX_VERSION)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        self.set_browser_version(browser_version.to_string());
+        Ok(browser_version.to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        todo!()
+    }
+
+    fn get_browser_url(&mut self) -> Result<String, Box<dyn Error>> {
+        let browser_version = self.get_browser_version();
+        let os = self.get_os();
+        let arch = self.get_arch();
+
+        let artifact_name;
+        let artifact_extension;
+        let platform_label;
+        if WINDOWS.is(os) {
+            artifact_name = "Firefox%20Setup%20";
+            artifact_extension = "exe";
+            if X32.is(arch) {
+                platform_label = "win32";
+            } else if ARM64.is(arch) {
+                platform_label = "win-aarch64";
+            } else {
+                platform_label = "win64";
+            }
+        } else if MACOS.is(os) {
+            artifact_name = "Firefox%%20";
+            artifact_extension = "dmg";
+            platform_label = "mac";
+        } else {
+            // Linux
+            artifact_name = "firefox-";
+            artifact_extension = "tar.bz2";
+            if X32.is(arch) {
+                platform_label = "linux-i686";
+            } else {
+                platform_label = "linux-x86_64";
+            }
+        }
+        // A possible future improvement is to allow downloading language-specific releases
+        let language = FIREFOX_DEFAULT_LANG;
+
+        Ok(format!(
+            "{}{}/{}/{}/{}{}.{}",
+            BROWSER_URL,
+            browser_version,
+            platform_label,
+            language,
+            artifact_name,
+            browser_version,
+            artifact_extension
+        ))
+    }
+
+    fn get_browser_binary_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+        let browser_in_cache = self.get_browser_path_in_cache()?;
+        if MACOS.is(self.get_os()) {
+            Ok(browser_in_cache.join(FIREFOX_MACOS_APP_NAME))
+        } else {
+            Ok(browser_in_cache.join(self.get_browser_name_with_extension()))
+        }
     }
 }
 
@@ -212,41 +302,12 @@ impl SeleniumManager for FirefoxManager {
     }
 
     fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
-        let driver_version = self.get_driver_version();
-        let os = self.get_os();
-        let arch = self.get_arch();
-        let minor_driver_version = self
-            .get_minor_version(driver_version)
-            .unwrap_or_default()
-            .parse::<i32>()
-            .unwrap_or_default();
-        let arch_folder = if WINDOWS.is(os) {
-            if X32.is(arch) {
-                "win32"
-            } else if ARM64.is(arch) && minor_driver_version > 31 {
-                "win-arm64"
-            } else {
-                "win64"
-            }
-        } else if MACOS.is(os) {
-            if ARM64.is(arch) {
-                "mac-arm64"
-            } else {
-                "mac64"
-            }
-        } else if X32.is(arch) {
-            "linux32"
-        } else if ARM64.is(arch) && minor_driver_version > 31 {
-            "linux-arm64"
-        } else {
-            "linux64"
-        };
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?,
             self.driver_name,
-            os,
-            arch_folder,
-            driver_version,
+            self.get_os(),
+            self.get_platform_label(),
+            self.get_driver_version(),
         ))
     }
 
@@ -271,7 +332,118 @@ impl SeleniumManager for FirefoxManager {
     }
 
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
-        Ok(None)
+        let browser_version;
+        let browser_name = self.browser_name;
+        let mut metadata = get_metadata(self.get_logger(), self.get_cache_path()?);
+        let major_browser_version = self.get_major_browser_version();
+
+        // Browser version is checked in the local metadata
+        match get_browser_version_from_metadata(
+            &metadata.browsers,
+            browser_name,
+            &major_browser_version,
+        ) {
+            Some(version) => {
+                self.get_logger().trace(format!(
+                    "Browser with valid TTL. Getting {} version from metadata",
+                    browser_name
+                ));
+                browser_version = version;
+                self.set_browser_version(browser_version.clone());
+            }
+            _ => {
+                // If not in metadata, discover version using Mozilla online metadata
+                if self.is_browser_version_stable() || self.is_browser_version_empty() {
+                    browser_version = self.request_latest_browser_version_from_online()?;
+                } else {
+                    browser_version = self.request_fixed_browser_version_from_online()?;
+                }
+                self.set_browser_version(browser_version.clone());
+
+                let browser_ttl = self.get_ttl();
+                if browser_ttl > 0
+                    && !self.is_browser_version_empty()
+                    && !self.is_browser_version_stable()
+                {
+                    metadata.browsers.push(create_browser_metadata(
+                        browser_name,
+                        &major_browser_version,
+                        &browser_version,
+                        browser_ttl,
+                    ));
+                    write_metadata(&metadata, self.get_logger(), self.get_cache_path()?);
+                }
+            }
+        }
+        self.get_logger().debug(format!(
+            "Required browser: {} {}",
+            browser_name, browser_version
+        ));
+
+        // Checking if browser version is in the cache
+        let browser_binary_path = self.get_browser_binary_path_in_cache()?;
+        if browser_binary_path.exists() {
+            self.get_logger().debug(format!(
+                "{} {} already in the cache",
+                browser_name, browser_version
+            ));
+        } else {
+            // If browser is not in the cache, download it
+            let browser_url = self.get_browser_url()?;
+            self.get_logger().debug(format!(
+                "Downloading {} {} from {}",
+                self.get_browser_name(),
+                self.get_browser_version(),
+                browser_url
+            ));
+            let (_tmp_folder, driver_zip_file) =
+                download_to_tmp_folder(self.get_http_client(), browser_url, self.get_logger())?;
+
+            uncompress(
+                &driver_zip_file,
+                &self.get_browser_path_in_cache()?,
+                self.get_logger(),
+                None,
+            )?;
+        }
+        if browser_binary_path.exists() {
+            self.set_browser_path(path_buf_to_string(browser_binary_path.clone()));
+            Ok(Some(browser_binary_path))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_platform_label(&self) -> &str {
+        let driver_version = self.get_driver_version();
+        let os = self.get_os();
+        let arch = self.get_arch();
+        let minor_driver_version = self
+            .get_minor_version(driver_version)
+            .unwrap_or_default()
+            .parse::<i32>()
+            .unwrap_or_default();
+        if WINDOWS.is(os) {
+            if X32.is(arch) {
+                "win32"
+            } else if ARM64.is(arch) && minor_driver_version > 31 {
+                "win-arm64"
+            } else {
+                "win64"
+            }
+        } else if MACOS.is(os) {
+            if ARM64.is(arch) {
+                "mac-arm64"
+            } else {
+                "mac64"
+            }
+        } else if X32.is(arch) {
+            "linux32"
+        } else if ARM64.is(arch) && minor_driver_version > 31 {
+            "linux-arm64"
+        } else {
+            "linux64"
+        }
     }
 }
 

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -227,12 +227,10 @@ impl SeleniumManager for GridManager {
     }
 
     fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 }

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -225,4 +225,14 @@ impl SeleniumManager for GridManager {
     fn get_platform_label(&self) -> &str {
         ""
     }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
 }

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -221,4 +221,8 @@ impl SeleniumManager for GridManager {
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
         Ok(None)
     }
+
+    fn get_platform_label(&self) -> &str {
+        ""
+    }
 }

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -195,18 +195,13 @@ impl SeleniumManager for IExplorerManager {
     }
 
     fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
-        let driver_version = self.get_driver_version();
-        let _minor_driver_version = self
-            .get_minor_version(driver_version)
-            .unwrap_or_default()
-            .parse::<i32>()
-            .unwrap_or_default();
+        // TODO check Windows
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?,
             self.driver_name,
             "Windows",
-            "win32",
-            driver_version,
+            self.get_platform_label(),
+            self.get_driver_version(),
         ))
     }
 
@@ -232,5 +227,9 @@ impl SeleniumManager for IExplorerManager {
 
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
         Ok(None)
+    }
+
+    fn get_platform_label(&self) -> &str {
+        "win32"
     }
 }

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -95,7 +95,7 @@ impl SeleniumManager for IExplorerManager {
     }
 
     fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
-        self.discover_general_browser_version(
+        self.general_discover_browser_version(
             r#"HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer"#,
             REG_VERSION_ARG,
             "",
@@ -230,5 +230,15 @@ impl SeleniumManager for IExplorerManager {
 
     fn get_platform_label(&self) -> &str {
         "win32"
+    }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
     }
 }

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -233,12 +233,10 @@ impl SeleniumManager for IExplorerManager {
     }
 
     fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 }

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -195,7 +195,6 @@ impl SeleniumManager for IExplorerManager {
     }
 
     fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
-        // TODO check Windows
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?,
             self.driver_name,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -536,8 +536,8 @@ pub trait SeleniumManager {
                 Err(err) => {
                     if driver_in_path_version.is_some() {
                         self.get_logger().warn(format!(
-                            "Exception trying to discover {} version: {}",
-                            self.get_driver_name(),
+                            "Exception managing {}: {}",
+                            self.get_browser_name(),
                             err
                         ));
                     } else {
@@ -551,9 +551,12 @@ pub trait SeleniumManager {
         if let (Some(version), Some(path)) = (&driver_in_path_version, &driver_in_path) {
             // If proper driver version is not the same as the driver in path, display warning
             let major_version = self.get_major_version(version)?;
-            if !self.get_driver_version().is_empty()
-                && !major_version.eq(&self.get_major_browser_version())
-            {
+            let driver_condition = if self.is_firefox() {
+                !version.eq(self.get_driver_version())
+            } else {
+                !major_version.eq(&self.get_major_browser_version())
+            };
+            if !self.get_driver_version().is_empty() && driver_condition {
                 self.get_logger().warn(format!(
                     "The {} version ({}) detected in PATH at {} might not be compatible with \
                     the detected {} version ({}); currently, {} {} is recommended for {} {}.*, \

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -142,8 +142,12 @@ pub trait SeleniumManager {
 
     fn download_driver(&mut self) -> Result<(), Box<dyn Error>> {
         let driver_url = self.get_driver_url()?;
-        self.get_logger()
-            .debug(format!("Driver URL: {}", driver_url));
+        self.get_logger().debug(format!(
+            "Downloading {} {} from {}",
+            self.get_driver_name(),
+            self.get_driver_version(),
+            driver_url
+        ));
         let (_tmp_folder, driver_zip_file) =
             download_to_tmp_folder(self.get_http_client(), driver_url, self.get_logger())?;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -505,7 +505,7 @@ pub trait SeleniumManager {
         self.get_browser_version().eq_ignore_ascii_case(STABLE)
     }
 
-    fn resolve_driver(&mut self) -> Result<PathBuf, Box<dyn Error>> {
+    fn setup(&mut self) -> Result<PathBuf, Box<dyn Error>> {
         let mut driver_in_path = None;
         let mut driver_in_path_version = None;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -72,6 +72,8 @@ pub const REG_VERSION_ARG: &str = "version";
 pub const REG_CURRENT_VERSION_ARG: &str = "CurrentVersion";
 pub const PLIST_COMMAND: &str =
     r#"/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" {}/Contents/Info.plist"#;
+pub const PKGUTIL_COMMAND: &str = "pkgutil --expand-full {} {}";
+pub const MV_PAYLOAD_COMMAND: &str = "mv {}/*{}/Payload/*.app {}";
 pub const DASH_VERSION: &str = "{}{}{} -v";
 pub const DASH_DASH_VERSION: &str = "{}{}{} --version";
 pub const DOUBLE_QUOTE: &str = "\"";
@@ -155,6 +157,7 @@ pub trait SeleniumManager {
                 &driver_zip_file,
                 &driver_path_in_cache,
                 self.get_logger(),
+                self.get_os(),
                 Some(driver_name_with_extension),
             )?)
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -75,6 +75,9 @@ pub const REG_CURRENT_VERSION_ARG: &str = "CurrentVersion";
 pub const PLIST_COMMAND: &str =
     r#"/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" {}/Contents/Info.plist"#;
 pub const PKGUTIL_COMMAND: &str = "pkgutil --expand-full {} {}";
+pub const HDIUTIL_ATTACH_COMMAND: &str = "hdiutil attach {}";
+pub const HDIUTIL_DETACH_COMMAND: &str = "hdiutil detach /Volumes/{}";
+pub const CP_VOLUME_COMMAND: &str = "cp -R /Volumes/{}/{}.app {}";
 pub const MV_PAYLOAD_COMMAND: &str = "mv {}/*{}/Payload/*.app {}";
 pub const MV_SFX_COMMAND: &str = r#"robocopy {}\core {} /e /move"#;
 pub const DASH_VERSION: &str = "{}{}{} -v";
@@ -171,6 +174,7 @@ pub trait SeleniumManager {
                 self.get_logger(),
                 self.get_os(),
                 Some(driver_name_with_extension),
+                None,
             )?)
         }
     }
@@ -325,7 +329,8 @@ pub trait SeleniumManager {
                         && !major_browser_version.eq(&discovered_major_browser_version)
                     {
                         self.get_logger().debug(format!(
-                            "Discovered browser version ({}) different to specified browser version ({})",
+                            "Discovered online {} version ({}) different to specified browser version ({})",
+                            self.get_browser_name(),
                             discovered_major_browser_version,
                             major_browser_version,
                         ));

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -74,6 +74,7 @@ pub const PLIST_COMMAND: &str =
     r#"/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" {}/Contents/Info.plist"#;
 pub const PKGUTIL_COMMAND: &str = "pkgutil --expand-full {} {}";
 pub const MV_PAYLOAD_COMMAND: &str = "mv {}/*{}/Payload/*.app {}";
+pub const MV_SFX_COMMAND: &str = r#"robocopy {}\core {} /e /move"#;
 pub const DASH_VERSION: &str = "{}{}{} -v";
 pub const DASH_DASH_VERSION: &str = "{}{}{} --version";
 pub const DOUBLE_QUOTE: &str = "\"";

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -97,6 +97,7 @@ pub const ESCAPE_COMMAND: &str = "printf %q \"{}\"";
 pub const SNAPSHOT: &str = "SNAPSHOT";
 pub const OFFLINE_REQUEST_ERR_MSG: &str = "Unable to discover proper {} version in offline mode";
 pub const OFFLINE_DOWNLOAD_ERR_MSG: &str = "Unable to download {} in offline mode";
+pub const UNAVAILABLE_DOWNLOAD_ERR_MSG: &str = "{} not available for downloading";
 pub const UNC_PREFIX: &str = r#"\\?\"#;
 
 pub trait SeleniumManager {
@@ -779,6 +780,10 @@ pub trait SeleniumManager {
         } else {
             format!(" {}", major_browser_version)
         }
+    }
+
+    fn unavailable_download(&mut self) -> Result<String, Box<dyn Error>> {
+        Err(format_one_arg(UNAVAILABLE_DOWNLOAD_ERR_MSG, self.get_browser_name()).into())
     }
 
     // ----------------------------------------------------------

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -79,6 +79,7 @@ pub const HDIUTIL_ATTACH_COMMAND: &str = "hdiutil attach {}";
 pub const HDIUTIL_DETACH_COMMAND: &str = "hdiutil detach /Volumes/{}";
 pub const CP_VOLUME_COMMAND: &str = "cp -R /Volumes/{}/{}.app {}";
 pub const MV_PAYLOAD_COMMAND: &str = "mv {}/*{}/Payload/*.app {}";
+pub const MV_PAYLOAD_OLD_VERSIONS_COMMAND: &str = "mv {}/Payload/*.app {}";
 pub const MV_SFX_COMMAND: &str = r#"robocopy {}\core {} /e /move"#;
 pub const DASH_VERSION: &str = "{}{}{} -v";
 pub const DASH_DASH_VERSION: &str = "{}{}{} --version";
@@ -174,6 +175,7 @@ pub trait SeleniumManager {
                 self.get_logger(),
                 self.get_os(),
                 Some(driver_name_with_extension),
+                None,
                 None,
             )?)
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -300,24 +300,24 @@ pub trait SeleniumManager {
                                 self.get_major_version(&online_browser_version.unwrap())?;
                             if discovered_major_browser_version.eq(&major_online_browser_version) {
                                 self.get_logger().debug(format!(
-                                    "Online {}{} version ({}) is the same as the one installed in the system",
+                                    "Discovered online {} version ({}) is the same as the detected local {} version",
                                     self.get_browser_name(),
-                                    self.get_browser_version_label(),
                                     discovered_major_browser_version,
+                                    self.get_browser_name(),
                                 ));
                                 self.set_browser_version(discovered_version);
                             } else {
                                 self.get_logger().debug(format!(
-                                    "Online {}{} version ({}) different to detected browser version ({})",
+                                    "Discovered online {} version ({}) is different to the detected local {} version ({})",
                                     self.get_browser_name(),
-                                    self.get_browser_version_label(),
                                     major_online_browser_version,
+                                    self.get_browser_name(),
                                     discovered_major_browser_version,
                                 ));
                                 download_browser = true;
                             }
                         } else {
-                            self.set_browser_version(discovered_version.to_string());
+                            self.set_browser_version(discovered_version);
                         }
                     } else if !major_browser_version.is_empty()
                         && !self.is_browser_version_unstable()
@@ -344,7 +344,7 @@ pub trait SeleniumManager {
             }
         }
 
-        if download_browser {
+        if download_browser && !self.is_avoid_browser_download() {
             let browser_path = self.download_browser()?;
             if browser_path.is_some() {
                 self.get_logger().debug(format!(
@@ -953,6 +953,16 @@ pub trait SeleniumManager {
     fn set_force_browser_download(&mut self, force_browser_download: bool) {
         if force_browser_download {
             self.get_config_mut().force_browser_download = true;
+        }
+    }
+
+    fn is_avoid_browser_download(&self) -> bool {
+        self.get_config().avoid_browser_download
+    }
+
+    fn set_avoid_browser_download(&mut self, avoid_browser_download: bool) {
+        if avoid_browser_download {
+            self.get_config_mut().avoid_browser_download = true;
         }
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -131,6 +131,8 @@ pub trait SeleniumManager {
 
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>>;
 
+    fn get_platform_label(&self) -> &str;
+
     // ----------------------------------------------------------
     // Shared functions
     // ----------------------------------------------------------
@@ -674,6 +676,14 @@ pub trait SeleniumManager {
         }
         self.set_browser_path(safari_path);
         Ok(self.detect_browser_version(commands))
+    }
+
+    fn get_browser_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+        Ok(self
+            .get_cache_path()?
+            .join(self.get_browser_name())
+            .join(self.get_platform_label())
+            .join(self.get_browser_version()))
     }
 
     // ----------------------------------------------------------

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -116,9 +116,13 @@ struct Cli {
     #[clap(long)]
     offline: bool,
 
-    /// Force to download browser. Currently Chrome for Testing (CfT) is supported
+    /// Force to download browser (even when browser is already in the system)
     #[clap(long)]
     force_browser_download: bool,
+
+    /// Avoid to download browser (even when browser-version is specified)
+    #[clap(long)]
+    avoid_browser_download: bool,
 }
 
 fn main() {
@@ -162,6 +166,7 @@ fn main() {
     selenium_manager.set_ttl(cli.ttl);
     selenium_manager.set_offline(cli.offline);
     selenium_manager.set_force_browser_download(cli.force_browser_download);
+    selenium_manager.set_avoid_browser_download(cli.avoid_browser_download);
     selenium_manager.set_cache_path(cache_path.clone());
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -179,7 +179,7 @@ fn main() {
     selenium_manager
         .set_timeout(cli.timeout)
         .and_then(|_| selenium_manager.set_proxy(cli.proxy.unwrap_or_default()))
-        .and_then(|_| selenium_manager.resolve_driver())
+        .and_then(|_| selenium_manager.setup())
         .map(|driver_path| {
             let log = selenium_manager.get_logger();
             if driver_path.exists() {

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -125,4 +125,14 @@ impl SeleniumManager for SafariManager {
     fn get_platform_label(&self) -> &str {
         ""
     }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
 }

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -121,4 +121,8 @@ impl SeleniumManager for SafariManager {
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
         Ok(None)
     }
+
+    fn get_platform_label(&self) -> &str {
+        ""
+    }
 }

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -127,12 +127,10 @@ impl SeleniumManager for SafariManager {
     }
 
     fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 }

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -133,4 +133,14 @@ impl SeleniumManager for SafariTPManager {
     fn get_platform_label(&self) -> &str {
         ""
     }
+
+    fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
+
+    fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+        // TODO review this
+        Ok("".to_string())
+    }
 }

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -135,12 +135,10 @@ impl SeleniumManager for SafariTPManager {
     }
 
     fn request_latest_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
-        // TODO review this
-        Ok("".to_string())
+        self.unavailable_download()
     }
 }

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -129,4 +129,8 @@ impl SeleniumManager for SafariTPManager {
     fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
         Ok(None)
     }
+
+    fn get_platform_label(&self) -> &str {
+        ""
+    }
 }

--- a/rust/tests/browser_download_tests.rs
+++ b/rust/tests/browser_download_tests.rs
@@ -22,12 +22,14 @@ use rstest::rstest;
 
 mod common;
 
-#[test]
-fn chrome_latest_download_test() {
+#[rstest]
+#[case("chrome")]
+#[case("firefox")]
+fn browser_latest_download_test(#[case] browser: String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     cmd.args([
         "--browser",
-        "chrome",
+        &browser,
         "--force-browser-download",
         "--output",
         "json",
@@ -42,13 +44,13 @@ fn chrome_latest_download_test() {
 }
 
 #[rstest]
-#[case("113")]
-#[case("beta")]
-fn chrome_version_download_test(#[case] browser_version: String) {
+#[case("chrome", "113")]
+#[case("chrome", "beta")]
+fn browser_version_download_test(#[case] browser: String, #[case] browser_version: String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     cmd.args([
         "--browser",
-        "chrome",
+        &browser,
         "--browser-version",
         &browser_version,
         "--output",

--- a/rust/tests/browser_download_tests.rs
+++ b/rust/tests/browser_download_tests.rs
@@ -46,6 +46,8 @@ fn browser_latest_download_test(#[case] browser: String) {
 #[rstest]
 #[case("chrome", "113")]
 #[case("chrome", "beta")]
+#[case("firefox", "116")]
+#[case("firefox", "beta")]
 fn browser_version_download_test(#[case] browser: String, #[case] browser_version: String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     cmd.args([

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -37,6 +37,7 @@ fn browser_version_test(
         "--browser-version",
         &browser_version,
         "--debug",
+        "--avoid-browser-download",
     ])
     .assert()
     .success()
@@ -100,7 +101,14 @@ fn wrong_parameters_test(
 fn browser_beta_test(#[case] browser: String, #[case] driver_name: String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     let assert = cmd
-        .args(["--browser", &browser, "--browser-version", "beta"])
+        .args([
+            "--browser",
+            &browser,
+            "--browser-version",
+            "beta",
+            "--avoid-browser-download",
+            "--debug",
+        ])
         .assert();
 
     let stdout = &assert.get_output().stdout;


### PR DESCRIPTION
### Description
This PR implements Firefox's automated browser management feature for the latest (stable) and given versions (unstable -beta, dev, nightly- and fixed versions -e.g., 116, 117, etc.-).

The minimum manageable Firefox versions by SM are the following (although it is improbable that ancient versions could be automated with Selenium):
- Firefox in Windows: 13
- Firefox in macOS: 4
- Firefox in Linux: 4

Some examples:

```
$ ./selenium-manager --debug --browser firefox --browser-version stable
DEBUG	geckodriver not found in PATH
DEBUG	firefox detected at /usr/lib/firefox/firefox.sh
DEBUG	Running command: /usr/lib/firefox/firefox.sh -v
DEBUG	Output: "Mozilla Firefox 116.0.1"
DEBUG	Detected browser: firefox 116.0.1
DEBUG	Discovered online firefox version (116) is the same as the detected local firefox version
DEBUG	Required driver: geckodriver 0.33.0
DEBUG	Downloading geckodriver 0.33.0 from https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz
INFO	Driver path: /home/boni/.cache/selenium/geckodriver/linux64/0.33.0/geckodriver
INFO	Browser path: /usr/lib/firefox/firefox.sh
```

```
$ ./selenium-manager --debug --browser firefox --browser-version beta
DEBUG	geckodriver not found in PATH
DEBUG	firefox detected at /usr/lib/firefox/firefox.sh
DEBUG	Running command: /usr/lib/firefox/firefox.sh -v
DEBUG	Output: "Mozilla Firefox 116.0.1"
DEBUG	Detected browser: firefox 116.0.1
DEBUG	Discovered online firefox version (117) is different to the detected local firefox version (116)
DEBUG	Required browser: firefox 117.0b9
DEBUG	Downloading firefox 117.0b9 from https://ftp.mozilla.org/pub/firefox/releases/117.0b9/linux-x86_64/en-US/firefox-117.0b9.tar.bz2
DEBUG	firefox 117.0b9 has been downloaded at /home/boni/.cache/selenium/firefox/linux64/117.0b9/firefox
DEBUG	Required driver: geckodriver 0.33.0
DEBUG	geckodriver 0.33.0 already in the cache
INFO	Driver path: /home/boni/.cache/selenium/geckodriver/linux64/0.33.0/geckodriver
INFO	Browser path: /home/boni/.cache/selenium/firefox/linux64/117.0b9/firefox
```

```
$ ./selenium-manager --debug --browser firefox --browser-version 80
DEBUG	geckodriver not found in PATH
DEBUG	firefox detected at /usr/lib/firefox/firefox.sh
DEBUG	Running command: /usr/lib/firefox/firefox.sh -v
DEBUG	Output: "Mozilla Firefox 116.0.1"
DEBUG	Detected browser: firefox 116.0.1
DEBUG	Discovered browser version (116) different to specified browser version (80)
DEBUG	Required browser: firefox 80.0.1
DEBUG	Downloading firefox 80.0.1 from https://ftp.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/en-US/firefox-80.0.1.tar.bz2
DEBUG	firefox 80.0.1 has been downloaded at /home/boni/.cache/selenium/firefox/linux64/80.0.1/firefox
DEBUG	Required driver: geckodriver 0.33.0
DEBUG	geckodriver 0.33.0 already in the cache
INFO	Driver path: /home/boni/.cache/selenium/geckodriver/linux64/0.33.0/geckodriver
INFO	Browser path: /home/boni/.cache/selenium/firefox/linux64/80.0.1/firefox
```

As a plus, this PR includes a new argument called `--avoid-browser-download`, which prevents browser download even when the browser version is specified. This argument is irrelevant to the bindings. I implemented it to ease some tests and just in case someone using SM as a CLI tool needs it (like `--force-browser-download`).

### Motivation and Context
This  PR implements #11680 and #11682, and it has been tested on:

- Windows (10)
- Linux (Ubuntu 22.04.2 and 22.10)
- macOS (Big Sur 11.0.1)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
