### PR TITLE
[dotnet] Fix saving png screenshot as file

### DIFF
--- a/dotnet/src/webdriver/Screenshot.cs
+++ b/dotnet/src/webdriver/Screenshot.cs
@@ -103,10 +103,12 @@ namespace OpenQA.Selenium
                     {
                         imageStream.WriteTo(fileStream);
                     }
-
-                    using (Image screenshotImage = Image.FromStream(imageStream))
+                    else
                     {
-                        screenshotImage.Save(fileStream, ConvertScreenshotImageFormat(format));
+                        using (Image screenshotImage = Image.FromStream(imageStream))
+                        {
+                            screenshotImage.Save(fileStream, ConvertScreenshotImageFormat(format));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description
Save PNG screenshots directly to file and skip further step of image encoding.

### Motivation and Context
Fixes #12652 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
