### PR TITLE
[rust] Fix webview2 support when browser path is set

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -483,7 +483,7 @@ pub trait SeleniumManager {
                     } else {
                         self.set_browser_version(discovered_version);
                     }
-                    if self.is_webview2() {
+                    if self.is_webview2() && PathBuf::from(self.get_browser_path()).is_dir() {
                         let browser_path = format!(
                             r#"{}\{}\msedge{}"#,
                             self.get_browser_path(),
@@ -1029,7 +1029,7 @@ pub trait SeleniumManager {
         let mut commands = Vec::new();
 
         if WINDOWS.is(self.get_os()) {
-            if !escaped_browser_path.is_empty() && !self.is_webview2() {
+            if !escaped_browser_path.is_empty() {
                 let wmic_command =
                     Command::new_single(format_one_arg(WMIC_COMMAND, &escaped_browser_path));
                 commands.push(wmic_command);


### PR DESCRIPTION
### Description
This PR fixes the support for Edge's WebView2 in Selenium Manager when browser path is set.

### Motivation and Context
Bug reported in #12738.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
