### PR TITLE
[dotnet] Fix WSS scheme determination for DevTools connection

### DIFF
--- a/dotnet/src/webdriver/DevTools/DevToolsSession.cs
+++ b/dotnet/src/webdriver/DevTools/DevToolsSession.cs
@@ -68,7 +68,7 @@ namespace OpenQA.Selenium.DevTools
 
             this.CommandTimeout = TimeSpan.FromSeconds(30);
             this.debuggerEndpoint = endpointAddress;
-            if (endpointAddress.StartsWith("ws:"))
+            if (endpointAddress.StartsWith("ws", StringComparison.InvariantCultureIgnoreCase))
             {
                 this.websocketAddress = endpointAddress;
             }


### PR DESCRIPTION
### Description
It was small bug in code how to determine web socket uri.

### Motivation and Context
Fixes #12950 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
