### PR TITLE
[rb] Replace the :capabilities paramater with :options in API examples

### DIFF
--- a/rb/lib/selenium/webdriver/chromium/options.rb
+++ b/rb/lib/selenium/webdriver/chromium/options.rb
@@ -47,7 +47,7 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::Chrome::Options.new(args: ['start-maximized', 'user-data-dir=/tmp/temp_profile'])
-        #   driver = Selenium::WebDriver.for(:chrome, capabilities: options)
+        #   driver = Selenium::WebDriver.for(:chrome, options: options)
         #
         # @param [Profile] profile An instance of a Chrome::Profile Class
         # @param [Hash] opts the pre-defined options to create the Chrome::Options with

--- a/rb/lib/selenium/webdriver/firefox/options.rb
+++ b/rb/lib/selenium/webdriver/firefox/options.rb
@@ -45,7 +45,7 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::Firefox::Options.new(args: ['--host=127.0.0.1'])
-        #   driver = Selenium::WebDriver.for :firefox, capabilities: options
+        #   driver = Selenium::WebDriver.for :firefox, options: options
         #
         # @param [Hash] opts the pre-defined options to create the Firefox::Options with
         # @option opts [String] :binary Path to the Firefox executable to use

--- a/rb/lib/selenium/webdriver/ie/options.rb
+++ b/rb/lib/selenium/webdriver/ie/options.rb
@@ -53,12 +53,12 @@ module Selenium
         #
         # @example
         #   options = Selenium::WebDriver::IE::Options.new(args: ['--host=127.0.0.1'])
-        #   driver = Selenium::WebDriver.for(:ie, capabilities: options)
+        #   driver = Selenium::WebDriver.for(:ie, options: options)
         #
         # @example
         #   options = Selenium::WebDriver::IE::Options.new
         #   options.element_scroll_behavior = Selenium::WebDriver::IE::Options::SCROLL_BOTTOM
-        #   driver = Selenium::WebDriver.for(:ie, capabilities: options)
+        #   driver = Selenium::WebDriver.for(:ie, options: options)
         #
         # @param [Hash] opts the pre-defined options
         # @option opts [Array<String>] args


### PR DESCRIPTION
### Description

The `:capabilities` parameter for webdriver classes is deprecated but still used in API example docs.

This change replaces the `:capabilites` parameter with `:options`.

<!--- Describe your changes in detail -->

### Motivation and Context

I would like to keep the API documentation up to date.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
