### PR TITLE
Don't manipulate exception backtrace.

### DIFF
--- a/rb/lib/selenium/webdriver/remote/response.rb
+++ b/rb/lib/selenium/webdriver/remote/response.rb
@@ -38,11 +38,7 @@ module Selenium
           error, message, backtrace = process_error
           klass = Error.for_error(error) || return
 
-          ex = klass.new(message)
-          ex.set_backtrace(caller)
-          add_backtrace ex, backtrace
-
-          ex
+          klass.new(message)
         end
 
         def [](key)
@@ -57,36 +53,6 @@ module Selenium
           return unless @code.nil? || @code >= 400
 
           raise Error::ServerError, self
-        end
-
-        def add_backtrace(ex, server_trace)
-          return unless server_trace
-
-          backtrace = case server_trace
-                      when Array
-                        backtrace_from_remote(server_trace)
-                      when String
-                        server_trace.split("\n")
-                      end
-
-          ex.set_backtrace(backtrace + ex.backtrace)
-        end
-
-        def backtrace_from_remote(server_trace)
-          server_trace.filter_map do |frame|
-            next unless frame.is_a?(Hash)
-
-            file = frame['fileName']
-            line = frame['lineNumber']
-            meth = frame['methodName']
-
-            class_name = frame['className']
-            file = "#{class_name}(#{file})" if class_name
-
-            meth = 'unknown' if meth.nil? || meth.empty?
-
-            "[remote server] #{file}:#{line}:in `#{meth}'"
-          end
         end
 
         def process_error


### PR DESCRIPTION
Using `set_backtrace` causes `Exception#backtrace_locations` to become `nil` which is a great loss for accurate error reporting. From what I've seen very little is gained by adding the backtrace from the server. I don't feel that this is a breaking change as no one could reasonably depend on this information anyway. However, by removing this, not only is the code simpler, test frameworks will be able to better consume the backtrace. For example, `sus` uses this to highlight the error in VSCode.

If you did decide you want to preserve the error, maybe a more elaborate approach is warranted. I would suggest the following:

1. Try to extract the call stack from the browser, however if no methods resolve, exit here.
2. Once at least some methods have resolved to something meaningful, append that to the message, e.g. `klass.new(messsage + "\n\n#{remote_backtrace})`.

Alternatively, you could extend the error classes to have the remote/server backtrace as an ivar, e.g. 

```ruby
class Selenium::WebDriver::RemoteError
  def initialize(message, remote_backtrace: nil)
    super(message)
    @remote_backtrace = remote_backtrace
  end

  attr :remote_backtrace
end
```

Then you would subclass all your existing errors from that, or something to that effect. This would preserve the normal Ruby `backtrace_locations` behaviour while still exposing the remote backtrace to those who wanted to consume it.

It also occurred to me there is one other potential option: Create two exception objects, one with the remote backtrace, and then use `klass.new(..., cause: remote_error)`. This would also hide the remote backtrace unless the code specifically looked for it. I still don't recommend sticking non-Ruby backtrace data in `backtrace` though.

Fixes https://github.com/SeleniumHQ/selenium/issues/13221

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
