### PR TITLE
[dotnet] Fix ci dotnet build on github actions

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -12,7 +12,7 @@ jobs:
       name: Build
       cache-key: false
       os: windows
-      run: bazel build //dotnet/src/webdriver:package //dotnet/src/support:package
+      run: bazel build //dotnet/src/webdriver //dotnet/src/support
 
   integration-tests:
     name: Browser Tests

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -12,7 +12,9 @@ jobs:
       name: Build
       cache-key: false
       os: windows
-      run: bazel build //dotnet/src/webdriver //dotnet/src/support
+      run: |
+        bazel build //dotnet/src/webdriver
+        bazel build //dotnet/src/support
 
   integration-tests:
     name: Browser Tests


### PR DESCRIPTION
### Description
Current CI .Net Build is broken because bazel targets were renamed.

### Motivation and Context
Align bazel target names to make CI for .NET Build workable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
