### PR TITLE
[java] use the java process builder to run external processes

### DIFF
--- a/java/src/org/openqa/selenium/os/CommandLine.java
+++ b/java/src/org/openqa/selenium/os/CommandLine.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriverException;
 
+@Deprecated
 public class CommandLine {
 
   private final OsProcess process;

--- a/java/src/org/openqa/selenium/os/ExternalProcess.java
+++ b/java/src/org/openqa/selenium/os/ExternalProcess.java
@@ -1,0 +1,286 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.os;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.io.CircularOutputStream;
+import org.openqa.selenium.io.MultiOutputStream;
+
+public class ExternalProcess {
+  private static final Logger LOG = Logger.getLogger(ExternalProcess.class.getName());
+
+  public static class Builder {
+
+    private ProcessBuilder builder;
+    private OutputStream copyOutputTo;
+    private int bufferSize = 32768;
+
+    Builder() {
+      this.builder = new ProcessBuilder();
+    }
+
+    /**
+     * Set the executable command to start the process, this consists of the executable and the
+     * arguments.
+     *
+     * @param executable the executable to build the command
+     * @param arguments the arguments to build the command
+     * @return this instance to continue building
+     */
+    public Builder command(String executable, List<String> arguments) {
+      List<String> command = new ArrayList<>(arguments.size() + 1);
+      command.add(executable);
+      command.addAll(arguments);
+      builder.command(command);
+
+      return this;
+    }
+
+    /**
+     * Set the executable command to start the process, this consists of the executable and the
+     * arguments.
+     *
+     * @param command the executable, followed by the arguments
+     * @return this instance to continue building
+     */
+    public Builder command(List<String> command) {
+      builder.command(command);
+
+      return this;
+    }
+
+    /**
+     * Set the executable command to start the process, this consists of the executable and the
+     * arguments.
+     *
+     * @param command the executable, followed by the arguments
+     * @return this instance to continue building
+     */
+    public Builder command(String... command) {
+      builder.command(command);
+
+      return this;
+    }
+
+    /**
+     * Get the executable command to start the process, this consists of the binary and the
+     * arguments.
+     *
+     * @return an editable list, changes to it will update the command executed.
+     */
+    public List<String> command() {
+      return Collections.unmodifiableList(builder.command());
+    }
+
+    /**
+     * Set one environment variable of the process to start, will replace the old value if exists.
+     *
+     * @return this instance to continue building
+     */
+    public Builder environment(String name, String value) {
+      Require.argument("name", name).nonNull();
+      Require.argument("value", value).nonNull();
+
+      builder.environment().put(name, value);
+
+      return this;
+    }
+
+    /**
+     * Get the environment variables of the process to start.
+     *
+     * @return an editable map, changes to it will update the environment variables of the command
+     *     executed.
+     */
+    public Map<String, String> environment() {
+      return builder.environment();
+    }
+
+    /**
+     * Get the working directory of the process to start, maybe null.
+     *
+     * @return the working directory
+     */
+    public File directory() {
+      return builder.directory();
+    }
+
+    /**
+     * Set the working directory of the process to start.
+     *
+     * @param directory the path to the directory
+     * @return this instance to continue building
+     */
+    public Builder directory(String directory) {
+      return directory(new File(directory));
+    }
+
+    /**
+     * Set the working directory of the process to start.
+     *
+     * @param directory the path to the directory
+     * @return this instance to continue building
+     */
+    public Builder directory(File directory) {
+      builder.directory(directory);
+
+      return this;
+    }
+
+    /**
+     * Where to copy the combined stdout and stderr output to, {@code OsProcess#getOutput} is still
+     * working when called.
+     *
+     * @param stream where to copy the combined output to
+     * @return this instance to continue building
+     */
+    public Builder copyOutputTo(OutputStream stream) {
+      copyOutputTo = stream;
+
+      return this;
+    }
+
+    /**
+     * The number of bytes to buffer for {@code OsProcess#getOutput} calls.
+     *
+     * @param toKeep the number of bytes, default is 4096
+     * @return this instance to continue building
+     */
+    public Builder bufferSize(int toKeep) {
+      bufferSize = toKeep;
+
+      return this;
+    }
+
+    public ExternalProcess start() throws UncheckedIOException {
+      // redirect the stderr to stdout
+      builder.redirectErrorStream(true);
+
+      Process process;
+      try {
+        process = builder.start();
+      } catch (IOException ex) {
+        throw new UncheckedIOException(ex);
+      }
+
+      CircularOutputStream circular;
+      try {
+        circular = new CircularOutputStream(bufferSize);
+
+        new Thread(
+                () -> {
+                  InputStream input = process.getInputStream();
+                  // use the CircularOutputStream as mandatory, we know it will never raise a
+                  // IOException
+                  OutputStream output = new MultiOutputStream(circular, copyOutputTo);
+                  while (process.isAlive()) {
+                    try {
+                      // we must read the output to ensure the process will not lock up
+                      input.transferTo(output);
+                    } catch (IOException ex) {
+                      LOG.log(
+                          Level.WARNING,
+                          "failed to copy the output of process " + process.pid(),
+                          ex);
+                    }
+                  }
+                })
+            .start();
+      } catch (Throwable t) {
+        // ensure we do not leak a process in case of failures
+        try {
+          process.destroyForcibly();
+        } catch (Throwable t2) {
+          t.addSuppressed(t2);
+        }
+        throw t;
+      }
+
+      return new ExternalProcess(process, circular);
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final Process process;
+  private final CircularOutputStream outputStream;
+
+  public ExternalProcess(Process process, CircularOutputStream outputStream) {
+    this.process = process;
+    this.outputStream = outputStream;
+  }
+
+  /**
+   * The last N bytes of the combined stdout and stderr as String, the value of N is set while
+   * building the OsProcess.
+   *
+   * @return stdout and stderr as String in Charset.defaultCharset() encoding
+   */
+  public String getOutput() {
+    return outputStream.toString();
+  }
+
+  public boolean isAlive() {
+    return process.isAlive();
+  }
+
+  public boolean waitFor(Duration duration) throws InterruptedException {
+    return process.waitFor(duration.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public int exitValue() {
+    return process.exitValue();
+  }
+
+  /**
+   * Initiate a normal shutdown of the process or kills it when the process is alive after 4
+   * seconds.
+   */
+  public void shutdown() {
+    if (process.supportsNormalTermination()) {
+      process.destroy();
+
+      try {
+        if (process.waitFor(4, SECONDS)) {
+          return;
+        }
+      } catch (InterruptedException ex) {
+        Thread.interrupted();
+      }
+    }
+
+    process.destroyForcibly();
+  }
+}

--- a/java/src/org/openqa/selenium/os/OsProcess.java
+++ b/java/src/org/openqa/selenium/os/OsProcess.java
@@ -44,6 +44,7 @@ import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.io.CircularOutputStream;
 import org.openqa.selenium.io.MultiOutputStream;
 
+@Deprecated
 class OsProcess {
   private static final Logger LOG = Logger.getLogger(OsProcess.class.getName());
 

--- a/java/src/org/openqa/selenium/remote/service/DriverCommandExecutor.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverCommandExecutor.java
@@ -145,7 +145,11 @@ public class DriverCommandExecutor extends HttpCommandExecutor implements Closea
       CompletableFuture<Response> processFinished =
           CompletableFuture.supplyAsync(
               () -> {
-                service.process.waitFor(service.getTimeout().toMillis());
+                try {
+                  service.process.waitFor(service.getTimeout());
+                } catch (InterruptedException ex) {
+                  Thread.currentThread().interrupt();
+                }
                 return null;
               },
               executorService);

--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -49,7 +49,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.net.UrlChecker;
-import org.openqa.selenium.os.CommandLine;
+import org.openqa.selenium.os.ExternalProcess;
 
 /**
  * Manages the life and death of a native executable driver server. It is expected that the driver
@@ -93,7 +93,7 @@ public class DriverService implements Closeable {
    * A reference to the current child process. Will be {@code null} whenever this service is not
    * running. Protected by {@link #lock}.
    */
-  protected CommandLine process = null;
+  protected ExternalProcess process = null;
 
   private OutputStream outputStream = System.err;
 
@@ -173,7 +173,7 @@ public class DriverService implements Closeable {
   public boolean isRunning() {
     lock.lock();
     try {
-      return process != null && process.isRunning();
+      return process != null && process.isAlive();
     } catch (IllegalThreadStateException e) {
       return true;
     } finally {
@@ -201,13 +201,12 @@ public class DriverService implements Closeable {
         this.executable = DriverFinder.getPath(this, getDefaultDriverOptions()).getDriverPath();
       }
       LOG.fine(String.format("Starting driver at %s with %s", this.executable, this.args));
-      process = new CommandLine(this.executable, args.toArray(new String[] {}));
-      process.setEnvironmentVariables(environment);
-      process.copyOutputTo(getOutputStream());
-      process.executeAsync();
-      if (!process.waitForProcessStarted(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
-        throw new WebDriverException("Timed out waiting for driver process to start.");
-      }
+
+      ExternalProcess.Builder builder =
+          ExternalProcess.builder().command(this.executable, args).copyOutputTo(getOutputStream());
+
+      environment.forEach(builder::environment);
+      process = builder.start();
 
       CompletableFuture<StartOrDie> serverStarted =
           CompletableFuture.supplyAsync(
@@ -221,11 +220,13 @@ public class DriverService implements Closeable {
           CompletableFuture.supplyAsync(
               () -> {
                 try {
-                  process.waitFor(getTimeout().toMillis());
-                } catch (org.openqa.selenium.TimeoutException ex) {
-                  return StartOrDie.PROCESS_IS_ACTIVE;
+                  return process.waitFor(getTimeout())
+                      ? StartOrDie.PROCESS_DIED
+                      : StartOrDie.PROCESS_IS_ACTIVE;
+                } catch (InterruptedException ex) {
+                  process.shutdown();
+                  return null;
                 }
-                return StartOrDie.PROCESS_DIED;
               },
               executorService);
 
@@ -234,6 +235,11 @@ public class DriverService implements Closeable {
             (StartOrDie)
                 CompletableFuture.anyOf(serverStarted, processFinished)
                     .get(getTimeout().toMillis() * 2, TimeUnit.MILLISECONDS);
+
+        if (status == null) {
+          throw new InterruptedException();
+        }
+
         switch (status) {
           case SERVER_STARTED:
             processFinished.cancel(true);
@@ -244,11 +250,16 @@ public class DriverService implements Closeable {
           case PROCESS_IS_ACTIVE:
             throw new WebDriverException("Timed out waiting for driver server to bind the port.");
         }
-      } catch (ExecutionException | TimeoutException e) {
+      } catch (ExecutionException e) {
+        process.shutdown();
+        throw new WebDriverException("Failed waiting for driver server to start.", e);
+      } catch (TimeoutException e) {
+        process.shutdown();
         throw new WebDriverException("Timed out waiting for driver server to start.", e);
       } catch (InterruptedException e) {
+        process.shutdown();
         Thread.currentThread().interrupt();
-        throw new WebDriverException("Timed out waiting for driver server to start.", e);
+        throw new WebDriverException("Interrupted while waiting for driver server to start.", e);
       }
     } finally {
       lock.unlock();
@@ -296,7 +307,7 @@ public class DriverService implements Closeable {
         }
       }
 
-      process.destroy();
+      process.shutdown();
 
       if (getOutputStream() instanceof FileOutputStream) {
         try {

--- a/java/test/org/openqa/selenium/os/ExternalProcessTest.java
+++ b/java/test/org/openqa/selenium/os/ExternalProcessTest.java
@@ -1,0 +1,124 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.os;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.build.BazelBuild;
+
+class ExternalProcessTest {
+
+  private static final String testExecutable =
+      findExecutable("java/test/org/openqa/selenium/os/echo");
+
+  @Test
+  void testSetEnvironmentVariableWithNullKeyThrows() {
+    ExternalProcess.Builder builder = ExternalProcess.builder().command(testExecutable);
+    var environment = builder.environment();
+
+    String key = null;
+    String value = "Bar";
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> builder.environment(key, value));
+    assertThat(environment).doesNotContainValue(value);
+  }
+
+  @Test
+  void testSetEnvironmentVariableWithNullValueThrows() {
+    ExternalProcess.Builder builder = ExternalProcess.builder().command(testExecutable);
+    var environment = builder.environment();
+
+    String key = "Foo";
+    String value = null;
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> builder.environment(key, value));
+    assertThat(environment).doesNotContainKey(key);
+  }
+
+  @Test
+  void testSetEnvironmentVariableWithNonNullValueSets() {
+    ExternalProcess.Builder builder = ExternalProcess.builder().command(testExecutable);
+    var environment = builder.environment();
+
+    String key = "Foo";
+    String value = "Bar";
+    builder.environment(key, value);
+    assertThat(environment).containsEntry(key, value);
+  }
+
+  @Test
+  void testDestroy() {
+    ExternalProcess process = ExternalProcess.builder().command(testExecutable).start();
+    assertThat(process.isAlive()).isTrue();
+    process.shutdown();
+    assertThat(process.isAlive()).isFalse();
+  }
+
+  @Test
+  void canHandleOutput() throws InterruptedException {
+    ExternalProcess process = ExternalProcess.builder().command(testExecutable, "ping").start();
+
+    assertThat(process.waitFor(Duration.ofSeconds(20))).isTrue();
+    assertThat(process.getOutput()).isNotEmpty().contains("ping");
+  }
+
+  @Test
+  void canCopyOutput() throws InterruptedException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    ExternalProcess process =
+        ExternalProcess.builder()
+            .command(testExecutable, "Who", "else", "likes", "cheese?")
+            .copyOutputTo(buffer)
+            .start();
+
+    assertThat(process.waitFor(Duration.ofSeconds(20))).isTrue();
+    assertThat(buffer.toByteArray()).isNotEmpty();
+    assertThat(process.getOutput()).isEqualTo(buffer.toString());
+  }
+
+  @Test
+  void canDetectSuccess() throws InterruptedException {
+    ExternalProcess process = ExternalProcess.builder().command(testExecutable, "foo").start();
+
+    assertThat(process.waitFor(Duration.ofSeconds(20))).isTrue();
+    assertThat(process.exitValue()).isZero();
+  }
+
+  @Test
+  void canDetectFailure() throws InterruptedException {
+    ExternalProcess process = ExternalProcess.builder().command(testExecutable).start();
+
+    assertThat(process.waitFor(Duration.ofSeconds(20))).isTrue();
+    assertThat(process.exitValue()).isNotEqualTo(0);
+  }
+
+  private static String findExecutable(String relativePath) {
+    if (Platform.getCurrent().is(Platform.WINDOWS)) {
+      File workingDir = BazelBuild.findBinRoot(new File(".").getAbsoluteFile());
+      return new File(workingDir, relativePath).getAbsolutePath();
+    } else {
+      return relativePath;
+    }
+  }
+}


### PR DESCRIPTION
### Description
Replaced commons-exec with the java process builder to get rid of the dependency.

### Motivation and Context
With Java 11 we now have all we need to implement the same functionality without a dependency.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
