### PR TITLE
[java] reduce log noise at FINE level

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -750,11 +750,12 @@ public class RemoteWebDriver
     }
     // No need to log a screenshot response.
     if ((commandName.equals(DriverCommand.SCREENSHOT)
-            || commandName.equals(DriverCommand.ELEMENT_SCREENSHOT))
+            || commandName.equals(DriverCommand.ELEMENT_SCREENSHOT)
+            || commandName.equals(DriverCommand.PRINT_PAGE))
         && toLog instanceof Response) {
       Response responseToLog = (Response) toLog;
       Response copyToLog = new Response(new SessionId((responseToLog).getSessionId()));
-      copyToLog.setValue("*Screenshot response suppressed*");
+      copyToLog.setValue(String.format("*%s response suppressed*", commandName));
       copyToLog.setStatus(responseToLog.getStatus());
       copyToLog.setState(responseToLog.getState());
       text = String.valueOf(copyToLog);

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -742,21 +742,33 @@ public class RemoteWebDriver
       return;
     }
     String text = String.valueOf(toLog);
-    if (commandName.equals(DriverCommand.EXECUTE_SCRIPT)
-        || commandName.equals(DriverCommand.EXECUTE_ASYNC_SCRIPT)) {
-      if (text.length() > 100 && Boolean.getBoolean("webdriver.remote.shorten_log_messages")) {
-        text = text.substring(0, 100) + "...";
+
+    if (Boolean.getBoolean("webdriver.remote.shorten_log_messages")) {
+      if (commandName.equals(DriverCommand.EXECUTE_SCRIPT)
+          || commandName.equals(DriverCommand.EXECUTE_ASYNC_SCRIPT)) {
+        if (text.length() > 100) {
+          text = text.substring(0, 100) + "...";
+        }
+      } else if (commandName.equals(DriverCommand.NEW_SESSION) && toLog instanceof Response) {
+        Response responseToLog = (Response) toLog;
+        try {
+          Map<String, Object> value = (Map<String, Object>) responseToLog.getValue();
+          text = new MutableCapabilities(value).toString();
+        } catch (ClassCastException ex) {
+          // keep existing text
+        }
       }
     }
-    // No need to log a screenshot response.
+
+    // No need to log a base64 encoded responses.
     if ((commandName.equals(DriverCommand.SCREENSHOT)
             || commandName.equals(DriverCommand.ELEMENT_SCREENSHOT)
-            || commandName.equals(DriverCommand.PRINT_PAGE))
+            || commandName.equals(DriverCommand.PRINT_PAGE)
+            || commandName.equals("fullPageScreenshot"))
         && toLog instanceof Response) {
       Response responseToLog = (Response) toLog;
       Response copyToLog = new Response(new SessionId((responseToLog).getSessionId()));
       copyToLog.setValue(String.format("*%s response suppressed*", commandName));
-      copyToLog.setStatus(responseToLog.getStatus());
       copyToLog.setState(responseToLog.getState());
       text = String.valueOf(copyToLog);
     }

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -742,21 +742,18 @@ public class RemoteWebDriver
       return;
     }
     String text = String.valueOf(toLog);
-
-    if (Boolean.getBoolean("webdriver.remote.shorten_log_messages")) {
-      if (commandName.equals(DriverCommand.EXECUTE_SCRIPT)
-          || commandName.equals(DriverCommand.EXECUTE_ASYNC_SCRIPT)) {
-        if (text.length() > 100) {
-          text = text.substring(0, 100) + "...";
-        }
-      } else if (commandName.equals(DriverCommand.NEW_SESSION) && toLog instanceof Response) {
-        Response responseToLog = (Response) toLog;
-        try {
-          Map<String, Object> value = (Map<String, Object>) responseToLog.getValue();
-          text = new MutableCapabilities(value).toString();
-        } catch (ClassCastException ex) {
-          // keep existing text
-        }
+    if (commandName.equals(DriverCommand.EXECUTE_SCRIPT)
+        || commandName.equals(DriverCommand.EXECUTE_ASYNC_SCRIPT)) {
+      if (text.length() > 100 && Boolean.getBoolean("webdriver.remote.shorten_log_messages")) {
+        text = text.substring(0, 100) + "...";
+      }
+    } else if (commandName.equals(DriverCommand.NEW_SESSION) && toLog instanceof Response) {
+      Response responseToLog = (Response) toLog;
+      try {
+        Map<String, Object> value = (Map<String, Object>) responseToLog.getValue();
+        text = new MutableCapabilities(value).toString();
+      } catch (ClassCastException ex) {
+        // keep existing text
       }
     }
 

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
@@ -76,7 +76,7 @@ public class W3CHttpResponseCodec extends AbstractHttpResponseCodec {
   public Response decode(HttpResponse encodedResponse) {
     String content = string(encodedResponse).trim();
     LOG.log(
-        Level.FINE,
+        Level.FINER,
         "Decoding response. Response code was: {0} and content: {1}",
         new Object[] {encodedResponse.getStatus(), content});
     String contentType = nullToEmpty(encodedResponse.getHeader(CONTENT_TYPE));

--- a/java/src/org/openqa/selenium/remote/http/DumpHttpExchangeFilter.java
+++ b/java/src/org/openqa/selenium/remote/http/DumpHttpExchangeFilter.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.internal.Require;
 
 public class DumpHttpExchangeFilter implements Filter {

--- a/java/src/org/openqa/selenium/remote/http/DumpHttpExchangeFilter.java
+++ b/java/src/org/openqa/selenium/remote/http/DumpHttpExchangeFilter.java
@@ -31,7 +31,7 @@ public class DumpHttpExchangeFilter implements Filter {
   private final Level logLevel;
 
   public DumpHttpExchangeFilter() {
-    this(Debug.getDebugLogLevel());
+    this(Level.FINER);
   }
 
   public DumpHttpExchangeFilter(Level logLevel) {


### PR DESCRIPTION
### Description
* Change `W3CHttpResponseCodec.decode()` & `DumpHttpExchangeFilter` log level to FINER
* Add PrintPage & fullPageScreenshot to the list of commands that does not log the response (since they are all base64 encoded responses)
* `NEW_SESSION` responses are parsed with Capabilities.toString() 

### Motivation and Context
* RemoteWebDriver logs most of the important information and intelligently removes responses with Base64 encoded values; `W3CHttpResponseCodec.decode` & `DumpHttpExchangeFilter` do not add much information and they destroy the logs.
* `NEW_SESSION` response can have Base64 values; the `Capabilities` classes have a complicated parser to truncate nested values that are > 100 characters. We should use that in the responses as well. I was going to put this behind `webdriver.remote.shorten_log_messages` system property, but if you want the full values, people can switch to `FINEST`.

So, this is the first time I realized we have `Debug.getDebugLogLevel()`. 
1. I don't think I like magically toggling `FINER` messages to `INFO` [when anyone runs anything in debug mode](https://github.com/SeleniumHQ/selenium/blob/selenium-4.13.0/java/src/org/openqa/selenium/internal/Debug.java#L28-L36). Really feels like we should let users do the more Java thing here. Who is this for? Why not just set the logging output for the user if they request it? Or set this in our tests instead of all of Selenium?
2. How about a system property of `selenium.webdriver.logger.level`?
3. If we do use this, we should be using it everywhere we are otherwise using `FINER`