### PR TITLE
[java] Allow resuing devtools instance with JDK 11 client

### DIFF
--- a/java/test/org/openqa/selenium/devtools/DevToolsReuseTest.java
+++ b/java/test/org/openqa/selenium/devtools/DevToolsReuseTest.java
@@ -19,7 +19,6 @@ package org.openqa.selenium.devtools;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
@@ -27,7 +26,6 @@ import org.openqa.selenium.remote.Augmenter;
 class DevToolsReuseTest extends DevToolsTestBase {
 
   @Test
-  @Disabled("JDK HTTP Client cannot get reused")
   public void shouldBeAbleToCloseDevToolsAndCreateNewInstance() {
     WebDriver driver = new Augmenter().augment(this.driver);
 


### PR DESCRIPTION

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Allow resuing devtools instance functionality threw an NPE after defaulting to JDK 11 Http Client. The changes fix this regression.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #12882

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
