### PR TITLE
Update visibility_tests.py to verify that "_" is not overwritten when calling "is_displayed()"

### DIFF
--- a/py/test/selenium/webdriver/common/visibility_tests.py
+++ b/py/test/selenium/webdriver/common/visibility_tests.py
@@ -127,6 +127,17 @@ def test_should_say_element_with_zero_transform_is_visible(driver, pages):
     assert zero_tranform.is_displayed() is True
 
 
+def test_checking_for_visibility_does_not_overwrite_underscore(driver, pages):
+    pages.load("cssTransform.html")
+    driver.execute_script("_ = 'abc123';")
+    zero_tranform = driver.find_element(By.ID, "zero-tranform")
+    underscore_1 = driver.execute_script("return _;")
+    zero_tranform.is_displayed()
+    underscore_2 = driver.execute_script("return _;")
+    assert underscore_1 == underscore_2
+    assert underscore_2 == 'abc123'
+
+
 def test_should_say_element_is_visible_when_it_has_negative_transform_but_elementisnt_in_anegative_space(driver, pages):
     pages.load("cssTransform2.html")
     zero_tranform = driver.find_element(By.ID, "negative-percentage-transformY")

--- a/py/test/selenium/webdriver/common/visibility_tests.py
+++ b/py/test/selenium/webdriver/common/visibility_tests.py
@@ -135,7 +135,7 @@ def test_checking_for_visibility_does_not_overwrite_underscore(driver, pages):
     zero_tranform.is_displayed()
     underscore_2 = driver.execute_script("return _;")
     assert underscore_1 == underscore_2
-    assert underscore_2 == 'abc123'
+    assert underscore_2 == "abc123"
 
 
 def test_should_say_element_is_visible_when_it_has_negative_transform_but_elementisnt_in_anegative_space(driver, pages):


### PR DESCRIPTION
Update visibility_tests.py to verify that ``_`` is not overwritten when calling ``is_displayed()``.

This is a test for https://github.com/SeleniumHQ/selenium/pull/12704, but in a separate PR to follow TDD principles. Currently, there is a bug in `4.12.0` (https://github.com/SeleniumHQ/selenium/issues/12659), and this test should catch that (and currently fail because of it). Once https://github.com/SeleniumHQ/selenium/pull/12704 is merged, this test should pass.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Add a test (TDD-style)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] I have added a test.
