### PR TITLE
[rust] Bump Selenium Manager version to 0.4.13

### DIFF
--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -77,7 +77,7 @@ rust_binary(
     name = "selenium-manager",
     srcs = ["src/main.rs"],
     edition = "2021",
-    version = "0.4.12",
+    version = "0.4.13",
     visibility = ["//visibility:public"],
     deps = [
         ":selenium_manager",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1f16f4cfa433faeb0bd8242b382da4d71e41405dc8a07363d8c1f410ee0d651e",
+  "checksum": "24231be79f3b3f23c29c0093148f7183cb564cd13ac0fe297c6e5efe9e6311a8",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -7720,9 +7720,9 @@
       },
       "license": "Apache-2.0/ISC/MIT"
     },
-    "selenium-manager 0.4.12": {
+    "selenium-manager 0.4.13": {
       "name": "selenium-manager",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "repository": null,
       "targets": [
         {
@@ -7839,7 +7839,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.12"
+        "version": "0.4.13"
       },
       "license": "Apache-2.0"
     },
@@ -12652,7 +12652,7 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "selenium-manager 0.4.12": "rust"
+    "selenium-manager 0.4.13": "rust"
   },
   "conditions": {
     "aarch64-apple-darwin": [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "selenium-manager"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "assert_cmd",
  "bzip2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selenium-manager"
-version = "0.4.12" # don't forget to update rust/BUILD.bazel
+version = "0.4.13" # don't forget to update rust/BUILD.bazel
 edition = "2021"
 authors = ["Selenium <selenium-developers@googlegroups.com"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Description
This PR bumps the Selenium Manager version to 0.4.13

### Motivation and Context
Part of the Selenium 4.13.0 release.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
