### PR TITLE
[dotnet] Don't break devtools processing events thread in case of unexpected exception

### DIFF
--- a/dotnet/src/webdriver/DevTools/DevToolsSession.cs
+++ b/dotnet/src/webdriver/DevTools/DevToolsSession.cs
@@ -455,7 +455,16 @@ namespace OpenQA.Selenium.DevTools
             // in the IEnumerable, meaning the foreach loop will terminate gracefully.
             foreach (string message in this.messageQueue.GetConsumingEnumerable())
             {
-                this.ProcessMessage(message);
+                // Don't breake entire thread in case of unsuccessful message,
+                // and give a chance for the next message in queue to be processed
+                try
+                {
+                    this.ProcessMessage(message);
+                }
+                catch(Exception ex)
+                {
+                    LogError("Unexpected error occured while processing message: {0}", ex);
+                }
             }
         }
 


### PR DESCRIPTION
### Description
All messages came from DevTools protocol are supposed to be processed. We are doing it in background thread one by one. If we could not process some message in queue by any reason, then the entire processing thread (actually `Task`) stops, which leads to another problem like `page cannot be loaded`.
 
It's is not ideal fix. But at least it gives more chances for web site to be loaded correctly while selenium is listening browser network via CDP.

### Motivation and Context
Try to make DevTools more robust.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
