### PR TITLE
[dotnet] Declare selenium manager binaries as content

### DIFF
--- a/dotnet/src/webdriver/build/Selenium.WebDriver.targets
+++ b/dotnet/src/webdriver/build/Selenium.WebDriver.targets
@@ -6,23 +6,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(Selenium_Manager_BinariesRootPath)\linux\selenium-manager">
+    <Content Include="$(Selenium_Manager_BinariesRootPath)\linux\selenium-manager">
       <Link>selenium-manager\linux\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </None>
+    </Content>
 
-    <None Include="$(Selenium_Manager_BinariesRootPath)\macos\selenium-manager">
+    <Content Include="$(Selenium_Manager_BinariesRootPath)\macos\selenium-manager">
       <Link>selenium-manager\macos\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </None>
+    </Content>
 
-    <None Include="$(Selenium_Manager_BinariesRootPath)\windows\selenium-manager.exe">
+    <Content Include="$(Selenium_Manager_BinariesRootPath)\windows\selenium-manager.exe">
       <Link>selenium-manager\windows\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </None>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description
It allows selenium manager to be included into installers, like `msi`/`exe` or `vsto`.

### Motivation and Context
Fixes #12577

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
