### PR TITLE
[ci] Use stable-i686-pc-windows-msvc target for release SM binary in Windows

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -18,12 +18,12 @@ jobs:
       - name: "Update Rust"
         run: |
           rustup update
-          rustup toolchain install stable-i686-pc-windows-gnu
-          rustup default stable-i686-pc-windows-gnu
-          rustc -vV
       - name: "Build release binary"
         if: ${{ inputs.debug == false }}
         run: |
+          rustup toolchain install stable-i686-pc-windows-msvc
+          rustup default stable-i686-pc-windows-msvc
+          rustc -vV
           cd rust
           cargo build --release
       - name: "Upload release binary"
@@ -36,6 +36,9 @@ jobs:
       - name: "Build debug binary"
         if: ${{ inputs.debug == true }}
         run: |
+          rustup toolchain install stable-i686-pc-windows-gnu
+          rustup default stable-i686-pc-windows-gnu
+          rustc -vV
           cd rust
           cargo build --profile dev
       - name: "Upload debug binary"


### PR DESCRIPTION
### Description
This PR reverts the use of `stable-i686-pc-windows-gnu` for the stable release of SM in Windows, and it uses `stable-i686-pc-windows-msvc` instead.

### Motivation and Context
That target was changed since `stable-i686-pc-windows-gnu` is required to build the SM binary with debug symbols. But it seems this new binary is detected as malware by some antivirus, as reported in #13130. Therefore, we can use `stable-i686-pc-windows-msvc` for the release SM in Windows (which seems safer for antivirus) and `stable-i686-pc-windows-gnu` for debug (only used for particular troubleshooting uses).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
