### PR TITLE
[rust] Include mirror arguments to change default online repository URLs (#11687)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d9d5f22625fe3080b3eef8acfa5d55ae7929945c9570e4d592189d3b69f4149f",
+  "checksum": "26d2f0f70ab29da1978d06932931cb213ac8d548130df293777080ce1eb8d4d3",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -78,20 +78,28 @@ impl ChromeManager {
     }
 
     fn create_latest_release_url(&self) -> String {
-        format!("{}{}", DRIVER_URL, LATEST_RELEASE)
+        format!(
+            "{}{}",
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
+            LATEST_RELEASE
+        )
     }
 
     fn create_latest_release_with_version_url(&self) -> String {
         format!(
             "{}{}_{}",
-            DRIVER_URL,
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
             LATEST_RELEASE,
             self.get_major_browser_version()
         )
     }
 
     fn create_cft_url(&self, endpoint: &str) -> String {
-        format!("{}{}", CFT_URL, endpoint)
+        format!(
+            "{}{}",
+            self.get_browser_mirror_url_or_default(CFT_URL),
+            endpoint
+        )
     }
 
     fn request_driver_version_from_latest(&self, driver_url: String) -> Result<String, Error> {
@@ -365,7 +373,10 @@ impl SeleniumManager for ChromeManager {
         };
         Ok(format!(
             "{}{}/{}_{}.zip",
-            DRIVER_URL, driver_version, self.driver_name, driver_label
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
+            driver_version,
+            self.driver_name,
+            driver_label
         ))
     }
 

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -37,6 +37,7 @@ pub const CONFIG_FILE: &str = "se-config.toml";
 pub const ENV_PREFIX: &str = "SE_";
 pub const VERSION_PREFIX: &str = "-version";
 pub const PATH_PREFIX: &str = "-path";
+pub const MIRROR_PREFIX: &str = "-mirror-url";
 pub const CACHE_PATH_KEY: &str = "cache-path";
 
 pub struct ManagerConfig {
@@ -44,6 +45,8 @@ pub struct ManagerConfig {
     pub browser_version: String,
     pub driver_version: String,
     pub browser_path: String,
+    pub driver_mirror_url: String,
+    pub browser_mirror_url: String,
     pub os: String,
     pub arch: String,
     pub proxy: String,
@@ -86,6 +89,8 @@ impl ManagerConfig {
         let browser_version_label = concat(browser_name, VERSION_PREFIX);
         let driver_version_label = concat(driver_name, VERSION_PREFIX);
         let browser_path_label = concat(browser_name, PATH_PREFIX);
+        let driver_mirror_label = concat(driver_name, MIRROR_PREFIX);
+        let browser_mirror_label = concat(browser_name, MIRROR_PREFIX);
 
         ManagerConfig {
             cache_path,
@@ -94,6 +99,10 @@ impl ManagerConfig {
             driver_version: StringKey(vec!["driver-version", &driver_version_label], "")
                 .get_value(),
             browser_path: StringKey(vec!["browser-path", &browser_path_label], "").get_value(),
+            driver_mirror_url: StringKey(vec!["driver-mirror-url", &driver_mirror_label], "")
+                .get_value(),
+            browser_mirror_url: StringKey(vec!["browser-mirror-url", &browser_mirror_label], "")
+                .get_value(),
             os: StringKey(vec!["os"], self_os).get_value(),
             arch: StringKey(vec!["arch"], self_arch.as_str()).get_value(),
             proxy: StringKey(vec!["proxy"], "").get_value(),

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -46,7 +46,7 @@ pub const WEBVIEW2_NAME: &str = "webview2";
 const DRIVER_URL: &str = "https://msedgedriver.azureedge.net/";
 const LATEST_STABLE: &str = "LATEST_STABLE";
 const LATEST_RELEASE: &str = "LATEST_RELEASE";
-const BROWSER_URL: &str = "https://edgeupdates.microsoft.com/api/products";
+const BROWSER_URL: &str = "https://edgeupdates.microsoft.com/api/products/";
 const MIN_EDGE_VERSION_DOWNLOAD: i32 = 113;
 const EDGE_WINDOWS_AND_LINUX_APP_NAME: &str = "msedge";
 const EDGE_MACOS_APP_NAME: &str = "Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
@@ -182,7 +182,11 @@ impl SeleniumManager for EdgeManager {
                     || major_browser_version.is_empty()
                     || self.is_browser_version_unstable()
                 {
-                    let latest_stable_url = format!("{}{}", DRIVER_URL, LATEST_STABLE);
+                    let latest_stable_url = format!(
+                        "{}{}",
+                        self.get_driver_mirror_url_or_default(DRIVER_URL),
+                        LATEST_STABLE
+                    );
                     self.log.debug(format!(
                         "Reading {} latest version from {}",
                         &self.driver_name, latest_stable_url
@@ -201,7 +205,7 @@ impl SeleniumManager for EdgeManager {
                 }
                 let driver_url = format!(
                     "{}{}_{}_{}",
-                    DRIVER_URL,
+                    self.get_driver_mirror_url_or_default(DRIVER_URL),
                     LATEST_RELEASE,
                     major_browser_version,
                     self.get_os().to_uppercase()
@@ -256,7 +260,9 @@ impl SeleniumManager for EdgeManager {
         };
         Ok(format!(
             "{}{}/edgedriver_{}.zip",
-            DRIVER_URL, driver_version, driver_label
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
+            driver_version,
+            driver_label
         ))
     }
 
@@ -320,10 +326,11 @@ impl SeleniumManager for EdgeManager {
         let is_fixed_browser_version = !self.is_empty(browser_version)
             && !self.is_stable(browser_version)
             && !self.is_unstable(browser_version);
+        let browser_url = self.get_browser_mirror_url_or_default(BROWSER_URL);
         let edge_updates_url = if is_fixed_browser_version {
-            format!("{}?view=enterprise", BROWSER_URL)
+            format!("{}?view=enterprise", browser_url)
         } else {
-            BROWSER_URL.to_string()
+            browser_url
         };
         self.get_logger().debug(format!(
             "Checking {} releases on {}",

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -202,7 +202,11 @@ impl SeleniumManager for FirefoxManager {
             _ => {
                 self.assert_online_or_err(OFFLINE_REQUEST_ERR_MSG)?;
 
-                let latest_url = format!("{}{}", DRIVER_URL, LATEST_RELEASE);
+                let latest_url = format!(
+                    "{}{}",
+                    self.get_driver_mirror_url_or_default(DRIVER_URL),
+                    LATEST_RELEASE
+                );
                 let driver_version =
                     read_redirect_from_link(self.get_http_client(), latest_url, self.get_logger())?;
 
@@ -260,7 +264,11 @@ impl SeleniumManager for FirefoxManager {
         };
         Ok(format!(
             "{}download/v{}/{}-v{}-{}",
-            DRIVER_URL, driver_version, self.driver_name, driver_version, driver_label
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
+            driver_version,
+            self.driver_name,
+            driver_version,
+            driver_label
         ))
     }
 
@@ -403,7 +411,11 @@ impl SeleniumManager for FirefoxManager {
             }
 
             for version in firefox_versions.iter().rev() {
-                let release_url = format_two_args("{}{}/", BROWSER_URL, version);
+                let release_url = format_two_args(
+                    "{}{}/",
+                    &self.get_browser_mirror_url_or_default(BROWSER_URL),
+                    version,
+                );
                 self.get_logger()
                     .trace(format!("Checking release URL: {}", release_url));
                 let content = read_content_from_link(self.get_http_client(), release_url)?;
@@ -501,7 +513,7 @@ impl SeleniumManager for FirefoxManager {
             let browser_version = self.get_browser_version();
             Ok(format!(
                 "{}{}/{}/{}/{}{}.{}",
-                BROWSER_URL,
+                self.get_browser_mirror_url_or_default(BROWSER_URL),
                 browser_version,
                 platform_label,
                 language,

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -185,7 +185,7 @@ impl SeleniumManager for GridManager {
         let release_version = self.get_selenium_release_version()?;
         Ok(format!(
             "{}download/{}/{}-{}.{}",
-            DRIVER_URL,
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
             release_version,
             GRID_RELEASE,
             self.get_driver_version(),

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -194,7 +194,7 @@ impl SeleniumManager for IExplorerManager {
         let release_version = self.get_selenium_release_version()?;
         Ok(format!(
             "{}download/{}/{}{}.zip",
-            DRIVER_URL,
+            self.get_driver_mirror_url_or_default(DRIVER_URL),
             release_version,
             IEDRIVER_RELEASE,
             self.get_driver_version()

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1151,6 +1151,47 @@ pub trait SeleniumManager {
         }
     }
 
+    fn get_driver_mirror_url(&self) -> &str {
+        self.get_config().driver_mirror_url.as_str()
+    }
+
+    fn set_driver_mirror_url(&mut self, mirror_url: String) {
+        if !mirror_url.is_empty() {
+            self.get_config_mut().driver_mirror_url = mirror_url;
+        }
+    }
+
+    fn get_browser_mirror_url(&self) -> &str {
+        self.get_config().browser_mirror_url.as_str()
+    }
+
+    fn set_browser_mirror_url(&mut self, mirror_url: String) {
+        if !mirror_url.is_empty() {
+            self.get_config_mut().browser_mirror_url = mirror_url;
+        }
+    }
+
+    fn get_driver_mirror_url_or_default<'a>(&'a self, default_url: &'a str) -> String {
+        self.get_url_or_default(self.get_driver_mirror_url(), default_url)
+    }
+
+    fn get_browser_mirror_url_or_default<'a>(&'a self, default_url: &'a str) -> String {
+        self.get_url_or_default(self.get_browser_mirror_url(), default_url)
+    }
+
+    fn get_url_or_default<'a>(&'a self, value_url: &'a str, default_url: &'a str) -> String {
+        let url = if value_url.is_empty() {
+            default_url
+        } else {
+            value_url
+        };
+        if !url.ends_with('/') {
+            format!("{}/", url)
+        } else {
+            url.to_string()
+        }
+    }
+
     fn canonicalize_path(&self, path_buf: PathBuf) -> String {
         let mut canon_path = path_to_string(&path_buf);
         if WINDOWS.is(self.get_os()) || canon_path.starts_with(UNC_PREFIX) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -67,6 +67,14 @@ struct Cli {
     #[clap(long, value_parser)]
     browser_path: Option<String>,
 
+    /// Mirror for driver repositories (e.g., https://registry.npmmirror.com/-/binary/chromedriver/)
+    #[clap(long, value_parser)]
+    driver_mirror_url: Option<String>,
+
+    /// Mirror for browser repositories
+    #[clap(long, value_parser)]
+    browser_mirror_url: Option<String>,
+
     /// Output type: LOGGER (using INFO, WARN, etc.), JSON (custom JSON notation), or SHELL (Unix-like)
     #[clap(long, value_parser, default_value = "LOGGER")]
     output: String,
@@ -179,6 +187,8 @@ fn main() {
     selenium_manager.set_browser_version(cli.browser_version.unwrap_or_default());
     selenium_manager.set_driver_version(cli.driver_version.unwrap_or_default());
     selenium_manager.set_browser_path(cli.browser_path.unwrap_or_default());
+    selenium_manager.set_driver_mirror_url(cli.driver_mirror_url.unwrap_or_default());
+    selenium_manager.set_browser_mirror_url(cli.browser_mirror_url.unwrap_or_default());
     selenium_manager.set_os(cli.os.unwrap_or_default());
     selenium_manager.set_arch(cli.arch.unwrap_or_default());
     selenium_manager.set_ttl(cli.ttl);

--- a/rust/tests/mirror_tests.rs
+++ b/rust/tests/mirror_tests.rs
@@ -1,0 +1,42 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::common::assert_driver;
+use assert_cmd::Command;
+
+mod common;
+
+#[test]
+fn mirror_test() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    cmd.args([
+        "--browser",
+        "chrome",
+        "--driver-mirror-url",
+        "https://registry.npmmirror.com/-/binary/chromedriver/",
+        "--browser-version",
+        "112",
+        "--avoid-browser-download",
+        "--output",
+        "json",
+    ])
+    .assert()
+    .success()
+    .code(0);
+
+    assert_driver(&mut cmd);
+}


### PR DESCRIPTION
### Description
This PR includes a couple of new arguments in Selenium Manager for specifying custom URLs for drivers and browsers (instead of the default ones, such as https://chromedriver.storage.googleapis.com/, https://googlechromelabs.github.io/chrome-for-testing/, etc). These arguments are:

- `--driver-mirror-url`: Mirror URL for driver repositories.
- `--browser-mirror-url`: Mirror URL for browser repositories.

As usual, these values can be configured using the config file or envs (e.g., `SE_DRIVER_MIRROR_URL` or `SE_BROWSER_MIRROR_URL`).

Finally, there are browser and driver-specific configuration keys, such as `SE_CHROMEDRIVER_MIRROR_URL`, `SE_GECKODRIVER_MIRROR_URL`, `SE_CHROME_MIRROR_URL`, `SE_FIREFOX_MIRROR_URL`, etc.).

Here is an example of usage:

```
./selenium-manager --debug --browser chrome --browser-version 100 --avoid-browser-download --driver-mirror-url=https://registry.npmmirror.com/-/binary/chromedriver/

DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=117.0.5938.150\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 117.0.5938.150
DEBUG   Discovered chrome version (117) different to specified browser version (100)
DEBUG   Required driver: chromedriver 100.0.4896.60
DEBUG   Downloading chromedriver 100.0.4896.60 from https://registry.npmmirror.com/-/binary/chromedriver/100.0.4896.60/chromedriver_win32.zip
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\100.0.4896.60\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

### Motivation and Context
This PR implements #11687.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
