### PR TITLE
[rb] implement toggle to use BiDi implementation

### DIFF
--- a/rb/lib/selenium/webdriver/bidi/browsing_context.rb
+++ b/rb/lib/selenium/webdriver/bidi/browsing_context.rb
@@ -28,8 +28,8 @@ module Selenium
 
         READINESS_STATE = {
           none: 'none',
-          interactive: 'interactive',
-          complete: 'complete'
+          eager: 'interactive',
+          normal: 'complete'
         }.freeze
 
         def initialize(driver:, browsing_context_id: nil, type: nil, reference_context: nil)
@@ -38,21 +38,11 @@ module Selenium
                   'WebDriver instance must support BiDi protocol'
           end
 
-          unless type.nil? || %i[window tab].include?(type)
-            raise ArgumentError,
-                  "Valid types are :window & :tab. Received: #{type.inspect}"
-          end
-
           @bidi = driver.bidi
           @id = browsing_context_id.nil? ? create(type, reference_context)['context'] : browsing_context_id
         end
 
         def navigate(url:, readiness_state: nil)
-          unless readiness_state.nil? || READINESS_STATE.key?(readiness_state)
-            raise ArgumentError,
-                  "Valid readiness states are :none, :interactive & :complete. Received: #{readiness_state.inspect}"
-          end
-
           navigate_result = @bidi.send_cmd('browsingContext.navigate', context: @id, url: url,
                                                                        wait: READINESS_STATE[readiness_state])
 

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -316,7 +316,7 @@ module Selenium
         bridge = Remote::Bridge.new(http_client: http_client, url: url)
         bridge.create_session(caps)
         socket_url = bridge.capabilities[:web_socket_url]
-        if socket_url
+        if socket_url.kind_of?(String)
           bridge.extend(Remote::BiDiBridge)
           bridge.bidi = Selenium::WebDriver::BiDi.new(url: socket_url)
         end

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -313,9 +313,14 @@ module Selenium
       attr_reader :bridge
 
       def create_bridge(caps:, url:, http_client: nil)
-        Remote::Bridge.new(http_client: http_client, url: url).tap do |bridge|
-          bridge.create_session(caps)
+        bridge = Remote::Bridge.new(http_client: http_client, url: url)
+        bridge.create_session(caps)
+        socket_url = bridge.capabilities[:web_socket_url]
+        if socket_url
+          bridge.extend(Remote::BiDiBridge)
+          bridge.bidi = Selenium::WebDriver::BiDi.new(url: socket_url)
         end
+        bridge
       end
 
       def service_url(service)

--- a/rb/lib/selenium/webdriver/remote/bi_di_bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bi_di_bridge.rb
@@ -17,23 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'uri'
-require 'selenium/webdriver/remote/server_error'
-
 module Selenium
   module WebDriver
     module Remote
-      autoload :Features,     'selenium/webdriver/remote/features'
-      autoload :BiDiBridge,   'selenium/webdriver/remote/bi_di_bridge'
-      autoload :Bridge,       'selenium/webdriver/remote/bridge'
-      autoload :Driver,       'selenium/webdriver/remote/driver'
-      autoload :Response,     'selenium/webdriver/remote/response'
-      autoload :Capabilities, 'selenium/webdriver/remote/capabilities'
+      module BiDiBridge
+        attr_accessor :bidi, :browsing_context
 
-      module Http
-        autoload :Common,  'selenium/webdriver/remote/http/common'
-        autoload :Default, 'selenium/webdriver/remote/http/default'
-      end
-    end
-  end
-end
+        def get(url)
+          @browsing_context ||= WebDriver::BiDi::BrowsingContext.new(driver: self,
+                                                                    browsing_context_id: window_handle,
+                                                                    type: :tab)
+          @browsing_context.navigate(url: url, readiness_state: capabilities[:page_load_strategy])
+        end
+      end # BiDiBridge
+    end # Remote
+  end # WebDriver
+end # Selenium

