### PR TITLE
[rust] Support for automatic management of Firefox ESR

### DIFF
--- a/rust/tests/browser_download_tests.rs
+++ b/rust/tests/browser_download_tests.rs
@@ -51,6 +51,7 @@ fn browser_latest_download_test(#[case] browser: String) {
 #[case("chrome", "beta")]
 #[case("firefox", "116")]
 #[case("firefox", "beta")]
+#[case("firefox", "esr")]
 #[case("edge", "beta")]
 fn browser_version_download_test(#[case] browser: String, #[case] browser_version: String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));


### PR DESCRIPTION
### Description
This PR enables the support for automatically managing Firefox ESR in Selenium Manager. For instance:

```
./selenium-manager --browser firefox --debug --browser-version esr
DEBUG   geckodriver not found in PATH
DEBUG   firefox detected at C:\Program Files\Mozilla Firefox\firefox.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Mozilla Firefox\\firefox.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=118.0.2.8682\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: firefox 118.0.2.8682
DEBUG   Discovered online firefox version (115) is different to the detected local firefox version (118)
DEBUG   Required browser: firefox 115.3.1esr
DEBUG   Downloading firefox 115.3.1esr from https://ftp.mozilla.org/pub/firefox/releases/115.3.1esr/win64/en-US/Firefox%20Setup%20115.3.1esr.exe
DEBUG   firefox 115.3.1esr is available at C:\Users\boni\.cache\selenium\firefox\win64\115.3.1esr\firefox.exe
DEBUG   Required driver: geckodriver 0.33.0
DEBUG   geckodriver 0.33.0 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\geckodriver\win64\0.33.0\geckodriver.exe
INFO    Browser path: C:\Users\boni\.cache\selenium\firefox\win64\115.3.1esr\firefox.exe
```

### Motivation and Context
Requested in #12926.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
