### PR TITLE
Ensure Selenium Manager returns an exit code

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -114,11 +114,7 @@ public class SeleniumManager {
     try {
       CommandLine command =
           new CommandLine(binary.toAbsolutePath().toString(), arguments.toArray(new String[0]));
-      command.executeAsync();
-      command.waitFor();
-      if (command.isRunning()) {
-        LOG.warning("Selenium Manager did not exit");
-      }
+      command.execute();
       code = command.getExitCode();
       output = command.getStdOut();
     } catch (Exception e) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -229,7 +229,7 @@ fn main() {
             }
         });
 
-        exit(0)
+    exit(0)
 }
 
 fn log_driver_and_browser_path(log: &Logger, driver_path: &Path, browser_path: &str) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -228,6 +228,8 @@ fn main() {
                 flush_and_exit(DATAERR, log);
             }
         });
+
+        exit(0)
 }
 
 fn log_driver_and_browser_path(log: &Logger, driver_path: &Path, browser_path: &str) {


### PR DESCRIPTION
Without this, the java process API will wait for the Selenium Manager to exit indefinitely.
