### PR TITLE
Look for Selenium Manager in path defined by Environment Variable

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -34,35 +34,36 @@ namespace OpenQA.Selenium
     /// </summary>
     public static class SeleniumManager
     {
-        private readonly static string binaryFullPath;
+        private static readonly string BinaryFullPath = Environment.GetEnvironmentVariable("SE_MANAGER_PATH");
 
         static SeleniumManager()
         {
-            var currentDirectory = AppContext.BaseDirectory;
 
-            string binary;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (BinaryFullPath == null)
             {
-                binary = "selenium-manager/windows/selenium-manager.exe";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                binary = "selenium-manager/linux/selenium-manager";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                binary = "selenium-manager/macos/selenium-manager";
-            }
-            else
-            {
-                throw new WebDriverException("Selenium Manager did not find supported operating system");
+                var currentDirectory = AppContext.BaseDirectory;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager\\windows\\selenium-manager.exe");
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager\\linux\\selenium-manager");
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager\\macos\\selenium-manager");
+                }
+                else
+                {
+                    throw new PlatformNotSupportedException(
+                        $"Selenium Manager doesn't support your runtime platform: {RuntimeInformation.OSDescription}");
+                }
             }
 
-            binaryFullPath = Path.Combine(currentDirectory, binary);
-
-            if (!File.Exists(binaryFullPath))
+            if (!File.Exists(BinaryFullPath))
             {
-                throw new WebDriverException($"Unable to locate or obtain Selenium Manager binary at {binaryFullPath}");
+                throw new WebDriverException($"Unable to locate or obtain Selenium Manager binary at {BinaryFullPath}");
             }
         }
 
@@ -102,7 +103,7 @@ namespace OpenQA.Selenium
                 }
             }
 
-            Dictionary<string, object> output = RunCommand(binaryFullPath, argsBuilder.ToString());
+            Dictionary<string, object> output = RunCommand(BinaryFullPath, argsBuilder.ToString());
             string browserPath = (string)output["browser_path"];
             string driverPath = (string)output["driver_path"];
 
@@ -130,7 +131,7 @@ namespace OpenQA.Selenium
         private static Dictionary<string, object> RunCommand(string fileName, string arguments)
         {
             Process process = new Process();
-            process.StartInfo.FileName = binaryFullPath;
+            process.StartInfo.FileName = BinaryFullPath;
             process.StartInfo.Arguments = arguments;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;

--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -61,11 +62,11 @@ public class SeleniumManager {
   private static final Logger LOG = Logger.getLogger(SeleniumManager.class.getName());
 
   private static final String SELENIUM_MANAGER = "selenium-manager";
-  private static final String EXE = ".exe";
 
   private static volatile SeleniumManager manager;
 
-  private Path binary;
+  private final String managerPath = System.getenv("SE_MANAGER_PATH");
+  private Path binary = managerPath == null ? null : Paths.get(managerPath);
 
   /** Wrapper for the Selenium Manager binary. */
   private SeleniumManager() {
@@ -158,30 +159,31 @@ public class SeleniumManager {
    */
   private synchronized Path getBinary() {
     if (binary == null) {
-      try {
-        Platform current = Platform.getCurrent();
-        String folder = "linux";
-        String extension = "";
-        if (current.is(WINDOWS)) {
-          extension = EXE;
-          folder = "windows";
-        } else if (current.is(MAC)) {
-          folder = "macos";
-        }
-        String binaryPath = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
-        try (InputStream inputStream = this.getClass().getResourceAsStream(binaryPath)) {
-          Path tmpPath = Files.createTempDirectory(SELENIUM_MANAGER + System.nanoTime());
+      Platform current = Platform.getCurrent();
+      String folder = "linux";
+      String extension = "";
+      if (current.is(WINDOWS)) {
+        extension = ".exe";
+        folder = "windows";
+      } else if (current.is(MAC)) {
+        folder = "macos";
+      }
+      String binaryPath = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
+      try (InputStream inputStream = this.getClass().getResourceAsStream(binaryPath)) {
+        Path tmpPath = Files.createTempDirectory(SELENIUM_MANAGER + System.nanoTime());
 
-          deleteOnExit(tmpPath);
+        deleteOnExit(tmpPath);
 
-          binary = tmpPath.resolve(SELENIUM_MANAGER + extension);
-          Files.copy(inputStream, binary, REPLACE_EXISTING);
-        }
-        binary.toFile().setExecutable(true);
+        binary = tmpPath.resolve(SELENIUM_MANAGER + extension);
+        Files.copy(inputStream, binary, REPLACE_EXISTING);
       } catch (Exception e) {
         throw new WebDriverException("Unable to obtain Selenium Manager Binary", e);
       }
+    } else if (!Files.exists(binary)) {
+      throw new WebDriverException(String.format("Unable to obtain Selenium Manager Binary at: %s", binary));
     }
+    binary.toFile().setExecutable(true);
+
     LOG.fine(String.format("Selenium Manager binary found at: %s", binary));
 
     return binary;

--- a/javascript/node/selenium-webdriver/common/seleniumManager.js
+++ b/javascript/node/selenium-webdriver/common/seleniumManager.js
@@ -46,7 +46,7 @@ function getBinary() {
 
   let seleniumManagerBasePath = path.join(__dirname, '..', '/bin')
 
-  const filePath = path.join(seleniumManagerBasePath, directory, file)
+  const filePath = process.env.SE_MANAGER_PATH || path.join(seleniumManagerBasePath, directory, file)
 
   if (!fs.existsSync(filePath)) {
     throw new Error(`Unable to obtain Selenium Manager at ${filePath}`)

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -40,19 +40,22 @@ class SeleniumManager:
 
         :Returns: The Selenium Manager executable location
         """
-        platform = sys.platform
 
-        dirs = {
-            "darwin": "macos",
-            "win32": "windows",
-            "cygwin": "windows",
-        }
+        if os.getenv("SE_MANAGER_PATH"):
+            path = os.getenv("SE_MANAGER_PATH")
+        else:
+            platform = sys.platform
 
-        directory = dirs.get(platform) if dirs.get(platform) else platform
+            dirs = {
+                "darwin": "macos",
+                "win32": "windows",
+                "cygwin": "windows",
+            }
 
-        file = "selenium-manager.exe" if directory == "windows" else "selenium-manager"
+            directory = dirs.get(platform) if dirs.get(platform) else platform
+            file = "selenium-manager.exe" if directory == "windows" else "selenium-manager"
 
-        path = Path(__file__).parent.joinpath(directory, file)
+            path = Path(__file__).parent.joinpath(directory, file)
 
         if not path.is_file() and os.environ["CONDA_PREFIX"]:
             # conda has a separate package selenium-manager, installs in bin


### PR DESCRIPTION
### Description
* each of the bindings look for `SE_MANAGER_PATH` environment variable for Selenium Manager first before looking in the standard location

### Motivation and Context
* Allows users to override the bundled copy of Selenium Manager which could be useful for:
    - debugging with unreleased binary
    - using custom build on non-supported architecture
    - designating the location from a package manager (e.g., Conda)
    - putting in a directory with known permissions
* This is an alternate solution to #11359
    - Java is the only language that uses SM in a temp directory for each process and would benefit from a standard location; no good reason to move the binary for other languages
    - Using an environment variable is a more flexible solution for package managers (see conversation in #12536)
    - The cached directory would change per Selenium release, where SM in a directory with environment variable won't need to be moved when Selenium is updated (useful for custom builds and package managers)
    - This code is much more straightforward and easier to maintain than #12547 & #12539
