### PR TITLE
[rb] Fully support Chrome 120+ old headless mode

### DIFF
--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -43,7 +43,7 @@ module Selenium
 
         def for(browser, opts = {})
           case browser
-          when :chrome
+          when :chrome, :chrome_headless_shell
             Chrome::Driver.new(**opts)
           when :internet_explorer, :ie
             IE::Driver.new(**opts)
@@ -329,7 +329,7 @@ module Selenium
 
       def add_extensions(browser)
         extensions = case browser
-                     when :chrome, :msedge
+                     when :chrome, :chrome_headless_shell, :msedge
                        Chromium::Driver::EXTENSIONS
                      when :firefox
                        Firefox::Driver::EXTENSIONS

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -60,7 +60,7 @@ module Selenium
           @capabilities = Capabilities.json_create(capabilities)
 
           case @capabilities[:browser_name]
-          when 'chrome'
+          when 'chrome', 'chrome-headless-shell'
             extend(WebDriver::Chrome::Features)
           when 'firefox'
             extend(WebDriver::Firefox::Features)
@@ -82,7 +82,7 @@ module Selenium
         def browser
           @browser ||= begin
             name = @capabilities.browser_name
-            name ? name.tr(' ', '_').downcase.to_sym : 'unknown'
+            name ? name.tr(' -', '_').downcase.to_sym : 'unknown'
           end
         end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When Chrome's new headless mode was announced, it was mentioned that they intended to remove the old headless mode from the Chrome binary. Some people still want to use the old headless mode, as it's more lightweight, performant, and has fewer dependencies - at the expense of having fewer features.

Chrome 120+ has a standalone `chrome-headless-shell` binary to keep the old headless mode working for those who wish to use it. If your Ruby code sets up the Chrome driver with `--headless` (which currently defaults to `old`) or `--headless=old` explicitly, you will lose capabilities such as setting permissions, fetching the logs, and using the CDP API.

This change is explained on the Chrome for Developers blog: [Download old Headless Chrome as chrome-headless-shell](https://developer.chrome.com/blog/chrome-headless-shell?hl=en)

That happens because the new binary has a browser name of `chrome-headless-shell`, instead of `chrome`. That makes it be recognized as something other than Chrome, not setting its capabilities.

### Description
<!--- Describe your changes in detail -->
This commit introduces `chrome-headless-shell` as an alternative Chrome browser name, fixing this issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

Fixes #13112
