### PR TITLE
[dotnet] Rename strong assembly name

### DIFF
--- a/dotnet/src/support/BUILD.bazel
+++ b/dotnet/src/support/BUILD.bazel
@@ -97,7 +97,7 @@ nuget_pack(
     libs = {
         ":support-strongnamed-lib": "WebDriver.Support.StrongNamed",
     },
-    nuspec_template = "WebDriver.Support.nuspec",
+    nuspec_template = "WebDriver.Support.StrongNamed.nuspec",
     tags = [
         "block-network",
     ],

--- a/dotnet/src/support/BUILD.bazel
+++ b/dotnet/src/support/BUILD.bazel
@@ -74,7 +74,7 @@ csharp_library(
         "PageObjects/**/*.cs",
         "UI/*.cs",
     ]) + [":assembly-info"],
-    out = "WebDriver.Support",
+    out = "WebDriver.Support.StrongNamed",
     keyfile = "//dotnet:WebDriver.snk",
     private_deps = [
         framework("nuget", "NETStandard.Library"),
@@ -95,7 +95,7 @@ nuget_pack(
     },
     id = "Selenium.Support.StrongNamed",
     libs = {
-        ":support-strongnamed-lib": "WebDriver.Support",
+        ":support-strongnamed-lib": "WebDriver.Support.StrongNamed",
     },
     nuspec_template = "WebDriver.Support.nuspec",
     tags = [

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -60,7 +60,7 @@ csharp_library(
     ] + glob([
         "**/*.cs",
     ]) + devtools_version_targets(),
-    out = "WebDriver",
+    out = "WebDriver.StrongNamed",
     keyfile = "//dotnet:WebDriver.snk",
     private_deps = [
         framework("nuget", "NETStandard.Library"),
@@ -130,7 +130,7 @@ nuget_pack(
     },
     id = "Selenium.WebDriver.StrongNamed",
     libs = {
-        ":webdriver-strongnamed-lib": "WebDriver",
+        ":webdriver-strongnamed-lib": "WebDriver.StrongNamed",
     },
     nuspec_template = "WebDriver.StrongNamed.nuspec",
     property_group_vars = {


### PR DESCRIPTION
### Description
Strong named packages should contain `WebDriver.StrongNamed.dll` inside. The same for Support package. Strong named Support package should be dependent on strong named WebDriver package.

### Motivation and Context
Fixes #12316

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
