### PR TITLE
[dotnet] remove non-w3c compliant capability code

### DIFF
--- a/dotnet/src/support/Extensions/WebDriverExtensions.cs
+++ b/dotnet/src/support/Extensions/WebDriverExtensions.cs
@@ -46,11 +46,6 @@ namespace OpenQA.Selenium.Support.Extensions
                     throw new WebDriverException("Driver does not implement ITakesScreenshot or IHasCapabilities");
                 }
 
-                if (!capabilitiesDriver.Capabilities.HasCapability(CapabilityType.TakesScreenshot) || !(bool)capabilitiesDriver.Capabilities.GetCapability(CapabilityType.TakesScreenshot))
-                {
-                    throw new WebDriverException("Driver capabilities do not support taking screenshots");
-                }
-
                 MethodInfo executeMethod = driver.GetType().GetMethod("Execute", BindingFlags.Instance | BindingFlags.NonPublic);
                 Response screenshotResponse = executeMethod.Invoke(driver, new object[] { DriverCommand.Screenshot, null }) as Response;
                 if (screenshotResponse == null)

--- a/dotnet/src/webdriver/CapabilityType.cs
+++ b/dotnet/src/webdriver/CapabilityType.cs
@@ -41,49 +41,9 @@ namespace OpenQA.Selenium
         public static readonly string PlatformName = "platformName";
 
         /// <summary>
-        /// Capability name used for the browser platform.
-        /// </summary>
-        public static readonly string Platform = "platform";
-
-        /// <summary>
-        /// Capability name used for the browser version.
-        /// </summary>
-        public static readonly string Version = "version";
-
-        /// <summary>
-        /// Capability name used to indicate whether JavaScript is enabled for the browser.
-        /// </summary>
-        public static readonly string IsJavaScriptEnabled = "javascriptEnabled";
-
-        /// <summary>
-        /// Capability name used to indicate whether the browser can take screenshots.
-        /// </summary>
-        public static readonly string TakesScreenshot = "takesScreenshot";
-
-        /// <summary>
-        /// Capability name used to indicate whether the browser can handle alerts.
-        /// </summary>
-        public static readonly string HandlesAlerts = "handlesAlerts";
-
-        /// <summary>
-        /// Capability name used to indicate whether the browser can find elements via CSS selectors.
-        /// </summary>
-        public static readonly string SupportsFindingByCss = "cssSelectorsEnabled";
-
-        /// <summary>
         /// Capability name used for the browser proxy.
         /// </summary>
         public static readonly string Proxy = "proxy";
-
-        /// <summary>
-        /// Capability name used to indicate whether the browser supports rotation.
-        /// </summary>
-        public static readonly string Rotatable = "rotatable";
-
-        /// <summary>
-        /// Capability name used to indicate whether the browser accepts SSL certificates.
-        /// </summary>
-        public static readonly string AcceptSslCertificates = "acceptSslCerts";
 
         /// <summary>
         /// Capability name used to indicate whether the browser accepts SSL certificates on W3C Endpoints
@@ -94,11 +54,6 @@ namespace OpenQA.Selenium
         /// Capability name used to indicate whether the browser uses native events.
         /// </summary>
         public static readonly string HasNativeEvents = "nativeEvents";
-
-        /// <summary>
-        /// Capability name used to indicate how the browser handles unexpected alerts.
-        /// </summary>
-        public static readonly string UnexpectedAlertBehavior = "unexpectedAlertBehaviour";
 
         /// <summary>
         /// Capability name used to indicate how the browser handles unhandled user prompts.
@@ -114,31 +69,6 @@ namespace OpenQA.Selenium
         /// Capability name used to indicate the logging preferences for the session.
         /// </summary>
         public static readonly string LoggingPreferences = "loggingPrefs";
-
-        /// <summary>
-        /// Capability name used to disable the check for overlapping elements.
-        /// </summary>
-        public static readonly string DisableOverlappedElementCheck = "overlappingCheckDisabled";
-
-        /// <summary>
-        /// Capability name used to enable the profiling log for the session.
-        /// </summary>
-        public static readonly string EnableProfiling = "webdriver.logging.profiler.enabled";
-
-        /// <summary>
-        /// Capability name used to indicate whether the driver supports geolocation context.
-        /// </summary>
-        public static readonly string SupportsLocationContext = "locationContextEnabled";
-
-        /// <summary>
-        /// Capability name used to indicate whether the driver supports application cache.
-        /// </summary>
-        public static readonly string SupportsApplicationCache = "applicationCacheEnabled";
-
-        /// <summary>
-        /// Capability name used to indicate whether the driver supports web storage.
-        /// </summary>
-        public static readonly string SupportsWebStorage = "webStorageEnabled";
 
         /// <summary>
         /// Capability name used to indicate whether the driver supports setting the browser window's size and position.

--- a/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
@@ -128,7 +128,6 @@ namespace OpenQA.Selenium.IE
             this.AddKnownCapabilityName(CapabilityType.HasNativeEvents, "EnableNativeEvents property");
             this.AddKnownCapabilityName(InitialBrowserUrlCapability, "InitialBrowserUrl property");
             this.AddKnownCapabilityName(ElementScrollBehaviorCapability, "ElementScrollBehavior property");
