### PR TITLE
[java] ensure proper error message gets logged

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/WebSocket.java
+++ b/java/src/org/openqa/selenium/remote/http/WebSocket.java
@@ -65,7 +65,7 @@ public interface WebSocket extends Closeable {
 
     default void onError(Throwable cause) {
       String message = cause.getMessage();
-      if (message == null && cause.getCause().getMessage() != null) {
+      if (message == null && cause.getCause() != null) {
         message = cause.getCause().getMessage();
       }
       LOG.log(WARNING, message, cause);

--- a/java/src/org/openqa/selenium/remote/http/WebSocket.java
+++ b/java/src/org/openqa/selenium/remote/http/WebSocket.java
@@ -64,7 +64,11 @@ public interface WebSocket extends Closeable {
     }
 
     default void onError(Throwable cause) {
-      LOG.log(WARNING, cause.getMessage(), cause);
+      String message = cause.getMessage();
+      if (message == null && cause.getCause().getMessage() != null) {
+        message = cause.getCause().getMessage();
+      }
+      LOG.log(WARNING, message, cause);
     }
   }
 }


### PR DESCRIPTION
Java Throwable class (at least for Java 11) does not set the detailMessage in the `initCause` method the same way it does in the way it does in the constructor:

```
    public Throwable(Throwable cause) {
        fillInStackTrace();
        detailMessage = (cause==null ? null : cause.toString());
        this.cause = cause;
    }
```
vs

```
    public synchronized Throwable initCause(Throwable cause) {
        if (this.cause != this)
            throw new IllegalStateException("Can't overwrite cause with " +
                                            Objects.toString(cause, "a null"), this);
        if (cause == this)
            throw new IllegalArgumentException("Self-causation not permitted", this);
        this.cause = cause;
        return this;
    }
```