### PR TITLE
[dotnet] Stabilize cdp network monitoring via increasing default timeout

### DIFF
--- a/dotnet/src/webdriver/DevTools/DevToolsSession.cs
+++ b/dotnet/src/webdriver/DevTools/DevToolsSession.cs
@@ -66,7 +66,7 @@ namespace OpenQA.Selenium.DevTools
                 throw new ArgumentNullException(nameof(endpointAddress));
             }
 
-            this.CommandTimeout = TimeSpan.FromSeconds(5);
+            this.CommandTimeout = TimeSpan.FromSeconds(30);
             this.debuggerEndpoint = endpointAddress;
             if (endpointAddress.StartsWith("ws:"))
             {
@@ -223,7 +223,7 @@ namespace OpenQA.Selenium.DevTools
 
                 if (!responseWasReceived && throwExceptionIfResponseNotReceived)
                 {
-                    throw new InvalidOperationException($"A command response was not received: {commandName}");
+                    throw new InvalidOperationException($"A command response was not received: {commandName}, timeout: {millisecondsTimeout.Value}ms");
                 }
 
                 if (this.pendingCommands.TryRemove(message.CommandId, out DevToolsCommandData modified))


### PR DESCRIPTION
### Description
Sometimes when network monitoring is enabled we get error like `A command response was not received`. More often it happens for `getResponseBody` command, and it is understandable. Default command timeout is 5 seconds, but sometimes network request may take more than 5 seconds. The issues becomes reproducible easier, if we open many browsers in parallel (network becomes slower).

This issue, which is actually hidden from user, leads to another issue like `Timeout while opening page aka navigate to url`.

### Motivation and Context
We can mitigate it by increasing default timeout. Also I have added info about actual timeout in the exception for future reference.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
