### PR TITLE
[dotnet] Use the lower version of Newtonsoft.Json as dependency

### DIFF
--- a/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
+++ b/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
@@ -28,7 +28,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.IdentityModel.Tokens" version="6.19.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="5.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Drawing.Common" version="7.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/dotnet/src/webdriver/WebDriver.csproj
+++ b/dotnet/src/webdriver/WebDriver.csproj
@@ -61,7 +61,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.19.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/webdriver/WebDriver.nuspec
+++ b/dotnet/src/webdriver/WebDriver.nuspec
@@ -28,7 +28,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.IdentityModel.Tokens" version="6.19.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="5.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Drawing.Common" version="7.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>


### PR DESCRIPTION
### Description
Any library should be dependent on lower version of dependency as possible. Selenium can work with `Newtonsoft.Json v5.0.1`.

### Motivation and Context
Just making selenium better.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
