### PR TITLE
[java] Remove browserVersion from options in SM Java wrapper (fix #12633)

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -31,10 +31,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriverException;
@@ -256,6 +258,7 @@ public class SeleniumManager {
     if (!options.getBrowserVersion().isEmpty()) {
       arguments.add("--browser-version");
       arguments.add(options.getBrowserVersion());
+      ((MutableCapabilities) options).setCapability("browserVersion", Optional.empty());
     }
 
     String browserBinary = getBrowserBinary(options);


### PR DESCRIPTION
### Description
This PR remove the `browserVersion` from options in the SM Java wrapper.

### Motivation and Context
This PR fixes #12633 in the Java bindings.

According to @titusfortner info, this is already done in Ruby, Python, and .Net:

https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/common/selenium_manager.rb#L50
https://github.com/SeleniumHQ/selenium/blob/trunk/py/selenium/webdriver/common/selenium_manager.py#L103
https://github.com/SeleniumHQ/selenium/blob/trunk/dotnet/src/webdriver/SeleniumManager.cs#L109

Does anybody know if JavaScript also removes `browserVersion`  from options in the SM wrapper class?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
