### PR TITLE
[java] allow setting version in the Http Client Config

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/ClientConfig.java
+++ b/java/src/org/openqa/selenium/remote/http/ClientConfig.java
@@ -23,7 +23,6 @@ import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import javax.net.ssl.SSLContext;
 import org.openqa.selenium.Credentials;
@@ -40,7 +39,7 @@ public class ClientConfig {
   private final Proxy proxy;
   private final Credentials credentials;
   private final SSLContext sslContext;
-  private HttpClient.Version version;
+  private String version;
 
   protected ClientConfig(
       URI baseUri,
@@ -50,7 +49,7 @@ public class ClientConfig {
       Proxy proxy,
       Credentials credentials,
       SSLContext sslContext,
-      HttpClient.Version version) {
+      String version) {
     this.baseUri = baseUri;
     this.connectionTimeout = Require.nonNegative("Connection timeout", connectionTimeout);
     this.readTimeout = Require.nonNegative("Read timeout", readTimeout);
@@ -214,7 +213,7 @@ public class ClientConfig {
     return sslContext;
   }
 
-  public ClientConfig version(HttpClient.Version version) {
+  public ClientConfig version(String version) {
     return new ClientConfig(
         baseUri,
         connectionTimeout,
@@ -226,7 +225,7 @@ public class ClientConfig {
         Require.nonNull("Version", version));
   }
 
-  public HttpClient.Version version() {
+  public String version() {
     return version;
   }
 

--- a/java/src/org/openqa/selenium/remote/http/ClientConfig.java
+++ b/java/src/org/openqa/selenium/remote/http/ClientConfig.java
@@ -23,6 +23,7 @@ import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import javax.net.ssl.SSLContext;
 import org.openqa.selenium.Credentials;
@@ -38,8 +39,8 @@ public class ClientConfig {
   private final Filter filters;
   private final Proxy proxy;
   private final Credentials credentials;
-
   private final SSLContext sslContext;
+  private HttpClient.Version version;
 
   protected ClientConfig(
       URI baseUri,
@@ -48,7 +49,8 @@ public class ClientConfig {
       Filter filters,
       Proxy proxy,
       Credentials credentials,
-      SSLContext sslContext) {
+      SSLContext sslContext,
+      HttpClient.Version version) {
     this.baseUri = baseUri;
     this.connectionTimeout = Require.nonNegative("Connection timeout", connectionTimeout);
     this.readTimeout = Require.nonNegative("Read timeout", readTimeout);
@@ -56,11 +58,19 @@ public class ClientConfig {
     this.proxy = proxy;
     this.credentials = credentials;
     this.sslContext = sslContext;
+    this.version = version;
   }
 
   public static ClientConfig defaultConfig() {
     return new ClientConfig(
-        null, Duration.ofSeconds(10), Duration.ofMinutes(3), DEFAULT_FILTER, null, null, null);
+        null,
+        Duration.ofSeconds(10),
+        Duration.ofMinutes(3),
+        DEFAULT_FILTER,
+        null,
+        null,
+        null,
+        null);
   }
 
   public ClientConfig baseUri(URI baseUri) {
@@ -71,7 +81,8 @@ public class ClientConfig {
         filters,
         proxy,
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public ClientConfig baseUrl(URL baseUrl) {
@@ -102,7 +113,8 @@ public class ClientConfig {
         filters,
         proxy,
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public Duration connectionTimeout() {
@@ -117,7 +129,8 @@ public class ClientConfig {
         filters,
         proxy,
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public Duration readTimeout() {
@@ -133,7 +146,8 @@ public class ClientConfig {
         filter.andThen(DEFAULT_FILTER),
         proxy,
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public ClientConfig withRetries() {
@@ -144,7 +158,8 @@ public class ClientConfig {
         filters.andThen(RETRY_FILTER),
         proxy,
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public Filter filter() {
@@ -159,7 +174,8 @@ public class ClientConfig {
         filters,
         Require.nonNull("Proxy", proxy),
         credentials,
-        sslContext);
+        sslContext,
+        version);
   }
 
   public Proxy proxy() {
@@ -174,7 +190,8 @@ public class ClientConfig {
         filters,
         proxy,
         Require.nonNull("Credentials", credentials),
-        sslContext);
+        sslContext,
+        version);
   }
 
   public Credentials credentials() {
@@ -189,11 +206,28 @@ public class ClientConfig {
         filters,
         proxy,
         credentials,
-        Require.nonNull("SSL Context", sslContext));
+        Require.nonNull("SSL Context", sslContext),
+        version);
   }
 
   public SSLContext sslContext() {
     return sslContext;
+  }
+
+  public ClientConfig version(HttpClient.Version version) {
+    return new ClientConfig(
+        baseUri,
+        connectionTimeout,
+        readTimeout,
+        filters,
+        proxy,
+        credentials,
+        sslContext,
+        Require.nonNull("Version", version));
+  }
+
+  public HttpClient.Version version() {
+    return version;
   }
 
   @Override
@@ -213,6 +247,8 @@ public class ClientConfig {
         + credentials
         + ", sslcontext="
         + sslContext
+        + ", version="
+        + version
         + '}';
   }
 }

--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
@@ -151,9 +151,9 @@ public class JdkHttpClient implements HttpClient {
       builder.sslContext(sslContext);
     }
 
-    Version version = config.version();
+    String version = config.version();
     if (version != null) {
-      builder.version(version);
+      builder.version(Version.valueOf(version));
     }
 
     this.client = builder.build();

--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
@@ -29,6 +29,7 @@ import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
@@ -148,6 +149,11 @@ public class JdkHttpClient implements HttpClient {
     SSLContext sslContext = config.sslContext();
     if (sslContext != null) {
       builder.sslContext(sslContext);
+    }
+
+    Version version = config.version();
+    if (version != null) {
+      builder.version(version);
     }
 
     this.client = builder.build();


### PR DESCRIPTION
### Description
Adds version to the constructor and all the methods for Http Client Config
I didn't add tests because our current tests don't seem to be testing the other parameters in a way I can manage. Would need some mocks that I don't have time to figure out.

### Motivation and Context
Addresses #12918 since the default is HTTP 2
