### PR TITLE
[py] Fix test for CONDA_PREFIX in selenium_manager

### DIFF
--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -57,7 +57,7 @@ class SeleniumManager:
 
             path = Path(__file__).parent.joinpath(directory, file)
 
-        if not path.is_file() and os.environ["CONDA_PREFIX"]:
+        if not path.is_file() and "CONDA_PREFIX" in os.environ:
             # conda has a separate package selenium-manager, installs in bin
             path = Path(os.path.join(os.environ["CONDA_PREFIX"], "bin", file))
             logger.debug("Conda environment detected, using `%s`", path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix test for CONDA_PREFIX in selenium manager, which regressed in 4.12.0.

### Description
Accessing CONDA_PREFIX in os.environ fails with a KeyError when it is not set. The condition should instead check for the existence of the key, before accessing it in the following codepath.

Fixes: d4285d1 ("fix for conda install of selenium-manager (#12536)")
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```pytb
Traceback (most recent call last):
 File "/nix/store/jdm5chqkmh3z0wbip7r165fas3bfg1y4-python3-3.11.5-env/lib/python3.11/site-packages/selenium/webdriver/common/driver_finder.py", line 38, in get_path
   path = SeleniumManager().driver_location(options) if path is None else path
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/nix/store/jdm5chqkmh3z0wbip7r165fas3bfg1y4-python3-3.11.5-env/lib/python3.11/site-packages/selenium/webdriver/common/selenium_manager.py", line 78, in driver_location
   args = [str(self.get_binary()), "--browser", browser]
               ^^^^^^^^^^^^^^^^^
 File "/nix/store/jdm5chqkmh3z0wbip7r165fas3bfg1y4-python3-3.11.5-env/lib/python3.11/site-packages/selenium/webdriver/common/selenium_manager.py", line 57, in get_binary
   if not path.is_file() and os.environ["CONDA_PREFIX"]:
                             ~~~~~~~~~~^^^^^^^^^^^^^^^^
 File "<frozen os>", line 679, in __getitem__
KeyError: 'CONDA_PREFIX'
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
