### PR TITLE
"Get Text" atom has to return the visible text from an element within a closed ShadowDOM

### DIFF
--- a/javascript/atoms/README.md
+++ b/javascript/atoms/README.md
@@ -14,10 +14,10 @@ the code in your IDE of choice, and then run the tests in a
 browser. You can do this by starting a debug server:
 
 ```shell
-bazel run javascript/atoms:test_debug_server  
+bazel run javascript/atoms:test_debug_server
 ```
 
-And then navigating to: http://localhost:2310/filez/selenium/javascript/atoms/
+And then navigating to: <http://localhost:2310/filez/selenium/javascript/atoms/>
 
 You'll be able to browse around the filesystem until you find the test
 you want to work on.
@@ -39,5 +39,5 @@ You can also filter to a specific test using the name of the file
 stripped of it's `.html` suffix. For example:
 
 ```shell
-bazel test --test_filter=shown_test --//common:headless=false javascript/atoms:test-chrome 
+bazel test --test_filter=shown_test --//common:headless=false javascript/atoms:test-chrome
 ```

--- a/javascript/atoms/dom.js
+++ b/javascript/atoms/dom.js
@@ -587,7 +587,7 @@ bot.dom.isShown = function(elem, opt_ignoreOpacity) {
     var parent = bot.dom.getParentNodeInComposedDom(e);
 
     if (bot.dom.IS_SHADOW_DOM_ENABLED && (parent instanceof ShadowRoot)) {
-      if (parent.host.shadowRoot !== parent) {
+      if (parent.host.shadowRoot && parent.host.shadowRoot !== parent) {
         // There is a younger shadow root, which will take precedence over
         // the shadow this element is in, thus this element won't be
         // displayed.

--- a/javascript/atoms/test/text_shadow_test.html
+++ b/javascript/atoms/test/text_shadow_test.html
@@ -32,45 +32,71 @@ limitations under the License.
     var findElement = bot.locators.findElement;
     var getText = bot.dom.getVisibleText;
 
-    customElements.define('custom-shadow-element',
+    customElements.define('open-shadow-element',
       class extends HTMLElement {
         constructor() {
-          {
-            super();
-            this.attachShadow({ mode: 'open' });
-          }
+          super();
+          this.attachShadow({ mode: 'open' });
         }
-      });
-    function setCustomElement(html) {
-      document.querySelector("custom-shadow-element").shadowRoot.innerHTML = html;
+      }
+    );
+
+    customElements.define('closed-shadow-element',
+      class extends HTMLElement {
+        constructor() {
+          super();
+          this._shadowRoot = this.attachShadow({ mode: 'closed' });
+        }
+      }
+    );
+
+    function setCustomElement(html, type='open') {
+      if (type == 'closed') {
+        document.querySelector(`closed-shadow-element`)._shadowRoot.innerHTML = html;
+      } else {
+        document.querySelector(`open-shadow-element`).shadowRoot.innerHTML = html;
+      }
     }
 
     function tearDown() {
-      let elem = document.querySelector("custom-shadow-element");
-      elem.shadowRoot.innerHTML = "";
+      let open = document.querySelector('open-shadow-element');
+      let closed = document.querySelector('closed-shadow-element');
 
+      open.shadowRoot.innerHTML = '';
+      closed._shadowRoot.innerHTML = '';
     }
 
     function testTextInShadowDOM() {
-      setCustomElement("<div><a href=# id=linkText>full link text</a></div>")
-      let elem = findElement({ tagName: "custom-shadow-element" });
-      let text = getText(elem);
-      assertEquals(text, "full link text");
+      setCustomElement('<div><a href=# id=linkText>full link text</a></div>');
+
+      let customEl = findElement({ tagName: 'open-shadow-element' });
+      let text = getText(customEl);
+      assertEquals(text, 'full link text');
     }
 
     function testHiddenTextInShadowDOM() {
-      setCustomElement("<div><a href=# id=linkText>full <div style='display:none'>link</div> text</a></div>")
-      let elem = findElement({ tagName: "custom-shadow-element" });
-      let text = getText(elem);
-      assertEquals(text, "full text");
+      setCustomElement(
+        '<div><a href=# id=linkText>full <div style="display:none">link</div> text</a></div>'
+      );
+
+      let customEl = findElement({ tagName: 'open-shadow-element' });
+      let text = getText(customEl);
+      assertEquals(text, 'full text');
     }
 
+    function testTextForElementWithinClosedShadowDOM() {
+      setCustomElement('<a href=# id=linkText>full link text</a>', 'closed');
+      let customEl = findElement({ tagName: 'closed-shadow-element' });
+      let innerEl = findElement({ css: 'a' }, customEl._shadowRoot);
+      let text = getText(innerEl);
+      assertEquals(text, 'full link text');
+    }
   </script>
-
 </head>
 
 <body>
-  <custom-shadow-element></custom-shadow-element>
+  <open-shadow-element></open-shadow-element>
+  <closed-shadow-element></closed-shadow-element>
 </body>
 
 </html>


### PR DESCRIPTION
Fixes #13132 

### Description
As discussed on issue #13132 the "Get Text" atom currently fails for elements that are located within a closed ShadowDOM. In those cases a check for `.shadowRoot` will not succeed because it's `null`. This patch fixes the check by making sure that it is only run when a valid ShadowRoot is actually available.

### Motivation and Context
This currently blocks WebDriver implementations using the `Get Text` atom to correctly retrieve the visible text of such an element.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

