### PR TITLE
don't leak a file descriptor to os.devnull by default

### DIFF
--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -135,7 +135,7 @@ class Service(ABC):
     def stop(self) -> None:
         """Stops the service."""
 
-        if self.log_output != PIPE:
+        if self.log_output not in {PIPE, subprocess.DEVNULL}:
             if isinstance(self.log_output, IOBase):
                 self.log_output.close()
             elif isinstance(self.log_output, int):

--- a/py/selenium/webdriver/common/service.py
+++ b/py/selenium/webdriver/common/service.py
@@ -56,10 +56,10 @@ class Service(ABC):
     ) -> None:
         if isinstance(log_output, str):
             self.log_output = open(log_output, "a+", encoding="utf-8")
-        elif log_output is subprocess.STDOUT:
+        elif log_output == subprocess.STDOUT:
             self.log_output = None
-        elif log_output is None or log_output is subprocess.DEVNULL:
-            self.log_output = open(os.devnull, "wb")
+        elif log_output is None or log_output == subprocess.DEVNULL:
+            self.log_output = subprocess.DEVNULL
         else:
             self.log_output = log_output
 


### PR DESCRIPTION
since this is passed along to subprocess directly we can use the subprocess constants still


**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description

avoid one `open` call without a close -- this doesn't fix the other one in the file but I am less concerned with that one since I am only using the default behaviour

I also adjusted `is` to `==` for the subprocess constants -- they are not guaranteed to be singletons so they should be compared with equality

### Motivation and Context

regression in #12103

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation. **N/A**
- [x] I have updated the documentation accordingly. **N/A**
- [x] I have added tests to cover my changes. **N/A**
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