--- a/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
@@ -66,7 +66,7 @@ module Selenium
           browsing_context = described_class.new(driver: driver, type: :tab)
 
           info = browsing_context.navigate url: url_for('/bidi/logEntryAdded.html'),
-                                           readiness_state: :complete
+                                           readiness_state: :normal
 
           expect(browsing_context.id).not_to be_nil
           expect(info.url).to include('/bidi/logEntryAdded.html')
@@ -76,7 +76,7 @@ module Selenium
           browsing_context_id = driver.window_handle
           parent_window = described_class.new(driver: driver, browsing_context_id: browsing_context_id)
           parent_window.navigate(url: url_for('iframes.html'),
-                                 readiness_state: :complete)
+                                 readiness_state: :normal)
 
           context_info = parent_window.get_tree
           expect(context_info.children.size).to eq(1)
@@ -88,7 +88,7 @@ module Selenium
           browsing_context_id = driver.window_handle
           parent_window = described_class.new(driver: driver, browsing_context_id: browsing_context_id)
           parent_window.navigate(url: url_for('iframes.html'),
-                                 readiness_state: :complete)
+                                 readiness_state: :normal)
 
           context_info = parent_window.get_tree(max_depth: 0)
           expect(context_info.children).to be_nil

--- a/rb/spec/integration/selenium/webdriver/bidi_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi_spec.rb
@@ -41,10 +41,9 @@ module Selenium
         log_inspector = BiDi::LogInspector.new(driver)
         log_inspector.on_javascript_exception { |log| log_entry = log }
 
-        browsing_context = BiDi::BrowsingContext.new(driver: driver, browsing_context_id: driver.window_handle)
-        info = browsing_context.navigate(url: url_for('/bidi/logEntryAdded.html'))
+        info = driver.navigate.to(url_for('/bidi/logEntryAdded.html'))
 
-        expect(browsing_context.id).not_to be_nil
+        expect(driver.send(:bridge).browsing_context.id).not_to be_nil
         expect(info.navigation_id).not_to be_nil
         expect(info.url).to include('/bidi/logEntryAdded.html')
 

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -90,7 +90,7 @@ module Selenium
                                              class: described_class)
           end
           let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
-          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
+          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}, capabilities: {}) }
 
           before do
             allow(Remote::Bridge).to receive(:new).and_return(bridge)

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -89,7 +89,7 @@ module Selenium
                                              class: described_class)
           end
           let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
-          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
+          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}, capabilities: {}) }
 
           before do
             allow(Remote::Bridge).to receive(:new).and_return(bridge)

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -86,7 +86,7 @@ module Selenium
                                              class: described_class)
           end
           let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
-          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
+          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}, capabilities: {}) }
 
           before do
             allow(Remote::Bridge).to receive(:new).and_return(bridge)

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -87,7 +87,7 @@ module Selenium
                                              class: described_class)
           end
           let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
-          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
+          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}, capabilities: {}) }
 
           before do
             allow(Remote::Bridge).to receive(:new).and_return(bridge)

--- a/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/safari/service_spec.rb
@@ -82,7 +82,7 @@ module Selenium
                                              class: described_class)
           end
           let(:service_manager) { instance_double(ServiceManager, uri: 'http://example.com') }
-          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}) }
+          let(:bridge) { instance_double(Remote::Bridge, quit: nil, create_session: {}, capabilities: {}) }
 
           before do
             allow(Remote::Bridge).to receive(:new).and_return(bridge)


### PR DESCRIPTION
### Description
If capabilities comes back with a populated `web_socket_url`, extends `Bridge` class with `BiDiBridge` module, to override the classic method and use the bidi method. The existing BiDi classes that are constructed with driver parameters should all accept bridge arguments, which allows this to work.

### Motivation and Context
And so begins the transition from WebDriver-Classic to WebDriver-BiDi