### PR TITLE
use property instead of atom to get index of option element

### DIFF
--- a/dotnet/src/support/UI/SelectElement.cs
+++ b/dotnet/src/support/UI/SelectElement.cs
@@ -247,7 +247,7 @@ namespace OpenQA.Selenium.Support.UI
 
             foreach (IWebElement option in this.Options)
             {
-                if (option.GetAttribute("index") == match)
+                if (option.GetDomProperty("index") == match)
                 {
                     SetSelected(option, true);
                     return;
@@ -364,7 +364,7 @@ namespace OpenQA.Selenium.Support.UI
             string match = index.ToString(CultureInfo.InvariantCulture);
             foreach (IWebElement option in this.Options)
             {
-                if (match == option.GetAttribute("index"))
+                if (match == option.GetDomProperty("index"))
                 {
                     SetSelected(option, false);
                     return;

--- a/javascript/node/selenium-webdriver/lib/select.js
+++ b/javascript/node/selenium-webdriver/lib/select.js
@@ -191,7 +191,7 @@ class Select {
     }
 
     for (let option of options) {
-      if ((await option.getAttribute('index')) === index.toString()) {
+      if ((await option.getProperty('index')) === index) {
         await this.setSelected(option)
       }
     }
@@ -415,7 +415,7 @@ class Select {
     }
 
     for (let option of options) {
-      if ((await option.getAttribute('index')) === index.toString()) {
+      if ((await option.getProperty('index')) === index) {
         if (await option.isSelected()) {
           await option.click()
         }

--- a/javascript/node/selenium-webdriver/test/select_test.js
+++ b/javascript/node/selenium-webdriver/test/select_test.js
@@ -78,13 +78,10 @@ suite(
         let selector = new Select(
           driver.findElement(By.name(singleSelectValues1['name']))
         )
-        for (let x in singleSelectValues1['values']) {
-          await selector.selectByIndex(x)
+        for (let [index, value] of singleSelectValues1['values'].entries()) {
+          await selector.selectByIndex(index)
           let ele = await selector.getFirstSelectedOption()
-          assert.deepEqual(
-            await ele.getText(),
-            singleSelectValues1['values'][x]
-          )
+          assert.deepEqual(await ele.getText(), value)
         }
       })
 

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -85,16 +85,15 @@ class Select:
 
     def select_by_index(self, index: int) -> None:
         """Select the option at the given index. This is done by examining the
-        "index" attribute of an element, and not merely by counting.
+        "index" property of an element, and not merely by counting.
 
         :Args:
          - index - The option at this index will be selected
 
         throws NoSuchElementException If there is no option with specified index in SELECT
         """
-        match = str(index)
         for opt in self.options:
-            if opt.get_attribute("index") == match:
+            if opt.get_property("index") == index:
                 self._set_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")
@@ -172,7 +171,7 @@ class Select:
 
     def deselect_by_index(self, index: int) -> None:
         """Deselect the option at the given index. This is done by examining
-        the "index" attribute of an element, and not merely by counting.
+        the "index" property of an element, and not merely by counting.
 
         :Args:
          - index - The option at this index will be deselected
@@ -182,7 +181,7 @@ class Select:
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
         for opt in self.options:
-            if opt.get_attribute("index") == str(index):
+            if opt.get_property("index") == index:
                 self._unset_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")


### PR DESCRIPTION
### Description
I've said I don't want to update code in the support module, but this was changed in Ruby & Java, but not Python, .NET or JS.

### Motivation and Context
1. Much more performant
2. Probably fixes whatever is going on in #12659

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
