### PR TITLE
[rb] fix http proxy configuration for chrome

### DIFF
--- a/rb/lib/selenium/webdriver/common/selenium_manager.rb
+++ b/rb/lib/selenium/webdriver/common/selenium_manager.rb
@@ -67,7 +67,7 @@ module Selenium
           end
           if options.proxy
             command << '--proxy'
-            (command << options.proxy.ssl) || options.proxy.http
+            command << (options.proxy.ssl || options.proxy.http)
           end
           command
         end


### PR DESCRIPTION
### Description
Fix an error that made selenium skip passing the http proxy params to chrome and chromium.

### Motivation and Context
After investigating an error that started after bumping selenium, we realized the proxy configuration was being loaded incorrectly. After much research into it, we discovered the error was likely coming from how selenium passed the arguments. The error is the following:
Selenium::WebDriver::Error::NoSuchDriverError
Unable to obtain chromedriver using Selenium Manager; Unsuccessful command executed: ["/usr/local/bundle/gems/selenium-webdriver-4.14.0/bin/linux/selenium-manager", "--browser", "chrome", "--proxy", nil, "--output", "json"]; no implicit conversion of nil into String; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
