### PR TITLE
[py] do not send parameters in payload that are used in endpoint

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -286,9 +286,12 @@ class RemoteConnection:
         """
         command_info = self._commands[command]
         assert command_info is not None, f"Unrecognised command {command}"
-        path = string.Template(command_info[1]).substitute(params)
-        if isinstance(params, dict) and "sessionId" in params:
-            del params["sessionId"]
+        path_string = command_info[1]
+        path = string.Template(path_string).substitute(params)
+        substitute_params = {word[1:] for word in path_string.split("/") if word.startswith("$")}  # remove dollar sign
+        if isinstance(params, dict) and substitute_params:
+            for word in substitute_params:
+                del params[word]
         data = utils.dump_json(params)
         url = f"{self._url}{path}"
         return self._request(command_info[0], url, body=data)


### PR DESCRIPTION
### Description
Removes parameters that matched the template for the endpoint from the body payload.
This is @isaulv solution that he asked me to PR.

### Motivation and Context
Fixes #12649