### PR TITLE
[rust] Tracking Selenium Manager usage through Plausible (#11211)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0b0c238a314773ea2af41d5e13962f5a27ffdf2974cab7953267ab4b6b99c34f",
+  "checksum": "3468f2b2abc234888e072c953d9cafe64affe1c53711fb6bf961f97743525229",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1610,6 +1610,7 @@
         ],
         "crate_features": {
           "common": [
+            "cargo",
             "color",
             "default",
             "derive",
@@ -1671,6 +1672,7 @@
         ],
         "crate_features": {
           "common": [
+            "cargo",
             "color",
             "error-context",
             "help",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ Selenium Manager is a CLI tool that automatically manages the browser/driver inf
 """
 
 [dependencies]
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4.8", features = ["derive", "cargo"] }
 log = "0.4.20"
 env_logger = "0.10.1"
 regex = "1.10.2"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -55,6 +55,7 @@ pub struct ManagerConfig {
     pub offline: bool,
     pub force_browser_download: bool,
     pub avoid_browser_download: bool,
+    pub language_binding: String,
 }
 
 impl ManagerConfig {
@@ -111,6 +112,7 @@ impl ManagerConfig {
             offline: BooleanKey("offline", false).get_value(),
             force_browser_download: BooleanKey("force-browser-download", false).get_value(),
             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
+            language_binding: StringKey(vec!["language-binding"], "").get_value(),
         }
     }
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -56,6 +56,7 @@ pub struct ManagerConfig {
     pub force_browser_download: bool,
     pub avoid_browser_download: bool,
     pub language_binding: String,
+    pub selenium_version: String,
 }
 
 impl ManagerConfig {
@@ -113,6 +114,7 @@ impl ManagerConfig {
             force_browser_download: BooleanKey("force-browser-download", false).get_value(),
             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
             language_binding: StringKey(vec!["language-binding"], "").get_value(),
+            selenium_version: StringKey(vec!["selenium-version"], "").get_value(),
         }
     }
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -57,6 +57,7 @@ pub struct ManagerConfig {
     pub avoid_browser_download: bool,
     pub language_binding: String,
     pub selenium_version: String,
+    pub avoid_stats: bool,
 }
 
 impl ManagerConfig {
@@ -115,6 +116,7 @@ impl ManagerConfig {
             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
             language_binding: StringKey(vec!["language-binding"], "").get_value(),
             selenium_version: StringKey(vec!["selenium-version"], "").get_value(),
+            avoid_stats: BooleanKey("avoid-stats", false).get_value(),
         }
     }
 }

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -30,6 +30,8 @@ use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
 
 pub const GRID_NAME: &str = "grid";
 const GRID_RELEASE: &str = "selenium-server";
@@ -45,6 +47,8 @@ pub struct GridManager {
     pub config: ManagerConfig,
     pub http_client: Client,
     pub log: Logger,
+    pub tx: Sender<String>,
+    pub rx: Receiver<String>,
     pub download_browser: bool,
     pub driver_url: Option<String>,
 }
@@ -57,12 +61,15 @@ impl GridManager {
         config.driver_version = driver_version;
         let default_timeout = config.timeout.to_owned();
         let default_proxy = &config.proxy;
+        let (tx, rx): (Sender<String>, Receiver<String>) = mpsc::channel();
         Ok(Box::new(GridManager {
             browser_name,
             driver_name,
             http_client: create_http_client(default_timeout, default_proxy)?,
             config,
             log: Logger::new(),
+            tx,
+            rx,
             download_browser: false,
             driver_url: None,
         }))
@@ -225,6 +232,14 @@ impl SeleniumManager for GridManager {
 
     fn set_logger(&mut self, log: Logger) {
         self.log = log;
+    }
+
+    fn get_sender(&self) -> &Sender<String> {
+        &self.tx
+    }
+
+    fn get_receiver(&self) -> &Receiver<String> {
+        &self.rx
     }
 
     fn get_platform_label(&self) -> &str {

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -27,6 +27,8 @@ use anyhow::Error;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
 
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -51,6 +53,8 @@ pub struct IExplorerManager {
     pub config: ManagerConfig,
     pub http_client: Client,
     pub log: Logger,
+    pub tx: Sender<String>,
+    pub rx: Receiver<String>,
     pub download_browser: bool,
     pub driver_url: Option<String>,
 }
@@ -63,12 +67,15 @@ impl IExplorerManager {
         let default_timeout = config.timeout.to_owned();
         let default_proxy = &config.proxy;
         config.os = WINDOWS.to_str_vector().first().unwrap().to_string();
+        let (tx, rx): (Sender<String>, Receiver<String>) = mpsc::channel();
         Ok(Box::new(IExplorerManager {
             browser_name,
             driver_name,
             http_client: create_http_client(default_timeout, default_proxy)?,
             config,
             log: Logger::new(),
+            tx,
+            rx,
             download_browser: false,
             driver_url: None,
         }))
@@ -231,6 +238,14 @@ impl SeleniumManager for IExplorerManager {
 
     fn set_logger(&mut self, log: Logger) {
         self.log = log;
+    }
+
+    fn get_sender(&self) -> &Sender<String> {
+        &self.tx
+    }
+
+    fn get_receiver(&self) -> &Receiver<String> {
+        &self.rx
     }
 
     fn get_platform_label(&self) -> &str {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -829,7 +829,7 @@ pub trait SeleniumManager {
         Ok(driver_path)
     }
 
-    fn stats(&self) {
+    fn stats(&self) -> Result<(), Error> {
         let props = Props {
             browser: self.get_browser_name().to_string(),
             browser_version: self.get_browser_version().to_string(),
@@ -839,6 +839,7 @@ pub trait SeleniumManager {
             selenium_version: self.get_selenium_version().to_string(),
         };
         send_stats_to_plausible(self.get_http_client(), props, self.get_logger());
+        Ok(())
     }
 
     fn check_error_with_driver_in_path(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -837,12 +837,12 @@ pub trait SeleniumManager {
     fn stats(&self) -> Result<(), Error> {
         if !self.is_avoid_stats() && !self.is_offline() {
             let props = Props {
-                browser: self.get_browser_name().to_string(),
-                browser_version: self.get_browser_version().to_string(),
-                os: self.get_os().to_string(),
-                arch: self.get_arch().to_string(),
-                lang: self.get_language_binding().to_string(),
-                selenium_version: self.get_selenium_version().to_string(),
+                browser: self.get_browser_name().to_ascii_lowercase(),
+                browser_version: self.get_browser_version().to_ascii_lowercase(),
+                os: self.get_os().to_ascii_lowercase(),
+                arch: self.get_arch().to_ascii_lowercase(),
+                lang: self.get_language_binding().to_ascii_lowercase(),
+                selenium_version: self.get_selenium_version().to_ascii_lowercase(),
             };
             let http_client = self.get_http_client().to_owned();
             let sender = self.get_sender().to_owned();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -830,15 +830,13 @@ pub trait SeleniumManager {
     }
 
     fn stats(&self) {
-        let sm_version = env!("CARGO_PKG_VERSION");
-        let selenium_version = sm_version.strip_prefix(SM_BETA_LABEL).unwrap_or(sm_version);
         let props = Props {
             browser: self.get_browser_name().to_string(),
             browser_version: self.get_browser_version().to_string(),
             os: self.get_os().to_string(),
             arch: self.get_arch().to_string(),
             lang: self.get_language_binding().to_string(),
-            selenium_version: selenium_version.to_string(),
+            selenium_version: self.get_selenium_version().to_string(),
         };
         send_stats_to_plausible(self.get_http_client(), props, self.get_logger());
     }
@@ -1452,6 +1450,16 @@ pub trait SeleniumManager {
     fn set_language_binding(&mut self, language_binding: String) {
         if !language_binding.is_empty() {
             self.get_config_mut().language_binding = language_binding;
+        }
+    }
+
+    fn get_selenium_version(&self) -> &str {
+        self.get_config().selenium_version.as_str()
+    }
+
+    fn set_selenium_version(&mut self, selenium_version: String) {
+        if !selenium_version.is_empty() {
+            self.get_config_mut().selenium_version = selenium_version;
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -830,15 +830,17 @@ pub trait SeleniumManager {
     }
 
     fn stats(&self) -> Result<(), Error> {
-        let props = Props {
-            browser: self.get_browser_name().to_string(),
-            browser_version: self.get_browser_version().to_string(),
-            os: self.get_os().to_string(),
-            arch: self.get_arch().to_string(),
-            lang: self.get_language_binding().to_string(),
-            selenium_version: self.get_selenium_version().to_string(),
-        };
-        send_stats_to_plausible(self.get_http_client(), props, self.get_logger());
+        if !self.is_avoid_stats() {
+            let props = Props {
+                browser: self.get_browser_name().to_string(),
+                browser_version: self.get_browser_version().to_string(),
+                os: self.get_os().to_string(),
+                arch: self.get_arch().to_string(),
+                lang: self.get_language_binding().to_string(),
+                selenium_version: self.get_selenium_version().to_string(),
+            };
+            send_stats_to_plausible(self.get_http_client(), props, self.get_logger());
+        }
         Ok(())
     }
 
@@ -1461,6 +1463,16 @@ pub trait SeleniumManager {
     fn set_selenium_version(&mut self, selenium_version: String) {
         if !selenium_version.is_empty() {
             self.get_config_mut().selenium_version = selenium_version;
+        }
+    }
+
+    fn is_avoid_stats(&self) -> bool {
+        self.get_config().avoid_stats
+    }
+
+    fn set_avoid_stats(&mut self, avoid_stats: bool) {
+        if avoid_stats {
+            self.get_config_mut().avoid_stats = true;
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -835,7 +835,7 @@ pub trait SeleniumManager {
     }
 
     fn stats(&self) -> Result<(), Error> {
-        if !self.is_avoid_stats() {
+        if !self.is_avoid_stats() && !self.is_offline() {
             let props = Props {
                 browser: self.get_browser_name().to_string(),
                 browser_version: self.get_browser_version().to_string(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -46,7 +46,7 @@ use reqwest::{Client, Proxy};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::{env, fs};
+use std::{env, fs, thread};
 use walkdir::DirEntry;
 
 pub mod chrome;
@@ -839,7 +839,10 @@ pub trait SeleniumManager {
                 lang: self.get_language_binding().to_string(),
                 selenium_version: self.get_selenium_version().to_string(),
             };
-            send_stats_to_plausible(self.get_http_client(), props, self.get_logger());
+            let http_client = self.get_http_client().clone();
+            thread::spawn(move || {
+                send_stats_to_plausible(http_client, props);
+            });
         }
         Ok(())
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -24,11 +24,11 @@ use selenium_manager::config::{BooleanKey, StringKey, CACHE_PATH_KEY};
 use selenium_manager::grid::GridManager;
 use selenium_manager::logger::{Logger, BROWSER_PATH, DRIVER_PATH};
 use selenium_manager::metadata::clear_metadata;
-use selenium_manager::REQUEST_TIMEOUT_SEC;
 use selenium_manager::TTL_SEC;
 use selenium_manager::{
     clear_cache, get_manager_by_browser, get_manager_by_driver, SeleniumManager,
 };
+use selenium_manager::{REQUEST_TIMEOUT_SEC, SM_BETA_LABEL};
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::path::Path;
 use std::process::exit;
@@ -203,6 +203,9 @@ fn main() {
     selenium_manager.set_cache_path(cache_path.clone());
     selenium_manager.set_offline(cli.offline);
     selenium_manager.set_language_binding(cli.language_binding.unwrap_or_default());
+    let sm_version = clap::crate_version!();
+    let selenium_version = sm_version.strip_prefix(SM_BETA_LABEL).unwrap_or(sm_version);
+    selenium_manager.set_selenium_version(selenium_version.to_string());
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
         clear_cache(selenium_manager.get_logger(), &cache_path);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -217,6 +217,7 @@ fn main() {
     selenium_manager
         .set_timeout(cli.timeout)
         .and_then(|_| selenium_manager.set_proxy(cli.proxy.unwrap_or_default()))
+        .and_then(|_| selenium_manager.stats())
         .and_then(|_| selenium_manager.setup())
         .map(|driver_path| {
             let log = selenium_manager.get_logger();
@@ -225,7 +226,6 @@ fn main() {
                 &driver_path,
                 &selenium_manager.get_browser_path_or_latest_from_cache(),
             );
-            selenium_manager.stats();
             flush_and_exit(OK, log, None);
         })
         .unwrap_or_else(|err| {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -137,6 +137,10 @@ struct Cli {
     /// DotNet, Ruby)
     #[clap(long)]
     language_binding: Option<String>,
+
+    /// Avoid sends usage statistics to plausible.io
+    #[clap(long)]
+    avoid_stats: bool,
 }
 
 fn main() {
@@ -206,6 +210,7 @@ fn main() {
     let sm_version = clap::crate_version!();
     let selenium_version = sm_version.strip_prefix(SM_BETA_LABEL).unwrap_or(sm_version);
     selenium_manager.set_selenium_version(selenium_version.to_string());
+    selenium_manager.set_avoid_stats(cli.avoid_stats);
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
         clear_cache(selenium_manager.get_logger(), &cache_path);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -132,6 +132,11 @@ struct Cli {
     /// Avoid to download browser (even when browser-version is specified)
     #[clap(long)]
     avoid_browser_download: bool,
+
+    /// Selenium language bindings that invokes Selenium Manager (e.g., Java, JavaScript, Python,
+    /// DotNet, Ruby)
+    #[clap(long)]
+    language_binding: Option<String>,
 }
 
 fn main() {
@@ -197,6 +202,7 @@ fn main() {
     selenium_manager.set_avoid_browser_download(cli.avoid_browser_download);
     selenium_manager.set_cache_path(cache_path.clone());
     selenium_manager.set_offline(cli.offline);
+    selenium_manager.set_language_binding(cli.language_binding.unwrap_or_default());
 
     if cli.clear_cache || BooleanKey("clear-cache", false).get_value() {
         clear_cache(selenium_manager.get_logger(), &cache_path);
@@ -216,6 +222,7 @@ fn main() {
                 &driver_path,
                 &selenium_manager.get_browser_path_or_latest_from_cache(),
             );
+            selenium_manager.stats();
             flush_and_exit(OK, log, None);
         })
         .unwrap_or_else(|err| {

--- a/rust/src/safaritp.rs
+++ b/rust/src/safaritp.rs
@@ -25,6 +25,8 @@ use reqwest::Client;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::string::ToString;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
 
 pub const SAFARITP_NAMES: &[&str] = &[
     "safaritp",
@@ -43,6 +45,8 @@ pub struct SafariTPManager {
     pub config: ManagerConfig,
     pub http_client: Client,
     pub log: Logger,
+    pub tx: Sender<String>,
+    pub rx: Receiver<String>,
     pub download_browser: bool,
 }
 
@@ -53,12 +57,15 @@ impl SafariTPManager {
         let config = ManagerConfig::default(browser_name, driver_name);
         let default_timeout = config.timeout.to_owned();
         let default_proxy = &config.proxy;
+        let (tx, rx): (Sender<String>, Receiver<String>) = mpsc::channel();
         Ok(Box::new(SafariTPManager {
             browser_name,
             driver_name,
             http_client: create_http_client(default_timeout, default_proxy)?,
             config,
             log: Logger::new(),
+            tx,
+            rx,
             download_browser: false,
         }))
     }
@@ -132,6 +139,14 @@ impl SeleniumManager for SafariTPManager {
 
     fn set_logger(&mut self, log: Logger) {
         self.log = log;
+    }
+
+    fn get_sender(&self) -> &Sender<String> {
+        &self.tx
+    }
+
+    fn get_receiver(&self) -> &Receiver<String> {
+        &self.rx
     }
 
     fn get_platform_label(&self) -> &str {

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -68,6 +68,6 @@ pub async fn send_stats_to_plausible(http_client: &Client, props: Props, log: &L
         .body(body);
 
     if let Err(err) = request.send().await {
-        log.warn(format!("Error sending stats to Plausible: {}", err));
+        log.warn(format!("Error sending stats to {}: {}", PLAUSIBLE_URL, err));
     }
 }

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -26,7 +26,7 @@ const PLAUSIBLE_URL: &str = "https://plausible.io/api/event";
 const SM_USER_AGENT: &str = "Selenium Manager {}";
 const APP_JSON: &str = "application/json";
 const PAGE_VIEW: &str = "pageview";
-const SELENIUM_DOMAIN: &str = "bonigarcia.dev"; // TODO change with selenium.dev
+const SELENIUM_DOMAIN: &str = "selenium.dev";
 const SM_STATS_URL: &str = "https://{}/sm-stats";
 
 #[derive(Default, Serialize, Deserialize)]

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -1,0 +1,75 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::format_one_arg;
+use crate::logger::Logger;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::header::USER_AGENT;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+const PLAUSIBLE_URL: &str = "https://plausible.io/api/event";
+const SM_USER_AGENT: &str = "Selenium Manager {}";
+const APP_JSON: &str = "application/json";
+const PAGE_VIEW: &str = "pageview";
+const SELENIUM_DOMAIN: &str = "bonigarcia.dev"; // TODO change with selenium.dev
+const SM_STATS_URL: &str = "https://{}/sm-stats";
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct Data {
+    pub name: String,
+    pub url: String,
+    pub domain: String,
+    pub props: Props,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct Props {
+    pub browser: String,
+    pub browser_version: String,
+    pub os: String,
+    pub arch: String,
+    pub lang: String,
+    pub selenium_version: String,
+}
+
+#[tokio::main]
+pub async fn send_stats_to_plausible(http_client: &Client, props: Props, log: &Logger) {
+    let sm_version = env!("CARGO_PKG_VERSION");
+    let user_agent = format_one_arg(SM_USER_AGENT, sm_version);
+    let sm_stats_url = format_one_arg(SM_STATS_URL, SELENIUM_DOMAIN);
+
+    let data = Data {
+        name: PAGE_VIEW.to_string(),
+        url: sm_stats_url,
+        domain: SELENIUM_DOMAIN.to_string(),
+        props,
+    };
+    let body = serde_json::to_string(&data).unwrap_or_default();
+    log.trace(format!("Sending props to plausible: {}", body));
+
+    let request = http_client
+        .post(PLAUSIBLE_URL)
+        .header(USER_AGENT, user_agent)
+        .header(CONTENT_TYPE, APP_JSON)
+        .body(body);
+    // TODO proxy
+
+    if let Err(err) = request.send().await {
+        log.warn(format!("Error sending stats to Plausible: {}", err));
+    }
+}

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -49,8 +49,7 @@ pub struct Props {
 
 #[tokio::main]
 pub async fn send_stats_to_plausible(http_client: &Client, props: Props, log: &Logger) {
-    let sm_version = env!("CARGO_PKG_VERSION");
-    let user_agent = format_one_arg(SM_USER_AGENT, sm_version);
+    let user_agent = format_one_arg(SM_USER_AGENT, &props.selenium_version);
     let sm_stats_url = format_one_arg(SM_STATS_URL, SELENIUM_DOMAIN);
 
     let data = Data {
@@ -67,7 +66,6 @@ pub async fn send_stats_to_plausible(http_client: &Client, props: Props, log: &L
         .header(USER_AGENT, user_agent)
         .header(CONTENT_TYPE, APP_JSON)
         .body(body);
-    // TODO proxy
 
     if let Err(err) = request.send().await {
         log.warn(format!("Error sending stats to Plausible: {}", err));

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -27,7 +27,7 @@ const PLAUSIBLE_URL: &str = "https://plausible.io/api/event";
 const SM_USER_AGENT: &str = "Selenium Manager {}";
 const APP_JSON: &str = "application/json";
 const PAGE_VIEW: &str = "pageview";
-const SELENIUM_DOMAIN: &str = "selenium.dev";
+const SELENIUM_DOMAIN: &str = "manager.selenium.dev";
 const SM_STATS_URL: &str = "https://{}/sm-stats";
 const REQUEST_TIMEOUT_SEC: u64 = 3;
 

--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -67,7 +67,8 @@ pub async fn send_stats_to_plausible(http_client: &Client, props: Props, log: &L
         .header(CONTENT_TYPE, APP_JSON)
         .body(body);
 
-    if let Err(err) = request.send().await {
+    let handle = tokio::spawn(async move { request.send().await });
+    if let Err(err) = handle.await {
         log.warn(format!("Error sending stats to {}: {}", PLAUSIBLE_URL, err));
     }
 }

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -48,7 +48,7 @@ fn browser_version_test(
         "--debug",
         "--avoid-browser-download",
         "--language-binding",
-        "java"
+        "java",
     ])
     .assert()
     .success()
@@ -62,6 +62,7 @@ fn browser_version_test(
     if !browser_version.is_empty() && output.contains("cache") {
         assert!(output.contains(&driver_version));
     }
+    assert!(!output.contains("Error sending stats"));
 }
 
 #[rstest]

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -47,6 +47,8 @@ fn browser_version_test(
         &browser_version,
         "--debug",
         "--avoid-browser-download",
+        "--language-binding",
+        "java"
     ])
     .assert()
     .success()


### PR DESCRIPTION
### Description
This PR implements a mechanism to track the usage of Selenium Manager through [Plausible](https://plausible.io/). 

To that, the Rust code sends a `pageview` request to plausible using the events API to track visitors. As requested in #11211, the data we want to collect is the following:

- Selenium version
- Language binding 
- Browser
- Browser version
- Operating system
- Architecture

For "language binding", a new flag called `--language-binding` has been introduced in this PR. Bindings should use this property to report it (e.g., `--language-binding java`, `--language-binding ruby`, etc.).

All of this information is gathered through custom properties (called `props` in the [Plausible Event API](https://plausible.io/docs/events-api)). The (fake) page to track these visitors will be the following:

https://selenium.dev/sm-stats

An example of the equivalent POST request to track a page view is the following:

```
curl -i -X POST https://plausible.io/api/event \
  -H 'User-Agent: Selenium Manager 0.4.16' \
  -H 'Content-Type: application/json' \
  --data '{"name":"pageview","url":"https://selenium.dev/sm-stats","domain":"selenium.dev","props":{"browser":"chrome","browser_version":"119.0.6045.105","os":"linux","arch":"x86_64","lang":"java","selenium_version":"4.16"}}'
```

The data gathered by Plausible will be available on:

https://plausible.io/selenium.dev

To configure the custom properties (e.g., for filtering), these properties should be enabled:

https://plausible.io/selenium.dev/settings/properties

I tested this feature using a free Plausible account and my personal domain  (bonigarcia.dev):

![image](https://github.com/SeleniumHQ/selenium/assets/5413013/d3c046de-f3fc-447b-ad67-38657b28950e)

This PR is already pointing to selenium.dev. @diemol @titusfortner If you want to check how data is gathered, you can trigger the [CI Rust workflow](https://github.com/SeleniumHQ/selenium/actions/workflows/ci-rust.yml) using the branch `sm_plausible`.

NOTE: I was concerned about the impact of this feature on the overall performance of Selenium Manager. To get some numbers, I calculated the average time of running the Selenium Manager tests using the `trunk` branch (i.e., without this feature) compared to the branch `sm_plausible`. 

For that, I executed the following command in Linux:

```
time cargo test
```

I executed this command (with every asset in the cache) 10 times for each branch, and I calculated the average total time.

average_total_time_trunk = 11.1399 seconds
average_total_time_plausible = 12.4713 seconds

Therefore, the overhead introduced to the requests made to Plausible averages 0.7341 seconds. Since 23 page views were requested during the tests, each `pageview` request added an overhead of around 32 ms, which seems reasonable.

### Motivation and Context
This PR resolves #11211.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
