### PR TITLE
[java] Delete SM binary only when SE_MANAGER_PATH is not set

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -70,21 +70,23 @@ public class SeleniumManager {
 
   /** Wrapper for the Selenium Manager binary. */
   private SeleniumManager() {
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  if (binary != null && Files.exists(binary)) {
-                    try {
-                      Files.delete(binary);
-                    } catch (IOException e) {
-                      LOG.warning(
-                          String.format(
-                              "%s deleting temporal file: %s",
-                              e.getClass().getSimpleName(), e.getMessage()));
+    if (managerPath == null) {
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    if (binary != null && Files.exists(binary)) {
+                      try {
+                        Files.delete(binary);
+                      } catch (IOException e) {
+                        LOG.warning(
+                            String.format(
+                                "%s deleting temporal file: %s",
+                                e.getClass().getSimpleName(), e.getMessage()));
+                      }
                     }
-                  }
-                }));
+                  }));
+    }
   }
 
   public static SeleniumManager getInstance() {


### PR DESCRIPTION
### Description
When the `SE_MANAGER_PATH` env is set in Java, after using it, the SM binary is deleted by the Java wrapper. This behavior makes sense for the SM binary in the temp folder, but it should not be deleted when the user is specifying `SE_MANAGER_PATH`.

### Motivation and Context
The `SE_MANAGER_PATH` env mechanism was introduced in Selenium 4.13.0.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
