### PR TITLE
[py] filter which bidi logs are recorded based on event type

### DIFF
--- a/py/selenium/webdriver/common/log.py
+++ b/py/selenium/webdriver/common/log.py
@@ -138,9 +138,6 @@ class Log:
         async with session.wait_for(self.devtools.runtime.ConsoleAPICalled) as messages:
             yield console
 
-        if event_type == Console.ERROR:
-            console["message"] = messages.value.args[0].value
-            console["level"] = messages.value.args[0].type_
-        if event_type == Console.ALL:
+        if event_type == Console.ALL or event_type.value == messages.value.type_:
             console["message"] = messages.value.args[0].value
             console["level"] = messages.value.args[0].type_

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -31,7 +31,7 @@ async def test_check_console_messages(driver, pages):
         pages.load("javascriptPage.html")
         from selenium.webdriver.common.bidi.console import Console
 
-        async with log.add_listener(Console.ALL) as messages:
+        async with log.add_listener(Console.LOG) as messages:
             driver.execute_script("console.log('I love cheese')")
         assert messages["message"] == "I love cheese"
 
@@ -46,8 +46,8 @@ async def test_check_error_console_messages(driver, pages):
         from selenium.webdriver.common.bidi.console import Console
 
         async with log.add_listener(Console.ERROR) as messages:
-            driver.execute_script('console.error("I don\'t cheese")')
             driver.execute_script("console.log('I love cheese')")
+            driver.execute_script('console.error("I don\'t cheese")')
         assert messages["message"] == "I don't cheese"
 
 

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -46,8 +46,8 @@ async def test_check_error_console_messages(driver, pages):
         from selenium.webdriver.common.bidi.console import Console
 
         async with log.add_listener(Console.ERROR) as messages:
-            driver.execute_script("console.log('I love cheese')")
             driver.execute_script('console.error("I don\'t cheese")')
+            driver.execute_script("console.log('I love cheese')")
         assert messages["message"] == "I don't cheese"
 
 


### PR DESCRIPTION
### Description
Changed the logic for updating the console message based on whether the message is an error or a log type.

### Motivation and Context
I updated the tests to show what doesn't work in current code.

@AutomatedTester I don't really understand how this is implemented, I'm just looking at the inputs/outputs. It appears that only one message can be processed, though, so a second execute script never gets triggered. I think that means it is ok to match off of `messages.value.type_`, but let me know if I'm misunderstanding this.