### PR TITLE
Closing out logging on quit

### DIFF
--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -23,9 +23,9 @@ import warnings
 from abc import ABC
 from abc import abstractmethod
 from platform import system
-from subprocess import DEVNULL
 from subprocess import PIPE
 from time import sleep
+from typing import TextIO
 from urllib import request
 from urllib.error import URLError
 
@@ -141,13 +141,12 @@ class Service(ABC):
 
     def stop(self) -> None:
         """Stops the service."""
-        if self.log_output != PIPE and not (self.log_output == DEVNULL):
-            try:
-                # Todo: Be explicit in what we are catching here.
-                if hasattr(self.log_output, "close"):
-                    self.log_file.close()  # type: ignore
-            except Exception:
-                pass
+
+        if self.log_output != PIPE:
+            if isinstance(self.log_output, TextIO):
+                self.log_output.close()
+            elif isinstance(self.log_output, int):
+                os.close(self.log_output)
 
         if self.process is not None:
             try:

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -21,7 +21,7 @@ import warnings
 import zipfile
 from contextlib import contextmanager
 from io import BytesIO
-
+from typing import TextIO
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
@@ -76,7 +76,10 @@ class WebDriver(RemoteWebDriver):
             # We don't care about the message because something probably has gone wrong
             pass
 
-        self.service.log_output.close()
+        if isinstance(self.service.log_output,TextIO):
+            self.service.log_output.close()
+        elif isinstance(self.service.log_output,int):
+            os.close(self.service.log_output)
         self.service.stop()
 
     def set_context(self, context) -> None:

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -76,8 +76,8 @@ class WebDriver(RemoteWebDriver):
             # We don't care about the message because something probably has gone wrong
             pass
 
+        self.service.log_output.close()
         self.service.stop()
-        self.log_output.close()
 
     def set_context(self, context) -> None:
         self.execute("SET_CONTEXT", {"context": context})

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -77,6 +77,7 @@ class WebDriver(RemoteWebDriver):
             pass
 
         self.service.stop()
+        self.log_output.close()
 
     def set_context(self, context) -> None:
         self.execute("SET_CONTEXT", {"context": context})

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -21,7 +21,7 @@ import warnings
 import zipfile
 from contextlib import contextmanager
 from io import BytesIO
-from typing import TextIO
+
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
@@ -76,10 +76,6 @@ class WebDriver(RemoteWebDriver):
             # We don't care about the message because something probably has gone wrong
             pass
 
-        if isinstance(self.service.log_output,TextIO):
-            self.service.log_output.close()
-        elif isinstance(self.service.log_output,int):
-            os.close(self.service.log_output)
         self.service.stop()
 
     def set_context(self, context) -> None:


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The line I added closes out the log file connections before the service performs a full shutdown

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A project I'm working on uses the Selenium webdriver and I noticed unclosed sockets remained in some of our unit tests, which could potentially affect performance. This addition should now properly close the open sockets of the log output file process.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
