### PR TITLE
[rust] Use latest browser from cache when browser path is not discovered

### DIFF
--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -561,7 +561,7 @@ pub fn find_latest_from_cache<F: Fn(&DirEntry) -> bool>(
     cache_path: PathBuf,
     filter: F,
 ) -> Result<Option<PathBuf>, Error> {
-    let files_in_cache: Vec<PathBuf> = WalkDir::new(&cache_path)
+    let files_in_cache: Vec<PathBuf> = WalkDir::new(cache_path)
         .into_iter()
         .filter_map(|entry| entry.ok())
         .filter(|entry| filter(entry))
@@ -571,5 +571,13 @@ pub fn find_latest_from_cache<F: Fn(&DirEntry) -> bool>(
         Ok(Some(files_in_cache.iter().last().unwrap().to_owned()))
     } else {
         Ok(None)
+    }
+}
+
+pub fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -211,7 +211,11 @@ fn main() {
         .and_then(|_| selenium_manager.setup())
         .map(|driver_path| {
             let log = selenium_manager.get_logger();
-            log_driver_and_browser_path(log, &driver_path, selenium_manager.get_browser_path());
+            log_driver_and_browser_path(
+                log,
+                &driver_path,
+                &selenium_manager.get_browser_path_or_latest_from_cache(),
+            );
             flush_and_exit(OK, log, None);
         })
         .unwrap_or_else(|err| {
@@ -221,13 +225,13 @@ fn main() {
             {
                 log.warn(format!(
                     "There was an error managing {} ({}); using driver found in the cache",
-                    selenium_manager.get_browser_name(),
+                    selenium_manager.get_driver_name(),
                     err
                 ));
                 log_driver_and_browser_path(
                     log,
                     &best_driver_from_cache,
-                    selenium_manager.get_browser_path(),
+                    &selenium_manager.get_browser_path_or_latest_from_cache(),
                 );
                 flush_and_exit(OK, log, Some(err));
             } else if selenium_manager.is_offline() {


### PR DESCRIPTION
### Description
This PR allows Selenium Manager to discover the latest browser version available in cache if there is some problem (e.g., the browser version cannot be discovered using online endpoints).

### Motivation and Context
Currently, there is a fallback to get the latest driver version in the cache when some error happens. This PR do the same, but for browsers. It will allow to avoid problems like the reported in #13238  (i.e.,  a temporal glitch in the Edge endpoint response).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
