### PR TITLE
[dotnet] implement file downloads

### DIFF
--- a/dotnet/src/webdriver/CapabilityType.cs
+++ b/dotnet/src/webdriver/CapabilityType.cs
@@ -161,6 +161,11 @@ namespace OpenQA.Selenium
         /// </summary>
         public static readonly string WebSocketUrl = "webSocketUrl";
 
+        /// <summary>
+        /// Capability name used to get a value indicating whether files may be downloaded from remote end.
+        /// </summary>
+        public static readonly string EnableDownloads = "se:downloadsEnabled";
+
         private static readonly List<string> KnownSpecCompliantCapabilityNames = new List<string>() {
             BrowserName,
             BrowserVersion,

--- a/dotnet/src/webdriver/DriverCommand.cs
+++ b/dotnet/src/webdriver/DriverCommand.cs
@@ -394,6 +394,21 @@ namespace OpenQA.Selenium
         public static readonly string SetUserVerified = "setUserVerified";
 
         /// <summary>
+        /// Represents the GetDownloadableFiles command.
+        /// </summary>
+        public static readonly string GetDownloadableFiles = "getDownloadableFiles";
+
+        /// <summary>
+        /// Represents the DownloadFile command.
+        /// </summary>
+        public static readonly string DownloadFile = "downloadFile";
+
+        /// <summary>
+        /// Represents the DeleteDownloadableFiles command.
+        /// </summary>
+        public static readonly string DeleteDownloadableFiles = "deleteDownloadableFiles";
+
+        /// <summary>
         /// Lists the set of known commands valid for the Selenium library.
         /// </summary>
         public static readonly IList<string> KnownCommands = new List<string>()
@@ -468,7 +483,10 @@ namespace OpenQA.Selenium
             GetCredentials,
             RemoveCredential,
             RemoveAllCredentials,
-            SetUserVerified
+            SetUserVerified,
+            GetDownloadableFiles,
+            DownloadFile,
+            DeleteDownloadableFiles
         }.AsReadOnly();
     }
 }

--- a/dotnet/src/webdriver/DriverOptions.cs
+++ b/dotnet/src/webdriver/DriverOptions.cs
@@ -101,6 +101,7 @@ namespace OpenQA.Selenium
         private bool? acceptInsecureCertificates;
         private bool? useWebSocketUrl;
         private bool useStrictFileInteractability;
+        private bool? enableDownloads;
         private UnhandledPromptBehavior unhandledPromptBehavior = UnhandledPromptBehavior.Default;
         private PageLoadStrategy pageLoadStrategy = PageLoadStrategy.Default;
         private Dictionary<string, object> additionalCapabilities = new Dictionary<string, object>();
@@ -120,6 +121,7 @@ namespace OpenQA.Selenium
             this.AddKnownCapabilityName(CapabilityType.PageLoadStrategy, "PageLoadStrategy property");
             this.AddKnownCapabilityName(CapabilityType.UseStrictFileInteractability, "UseStrictFileInteractability property");
             this.AddKnownCapabilityName(CapabilityType.WebSocketUrl, "UseWebSocketUrl property");
+            this.AddKnownCapabilityName(CapabilityType.EnableDownloads, "EnableDownloads property");
         }
 
         /// <summary>
