### PR TITLE
[java] Increase execution timeout of SM in Java from 10 to 120 seconds

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -111,7 +111,7 @@ public class SeleniumManager {
       CommandLine command =
           new CommandLine(binary.toAbsolutePath().toString(), arguments.toArray(new String[0]));
       command.executeAsync();
-      command.waitFor(10000); // A generous timeout
+      command.waitFor(120000); // TODO: make this configurable
       if (command.isRunning()) {
         LOG.warning("Selenium Manager did not exit");
       }


### PR DESCRIPTION
### Description
This PR increases execution timeout of SM in Java from 10 to 120 seconds.

### Motivation and Context
This PR fixes #12630, as discussed on Slack.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
