### PR TITLE
[java] Use Process class to execute SM in Java (fix #13091)

### DIFF
--- a/java/src/org/openqa/selenium/manager/BUILD.bazel
+++ b/java/src/org/openqa/selenium/manager/BUILD.bazel
@@ -21,7 +21,6 @@ java_export(
     deps = [
         "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/json",
-        "//java/src/org/openqa/selenium/os",
     ],
 )
 


### PR DESCRIPTION
### Description
This PR changes the use of the `org.openqa.selenium.build.ExternalProcess` Selenium class to the standard `java.lang.Process` (through `java.lang.ProcessBuilder`) to execute Selenium Manager in Java.

UPDATE: The second commit in this PR includes some logic for retrying the command execution, as reported in #13091.

### Motivation and Context
It has been reported by some users (see #13091) that sometimes, the `SeleniumManager` Java logic fails due to an empty output by Selenium Manager. After troubleshooting it, it seems the cause is the use of `ExternalProcess`, and using `Process` fixes it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