@@ -206,6 +208,15 @@ namespace OpenQA.Selenium
         {
             get { return this.useStrictFileInteractability; }
             set { this.useStrictFileInteractability = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether files may be downloaded from remote node.
+        /// </summary>
+        public bool? EnableDownloads
+        {
+            get { return this.enableDownloads; }
+            set { this.enableDownloads = value; }
         }
 
         /// <summary>
@@ -458,6 +469,11 @@ namespace OpenQA.Selenium
             if (this.useWebSocketUrl.HasValue)
             {
                 capabilities.SetCapability(CapabilityType.WebSocketUrl, this.useWebSocketUrl);
+            }
+
+            if (this.enableDownloads.HasValue)
+            {
+                capabilities.SetCapability(CapabilityType.EnableDownloads, this.enableDownloads);
             }
 
             if (this.useStrictFileInteractability)

--- a/dotnet/src/webdriver/IHasDownloads.cs
+++ b/dotnet/src/webdriver/IHasDownloads.cs
@@ -1,0 +1,47 @@
+// <copyright file="IHasSessionId.cs" company="WebDriver Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenQA.Selenium
+{
+    using System.Collections.Generic;
+
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Interface indicating the driver can handle downloading remote files.
+    /// </summary>
+    public interface IHasDownloads
+    {
+        /// <summary>
+        /// Retrieves the downloadable files.
+        /// </summary>
+        /// <returns>A list of file names available for download.</returns>
+        List<string> GetDownloadableFiles();
+
+        /// <summary>
+        /// Downloads a file with the specified file name and returns a dictionary containing the downloaded file's data.
+        /// </summary>
+        /// <param name="fileName">The name of the file to be downloaded.</param>
+        /// <param name="targetDirectory">The location to save the downloaded file.</param>
+        void DownloadFile(string fileName, string targetDirectory);
+
+        /// <summary>
+        /// Deletes the downloadable files.
+        /// </summary>
+        void DeleteDownloadableFiles();
+    }}

--- a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
@@ -19,9 +19,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using OpenQA.Selenium.DevTools;
-using OpenQA.Selenium.Internal;
 
 namespace OpenQA.Selenium.Remote
 {
@@ -58,7 +60,7 @@ namespace OpenQA.Selenium.Remote
     /// }
     /// </code>
     /// </example>
-    public class RemoteWebDriver : WebDriver, IDevTools
+    public class RemoteWebDriver : WebDriver, IDevTools, IHasDownloads
     {
         /// <summary>
         /// The name of the Selenium grid remote DevTools end point capability.
@@ -466,6 +468,73 @@ namespace OpenQA.Selenium.Remote
             }
 
             return this.devToolsSession;
+        }
+
+        /// <summary>
+        /// Retrieves the downloadable files as a map of file names and their corresponding URLs.
+        /// </summary>
+        /// <returns>A list containing file names as keys and URLs as values.</returns>
+        public List<string> GetDownloadableFiles()
+        {
+            var enableDownloads = this.Capabilities.GetCapability(CapabilityType.EnableDownloads);
+            if (enableDownloads == null || !(bool) enableDownloads) {
+                throw new WebDriverException("You must enable downloads in order to work with downloadable files.");
+            }
+
+            Response commandResponse = this.Execute(DriverCommand.GetDownloadableFiles, null);
+            Dictionary<string, object> value = (Dictionary<string, object>)commandResponse.Value;
+            object[] namesArray = (object[])value["names"];
+            return namesArray.Select(obj => obj.ToString()).ToList();
+        }
+
+        /// <summary>
+        /// Downloads a file with the specified file name.
+        /// </summary>
+        /// <param name="fileName">the name of the file to be downloaded</param>
+        public void DownloadFile(string fileName, string targetDirectory)
+        {
+            var enableDownloads = this.Capabilities.GetCapability(CapabilityType.EnableDownloads);
+            if (enableDownloads == null || !(bool) enableDownloads) {
+                throw new WebDriverException("You must enable downloads in order to work with downloadable files.");
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>
+            {
+                { "name", fileName }
+            };
+
+            Response commandResponse = this.Execute(DriverCommand.DownloadFile, parameters);
+            string contents = ((Dictionary<string, object>)commandResponse.Value)["contents"].ToString();
+            byte[] fileData = Convert.FromBase64String(contents);
+
+            Directory.CreateDirectory(targetDirectory);
+            string tempFile = Path.Combine(targetDirectory, "temp.zip");
+            File.WriteAllBytes(tempFile, fileData);
+
+            using (ZipArchive archive = ZipFile.OpenRead(tempFile))
+            {
+                foreach (ZipArchiveEntry entry in archive.Entries)
+                {
+                    string destinationPath = Path.Combine(targetDirectory, entry.FullName);
+
+                    entry.ExtractToFile(destinationPath);
+                }
+            }
+
+            File.Delete(tempFile);
+        }
+
+        /// <summary>
+        /// Deletes all downloadable files.
+        /// </summary>
+        public void DeleteDownloadableFiles()
+        {
+            var enableDownloads = this.Capabilities.GetCapability(CapabilityType.EnableDownloads);
+            if (enableDownloads == null || !(bool) enableDownloads) {
+                throw new WebDriverException("You must enable downloads in order to work with downloadable files.");
+            }
+
+            this.Execute(DriverCommand.DeleteDownloadableFiles, null);
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/Remote/W3CWireProtocolCommandInfoRepository.cs
+++ b/dotnet/src/webdriver/Remote/W3CWireProtocolCommandInfoRepository.cs
@@ -134,6 +134,9 @@ namespace OpenQA.Selenium.Remote
             this.TryAddCommand(DriverCommand.IsElementDisplayed, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/element/{id}/displayed"));
             this.TryAddCommand(DriverCommand.ElementEquals, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/element/{id}/equals/{other}"));
             this.TryAddCommand(DriverCommand.UploadFile, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/file"));
+            this.TryAddCommand(DriverCommand.GetDownloadableFiles, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/se/files"));
+            this.TryAddCommand(DriverCommand.DownloadFile, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/files"));
+            this.TryAddCommand(DriverCommand.DeleteDownloadableFiles, new HttpCommandInfo(HttpCommandInfo.DeleteCommand, "/session/{sessionId}/se/files"));
         }
     }
 }

--- a/dotnet/test/common/DownloadsTest.cs
+++ b/dotnet/test/common/DownloadsTest.cs
@@ -1,0 +1,111 @@
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Environment;
+using System.Collections.Generic;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.UI;
+
+namespace OpenQA.Selenium
+{
+    [TestFixture]
+    public class DownLoadsTest : DriverTestFixture
+    {
+        private IWebDriver localDriver;
+
+        [SetUp]
+        public void ResetDriver()
+        {
+            EnvironmentManager.Instance.CloseCurrentDriver();
+            InitLocalDriver();
+        }
+
+        [TearDown]
+        public void QuitAdditionalDriver()
+        {
+            if (localDriver != null)
+            {
+                localDriver.Quit();
+                localDriver = null;
+            }
+
+            EnvironmentManager.Instance.CreateFreshDriver();
+        }
+
+        [Test]
+        [Ignore("Needs to run with Remote WebDriver")]
+        public void CanListDownloadableFiles()
+        {
+            DownloadWithBrowser();
+
+            List<string> names = ((RemoteWebDriver) driver).GetDownloadableFiles();
+            Assert.That(names, Contains.Item("file_1.txt"));
+            Assert.That(names, Contains.Item("file_2.jpg"));
+        }
+
+        [Test]
+        [Ignore("Needs to run with Remote WebDriver")]
+        public void CanDownloadFile()
+        {
+            DownloadWithBrowser();
+
+            List<string> names = ((RemoteWebDriver) driver).GetDownloadableFiles();
+            string fileName = names[0];
+            string targetDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            ((RemoteWebDriver) driver).DownloadFile(fileName, targetDirectory);
+
+            string fileContent = File.ReadAllText(Path.Combine(targetDirectory, fileName));
+            Assert.AreEqual("Hello, World!", fileContent.Trim());
+
+            Directory.Delete(targetDirectory, recursive: true);
+        }
+
+        [Test]
+        [Ignore("Needs to run with Remote WebDriver")]
+        public void CanDeleteFiles()
+        {
+            DownloadWithBrowser();
+
+            ((RemoteWebDriver)driver).DeleteDownloadableFiles();
+
+            List<string> names = ((RemoteWebDriver) driver).GetDownloadableFiles();
+            Assert.IsEmpty(names, "The names list should be empty.");
+        }
+
+        private void DownloadWithBrowser()
+        {
+            string downloadPage = EnvironmentManager.Instance.UrlBuilder.WhereIs("downloads/download.html");
+            localDriver.Url = downloadPage;
+            driver.FindElement(By.Id("file-1")).Click();
+            driver.FindElement(By.Id("file-2")).Click();
+
+            WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(3));
+            wait.Until(d => ((RemoteWebDriver) d).GetDownloadableFiles().Contains("file_2.jpg"));
+        }
+
+        private void InitLocalDriver()
+        {
+            DownloadableFilesOptions options = new DownloadableFilesOptions();
+            options.EnableDownloads = true;
+
+            localDriver = EnvironmentManager.Instance.CreateDriverInstance(options);
+        }
+
+        public class DownloadableFilesOptions : DriverOptions
+        {
+            public override void AddAdditionalOption(string capabilityName, object capabilityValue)
+            {
+            }
+
+            public override ICapabilities ToCapabilities()
+            {
+                return null;
+            }
+        }
+    }
+}
+

--- a/dotnet/test/common/Environment/RemoteSeleniumServer.cs
+++ b/dotnet/test/common/Environment/RemoteSeleniumServer.cs
@@ -34,7 +34,7 @@ namespace OpenQA.Selenium.Environment
 
                 webserverProcess = new Process();
                 webserverProcess.StartInfo.FileName = "java.exe";
-                webserverProcess.StartInfo.Arguments = " -jar " + serverJarName + " standalone --port 6000 --selenium-manager true";
+                webserverProcess.StartInfo.Arguments = " -jar " + serverJarName + " standalone --port 6000 --selenium-manager true --enable-managed-downloads true";
                 webserverProcess.StartInfo.WorkingDirectory = projectRootPath;
                 webserverProcess.Start();
                 DateTime timeout = DateTime.Now.Add(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
### Description
* Implements driver methods: `GetDownloadableFiles`, `DownloadFile` and `DeleteDownloadableFiles`
* Implements option property: `EnableDownloads`

I can't test this because I can't figure out how to run it in remote with bazel, or if that's possible right now. But I think this is right.

### Motivation and Context
Implements https://github.com/SeleniumHQ/selenium/issues/11657

