### PR TITLE
[rust] Panic if JSON output is used but no entries are collected

### DIFF
--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -33,7 +33,7 @@ use Color::{Blue, Cyan, Green, Red, Yellow};
 pub const DRIVER_PATH: &str = "Driver path: ";
 pub const BROWSER_PATH: &str = "Browser path: ";
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 enum OutputType {
     #[default]
     Logger,
@@ -219,6 +219,8 @@ impl Logger {
         let json = json_output.deref();
         if !json.logs.is_empty() {
             print!("{}", serde_json::to_string_pretty(json).unwrap());
+        } else if self.output == OutputType::Json {
+            panic!("JSON output has been specified, but no entries have been collected")
         }
     }
 }


### PR DESCRIPTION
### Description
This PR includes a panic call when JSON output is used (e.g., by the bindings) but no entries are collected by SM.

### Motivation and Context
In theory, this panic will never be called. But if it happens, it will allow to discover that problems like #13091 are caused in the Rust side.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
