### PR TITLE
[rust] Use original path when unwrap fails in canonicalize function

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -867,13 +867,7 @@ pub trait SeleniumManager {
     }
 
     fn canonicalize_path(&self, path_buf: PathBuf) -> String {
-        let canon_path = path_buf
-            .as_path()
-            .canonicalize()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
+        let canon_path = path_buf_to_string(path_buf.as_path().canonicalize().unwrap_or(path_buf));
         if WINDOWS.is(self.get_os()) {
             canon_path.replace(UNC_PREFIX, "")
         } else {


### PR DESCRIPTION
### Description
This PR makes more robust the function to canonicalize paths in SM.

### Motivation and Context
This PR prevents #12675.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
