### PR TITLE
Fix dangling log_output in Service

### DIFF
--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -21,10 +21,10 @@ import subprocess
 import typing
 from abc import ABC
 from abc import abstractmethod
+from io import IOBase
 from platform import system
 from subprocess import PIPE
 from time import sleep
-from typing import TextIO
 from urllib import request
 from urllib.error import URLError
 
@@ -136,7 +136,7 @@ class Service(ABC):
         """Stops the service."""
 
         if self.log_output != PIPE:
-            if isinstance(self.log_output, TextIO):
+            if isinstance(self.log_output, IOBase):
                 self.log_output.close()
             elif isinstance(self.log_output, int):
                 os.close(self.log_output)


### PR DESCRIPTION
The isinstance check was faulty and checked wrong type

Fixes #12870

### Description
The #12637 change also introduced a bug by making an incorrect `isinstance` check.

### Motivation and Context
It solves dangling I/O handle.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
