### PR TITLE
[rust] Include webview2 in Edge module

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -36,8 +36,14 @@ use crate::{
     REG_VERSION_ARG, STABLE,
 };
 
-pub const EDGE_NAMES: &[&str] = &["edge", "msedge", "microsoftedge"];
+pub const EDGE_NAMES: &[&str] = &[
+    "edge",
+    EDGE_WINDOWS_AND_LINUX_APP_NAME,
+    "microsoftedge",
+    WEBVIEW2_NAME,
+];
 pub const EDGEDRIVER_NAME: &str = "msedgedriver";
+pub const WEBVIEW2_NAME: &str = "webview2";
 const DRIVER_URL: &str = "https://msedgedriver.azureedge.net/";
 const LATEST_STABLE: &str = "LATEST_STABLE";
 const LATEST_RELEASE: &str = "LATEST_RELEASE";
@@ -61,13 +67,17 @@ pub struct EdgeManager {
 
 impl EdgeManager {
     pub fn new() -> Result<Box<Self>, Error> {
-        let browser_name = EDGE_NAMES[0];
+        Self::new_with_name(EDGE_NAMES[0].to_string())
+    }
+
+    pub fn new_with_name(browser_name: String) -> Result<Box<Self>, Error> {
+        let static_browser_name: &str = Box::leak(browser_name.into_boxed_str());
         let driver_name = EDGEDRIVER_NAME;
-        let config = ManagerConfig::default(browser_name, driver_name);
+        let config = ManagerConfig::default(static_browser_name, driver_name);
         let default_timeout = config.timeout.to_owned();
         let default_proxy = &config.proxy;
         Ok(Box::new(EdgeManager {
-            browser_name,
+            browser_name: static_browser_name,
             driver_name,
             http_client: create_http_client(default_timeout, default_proxy)?,
             config,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::chrome::{ChromeManager, CHROMEDRIVER_NAME, CHROME_NAME};
-use crate::edge::{EdgeManager, EDGEDRIVER_NAME, EDGE_NAMES};
+use crate::edge::{EdgeManager, EDGEDRIVER_NAME, EDGE_NAMES, WEBVIEW2_NAME};
 use crate::files::{
     create_parent_path_if_not_exists, create_path_if_not_exists, default_cache_folder,
     get_binary_extension, path_to_string,
@@ -499,6 +499,7 @@ pub trait SeleniumManager {
             && !self.is_iexplorer()
             && !self.is_grid()
             && !self.is_safari()
+            && !self.is_webview2()
         {
             let browser_path = self.download_browser()?;
             if browser_path.is_some() {
@@ -640,6 +641,10 @@ pub trait SeleniumManager {
 
     fn is_edge(&self) -> bool {
         self.get_browser_name().eq(EDGE_NAMES[0])
+    }
+
+    fn is_webview2(&self) -> bool {
+        self.get_browser_name().eq(WEBVIEW2_NAME)
     }
 
     fn is_browser_version_beta(&self) -> bool {
@@ -1144,7 +1149,7 @@ pub trait SeleniumManager {
     }
 
     fn set_browser_path(&mut self, browser_path: String) {
-        if !browser_path.is_empty() {
+        if !browser_path.is_empty() && !self.is_webview2() {
             self.get_config_mut().browser_path = browser_path;
         }
     }
@@ -1307,7 +1312,7 @@ pub fn get_manager_by_browser(browser_name: String) -> Result<Box<dyn SeleniumMa
     } else if browser_name_lower_case.eq(FIREFOX_NAME) {
         Ok(FirefoxManager::new()?)
     } else if EDGE_NAMES.contains(&browser_name_lower_case.as_str()) {
-        Ok(EdgeManager::new()?)
+        Ok(EdgeManager::new_with_name(browser_name)?)
     } else if IE_NAMES.contains(&browser_name_lower_case.as_str()) {
         Ok(IExplorerManager::new()?)
     } else if browser_name_lower_case.eq(SAFARI_NAME) {

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -17,9 +17,10 @@
 
 use assert_cmd::Command;
 use rstest::rstest;
+use selenium_manager::logger::JsonOutput;
 use std::env::consts::OS;
 
-use crate::common::assert_output;
+use crate::common::{assert_driver, assert_output};
 
 mod common;
 
@@ -146,4 +147,21 @@ fn browser_path_test(#[case] os: String, #[case] browser: String, #[case] browse
         println!("{}", output);
         assert!(!output.contains("WARN"));
     }
+}
+
+#[test]
+fn webview2_test() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    cmd.args(["--browser", "webview2", "--output", "json"])
+        .assert()
+        .success()
+        .code(0);
+
+    assert_driver(&mut cmd);
+
+    let stdout = &cmd.unwrap().stdout;
+    let output = std::str::from_utf8(stdout).unwrap();
+    let json: JsonOutput = serde_json::from_str(output).unwrap();
+    let browser_path = json.result.browser_path;
+    assert!(browser_path.is_empty());
 }


### PR DESCRIPTION
### Description
This PR includes the label `webview2` as synonymous of Microsoft Edge in the Edge module. 

This way, Selenium Manager can be invoked using `--browser webview2`. As requested in #issues, in this case, Selenium Manager will treat `webview2` like Microsoft Edge for getting the driver but returning an empty string for the browser's location instead of trying to obtain it. For instance:

```
./selenium-manager --debug --browser webview2
DEBUG   msedgedriver not found in PATH
DEBUG   webview2 detected at C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=117.0.2045.60\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: webview2 117.0.2045.60
DEBUG   Required driver: msedgedriver 117.0.2045.60
DEBUG   msedgedriver 117.0.2045.60 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\msedgedriver\win64\117.0.2045.60\msedgedriver.exe
```

```
./selenium-manager --browser webview2 --output json
{
  "logs": [
    {
      "level": "INFO",
      "timestamp": 1696863192,
      "message": "Driver path: C:\\Users\\boni\\.cache\\selenium\\msedgedriver\\win64\\117.0.2045.60\\msedgedriver.exe"
    }
  ],
  "result": {
    "code": 0,
    "message": "C:\\Users\\boni\\.cache\\selenium\\msedgedriver\\win64\\117.0.2045.60\\msedgedriver.exe",
    "driver_path": "C:\\Users\\boni\\.cache\\selenium\\msedgedriver\\win64\\117.0.2045.60\\msedgedriver.exe",
    "browser_path": ""
  }
}
```

### Motivation and Context
This issue will support WebView2, as requested in #12738.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
