### PR TITLE
[dotnet] Return back AlertsTest on .net 4.8

### DIFF
--- a/dotnet/test/common/AlertsTest.cs
+++ b/dotnet/test/common/AlertsTest.cs
@@ -6,7 +6,6 @@ using OpenQA.Selenium.Environment;
 namespace OpenQA.Selenium
 {
     [TestFixture]
-    [IgnoreTarget("net48", "Cannot create inline page with UrlBuilder")]
     public class AlertsTest : DriverTestFixture
     {
         [Test]


### PR DESCRIPTION
Jim already fixed this issue, we can return tests back.

### Motivation and Context
Getting more test coverage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
