### PR TITLE
[ci] Restore rust flags for build SM in CI

### DIFF
--- a/.github/workflows/build-selenium-manager.yml
+++ b/.github/workflows/build-selenium-manager.yml
@@ -12,6 +12,8 @@ jobs:
   win32:
     name: "[Windows x32] Build selenium-manager"
     runs-on: windows-latest
+    env:
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v4
@@ -95,6 +97,8 @@ jobs:
   macos64:
     name: "[macOS x64/arm64] Build selenium-manager"
     runs-on: macos-latest
+    env:
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
     steps:
       - name: "Checkout project"
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
This PR adds the flags `-Ctarget-feature=+crt-static` to build SM in Windows and macOS. They are not required in Linux since we use target `x86_64-unknown-linux-musl`, which already provides static linking.

### Motivation and Context
To avoid problems like the reported in #13261.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
