### PR TITLE
[dotnet] Update cdp default command timeout in inline docs

### DIFF
--- a/dotnet/src/webdriver/DevTools/DevToolsSession.cs
+++ b/dotnet/src/webdriver/DevTools/DevToolsSession.cs
@@ -86,7 +86,7 @@ namespace OpenQA.Selenium.DevTools
         public event EventHandler<DevToolsEventReceivedEventArgs> DevToolsEventReceived;
 
         /// <summary>
-        /// Gets or sets the time to wait for a command to complete. Default is 5 seconds.
+        /// Gets or sets the time to wait for a command to complete. Default is 30 seconds.
         /// </summary>
         public TimeSpan CommandTimeout { get; set; }
 


### PR DESCRIPTION
### Description
Fix cdp default command timeout in inline docs.

### Motivation and Context
Be consistent and avoid messing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
