### PR TITLE
[rust] Use drivers found in PATH only when browser version is not specified

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -210,7 +210,7 @@ pub trait SeleniumManager {
 
     fn download_browser(
         &mut self,
-        original_browser_version: String,
+        original_browser_version: &str,
     ) -> Result<Option<PathBuf>, Error> {
         let browser_version;
         let cache_path = self.get_cache_path()?;
@@ -251,10 +251,10 @@ pub trait SeleniumManager {
                 // If not in metadata, discover version using online metadata
                 if self.is_browser_version_stable() || self.is_browser_version_empty() {
                     browser_version =
-                        self.request_latest_browser_version_from_online(&original_browser_version)?;
+                        self.request_latest_browser_version_from_online(original_browser_version)?;
                 } else {
                     browser_version =
-                        self.request_fixed_browser_version_from_online(&original_browser_version)?;
+                        self.request_fixed_browser_version_from_online(original_browser_version)?;
                 }
                 self.set_browser_version(browser_version.clone());
 
@@ -280,7 +280,7 @@ pub trait SeleniumManager {
         ));
 
         // Checking if browser version is in the cache
-        let browser_binary_path = self.get_browser_binary_path(&original_browser_version)?;
+        let browser_binary_path = self.get_browser_binary_path(original_browser_version)?;
         if browser_binary_path.exists() {
             self.get_logger().debug(format!(
                 "{} {} already exists",
@@ -296,7 +296,7 @@ pub trait SeleniumManager {
                 )));
             }
 
-            let browser_url = self.get_browser_url_for_download(&original_browser_version)?;
+            let browser_url = self.get_browser_url_for_download(original_browser_version)?;
             self.get_logger().debug(format!(
                 "Downloading {} {} from {}",
                 self.get_browser_name(),
@@ -311,7 +311,7 @@ pub trait SeleniumManager {
                 .parse::<i32>()
                 .unwrap_or_default();
             let browser_label_for_download =
-                self.get_browser_label_for_download(&original_browser_version)?;
+                self.get_browser_label_for_download(original_browser_version)?;
             uncompress(
                 &driver_zip_file,
                 &self.get_browser_path_in_cache()?,
@@ -510,7 +510,7 @@ pub trait SeleniumManager {
 
     fn download_browser_if_necessary(
         &mut self,
-        original_browser_version: String,
+        original_browser_version: &str,
     ) -> Result<(), Error> {
         if self.is_download_browser()
             && !self.is_avoid_browser_download()
@@ -751,21 +751,20 @@ pub trait SeleniumManager {
                     .debug(format!("{} not found in PATH", self.get_driver_name()));
             }
         }
+        let use_driver_in_path = driver_in_path_version.is_some()
+            && driver_in_path.is_some()
+            && original_browser_version.is_empty();
 
         // Discover browser version (or the need to download it, if not available and possible)
         match self.discover_local_browser() {
             Ok(_) => {}
-            Err(err) => {
-                self.check_error_with_driver_in_path(&driver_in_path, &driver_in_path_version, err)?
-            }
+            Err(err) => self.check_error_with_driver_in_path(&use_driver_in_path, err)?,
         }
 
         // Download browser if necessary
-        match self.download_browser_if_necessary(original_browser_version) {
+        match self.download_browser_if_necessary(&original_browser_version) {
             Ok(_) => {}
-            Err(err) => {
-                self.check_error_with_driver_in_path(&driver_in_path, &driver_in_path_version, err)?
-            }
+            Err(err) => self.check_error_with_driver_in_path(&use_driver_in_path, err)?,
         }
 
         // With the discovered browser version, discover the proper driver version using online endpoints
@@ -774,18 +773,17 @@ pub trait SeleniumManager {
                 Ok(driver_version) => {
                     self.set_driver_version(driver_version);
                 }
-                Err(err) => self.check_error_with_driver_in_path(
-                    &driver_in_path,
-                    &driver_in_path_version,
-                    err,
-                )?,
+                Err(err) => self.check_error_with_driver_in_path(&use_driver_in_path, err)?,
             }
         }
 
-        // If driver is in path, always use it
-        if let (Some(version), Some(path)) = (&driver_in_path_version, &driver_in_path) {
-            // If proper driver version is not the same as the driver in path, display warning
-            let major_version = self.get_major_version(version)?;
+        // Use driver in PATH when the user has not specified any browser version
+        if use_driver_in_path {
+            let version = driver_in_path_version.unwrap();
+            let path = driver_in_path.unwrap();
+            let major_version = self.get_major_version(&version)?;
+
+            // Display warning if the discovered driver version is not the same as the driver in PATH
             if !self.get_driver_version().is_empty()
                 && (self.is_firefox() && !version.eq(self.get_driver_version()))
                 || (!self.is_firefox() && !major_version.eq(&self.get_major_browser_version()))
@@ -795,7 +793,7 @@ pub trait SeleniumManager {
                     the detected {} version ({}); currently, {} {} is recommended for {} {}.*, \
                     so it is advised to delete the driver in PATH and retry",
                     self.get_driver_name(),
-                    version,
+                    &version,
                     path,
                     self.get_browser_name(),
                     self.get_browser_version(),
@@ -829,11 +827,10 @@ pub trait SeleniumManager {
 
     fn check_error_with_driver_in_path(
         &mut self,
-        driver_in_path: &Option<String>,
-        driver_in_path_version: &Option<String>,
+        is_driver_in_path: &bool,
         err: Error,
     ) -> Result<(), Error> {
-        if driver_in_path_version.is_some() && driver_in_path.is_some() {
+        if *is_driver_in_path {
             self.get_logger().warn(format!(
                 "Exception managing {}: {}",
                 self.get_browser_name(),


### PR DESCRIPTION
### Description
This PR changes the internal driver resolution algorithm of Selenium Manager to honor `browser-version` even when a driver in `PATH` is found. Some examples:

**Invalid chromedriver in PATH and browser-version is not specified**
```
./selenium-manager --debug --browser chrome
DEBUG   Found chromedriver 107.0.5304.62 in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=119.0.6045.124\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 119.0.6045.124
DEBUG   Required driver: chromedriver 119.0.6045.105
WARN    The chromedriver version (107.0.5304.62) detected in PATH at C:\Users\boni\Documents\bat\chromedriver.exe might not be compatible with the detected chrome version (119.0.6045.124); currently, chromedriver 119.0.6045.105 is recommended for chrome 119.*, so it is advised to delete the driver in PATH and retry
INFO    Driver path: C:\Users\boni\Documents\bat\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

**Invalid chromedriver in PATH but browser-version is specified**
```
./selenium-manager --debug --browser chrome --browser-version stable
DEBUG   Found chromedriver 107.0.5304.62 in PATH: C:\Users\boni\Documents\bat\chromedriver.exe
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=119.0.6045.124\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 119.0.6045.124
DEBUG   Discovered online chrome version (119) is the same as the detected local chrome version
DEBUG   Required driver: chromedriver 119.0.6045.105
DEBUG   chromedriver 119.0.6045.105 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\119.0.6045.105\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

### Motivation and Context
This PR implements #13128.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
