### PR TITLE
[rust] Capture Rust backtrace in case of error (displayed at DEBUG level)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ac879e4513ac137fb555c16e74c747e59a78e2847d2a1121f432e73c4c37ad81",
+  "checksum": "4745128072794bf6ed7da8d621ea818d5d0e11d98386c45fd55852bd6ca41af8",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4745128072794bf6ed7da8d621ea818d5d0e11d98386c45fd55852bd6ca41af8",
+  "checksum": "d9d5f22625fe3080b3eef8acfa5d55ae7929945c9570e4d592189d3b69f4149f",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -540,6 +540,73 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "ar 0.9.0": {
+      "name": "ar",
+      "version": "0.9.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ar/0.9.0/download",
+          "sha256": "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ar",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "ar",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.9.0"
+      },
+      "license": "MIT"
+    },
+    "arrayvec 0.7.4": {
+      "name": "arrayvec",
+      "version": "0.7.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/arrayvec/0.7.4/download",
+          "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arrayvec",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "arrayvec",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.7.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2092,6 +2159,81 @@
         "version": "0.1.6"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "debpkg 0.6.0": {
+      "name": "debpkg",
+      "version": "0.6.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/debpkg/0.6.0/download",
+          "sha256": "7ffffa9a03449467cfac11c9a4260556f477de22a935bb5e9475153de323c337"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "debpkg",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "debpkg",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ar 0.9.0",
+              "target": "ar"
+            },
+            {
+              "id": "arrayvec 0.7.4",
+              "target": "arrayvec"
+            },
+            {
+              "id": "bzip2 0.4.4",
+              "target": "bzip2"
+            },
+            {
+              "id": "flate2 1.0.27",
+              "target": "flate2"
+            },
+            {
+              "id": "indexmap 1.9.2",
+              "target": "indexmap"
+            },
+            {
+              "id": "infer 0.8.1",
+              "target": "infer"
+            },
+            {
+              "id": "log 0.4.20",
+              "target": "log"
+            },
+            {
+              "id": "tar 0.4.40",
+              "target": "tar"
+            },
+            {
+              "id": "xz2 0.1.7",
+              "target": "xz2"
+            },
+            {
+              "id": "zstd 0.11.2+zstd.1.5.2",
+              "target": "zstd"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.0"
+      },
+      "license": "MIT"
     },
     "difflib 0.4.0": {
       "name": "difflib",
@@ -4726,6 +4868,54 @@
       },
       "license": "MIT"
     },
+    "infer 0.8.1": {
+      "name": "infer",
+      "version": "0.8.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/infer/0.8.1/download",
+          "sha256": "e035cede526e0b21d5adffc9fa0eb4ef5d6026fe9c5b0bfe8084b9472b587a55"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "infer",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "infer",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "cfb",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cfb 0.7.3",
+              "target": "cfb"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.1"
+      },
+      "license": "MIT"
+    },
     "inout 0.1.3": {
       "name": "inout",
       "version": "0.1.3",
@@ -5358,6 +5548,77 @@
         "version": "0.1.4"
       },
       "license": "Apache-2.0"
+    },
+    "lzma-sys 0.1.20": {
+      "name": "lzma-sys",
+      "version": "0.1.20",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/lzma-sys/0.1.20/download",
+          "sha256": "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "lzma_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "lzma_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.147",
+              "target": "libc"
+            },
+            {
+              "id": "lzma-sys 0.1.20",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.20"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.79",
+              "target": "cc"
+            },
+            {
+              "id": "pkg-config 0.3.26",
+              "target": "pkg_config"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "lzma"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "memchr 2.5.0": {
       "name": "memchr",
@@ -7844,6 +8105,10 @@
             {
               "id": "clap 4.3.23",
               "target": "clap"
+            },
+            {
+              "id": "debpkg 0.6.0",
+              "target": "debpkg"
             },
             {
               "id": "directories 5.0.1",
@@ -12441,6 +12706,45 @@
         },
         "edition": "2021",
         "version": "1.0.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "xz2 0.1.7": {
+      "name": "xz2",
+      "version": "0.1.7",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/xz2/0.1.7/download",
+          "sha256": "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "xz2",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "xz2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "lzma-sys 0.1.20",
+              "target": "lzma_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.7"
       },
       "license": "MIT/Apache-2.0"
     },

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4745128072794bf6ed7da8d621ea818d5d0e11d98386c45fd55852bd6ca41af8",
+  "checksum": "ac879e4513ac137fb555c16e74c747e59a78e2847d2a1121f432e73c4c37ad81",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7bb62c0cb24820374fb08c7eb1d2c1661ceb1a296f8cf2cad91579a7d2687eaf",
+  "checksum": "4745128072794bf6ed7da8d621ea818d5d0e11d98386c45fd55852bd6ca41af8",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -478,70 +478,68 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ar 0.9.0": {
-      "name": "ar",
-      "version": "0.9.0",
+    "anyhow 1.0.75": {
+      "name": "anyhow",
+      "version": "1.0.75",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ar/0.9.0/download",
-          "sha256": "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.75/download",
+          "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "ar",
+            "crate_name": "anyhow",
             "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
           }
         }
       ],
-      "library_target_name": "ar",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.9.0"
-      },
-      "license": "MIT"
-    },
-    "arrayvec 0.7.4": {
-      "name": "arrayvec",
-      "version": "0.7.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/arrayvec/0.7.4/download",
-          "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "arrayvec",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "arrayvec",
+      "library_target_name": "anyhow",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": {
           "common": [
+            "backtrace",
             "default",
             "std"
           ],
           "selects": {}
         },
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.75",
+              "target": "build_script_build"
+            },
+            {
+              "id": "backtrace 0.3.67",
+              "target": "backtrace"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
-        "version": "0.7.4"
+        "version": "1.0.75"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -672,6 +670,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -2087,81 +2092,6 @@
         "version": "0.1.6"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "debpkg 0.6.0": {
-      "name": "debpkg",
-      "version": "0.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/debpkg/0.6.0/download",
-          "sha256": "7ffffa9a03449467cfac11c9a4260556f477de22a935bb5e9475153de323c337"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "debpkg",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "debpkg",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "ar 0.9.0",
-              "target": "ar"
-            },
-            {
-              "id": "arrayvec 0.7.4",
-              "target": "arrayvec"
-            },
-            {
-              "id": "bzip2 0.4.4",
-              "target": "bzip2"
-            },
-            {
-              "id": "flate2 1.0.27",
-              "target": "flate2"
-            },
-            {
-              "id": "indexmap 1.9.2",
-              "target": "indexmap"
-            },
-            {
-              "id": "infer 0.8.1",
-              "target": "infer"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "tar 0.4.40",
-              "target": "tar"
-            },
-            {
-              "id": "xz2 0.1.7",
-              "target": "xz2"
-            },
-            {
-              "id": "zstd 0.11.2+zstd.1.5.2",
-              "target": "zstd"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.0"
-      },
-      "license": "MIT"
     },
     "difflib 0.4.0": {
       "name": "difflib",
@@ -3860,6 +3790,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "read",
+            "read-core"
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "0.27.3"
       },
@@ -4789,54 +4726,6 @@
       },
       "license": "MIT"
     },
