### PR TITLE
[rust] Use online mapping to discover proper geckodriver version (#11671)

### DIFF
--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -17,6 +17,7 @@
 
 use crate::common::{assert_driver, assert_output};
 use assert_cmd::Command;
+use exitcode::DATAERR;
 use rstest::rstest;
 use std::env::consts::OS;
 
@@ -27,6 +28,11 @@ mod common;
 #[case("chrome", "chromedriver", "115", "115.0.5790")]
 #[case("edge", "msedgedriver", "105", "105.0")]
 #[case("edge", "msedgedriver", "106", "106.0")]
+#[case("firefox", "geckodriver", "101", "0.31.0")]
+#[case("firefox", "geckodriver", "91", "0.31.0")]
+#[case("firefox", "geckodriver", "90", "0.30.0")]
+#[case("firefox", "geckodriver", "62", "0.29.1")]
+#[case("firefox", "geckodriver", "53", "0.18.0")]
 fn browser_version_test(
     #[case] browser: String,
     #[case] driver_name: String,
@@ -57,13 +63,13 @@ fn browser_version_test(
 }
 
 #[rstest]
-#[case("wrong-browser", "", "", exitcode::DATAERR)]
-#[case("chrome", "wrong-browser-version", "", exitcode::DATAERR)]
-#[case("chrome", "", "wrong-driver-version", exitcode::DATAERR)]
-#[case("firefox", "", "wrong-driver-version", exitcode::DATAERR)]
-#[case("edge", "wrong-browser-version", "", exitcode::DATAERR)]
-#[case("edge", "", "wrong-driver-version", exitcode::DATAERR)]
-#[case("iexplorer", "", "wrong-driver-version", exitcode::DATAERR)]
+#[case("wrong-browser", "", "", DATAERR)]
+#[case("chrome", "wrong-browser-version", "", DATAERR)]
+#[case("chrome", "", "wrong-driver-version", DATAERR)]
+#[case("firefox", "", "wrong-driver-version", DATAERR)]
+#[case("edge", "wrong-browser-version", "", DATAERR)]
+#[case("edge", "", "wrong-driver-version", DATAERR)]
+#[case("iexplorer", "", "wrong-driver-version", DATAERR)]
 fn wrong_parameters_test(
     #[case] browser: String,
     #[case] browser_version: String,
@@ -85,6 +91,28 @@ fn wrong_parameters_test(
         .try_success();
 
     assert_output(&mut cmd, result, vec!["in PATH"], error_code);
+}
+
+#[test]
+fn invalid_geckodriver_version_test() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_selenium-manager"));
+    let result = cmd
+        .args([
+            "--browser",
+            "firefox",
+            "--browser-version",
+            "51",
+            "--avoid-browser-download",
+        ])
+        .assert()
+        .try_success();
+
+    assert_output(
+        &mut cmd,
+        result,
+        vec!["Not valid geckodriver version found"],
+        DATAERR,
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
### Description
This PR implements a mechanism to discover the proper geckodriver based on online metadata.

Since the official Firefox-geckodriver mapping metadata are still unavailable (see [feature request](https://bugzilla.mozilla.org/show_bug.cgi?id=1794550)), we can maintain our mapping as proposed in #11671.

As a first step of this PR, I have uploaded this mapping (as a JSON file, as proposed [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1794550)) to the trunk branch. This mapping is available at:

https://raw.githubusercontent.com/SeleniumHQ/selenium/trunk/common/geckodriver/geckodriver-support.json

This file is a JSON representation of the official supported versions by geckodriver:

https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html

I am subscribed to the new geckodriver releases, so I will manually update our `geckodriver-support.json` file when new geckodriver versions are released.

Some example of this feature:

```
./selenium-manager --browser firefox --debug --avoid-browser-download --browser-version 90
DEBUG   geckodriver not found in PATH
DEBUG   firefox detected at C:\Program Files\Mozilla Firefox\firefox.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Mozilla Firefox\\firefox.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=119.0.0.8692\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: firefox 119.0.0.8692
DEBUG   Discovered firefox version (119) different to specified browser version (90)
DEBUG   Valid geckodriver versions for firefox 90: ["0.30.0", "0.29.1", "0.29.0", "0.28.0", "0.27.0", "0.26.0", "0.25.0"]
DEBUG   Required driver: geckodriver 0.30.0
DEBUG   geckodriver 0.30.0 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\geckodriver\win64\0.30.0\geckodriver.exe
INFO    Browser path: C:\Program Files\Mozilla Firefox\firefox.exe
```

### Motivation and Context
This issue implements #11671.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
