### PR TITLE
[dotnet] allow user to start service before creating driver

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeDriverService.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriverService.cs
@@ -41,6 +41,12 @@ namespace OpenQA.Selenium.Chrome
         {
         }
 
+        /// <inheritdoc />
+        protected override DriverOptions GetDefaultDriverOptions()
+        {
+            return new ChromeOptions();
+        }
+
         /// <summary>
         /// Creates a default instance of the ChromeDriverService.
         /// </summary>

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -262,6 +262,11 @@ namespace OpenQA.Selenium
                 return;
             }
 
+            if (this.driverServicePath == null)
+            {
+                DriverFinder.FullPath(this.GetDefaultDriverOptions());
+            }
+
             this.driverServiceProcess = new Process();
             this.driverServiceProcess.StartInfo.FileName = Path.Combine(this.driverServicePath, this.driverServiceExecutableName);
             this.driverServiceProcess.StartInfo.Arguments = this.CommandLineArguments;
@@ -282,6 +287,12 @@ namespace OpenQA.Selenium
                 throw new WebDriverException(msg);
             }
         }
+
+        /// <summary>
+        /// The browser options instance that corresponds to the driver service
+        /// </summary>
+        /// <returns></returns>
+        protected abstract DriverOptions GetDefaultDriverOptions();
 
         /// <summary>
         /// Releases all resources associated with this <see cref="DriverService"/>.

--- a/dotnet/src/webdriver/Edge/EdgeDriverService.cs
+++ b/dotnet/src/webdriver/Edge/EdgeDriverService.cs
@@ -41,6 +41,12 @@ namespace OpenQA.Selenium.Edge
         {
         }
 
+        /// <inheritdoc />
+        protected override DriverOptions GetDefaultDriverOptions()
+        {
+            return new EdgeOptions();
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether the service should use verbose logging.
         /// </summary>

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -50,6 +50,12 @@ namespace OpenQA.Selenium.Firefox
         {
         }
 
+        /// <inheritdoc />
+        protected override DriverOptions GetDefaultDriverOptions()
+        {
+            return new FirefoxOptions();
+        }
+
         /// <summary>
         /// Gets or sets the location of the Firefox binary executable.
         /// </summary>

--- a/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
@@ -48,6 +48,12 @@ namespace OpenQA.Selenium.IE
         {
         }
 
+        /// <inheritdoc />
+        protected override DriverOptions GetDefaultDriverOptions()
+        {
+            return new InternetExplorerOptions();
+        }
+
         /// <summary>
         /// Gets or sets the value of the host adapter on which the IEDriverServer should listen for connections.
         /// </summary>

--- a/dotnet/src/webdriver/Safari/SafariDriverService.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriverService.cs
@@ -46,6 +46,12 @@ namespace OpenQA.Selenium.Safari
         {
         }
 
+        /// <inheritdoc />
+        protected override DriverOptions GetDefaultDriverOptions()
+        {
+            return new SafariOptions();
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether to use the default open-source project
         /// dialect of the protocol instead of the default dialect compliant with the


### PR DESCRIPTION
### Description
Create a `GetDefaultDriverOptions()` method in each driver service class to allow passing to the `DriverFinder` method if starting the driver without a provided location.

### Motivation and Context
Fixes #12805 
Similar to how 5bce8d952c5e18454dc9face3e7e3489075adeab fixes #12682 
