### PR TITLE
[dotnet] Removed {{separator}} token from C# filename codegen

### DIFF
--- a/third_party/dotnet/devtools/src/generator/CodeGen/CodeGenerationDefinitionTemplateSettings.cs
+++ b/third_party/dotnet/devtools/src/generator/CodeGen/CodeGenerationDefinitionTemplateSettings.cs
@@ -42,7 +42,7 @@
             TypeEnumTemplate = new CodeGenerationTemplateSettings
             {
                 TemplatePath = "type-enum.hbs",
-                OutputPath = "{{domainName}}{{separator}}{{className}}.cs",
+                OutputPath = "{{domainName}}\\{{className}}.cs",
             };
         }
 

--- a/third_party/dotnet/devtools/src/generator/CodeGen/CodeGenerationDefinitionTemplateSettings.cs
+++ b/third_party/dotnet/devtools/src/generator/CodeGen/CodeGenerationDefinitionTemplateSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenQA.Selenium.DevToolsGenerator.CodeGen
+namespace OpenQA.Selenium.DevToolsGenerator.CodeGen
 {
     using Newtonsoft.Json;
 
@@ -42,7 +42,7 @@
             TypeEnumTemplate = new CodeGenerationTemplateSettings
             {
                 TemplatePath = "type-enum.hbs",
-                OutputPath = "{{domainName}}\\{{className}}.cs",
+                OutputPath = "{{domainName}}{{separator}}{{className}}.cs",
             };
         }
 

--- a/third_party/dotnet/devtools/src/generator/CodeGen/Utility.cs
+++ b/third_party/dotnet/devtools/src/generator/CodeGen/Utility.cs
@@ -26,6 +26,7 @@ namespace OpenQA.Selenium.DevToolsGenerator.CodeGen
             path = path.Replace("{{templatePath}}", settings.TemplatesPath);
             path = path.Replace("{{domainName}}", context.Domain.Name);
             path = path.Replace('\\', System.IO.Path.DirectorySeparatorChar);
+            path = path.Replace("{{separator}}", System.IO.Path.DirectorySeparatorChar.ToString());
             return path;
         }
 


### PR DESCRIPTION
### Description

On our own build environment we noticed that the intermediate files being generated when running the codegen contain the {{separator}} token. When looking into the Utility.cs ReplaceTokensInPath function there is no replacement being done on the {{separator}} token. This PR removes the {{separator}} token from the template within CodeGenerationDefinitionTemplateSettings.cs causing filenames to be outputted without {{separator}}. 

Also this issue caused some files to end up in the wrong directory. The AXPropertyName.cs should be located in the Accesibility domain, but it ended up in WebAuthn. 

Before fix.
![SeparatorIssue](https://github.com/SeleniumHQ/selenium/assets/1215585/a432e7c8-38bd-4859-b783-9d60973e36c0)

After fix.
![SeparatorIssueFixed](https://github.com/SeleniumHQ/selenium/assets/1215585/734619fb-c784-4c8f-affb-aeb2cfa8720b)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
