### PR TITLE
[dotnet] Indicate end of output taken from selenium manager

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -163,20 +163,20 @@ namespace OpenQA.Selenium
 
                     var exceptionMessageBuilder = new StringBuilder($"Selenium Manager process exited abnormally with {process.ExitCode} code: {fileName} {arguments}");
 
-                    if (!string.IsNullOrEmpty(errorOutputBuilder.ToString()))
+                    if (!string.IsNullOrWhiteSpace(errorOutputBuilder.ToString()))
                     {
                         exceptionMessageBuilder.AppendLine();
-                        exceptionMessageBuilder.Append("Error Output >>");
-                        exceptionMessageBuilder.AppendLine();
+                        exceptionMessageBuilder.AppendLine("Error Output >>");
                         exceptionMessageBuilder.Append(errorOutputBuilder);
+                        exceptionMessageBuilder.AppendLine("<<");
                     }
 
-                    if (!string.IsNullOrEmpty(outputBuilder.ToString()))
+                    if (!string.IsNullOrWhiteSpace(outputBuilder.ToString()))
                     {
                         exceptionMessageBuilder.AppendLine();
-                        exceptionMessageBuilder.Append("Standard Output >>");
-                        exceptionMessageBuilder.AppendLine();
+                        exceptionMessageBuilder.AppendLine("Standard Output >>");
                         exceptionMessageBuilder.Append(outputBuilder);
+                        exceptionMessageBuilder.AppendLine("<<");
                     }
 
                     throw new WebDriverException(exceptionMessageBuilder.ToString());


### PR DESCRIPTION
### Description
When selenium manager fails to do something, we raise output in exception. This PR improves slightly output to indicate where output starts and **ends**.

### Motivation and Context
Improve readability of SM process output.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