-    "infer 0.8.1": {
-      "name": "infer",
-      "version": "0.8.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/infer/0.8.1/download",
-          "sha256": "e035cede526e0b21d5adffc9fa0eb4ef5d6026fe9c5b0bfe8084b9472b587a55"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "infer",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "infer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "cfb",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfb 0.7.3",
-              "target": "cfb"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.1"
-      },
-      "license": "MIT"
-    },
     "inout 0.1.3": {
       "name": "inout",
       "version": "0.1.3",
@@ -5470,77 +5359,6 @@
       },
       "license": "Apache-2.0"
     },
-    "lzma-sys 0.1.20": {
-      "name": "lzma-sys",
-      "version": "0.1.20",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/lzma-sys/0.1.20/download",
-          "sha256": "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lzma_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "lzma_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.147",
-              "target": "libc"
-            },
-            {
-              "id": "lzma-sys 0.1.20",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.20"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.79",
-              "target": "cc"
-            },
-            {
-              "id": "pkg-config 0.3.26",
-              "target": "pkg_config"
-            }
-          ],
-          "selects": {}
-        },
-        "links": "lzma"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "memchr 2.5.0": {
       "name": "memchr",
       "version": "2.5.0",
@@ -5965,6 +5783,18 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "archive",
+            "coff",
+            "elf",
+            "macho",
+            "pe",
+            "read_core",
+            "unaligned"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -8004,16 +7834,16 @@
         "deps": {
           "common": [
             {
+              "id": "anyhow 1.0.75",
+              "target": "anyhow"
+            },
+            {
               "id": "bzip2 0.4.4",
               "target": "bzip2"
             },
             {
               "id": "clap 4.3.23",
               "target": "clap"
-            },
-            {
-              "id": "debpkg 0.6.0",
-              "target": "debpkg"
             },
             {
               "id": "directories 5.0.1",
@@ -12611,45 +12441,6 @@
         },
         "edition": "2021",
         "version": "1.0.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "xz2 0.1.7": {
-      "name": "xz2",
-      "version": "0.1.7",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/xz2/0.1.7/download",
-          "sha256": "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "xz2",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "xz2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "lzma-sys 0.1.20",
-              "target": "lzma_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.7"
       },
       "license": "MIT/Apache-2.0"
     },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -99,6 +99,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "ar"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1501,7 @@ dependencies = [
 name = "selenium-manager"
 version = "0.4.14"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "bzip2",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ bzip2 = "0.4.4"
 sevenz-rust = "0.5.2"
 walkdir = "2.4.0"
 debpkg = "0.6.0"
+anyhow = { version = "1.0.75", features = ["backtrace"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,4 +44,4 @@ opt-level = 'z'     # Optimize for size
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
 panic = 'abort'     # Abort on panic
-debug = true        # Full debug info
+strip = true        # Strip symbols from binary*

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,4 +44,4 @@ opt-level = 'z'     # Optimize for size
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
 panic = 'abort'     # Abort on panic
-strip = true        # Strip symbols from binary*
+debug = true        # Full debug info

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -191,15 +191,6 @@ impl ChromeManager {
 
         Ok(driver_version.version.to_string())
     }
-
-    fn get_browser_binary_path_in_cache(&self) -> Result<PathBuf, Error> {
-        let browser_in_cache = self.get_browser_path_in_cache()?;
-        if MACOS.is(self.get_os()) {
-            Ok(browser_in_cache.join(CFT_MACOS_APP_NAME))
-        } else {
-            Ok(browser_in_cache.join(self.get_browser_name_with_extension()))
-        }
-    }
 }
 
 impl SeleniumManager for ChromeManager {
@@ -524,14 +515,11 @@ impl SeleniumManager for ChromeManager {
         }
     }
 
-    fn get_min_browser_version_for_download(&self) -> Result<i32, Box<dyn Error>> {
+    fn get_min_browser_version_for_download(&self) -> Result<i32, Error> {
         Ok(MIN_CHROME_VERSION_CFT)
     }
 
-    fn get_browser_binary_path(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_browser_binary_path(&mut self, _browser_version: &str) -> Result<PathBuf, Error> {
         let browser_in_cache = self.get_browser_path_in_cache()?;
         if MACOS.is(self.get_os()) {
             Ok(browser_in_cache.join(CFT_MACOS_APP_NAME))
@@ -540,10 +528,7 @@ impl SeleniumManager for ChromeManager {
         }
     }
 
-    fn get_browser_url_for_download(
-        &mut self,
-        browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    fn get_browser_url_for_download(&mut self, browser_version: &str) -> Result<String, Error> {
         if let Some(browser_url) = self.browser_url.clone() {
             Ok(browser_url)
         } else {
@@ -559,7 +544,7 @@ impl SeleniumManager for ChromeManager {
     fn get_browser_label_for_download(
         &self,
         _browser_version: &str,
-    ) -> Result<Option<&str>, Box<dyn Error>> {
+    ) -> Result<Option<&str>, Error> {
         Ok(None)
     }
 }

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -19,7 +19,9 @@ use crate::config::ManagerConfig;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::anyhow;
+use anyhow::Error;
 use std::option::Option;
 use std::path::PathBuf;
 
@@ -60,7 +62,7 @@ pub struct ChromeManager {
 }
 
 impl ChromeManager {
-    pub fn new() -> Result<Box<Self>, Box<dyn Error>> {
+    pub fn new() -> Result<Box<Self>, Error> {
         let browser_name = CHROME_NAME;
         let driver_name = CHROMEDRIVER_NAME;
         let config = ManagerConfig::default(browser_name, driver_name);
@@ -94,10 +96,7 @@ impl ChromeManager {
         format!("{}{}", CFT_URL, endpoint)
     }
 
-    fn request_driver_version_from_latest(
-        &self,
-        driver_url: String,
-    ) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version_from_latest(&self, driver_url: String) -> Result<String, Error> {
         self.log.debug(format!(
             "Reading {} version from {}",
             &self.driver_name, driver_url
@@ -105,7 +104,7 @@ impl ChromeManager {
         read_version_from_link(self.get_http_client(), driver_url, self.get_logger())
     }
 
-    fn request_versions_from_online<T>(&self, driver_url: String) -> Result<T, Box<dyn Error>>
+    fn request_versions_from_online<T>(&self, driver_url: String) -> Result<T, Error>
     where
         T: Serialize + for<'a> Deserialize<'a>,
     {
@@ -114,7 +113,7 @@ impl ChromeManager {
         parse_json_from_url::<T>(self.get_http_client(), driver_url)
     }
 
-    fn request_latest_driver_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_latest_driver_version_from_online(&mut self) -> Result<String, Error> {
         let driver_name = self.driver_name;
         self.get_logger().trace(format!(
             "Using Chrome for Testing (CfT) endpoints to find out latest stable {} version",
@@ -150,7 +149,7 @@ impl ChromeManager {
         Ok(stable_channel.version)
     }
 
-    fn request_good_driver_version_from_online(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_good_driver_version_from_online(&mut self) -> Result<String, Error> {
         let browser_or_driver_version = if self.get_driver_version().is_empty() {
             self.get_browser_version()
         } else {
@@ -170,13 +169,12 @@ impl ChromeManager {
             .filter(|r| r.version.starts_with(version_for_filtering.as_str()))
             .collect();
         if filtered_versions.is_empty() {
-            return Err(format_three_args(
+            return Err(anyhow!(format_three_args(
                 UNAVAILABLE_DOWNLOAD_WITH_MIN_VERSION_ERR_MSG,
                 self.get_driver_name(),
                 &version_for_filtering,
                 &MIN_CHROMEDRIVER_VERSION_CFT.to_string(),
-            )
-            .into());
+            )));
         }
 
         let driver_version = filtered_versions.last().unwrap();
@@ -192,6 +190,15 @@ impl ChromeManager {
         self.driver_url = Some(url.first().unwrap().url.to_string());
 
         Ok(driver_version.version.to_string())
+    }
+
+    fn get_browser_binary_path_in_cache(&self) -> Result<PathBuf, Error> {
+        let browser_in_cache = self.get_browser_path_in_cache()?;
+        if MACOS.is(self.get_os()) {
+            Ok(browser_in_cache.join(CFT_MACOS_APP_NAME))
+        } else {
+            Ok(browser_in_cache.join(self.get_browser_name_with_extension()))
+        }
     }
 }
 
@@ -255,7 +262,7 @@ impl SeleniumManager for ChromeManager {
         ])
     }
 
-    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Error> {
         self.general_discover_browser_version(
             r#"HKCU\Software\Google\Chrome\BLBeacon"#,
             REG_VERSION_ARG,
@@ -267,7 +274,7 @@ impl SeleniumManager for ChromeManager {
         self.driver_name
     }
 
-    fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version(&mut self) -> Result<String, Error> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
         let cache_path = self.get_cache_path()?;
@@ -327,11 +334,11 @@ impl SeleniumManager for ChromeManager {
         }
     }
 
-    fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn request_browser_version(&mut self) -> Result<Option<String>, Error> {
         self.general_request_browser_version(self.browser_name)
     }
 
-    fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_driver_url(&mut self) -> Result<String, Error> {
         let major_driver_version = self
             .get_major_driver_version()
             .parse::<i32>()
@@ -373,7 +380,7 @@ impl SeleniumManager for ChromeManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Error> {
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?.unwrap_or_default(),
             self.driver_name,
@@ -426,7 +433,7 @@ impl SeleniumManager for ChromeManager {
     fn request_latest_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         let browser_name = self.browser_name;
         self.get_logger().trace(format!(
             "Using Chrome for Testing (CfT) endpoints to find out latest stable {} version",
@@ -457,7 +464,7 @@ impl SeleniumManager for ChromeManager {
     fn request_fixed_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         let browser_name = self.browser_name;
         let mut browser_version = self.get_browser_version().to_string();
         let major_browser_version = self.get_major_browser_version();
@@ -497,13 +504,12 @@ impl SeleniumManager for ChromeManager {
                 .filter(|r| r.version.starts_with(major_browser_version.as_str()))
                 .collect();
             if filtered_versions.is_empty() {
-                return Err(format_three_args(
+                return Err(anyhow!(format_three_args(
                     UNAVAILABLE_DOWNLOAD_WITH_MIN_VERSION_ERR_MSG,
                     browser_name,
                     &major_browser_version,
                     &MIN_CHROME_VERSION_CFT.to_string(),
-                )
-                .into());
+                )));
             }
             let last_browser = filtered_versions.last().unwrap();
             let platform_url: Vec<&PlatformUrl> = last_browser

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -25,7 +25,9 @@ use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, TTL_SEC, WMIC_COMMAND_OS};
 use std::cell::RefCell;
 use std::env;
 use std::env::consts::OS;
-use std::error::Error;
+
+use anyhow::anyhow;
+use anyhow::Error;
 use std::fs::read_to_string;
 use std::path::Path;
 use toml::Table;
@@ -129,7 +131,7 @@ impl OS {
     }
 }
 
-pub fn str_to_os(os: &str) -> Result<OS, Box<dyn Error>> {
+pub fn str_to_os(os: &str) -> Result<OS, Error> {
     if WINDOWS.is(os) {
         Ok(WINDOWS)
     } else if MACOS.is(os) {
@@ -137,7 +139,7 @@ pub fn str_to_os(os: &str) -> Result<OS, Box<dyn Error>> {
     } else if LINUX.is(os) {
         Ok(LINUX)
     } else {
-        Err(format!("Invalid operating system: {os}").into())
+        Err(anyhow!(format!("Invalid operating system: {os}")))
     }
 }
 
@@ -232,7 +234,7 @@ fn get_env_name(suffix: &str) -> String {
     concat(ENV_PREFIX, suffix_uppercase.as_str())
 }
 
-fn get_config() -> Result<Table, Box<dyn Error>> {
+fn get_config() -> Result<Table, Error> {
     let cache_path = read_cache_path();
     let config_path = Path::new(&cache_path).to_path_buf().join(CONFIG_FILE);
     Ok(read_to_string(config_path)?.parse()?)

--- a/rust/src/downloads.rs
+++ b/rust/src/downloads.rs
@@ -15,10 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use anyhow::Error;
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::error::Error;
+
+use anyhow::anyhow;
 use std::fs::File;
 use std::io::copy;
 use std::io::Cursor;
@@ -33,7 +35,7 @@ pub async fn download_to_tmp_folder(
     http_client: &Client,
     url: String,
     log: &Logger,
-) -> Result<(TempDir, String), Box<dyn Error>> {
+) -> Result<(TempDir, String), Error> {
     let tmp_dir = Builder::new().prefix("selenium-manager").tempdir()?;
     log.trace(format!(
         "Downloading {} to temporal folder {:?}",
@@ -44,7 +46,10 @@ pub async fn download_to_tmp_folder(
     let response = http_client.get(&url).send().await?;
     let status_code = response.status();
     if status_code != StatusCode::OK {
-        return Err(format!("Unsuccessful response ({}) for URL {}", status_code, url).into());
+        return Err(anyhow!(format!(
+            "Unsuccessful response ({}) for URL {}",
+            status_code, url
+        )));
     }
 
     let target_path;
@@ -76,15 +81,12 @@ pub fn read_version_from_link(
     http_client: &Client,
     url: String,
     log: &Logger,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, Error> {
     parse_version(read_content_from_link(http_client, url)?, log)
 }
 
 #[tokio::main]
-pub async fn read_content_from_link(
-    http_client: &Client,
-    url: String,
-) -> Result<String, Box<dyn Error>> {
+pub async fn read_content_from_link(http_client: &Client, url: String) -> Result<String, Error> {
     Ok(http_client.get(url).send().await?.text().await?)
 }
 
@@ -93,14 +95,14 @@ pub async fn read_redirect_from_link(
     http_client: &Client,
     url: String,
     log: &Logger,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, Error> {
     parse_version(
         http_client.get(&url).send().await?.url().path().to_string(),
         log,
     )
 }
 
-pub fn parse_json_from_url<T>(http_client: &Client, url: String) -> Result<T, Box<dyn Error>>
+pub fn parse_json_from_url<T>(http_client: &Client, url: String) -> Result<T, Error>
 where
     T: Serialize + for<'a> Deserialize<'a>,
 {
@@ -109,10 +111,7 @@ where
     Ok(response)
 }
 
-pub fn parse_generic_json_from_url(
-    http_client: &Client,
-    url: String,
-) -> Result<Value, Box<dyn Error>> {
+pub fn parse_generic_json_from_url(http_client: &Client, url: String) -> Result<Value, Error> {
     let content = read_content_from_link(http_client, url)?;
     let response: Value = serde_json::from_str(&content)?;
     Ok(response)

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -281,10 +281,6 @@ impl SeleniumManager for EdgeManager {
         self.log = log;
     }
 
-    fn download_browser(&mut self) -> Result<Option<PathBuf>, Error> {
-        Ok(None)
-    }
-
     fn get_platform_label(&self) -> &str {
         let os = self.get_os();
         let arch = self.get_arch();

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use crate::config::ManagerConfig;
-use anyhow::anyhow;
 use anyhow::Error;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
+use std::env;
+use std::path::Path;
 use std::path::PathBuf;
 
 use crate::config::ARCH::{ARM64, X32};

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -21,8 +21,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::ARCH::{ARM64, X32};
 use crate::config::OS::{LINUX, MACOS, WINDOWS};

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::error::Error;
+use anyhow::Error;
 use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::{BufReader, Cursor, Read};
 
+use anyhow::anyhow;
 use bzip2::read::BzDecoder;
 use std::path::{Path, PathBuf};
 
@@ -69,7 +70,7 @@ impl BrowserPath {
     }
 }
 
-pub fn create_empty_parent_path_if_not_exists(path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn create_empty_parent_path_if_not_exists(path: &Path) -> Result<(), Error> {
     if let Some(p) = path.parent() {
         create_path_if_not_exists(p)?;
         fs::remove_dir_all(p).and_then(|_| fs::create_dir(p))?;
@@ -77,14 +78,14 @@ pub fn create_empty_parent_path_if_not_exists(path: &Path) -> Result<(), Box<dyn
     Ok(())
 }
 
-pub fn create_parent_path_if_not_exists(path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn create_parent_path_if_not_exists(path: &Path) -> Result<(), Error> {
     if let Some(p) = path.parent() {
         create_path_if_not_exists(p)?;
     }
     Ok(())
 }
 
-pub fn create_path_if_not_exists(path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn create_path_if_not_exists(path: &Path) -> Result<(), Error> {
     if !path.exists() {
         fs::create_dir_all(path)?;
     }
@@ -99,7 +100,7 @@ pub fn uncompress(
     single_file: Option<String>,
     volume: Option<&str>,
     major_browser_version: Option<i32>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let mut extension = match infer::get_from_path(compressed_file)? {
         Some(kind) => kind.extension(),
         _ => {
@@ -107,12 +108,13 @@ pub fn uncompress(
                 if MACOS.is(os) {
                     PKG
                 } else {
-                    return Err(format_one_arg(UNCOMPRESS_MACOS_ERR_MSG, PKG).into());
+                    return Err(anyhow!(format_one_arg(UNCOMPRESS_MACOS_ERR_MSG, PKG)));
                 }
             } else {
-                return Err(
-                    format!("Format for file {} cannot be inferred", compressed_file).into(),
-                );
+                return Err(anyhow!(format!(
+                    "Format for file {} cannot be inferred",
+                    compressed_file
+                )));
             }
         }
     };
@@ -120,7 +122,7 @@ pub fn uncompress(
         if MACOS.is(os) {
             extension = DMG;
         } else {
-            return Err(format_one_arg(UNCOMPRESS_MACOS_ERR_MSG, DMG).into());
+            return Err(anyhow!(format_one_arg(UNCOMPRESS_MACOS_ERR_MSG, DMG)));
         }
     }
     log.trace(format!(
@@ -155,22 +157,17 @@ pub fn uncompress(
             "Wrong downloaded driver: {}",
             fs::read_to_string(compressed_file).unwrap_or_default()
         ));
-        return Err(PARSE_ERROR.into());
+        return Err(anyhow!(PARSE_ERROR));
     } else {
-        return Err(format!(
+        return Err(anyhow!(format!(
             "Downloaded file cannot be uncompressed ({} extension)",
             extension
-        )
-        .into());
+        )));
     }
     Ok(())
 }
 
-pub fn uncompress_sfx(
-    compressed_file: &str,
-    target: &Path,
-    log: &Logger,
-) -> Result<(), Box<dyn Error>> {
+pub fn uncompress_sfx(compressed_file: &str, target: &Path, log: &Logger) -> Result<(), Error> {
     let zip_parent = Path::new(compressed_file).parent().unwrap();
     log.trace(format!(
         "Decompressing {} to {}",
@@ -180,7 +177,7 @@ pub fn uncompress_sfx(
 
     let file_bytes = read_bytes_from_file(compressed_file)?;
     let header = find_bytes(&file_bytes, SEVEN_ZIP_HEADER);
-    let index_7z = header.ok_or("Incorrect SFX (self extracting exe) file")?;
+    let index_7z = header.ok_or(anyhow!("Incorrect SFX (self extracting exe) file"))?;
     let file_reader = Cursor::new(&file_bytes[index_7z..]);
     sevenz_rust::decompress(file_reader, zip_parent).unwrap();
 
@@ -203,7 +200,7 @@ pub fn uncompress_pkg(
     log: &Logger,
     os: &str,
     major_browser_version: i32,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let tmp_dir = Builder::new().prefix(PKG).tempdir()?;
     let out_folder = format!("{}/{}", path_to_string(tmp_dir.path()), PKG);
     let mut command = Command::new_single(format_two_args(
@@ -242,7 +239,7 @@ pub fn uncompress_dmg(
     log: &Logger,
     os: &str,
     volume: &str,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let dmg_file_name = Path::new(compressed_file)
         .file_name()
         .unwrap_or_default()
@@ -278,7 +275,7 @@ pub fn uncompress_deb(
     target: &Path,
     log: &Logger,
     label: &str,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let zip_parent = Path::new(compressed_file).parent().unwrap();
     log.trace(format!(
         "Extracting from {} to {}",
@@ -303,7 +300,7 @@ pub fn uncompress_deb(
     Ok(())
 }
 
-pub fn install_msi(msi_file: &str, log: &Logger, os: &str) -> Result<(), Box<dyn Error>> {
+pub fn install_msi(msi_file: &str, log: &Logger, os: &str) -> Result<(), Error> {
     let msi_file_name = Path::new(msi_file)
         .file_name()
         .unwrap_or_default()
@@ -320,7 +317,7 @@ pub fn install_msi(msi_file: &str, log: &Logger, os: &str) -> Result<(), Box<dyn
     Ok(())
 }
 
-pub fn untargz(compressed_file: &str, target: &Path, log: &Logger) -> Result<(), Box<dyn Error>> {
+pub fn untargz(compressed_file: &str, target: &Path, log: &Logger) -> Result<(), Error> {
     log.trace(format!(
         "Untargz {} to {}",
         compressed_file,
@@ -331,18 +328,14 @@ pub fn untargz(compressed_file: &str, target: &Path, log: &Logger) -> Result<(),
     let mut archive = Archive::new(tar);
     let parent_path = target
         .parent()
-        .ok_or(format!("Error getting parent of {:?}", file))?;
+        .ok_or(anyhow!(format!("Error getting parent of {:?}", file)))?;
     if !target.exists() {
         archive.unpack(parent_path)?;
     }
     Ok(())
 }
 
-pub fn uncompress_bz2(
-    compressed_file: &str,
-    target: &Path,
-    log: &Logger,
-) -> Result<(), Box<dyn Error>> {
+pub fn uncompress_bz2(compressed_file: &str, target: &Path, log: &Logger) -> Result<(), Error> {
     log.trace(format!(
         "Uncompress {} to {}",
         compressed_file,
@@ -369,7 +362,7 @@ pub fn unzip(
     target: &Path,
     log: &Logger,
     single_file: Option<String>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Error> {
     let file = File::open(compressed_file)?;
     let compressed_path = Path::new(compressed_file);
     let tmp_path = compressed_path
@@ -435,11 +428,10 @@ pub fn unzip(
         }
     }
     if unzipped_files == 0 {
-        return Err(format!(
+        return Err(anyhow!(format!(
             "Problem uncompressing zip ({} files extracted)",
             unzipped_files
-        )
-        .into());
+        )));
     }
 
     fs::remove_file(compressed_path)?;
@@ -534,10 +526,10 @@ pub fn get_binary_extension(os: &str) -> &str {
     }
 }
 
-pub fn parse_version(version_text: String, log: &Logger) -> Result<String, Box<dyn Error>> {
+pub fn parse_version(version_text: String, log: &Logger) -> Result<String, Error> {
     if version_text.to_ascii_lowercase().contains("error") {
         log.debug(format!("Error parsing version: {}", version_text));
-        return Err(PARSE_ERROR.into());
+        return Err(anyhow!(PARSE_ERROR));
     }
     let mut parsed_version = "".to_string();
     let re_numbers_dots = Regex::new(r"[^\d^.]")?;
@@ -561,7 +553,7 @@ pub fn path_to_string(path: &Path) -> String {
         .unwrap_or_default()
 }
 
-pub fn read_bytes_from_file(file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+pub fn read_bytes_from_file(file_path: &str) -> Result<Vec<u8>, Error> {
     let file = File::open(file_path)?;
     let mut reader = BufReader::new(file);
     let mut buffer = Vec::new();

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::anyhow;
 use std::path::PathBuf;
 
 use crate::files::BrowserPath;
@@ -51,7 +53,7 @@ pub struct GridManager {
 }
 
 impl GridManager {
-    pub fn new(driver_version: String) -> Result<Box<Self>, Box<dyn Error>> {
+    pub fn new(driver_version: String) -> Result<Box<Self>, Error> {
         let browser_name = GRID_NAME;
         let driver_name = GRID_RELEASE;
         let mut config = ManagerConfig::default(browser_name, driver_name);
@@ -90,7 +92,7 @@ impl SeleniumManager for GridManager {
         HashMap::new()
     }
 
-    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Error> {
         Ok(None)
     }
 
@@ -98,7 +100,7 @@ impl SeleniumManager for GridManager {
         self.driver_name
     }
 
-    fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version(&mut self) -> Result<String, Error> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
         let cache_path = self.get_cache_path()?;
@@ -166,17 +168,20 @@ impl SeleniumManager for GridManager {
 
                     Ok(driver_version)
                 } else {
-                    Err(format!("{} release not available", self.get_driver_name()).into())
+                    Err(anyhow!(format!(
+                        "{} release not available",
+                        self.get_driver_name()
+                    )))
                 }
             }
         }
     }
 
-    fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn request_browser_version(&mut self) -> Result<Option<String>, Error> {
         Ok(None)
     }
 
-    fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_driver_url(&mut self) -> Result<String, Error> {
         if self.driver_url.is_some() {
             return Ok(self.driver_url.as_ref().unwrap().to_string());
         }
@@ -192,7 +197,7 @@ impl SeleniumManager for GridManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Error> {
         let browser_name = self.get_browser_name();
         let driver_name = self.get_driver_name();
         let driver_version = self.get_driver_version();
@@ -231,39 +236,33 @@ impl SeleniumManager for GridManager {
     fn request_latest_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
-    fn get_min_browser_version_for_download(&self) -> Result<i32, Box<dyn Error>> {
+    fn get_min_browser_version_for_download(&self) -> Result<i32, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_binary_path(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_browser_binary_path(&mut self, _browser_version: &str) -> Result<PathBuf, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_url_for_download(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    fn get_browser_url_for_download(&mut self, _browser_version: &str) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn get_browser_label_for_download(
         &self,
         _browser_version: &str,
-    ) -> Result<Option<&str>, Box<dyn Error>> {
+    ) -> Result<Option<&str>, Error> {
         self.unavailable_download()
     }
 }

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::anyhow;
 use std::path::PathBuf;
 
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
@@ -56,7 +58,7 @@ pub struct IExplorerManager {
 }
 
 impl IExplorerManager {
-    pub fn new() -> Result<Box<Self>, Box<dyn Error>> {
+    pub fn new() -> Result<Box<Self>, Error> {
         let browser_name = IE_NAMES[0];
         let driver_name = IEDRIVER_NAME;
         let mut config = ManagerConfig::default(browser_name, driver_name);
@@ -98,7 +100,7 @@ impl SeleniumManager for IExplorerManager {
         )])
     }
 
-    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Error> {
         self.general_discover_browser_version(
             r#"HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer"#,
             REG_VERSION_ARG,
@@ -110,7 +112,7 @@ impl SeleniumManager for IExplorerManager {
         self.driver_name
     }
 
-    fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version(&mut self) -> Result<String, Error> {
         let major_browser_version_binding = self.get_major_browser_version();
         let major_browser_version = major_browser_version_binding.as_str();
         let cache_path = self.get_cache_path()?;
@@ -174,17 +176,20 @@ impl SeleniumManager for IExplorerManager {
 
                     Ok(driver_version)
                 } else {
-                    Err(format!("{} release not available", self.get_driver_name()).into())
+                    Err(anyhow!(format!(
+                        "{} release not available",
+                        self.get_driver_name()
+                    )))
                 }
             }
         }
     }
 
-    fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn request_browser_version(&mut self) -> Result<Option<String>, Error> {
         Ok(None)
     }
 
-    fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
+    fn get_driver_url(&mut self) -> Result<String, Error> {
         if self.driver_url.is_some() {
             return Ok(self.driver_url.as_ref().unwrap().to_string());
         }
@@ -199,7 +204,7 @@ impl SeleniumManager for IExplorerManager {
         ))
     }
 
-    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Error> {
         Ok(compose_driver_path_in_cache(
             self.get_cache_path()?.unwrap_or_default(),
             self.driver_name,
@@ -236,39 +241,33 @@ impl SeleniumManager for IExplorerManager {
     fn request_latest_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
-    fn get_min_browser_version_for_download(&self) -> Result<i32, Box<dyn Error>> {
+    fn get_min_browser_version_for_download(&self) -> Result<i32, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_binary_path(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_browser_binary_path(&mut self, _browser_version: &str) -> Result<PathBuf, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_url_for_download(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    fn get_browser_url_for_download(&mut self, _browser_version: &str) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn get_browser_label_for_download(
         &self,
         _browser_version: &str,
-    ) -> Result<Option<&str>, Box<dyn Error>> {
+    ) -> Result<Option<&str>, Error> {
         self.unavailable_download()
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -166,7 +166,7 @@ pub trait SeleniumManager {
 
     fn get_browser_binary_path(&mut self, browser_version: &str) -> Result<PathBuf, Error>;
 
-    fn get_browser_url_for_download(&mut self, browser_version: &str) -> Result<String, dyn Error>;
+    fn get_browser_url_for_download(&mut self, browser_version: &str) -> Result<String, Error>;
 
     fn get_browser_label_for_download(&self, _browser_version: &str)
         -> Result<Option<&str>, Error>;
@@ -205,13 +205,12 @@ pub trait SeleniumManager {
         }
     }
 
-    fn download_browser(&mut self) -> Result<Option<PathBuf>, Box<dyn Error>> {
+    fn download_browser(&mut self) -> Result<Option<PathBuf>, Error> {
         if WINDOWS.is(self.get_os()) && self.is_edge() && !self.is_windows_admin() {
-            return Err(format_one_arg(
+            return Err(anyhow!(format_one_arg(
                 NOT_ADMIN_FOR_EDGE_INSTALLER_ERR_MSG,
                 self.get_browser_name(),
-            )
-            .into());
+            )));
         }
 
         let browser_version;
@@ -228,13 +227,12 @@ pub trait SeleniumManager {
             && !self.is_browser_version_empty()
             && major_browser_version_int < min_browser_version_for_download
         {
-            return Err(format_three_args(
+            return Err(anyhow!(format_three_args(
                 UNAVAILABLE_DOWNLOAD_WITH_MIN_VERSION_ERR_MSG,
                 self.get_browser_name(),
                 &major_browser_version,
                 &min_browser_version_for_download.to_string(),
-            )
-            .into());
+            )));
         }
 
         // Browser version is checked in the local metadata

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -203,11 +203,7 @@ fn main() {
         .and_then(|_| selenium_manager.setup())
         .map(|driver_path| {
             let log = selenium_manager.get_logger();
-            log_driver_and_browser_path(
-                log,
-                &driver_path,
-                selenium_manager.get_browser_path(),
-            );
+            log_driver_and_browser_path(log, &driver_path, selenium_manager.get_browser_path());
             flush_and_exit(OK, log, None);
         })
         .unwrap_or_else(|err| {
@@ -236,11 +232,7 @@ fn main() {
         });
 }
 
-fn log_driver_and_browser_path(
-    log: &Logger,
-    driver_path: &Path,
-    browser_path: &str,
-) {
+fn log_driver_and_browser_path(log: &Logger, driver_path: &Path, browser_path: &str) {
     if driver_path.exists() {
         log.info(format!("{}{}", DRIVER_PATH, driver_path.display()));
     } else {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -137,9 +137,9 @@ fn main() {
     let cache_path =
         StringKey(vec![CACHE_PATH_KEY], &cli.cache_path.unwrap_or_default()).get_value();
 
-    let debug = cli.debug || BooleanKey("debug", false).get_value();
-    let trace = cli.trace || BooleanKey("trace", false).get_value();
     let backtrace = cli.backtrace || BooleanKey("backtrace", false).get_value();
+    let debug = backtrace || cli.debug || BooleanKey("debug", false).get_value();
+    let trace = cli.trace || BooleanKey("trace", false).get_value();
     let log = Logger::create(&cli.output, debug, trace);
     let grid = cli.grid;
     let mut browser_name: String = cli.browser.unwrap_or_default();
@@ -261,10 +261,11 @@ fn log_driver_and_browser_path(
 }
 
 fn flush_and_exit(code: i32, log: &Logger, is_backtrace: bool, err: Option<Error>) -> ! {
-    if err.is_some() && is_backtrace {
-        let backtrace = Backtrace::force_capture();
+    if err.is_some() {
+        let mut backtrace = Backtrace::capture();
         let backtrace_status = backtrace.status();
-        if backtrace_status == BacktraceStatus::Captured {
+        if is_backtrace || backtrace_status == BacktraceStatus::Captured {
+            backtrace = Backtrace::force_capture();
             log.debug(format!("Backtrace:\n{}", backtrace));
         }
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::backtrace::{Backtrace, BacktraceStatus};
+use std::env;
 use std::path::Path;
 use std::process::exit;
 
@@ -129,6 +129,8 @@ struct Cli {
 }
 
 fn main() {
+    env::set_var("RUST_BACKTRACE", "1"); // Enable capture backtrace by default
+
     let mut cli = Cli::parse();
     let cache_path =
         StringKey(vec![CACHE_PATH_KEY], &cli.cache_path.unwrap_or_default()).get_value();
@@ -203,11 +205,7 @@ fn main() {
         .and_then(|_| selenium_manager.setup())
         .map(|driver_path| {
             let log = selenium_manager.get_logger();
-            log_driver_and_browser_path(
-                log,
-                &driver_path,
-                selenium_manager.get_browser_path(),
-            );
+            log_driver_and_browser_path(log, &driver_path, selenium_manager.get_browser_path());
             flush_and_exit(OK, log, None);
         })
         .unwrap_or_else(|err| {
@@ -236,11 +234,7 @@ fn main() {
         });
 }
 
-fn log_driver_and_browser_path(
-    log: &Logger,
-    driver_path: &Path,
-    browser_path: &str,
-) {
+fn log_driver_and_browser_path(log: &Logger, driver_path: &Path, browser_path: &str) {
     if driver_path.exists() {
         log.info(format!("{}{}", DRIVER_PATH, driver_path.display()));
     } else {
@@ -254,10 +248,9 @@ fn log_driver_and_browser_path(
 
 fn flush_and_exit(code: i32, log: &Logger, err: Option<Error>) -> ! {
     if let Some(error) = err {
-        let backtrace = Backtrace::capture();
-        let backtrace_status = backtrace.status();
-        if backtrace_status == BacktraceStatus::Captured {
-            log.debug(format!("Backtrace:\n{}", error.backtrace()));
+        let backtrace = error.backtrace();
+        if !backtrace.to_string().ends_with("backtrace") {
+            log.debug(format!("Backtrace:\n{}", backtrace));
         }
     }
     log.set_code(code);

--- a/rust/src/safari.rs
+++ b/rust/src/safari.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::anyhow;
 use std::path::PathBuf;
 use std::string::ToString;
 
@@ -41,7 +43,7 @@ pub struct SafariManager {
 }
 
 impl SafariManager {
-    pub fn new() -> Result<Box<Self>, Box<dyn Error>> {
+    pub fn new() -> Result<Box<Self>, Error> {
         let browser_name = SAFARI_NAME;
         let driver_name = SAFARIDRIVER_NAME;
         let config = ManagerConfig::default(browser_name, driver_name);
@@ -78,7 +80,7 @@ impl SeleniumManager for SafariManager {
         HashMap::from([(BrowserPath::new(MACOS, STABLE), SAFARI_PATH)])
     }
 
-    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Error> {
         self.discover_safari_version(SAFARI_FULL_PATH.to_string())
     }
 
@@ -86,19 +88,22 @@ impl SeleniumManager for SafariManager {
         self.driver_name
     }
 
-    fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version(&mut self) -> Result<String, Error> {
         Ok("(local)".to_string())
     }
 
-    fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn request_browser_version(&mut self) -> Result<Option<String>, Error> {
         Ok(None)
     }
 
-    fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
-        Err(format!("{} not available for download", self.get_driver_name()).into())
+    fn get_driver_url(&mut self) -> Result<String, Error> {
+        Err(anyhow!(format!(
+            "{} not available for download",
+            self.get_driver_name()
+        )))
     }
 
-    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Error> {
         Ok(PathBuf::from("/usr/bin/safaridriver"))
     }
 
@@ -129,39 +134,33 @@ impl SeleniumManager for SafariManager {
     fn request_latest_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
-    fn get_min_browser_version_for_download(&self) -> Result<i32, Box<dyn Error>> {
+    fn get_min_browser_version_for_download(&self) -> Result<i32, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_binary_path(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_browser_binary_path(&mut self, _browser_version: &str) -> Result<PathBuf, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_url_for_download(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    fn get_browser_url_for_download(&mut self, _browser_version: &str) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn get_browser_label_for_download(
         &self,
         _browser_version: &str,
-    ) -> Result<Option<&str>, Box<dyn Error>> {
+    ) -> Result<Option<&str>, Error> {
         self.unavailable_download()
     }
 }

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use crate::config::ManagerConfig;
+use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::anyhow;
 use std::path::PathBuf;
 use std::string::ToString;
 
@@ -47,7 +49,7 @@ pub struct SafariTPManager {
 }
 
 impl SafariTPManager {
-    pub fn new() -> Result<Box<Self>, Box<dyn Error>> {
+    pub fn new() -> Result<Box<Self>, Error> {
         let browser_name = SAFARITP_NAMES[0];
         let driver_name = SAFARITPDRIVER_NAME;
         let config = ManagerConfig::default(browser_name, driver_name);
@@ -84,7 +86,7 @@ impl SeleniumManager for SafariTPManager {
         HashMap::from([(BrowserPath::new(MACOS, STABLE), SAFARITP_PATH)])
     }
 
-    fn discover_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn discover_browser_version(&mut self) -> Result<Option<String>, Error> {
         self.discover_safari_version(SAFARITP_FULL_PATH.to_string())
     }
 
@@ -92,19 +94,22 @@ impl SeleniumManager for SafariTPManager {
         self.driver_name
     }
 
-    fn request_driver_version(&mut self) -> Result<String, Box<dyn Error>> {
+    fn request_driver_version(&mut self) -> Result<String, Error> {
         Ok("(local)".to_string())
     }
 
-    fn request_browser_version(&mut self) -> Result<Option<String>, Box<dyn Error>> {
+    fn request_browser_version(&mut self) -> Result<Option<String>, Error> {
         Ok(None)
     }
 
-    fn get_driver_url(&mut self) -> Result<String, Box<dyn Error>> {
-        Err(format!("{} not available for download", self.get_driver_name()).into())
+    fn get_driver_url(&mut self) -> Result<String, Error> {
+        Err(anyhow!(format!(
+            "{} not available for download",
+            self.get_driver_name()
+        )))
     }
 
-    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_driver_path_in_cache(&self) -> Result<PathBuf, Error> {
         Ok(PathBuf::from(
             "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver",
         ))
@@ -137,39 +142,33 @@ impl SeleniumManager for SafariTPManager {
     fn request_latest_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn request_fixed_browser_version_from_online(
         &mut self,
         _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         self.unavailable_download()
     }
 
-    fn get_min_browser_version_for_download(&self) -> Result<i32, Box<dyn Error>> {
+    fn get_min_browser_version_for_download(&self) -> Result<i32, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_binary_path(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<PathBuf, Box<dyn Error>> {
+    fn get_browser_binary_path(&mut self, _browser_version: &str) -> Result<PathBuf, Error> {
         self.unavailable_download()
     }
 
-    fn get_browser_url_for_download(
-        &mut self,
-        _browser_version: &str,
-    ) -> Result<String, Box<dyn Error>> {
+    fn get_browser_url_for_download(&mut self, _browser_version: &str) -> Result<String, Error> {
         self.unavailable_download()
     }
 
     fn get_browser_label_for_download(
         &self,
         _browser_version: &str,
-    ) -> Result<Option<&str>, Box<dyn Error>> {
+    ) -> Result<Option<&str>, Error> {
         self.unavailable_download()
     }
 }

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::{Logger, WINDOWS};
-use std::error::Error;
+use anyhow::Error;
 
 pub const CRLF: &str = "\r\n";
 pub const LF: &str = "\n";
@@ -68,14 +68,14 @@ pub fn run_shell_command_with_log(
     log: &Logger,
     os: &str,
     command: Command,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, Error> {
     log.debug(format!("Running command: {}", command.display()));
     let output = run_shell_command_by_os(os, command)?;
     log.debug(format!("Output: {:?}", output));
     Ok(output)
 }
 
-pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Box<dyn Error>> {
+pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Error> {
     let (shell, flag) = if WINDOWS.is(os) {
         ("cmd", "/c")
     } else {
@@ -84,11 +84,7 @@ pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Box
     run_shell_command(shell, flag, command)
 }
 
-pub fn run_shell_command(
-    shell: &str,
-    flag: &str,
-    command: Command,
-) -> Result<String, Box<dyn Error>> {
+pub fn run_shell_command(shell: &str, flag: &str, command: Command) -> Result<String, Error> {
     let mut process = std::process::Command::new(shell);
     process.arg(flag);
 

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -75,7 +75,6 @@ fn wrong_parameters_test(
     let result = cmd
         .args([
             "--debug",
-            "--backtrace",
             "--browser",
             &browser,
             "--browser-version",
@@ -86,7 +85,7 @@ fn wrong_parameters_test(
         .assert()
         .try_success();
 
-    assert_output(&mut cmd, result, vec!["in PATH", "Backtrace"], error_code);
+    assert_output(&mut cmd, result, vec!["in PATH"], error_code);
 }
 
 #[rstest]

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -75,6 +75,7 @@ fn wrong_parameters_test(
     let result = cmd
         .args([
             "--debug",
+            "--backtrace",
             "--browser",
             &browser,
             "--browser-version",
@@ -85,7 +86,7 @@ fn wrong_parameters_test(
         .assert()
         .try_success();
 
-    assert_output(&mut cmd, result, "in PATH", error_code);
+    assert_output(&mut cmd, result, vec!["in PATH", "Backtrace"], error_code);
 }
 
 #[rstest]

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -78,13 +78,15 @@ pub fn display_output(cmd: &mut Command) {
 pub fn assert_output(
     cmd: &mut Command,
     assert_result: AssertResult,
-    expected_output: &str,
+    expected_output: Vec<&str>,
     error_code: i32,
 ) {
     if assert_result.is_ok() {
         let stdout = &cmd.unwrap().stdout;
         let output = std::str::from_utf8(stdout).unwrap();
-        assert!(output.contains(expected_output));
+        expected_output
+            .iter()
+            .for_each(|o| assert!(output.contains(o)));
     } else {
         assert!(assert_result
             .err()

--- a/rust/tests/grid_tests.rs
+++ b/rust/tests/grid_tests.rs
@@ -78,5 +78,5 @@ fn grid_error_test(#[case] grid_version: &str) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
     let result = cmd.args(["--grid", grid_version]).assert().try_success();
 
-    assert_output(&mut cmd, result, "There was an error", DATAERR);
+    assert_output(&mut cmd, result, vec!["There was an error"], DATAERR);
 }

--- a/rust/tests/proxy_tests.rs
+++ b/rust/tests/proxy_tests.rs
@@ -35,7 +35,7 @@ async fn wrong_proxy_test() {
         .assert()
         .try_success();
 
-    assert_output(&mut cmd, result, "in PATH", DATAERR);
+    assert_output(&mut cmd, result, vec!["in PATH"], DATAERR);
 }
 #[test]
 fn wrong_protocol_proxy_test() {
@@ -45,7 +45,7 @@ fn wrong_protocol_proxy_test() {
         .assert()
         .try_success();
 
-    assert_output(&mut cmd, result, "There was an error", DATAERR);
+    assert_output(&mut cmd, result, vec!["There was an error"], DATAERR);
 }
 
 #[test]
@@ -61,5 +61,5 @@ fn wrong_port_proxy_test() {
         .assert()
         .try_success();
 
-    assert_output(&mut cmd, result, "There was an error", DATAERR);
+    assert_output(&mut cmd, result, vec!["There was an error"], DATAERR);
 }


### PR DESCRIPTION
### Description
This PR uses the [anyhow crate](https://crates.io/crates/anyhow) to display backtrace in case of error.

### Motivation and Context

The standard Rust library for error types does not include a stack trace. This fact can sometimes be problematic for troubleshooting, especially when some standard error (e.g., due to the file system) happens in the internal logic of Selenium Manager. Some typical example is as follows:

```
Permission denied (os error 13)
```

There is currently a [reported issue](https://github.com/SeleniumHQ/selenium/issues/12828) in which that error happens. And in that case, we don't know in which code line that error is happening.

To ease the troubleshooting procedure in future issues, this PR includes the [anyhow crate](https://crates.io/crates/anyhow) for handling errors in all the Selenium Manager Rust logic.

Thanks to this crate, we can capture the backtrace, and with that, we can discover in which line of the Rust code the error happened. To enable the backtrace capture, we set the standard Rust environment variable  `RUST_BACKTRACE` to `1`.

For example, consider the following forced error:

```
$ ./selenium-manager --debug --browser BAD

ERROR   Invalid browser name: BAD
```

Selenium Manager finished due to a bad name in the specified browser. But if `RUST_BACKTRACE` is set to `1`, in addition, we have the complete backtrace in the output:

```
$ RUST_BACKTRACE=1 ./selenium-manager --debug --browser BAD
DEBUG   Backtrace:
   0: backtrace::backtrace::trace<anyhow::backtrace::capture::impl$4::create::closure_env$0>
             at C:\Users\boni\.cargo\registry\src\index.crates.io-1cd66030c949c28d\backtrace-0.3.67\src\backtrace\mod.rs:53
   1: anyhow::backtrace::capture::Backtrace::create
             at C:\Users\boni\.cargo\registry\src\index.crates.io-1cd66030c949c28d\anyhow-1.0.75\src\backtrace.rs:216
   2: anyhow::backtrace::capture::Backtrace::capture
             at C:\Users\boni\.cargo\registry\src\index.crates.io-1cd66030c949c28d\anyhow-1.0.75\src\backtrace.rs:204
   3: selenium_manager::get_manager_by_browser
             at .\src\lib.rs:1091
   4: selenium_manager::get_manager_by_browser
             at .\src\lib.rs:1091
   5: selenium_manager::main
             at .\src\main.rs:149
   6: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\library\core\src\ops\function.rs:250
   7: std::sys_common::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\library\std\src\sys_common\backtrace.rs:134
   8: std::sys_common::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\library\std\src\sys_common\backtrace.rs:134
   9: core::ops::function::impls::impl$2::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\core\src\ops\function.rs:287
  10: std::panicking::try::do_call
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panicking.rs:485
  11: std::panicking::try
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panicking.rs:449
  12: std::panic::catch_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panic.rs:140
  13: std::rt::lang_start_internal::closure$2
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\rt.rs:148
  14: std::panicking::try::do_call
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panicking.rs:485
  15: std::panicking::try
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panicking.rs:449
  16: std::panic::catch_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\panic.rs:140
  17: std::rt::lang_start_internal
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\rt.rs:148
  18: std::rt::lang_start<tuple$<> >
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\library\std\src\rt.rs:165
  19: invoke_main
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  20: __scrt_common_main_seh
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  21: BaseThreadInitThunk
  22: RtlGetAppContainerNamedObjectPath
  23: RtlGetAppContainerNamedObjectPath
```

The backtrace is also captured in the JSON output, which is the relevant one for the integration in the bindings:

```
$ RUST_BACKTRACE=1 ./selenium-manager --debug --browser BAD --output json

{
  "logs": [
    {
      "level": "ERROR",
      "timestamp": 1696258893,
      "message": "Invalid browser name: BAD"
    },
    {
      "level": "DEBUG",
      "timestamp": 1696258893,
      "message": "Backtrace:\n   0: backtrace::backtrace::trace<anyhow::backtrace::capture::impl$4::create::closure_env$0>\n             at C:\\Users\\boni\\.cargo\\registry\\src\\index.crates.io-1cd66030c949c28d\\backtrace-0.3.67\\src\\backtrace\\mod.rs:53\n   1: anyhow::backtrace::capture::Backtrace::create\n             at C:\\Users\\boni\\.cargo\\registry\\src\\index.crates.io-1cd66030c949c28d\\anyhow-1.0.75\\src\\backtrace.rs:216\n   2: anyhow::backtrace::capture::Backtrace::capture\n             at C:\\Users\\boni\\.cargo\\registry\\src\\index.crates.io-1cd66030c949c28d\\anyhow-1.0.75\\src\\backtrace.rs:204\n   3: selenium_manager::get_manager_by_browser\n             at .\\src\\lib.rs:1091\n   4: selenium_manager::get_manager_by_browser\n             at .\\src\\lib.rs:1091\n   5: selenium_manager::main\n             at .\\src\\main.rs:149\n   6: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\\library\\core\\src\\ops\\function.rs:250\n   7: std::sys_common::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\\library\\std\\src\\sys_common\\backtrace.rs:134\n   8: std::sys_common::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\\library\\std\\src\\sys_common\\backtrace.rs:134\n   9: core::ops::function::impls::impl$2::call_once\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\core\\src\\ops\\function.rs:287\n  10: std::panicking::try::do_call\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panicking.rs:485\n  11: std::panicking::try\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panicking.rs:449\n  12: std::panic::catch_unwind\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panic.rs:140\n  13: std::rt::lang_start_internal::closure$2\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\rt.rs:148\n  14: std::panicking::try::do_call\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panicking.rs:485\n  15: std::panicking::try\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panicking.rs:449\n  16: std::panic::catch_unwind\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\panic.rs:140\n  17: std::rt::lang_start_internal\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\\std\\src\\rt.rs:148\n  18: std::rt::lang_start<tuple$<> >\n             at /rustc/90c541806f23a127002de5b4038be731ba1458ca\\library\\std\\src\\rt.rs:165\n  19: invoke_main\n             at D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl:78\n  20: __scrt_common_main_seh\n             at D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl:288\n  21: BaseThreadInitThunk\n  22: RtlGetAppContainerNamedObjectPath\n  23: RtlGetAppContainerNamedObjectPath\n"
    }
  ],
  "result": {
    "code": 65,
    "message": "Invalid browser name: BAD",
    "driver_path": "",
    "browser_path": ""
  }
}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
