### PR TITLE
[rust] Include arguments for skipping drivers and browsers in path

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -55,6 +55,8 @@ pub struct ManagerConfig {
     pub offline: bool,
     pub force_browser_download: bool,
     pub avoid_browser_download: bool,
+    pub skip_driver_in_path: bool,
+    pub skip_browser_in_path: bool,
 }
 
 impl ManagerConfig {
@@ -111,6 +113,8 @@ impl ManagerConfig {
             offline: BooleanKey("offline", false).get_value(),
             force_browser_download: BooleanKey("force-browser-download", false).get_value(),
             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
+            skip_driver_in_path: BooleanKey("skip-driver-in-path", false).get_value(),
+            skip_browser_in_path: BooleanKey("skip-browser-in-path", false).get_value(),
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -382,7 +382,16 @@ pub trait SeleniumManager {
             // Check browser in PATH
             let browser_in_path = self.find_browser_in_path();
             if let Some(path) = &browser_in_path {
-                self.set_browser_path(path_to_string(path));
+                if self.is_skip_browser_in_path() {
+                    self.get_logger().debug(format!(
+                        "Skipping {} in path: {}",
+                        self.get_browser_name(),
+                        path.display()
+                    ));
+                    return None;
+                } else {
+                    self.set_browser_path(path_to_string(path));
+                }
             }
             browser_in_path
         }
@@ -775,8 +784,16 @@ pub trait SeleniumManager {
                     self.get_major_browser_version()
                 ));
             }
-            self.set_driver_version(version.to_string());
-            return Ok(PathBuf::from(path));
+            if self.is_skip_driver_in_path() {
+                self.get_logger().debug(format!(
+                    "Skipping {} in path: {}",
+                    self.get_driver_name(),
+                    path
+                ));
+            } else {
+                self.set_driver_version(version.to_string());
+                return Ok(PathBuf::from(path));
+            }
         }
 
         // If driver was not in the PATH, try to find it in the cache
@@ -1324,6 +1341,26 @@ pub trait SeleniumManager {
     fn set_avoid_browser_download(&mut self, avoid_browser_download: bool) {
         if avoid_browser_download {
             self.get_config_mut().avoid_browser_download = true;
+        }
+    }
+
+    fn is_skip_driver_in_path(&self) -> bool {
+        self.get_config().skip_driver_in_path
+    }
+
+    fn set_skip_driver_in_path(&mut self, skip_driver_in_path: bool) {
+        if skip_driver_in_path {
+            self.get_config_mut().skip_driver_in_path = true;
+        }
+    }
+
+    fn is_skip_browser_in_path(&self) -> bool {
+        self.get_config().skip_browser_in_path
+    }
+
+    fn set_skip_browser_in_path(&mut self, skip_browser_in_path: bool) {
+        if skip_browser_in_path {
+            self.get_config_mut().skip_browser_in_path = true;
         }
     }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -131,6 +131,14 @@ struct Cli {
     /// Avoid to download browser (even when browser-version is specified)
     #[clap(long)]
     avoid_browser_download: bool,
+
+    /// Not using drivers found in the PATH
+    #[clap(long)]
+    skip_driver_in_path: bool,
+
+    /// Not using browsers found in the PATH
+    #[clap(long)]
+    skip_browser_in_path: bool,
 }
 
 fn main() {
@@ -196,6 +204,8 @@ fn main() {
     selenium_manager.set_avoid_browser_download(cli.avoid_browser_download);
     selenium_manager.set_cache_path(cache_path.clone());
     selenium_manager.set_offline(cli.offline);
+    selenium_manager.set_skip_driver_in_path(cli.skip_driver_in_path);
+    selenium_manager.set_skip_browser_in_path(cli.skip_browser_in_path);
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
         clear_cache(selenium_manager.get_logger(), &cache_path);


### PR DESCRIPTION
### Description
This PR implements a couple of new arguments in Selenium Manager:

- `--skip_driver_in_path`: For not using the drivers found in the PATH.
- `--skip_browser_in_path`: For not using the browsers found in the PATH.

As usual, these arguments can be enabled using the config file or environment variables (e.g., `SE_SKIP_DRIVER_IN_PATH=true`).

The following executions showcase its use:

**Usual execution with (incompatible) driver in path:**
```
./selenium-manager --browser chrome --debug
DEBUG   Found chromedriver 107.0.5304.62 in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=118.0.5993.70\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 118.0.5993.70
DEBUG   Required driver: chromedriver 118.0.5993.70
WARN    The chromedriver version (107.0.5304.62) detected in PATH at C:\Users\boni\Documents\bat\chromedriver.exe might not be compatible with the detected chrome version (118.0.5993.70); currently, chromedriver 118.0.5993.70 is recommended for chrome 118.*, so it is advised to delete the driver in PATH and retry
INFO    Driver path: C:\Users\boni\Documents\bat\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

**Same execution with (incompatible) driver in the path but using `--skip_driver_in_path`:**
```
./selenium-manager --browser chrome --debug --skip-driver-in-path
DEBUG   Found chromedriver 107.0.5304.62 in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=118.0.5993.70\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 118.0.5993.70
DEBUG   Required driver: chromedriver 118.0.5993.70
WARN    The chromedriver version (107.0.5304.62) detected in PATH at C:\Users\boni\Documents\bat\chromedriver.exe might not be compatible with the detected chrome version (118.0.5993.70); currently, chromedriver 118.0.5993.70 is recommended for chrome 118.*, so it is advised to delete the driver in PATH and retry
DEBUG   Skipping chromedriver in path: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   chromedriver 118.0.5993.70 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\118.0.5993.70\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

### Motivation and Context
Although this is not the usual use case, it might be helpful for some users (e.g., #12957).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