-            this.AddKnownCapabilityName(CapabilityType.UnexpectedAlertBehavior, "UnhandledPromptBehavior property");
             this.AddKnownCapabilityName(EnablePersistentHoverCapability, "EnablePersistentHover property");
             this.AddKnownCapabilityName(RequireWindowFocusCapability, "RequireWindowFocus property");
             this.AddKnownCapabilityName(BrowserAttachTimeoutCapability, "BrowserAttachTimeout property");

--- a/dotnet/src/webdriver/Remote/DesiredCapabilities.cs
+++ b/dotnet/src/webdriver/Remote/DesiredCapabilities.cs
@@ -34,19 +34,6 @@ namespace OpenQA.Selenium.Remote
         /// <summary>
         /// Initializes a new instance of the <see cref="DesiredCapabilities"/> class
         /// </summary>
-        /// <param name="browser">Name of the browser e.g. firefox, internet explorer, safari</param>
-        /// <param name="version">Version of the browser</param>
-        /// <param name="platform">The platform it works on</param>
-        public DesiredCapabilities(string browser, string version, Platform platform)
-        {
-            this.SetCapability(CapabilityType.BrowserName, browser);
-            this.SetCapability(CapabilityType.Version, version);
-            this.SetCapability(CapabilityType.Platform, platform);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DesiredCapabilities"/> class
-        /// </summary>
         public DesiredCapabilities()
         {
         }
@@ -66,41 +53,9 @@ namespace OpenQA.Selenium.Remote
             {
                 foreach (string key in rawMap.Keys)
                 {
-                    if (key == CapabilityType.Platform)
-                    {
-                        object raw = rawMap[CapabilityType.Platform];
-                        string rawAsString = raw as string;
-                        Platform rawAsPlatform = raw as Platform;
-                        if (rawAsString != null)
-                        {
-                            this.SetCapability(CapabilityType.Platform, Platform.FromString(rawAsString));
-                        }
-                        else if (rawAsPlatform != null)
-                        {
-                            this.SetCapability(CapabilityType.Platform, rawAsPlatform);
-                        }
-                    }
-                    else
-                    {
-                        this.SetCapability(key, rawMap[key]);
-                    }
+                    this.SetCapability(key, rawMap[key]);
                 }
             }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DesiredCapabilities"/> class
-        /// </summary>
-        /// <param name="browser">Name of the browser e.g. firefox, internet explorer, safari</param>
-        /// <param name="version">Version of the browser</param>
-        /// <param name="platform">The platform it works on</param>
-        /// <param name="isSpecCompliant">Sets a value indicating whether the capabilities are
-        /// compliant with the W3C WebDriver specification.</param>
-        internal DesiredCapabilities(string browser, string version, Platform platform, bool isSpecCompliant)
-        {
-            this.SetCapability(CapabilityType.BrowserName, browser);
-            this.SetCapability(CapabilityType.Version, version);
-            this.SetCapability(CapabilityType.Platform, platform);
         }
 
         /// <summary>
@@ -124,28 +79,28 @@ namespace OpenQA.Selenium.Remote
         /// <summary>
         /// Gets or sets the platform
         /// </summary>
-        public Platform Platform
+        public Platform PlatformName
         {
             get
             {
-                return this.GetCapability(CapabilityType.Platform) as Platform ?? new Platform(PlatformType.Any);
+                return this.GetCapability(CapabilityType.PlatformName) as Platform ?? new Platform(PlatformType.Any);
             }
 
             set
             {
-                this.SetCapability(CapabilityType.Platform, value);
+                this.SetCapability(CapabilityType.PlatformName, value);
             }
         }
 
         /// <summary>
         /// Gets the browser version
         /// </summary>
-        public string Version
+        public string BrowserVersion
         {
             get
             {
                 string browserVersion = string.Empty;
-                object capabilityValue = this.GetCapability(CapabilityType.Version);
+                object capabilityValue = this.GetCapability(CapabilityType.BrowserVersion);
                 if (capabilityValue != null)
                 {
                     browserVersion = capabilityValue.ToString();
@@ -238,7 +193,7 @@ namespace OpenQA.Selenium.Remote
             {
                 capabilityValue = this.capabilities[capability];
                 string capabilityValueString = capabilityValue as string;
-                if (capability == CapabilityType.Platform && capabilityValueString != null)
+                if (capability == CapabilityType.PlatformName && capabilityValueString != null)
                 {
                     capabilityValue = Platform.FromString(capabilityValue.ToString());
                 }
@@ -276,8 +231,8 @@ namespace OpenQA.Selenium.Remote
         {
             int result;
             result = this.BrowserName != null ? this.BrowserName.GetHashCode() : 0;
-            result = (31 * result) + (this.Version != null ? this.Version.GetHashCode() : 0);
-            result = (31 * result) + (this.Platform != null ? this.Platform.GetHashCode() : 0);
+            result = (31 * result) + (this.BrowserVersion != null ? this.BrowserVersion.GetHashCode() : 0);
+            result = (31 * result) + (this.PlatformName != null ? this.PlatformName.GetHashCode() : 0);
             return result;
         }
 
@@ -287,7 +242,7 @@ namespace OpenQA.Selenium.Remote
         /// <returns>String of capabilities being used</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "Capabilities [BrowserName={0}, Platform={1}, Version={2}]", this.BrowserName, this.Platform.PlatformType.ToString(), this.Version);
+            return string.Format(CultureInfo.InvariantCulture, "Capabilities [BrowserName={0}, Platform={1}, Version={2}]", this.BrowserName, this.PlatformName.PlatformType.ToString(), this.BrowserVersion);
         }
 
         /// <summary>
@@ -313,12 +268,12 @@ namespace OpenQA.Selenium.Remote
                 return false;
             }
 
-            if (!this.Platform.IsPlatformType(other.Platform.PlatformType))
+            if (!this.PlatformName.IsPlatformType(other.PlatformName.PlatformType))
             {
                 return false;
             }
 
-            if (this.Version != null ? this.Version != other.Version : other.Version != null)
+            if (this.BrowserVersion != null ? this.BrowserVersion != other.BrowserVersion : other.BrowserVersion != null)
             {
                 return false;
             }

--- a/dotnet/src/webdriver/Remote/ReadOnlyDesiredCapabilities.cs
+++ b/dotnet/src/webdriver/Remote/ReadOnlyDesiredCapabilities.cs
@@ -69,23 +69,23 @@ namespace OpenQA.Selenium.Remote
         /// <summary>
         /// Gets or sets the platform
         /// </summary>
-        public Platform Platform
+        public Platform PlatformName
         {
             get
             {
-                return this.GetCapability(CapabilityType.Platform) as Platform ?? new Platform(PlatformType.Any);
+                return this.GetCapability(CapabilityType.PlatformName) as Platform ?? new Platform(PlatformType.Any);
             }
         }
 
         /// <summary>
         /// Gets the browser version
         /// </summary>
-        public string Version
+        public string BrowserVersion
         {
             get
             {
                 string browserVersion = string.Empty;
-                object capabilityValue = this.GetCapability(CapabilityType.Version);
+                object capabilityValue = this.GetCapability(CapabilityType.BrowserVersion);
                 if (capabilityValue != null)
                 {
                     browserVersion = capabilityValue.ToString();
@@ -173,7 +173,7 @@ namespace OpenQA.Selenium.Remote
             {
                 capabilityValue = this.capabilities[capability];
                 string capabilityValueString = capabilityValue as string;
-                if (capability == CapabilityType.Platform && capabilityValueString != null)
+                if (capability == CapabilityType.PlatformName && capabilityValueString != null)
                 {
                     capabilityValue = Platform.FromString(capabilityValue.ToString());
                 }
@@ -199,8 +199,8 @@ namespace OpenQA.Selenium.Remote
         {
             int result;
             result = this.BrowserName != null ? this.BrowserName.GetHashCode() : 0;
-            result = (31 * result) + (this.Version != null ? this.Version.GetHashCode() : 0);
-            result = (31 * result) + (this.Platform != null ? this.Platform.GetHashCode() : 0);
+            result = (31 * result) + (this.BrowserVersion != null ? this.BrowserVersion.GetHashCode() : 0);
+            result = (31 * result) + (this.PlatformName != null ? this.PlatformName.GetHashCode() : 0);
             return result;
         }
 
@@ -236,12 +236,12 @@ namespace OpenQA.Selenium.Remote
                 return false;
             }
 
-            if (!this.Platform.IsPlatformType(other.Platform.PlatformType))
+            if (!this.PlatformName.IsPlatformType(other.PlatformName.PlatformType))
             {
                 return false;
             }
 
-            if (this.Version != null ? this.Version != other.Version : other.Version != null)
+            if (this.BrowserVersion != null ? this.BrowserVersion != other.BrowserVersion : other.BrowserVersion != null)
             {
                 return false;
             }

--- a/dotnet/test/common/UnhandledPromptBehaviorTest.cs
+++ b/dotnet/test/common/UnhandledPromptBehaviorTest.cs
@@ -6,7 +6,7 @@ using System;
 namespace OpenQA.Selenium
 {
     [TestFixture]
-    public class UnexpectedAlertBehaviorTest : DriverTestFixture
+    public class UnhandledPromptBehaviorTest : DriverTestFixture
     {
         private IWebDriver localDriver;
 


### PR DESCRIPTION
### Description
* Remove invalid capabilities
* Update invalid capabilities to valid capabilities

### Motivation and Context
As best as I can tell, if the capability isn't in [this list](https://github.com/SeleniumHQ/selenium/blob/selenium-4.14.0/dotnet/src/webdriver/CapabilityType.cs#L164-L176) it gets ignored when starting a session — https://github.com/SeleniumHQ/selenium/blob/selenium-4.14.0/dotnet/src/webdriver/WebDriver.cs#L652-L655

I don't know if the browser version and platform name code is necessary, but if it is looking for the old values it won't work.

Whatever is going on here, it can be cleaned up more, I just made some quick changes while I noticed it.