### PR TITLE
[rust] Throw a descriptive message when error parsing JSON from response

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -220,11 +220,10 @@ impl SeleniumManager for EdgeManager {
                     ));
                     let latest_driver_version = read_version_from_link(
                         self.get_http_client(),
-                        latest_stable_url,
+                        &latest_stable_url,
                         self.get_logger(),
                     )?;
-                    major_browser_version =
-                        self.get_major_version(latest_driver_version.as_str())?;
+                    major_browser_version = self.get_major_version(&latest_driver_version)?;
                     self.log.debug(format!(
                         "Latest {} major version is {}",
                         &self.driver_name, major_browser_version
@@ -242,7 +241,7 @@ impl SeleniumManager for EdgeManager {
                     &self.driver_name, driver_url
                 ));
                 let driver_version =
-                    read_version_from_link(self.get_http_client(), driver_url, self.get_logger())?;
+                    read_version_from_link(self.get_http_client(), &driver_url, self.get_logger())?;
 
                 let driver_ttl = self.get_ttl();
                 if driver_ttl > 0 && !major_browser_version.is_empty() {
@@ -365,7 +364,7 @@ impl SeleniumManager for EdgeManager {
         ));
 
         let edge_products =
-            parse_json_from_url::<Vec<EdgeProduct>>(self.get_http_client(), edge_updates_url)?;
+            parse_json_from_url::<Vec<EdgeProduct>>(self.get_http_client(), &edge_updates_url)?;
 
         let edge_channel = if self.is_beta(browser_version) {
             "Beta"

--- a/rust/src/firefox.rs
+++ b/rust/src/firefox.rs
@@ -19,10 +19,7 @@
 use crate::config::ManagerConfig;
 use crate::config::ARCH::{ARM64, X32};
 use crate::config::OS::{LINUX, MACOS, WINDOWS};
-use crate::downloads::{
-    parse_generic_json_from_url, parse_json_from_url, read_content_from_link,
-    read_redirect_from_link,
-};
+use crate::downloads::{parse_json_from_url, read_content_from_link, read_redirect_from_link};
 use crate::files::{compose_driver_path_in_cache, BrowserPath};
 use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
@@ -36,6 +33,7 @@ use anyhow::Error;
 use reqwest::Client;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -101,7 +99,7 @@ impl FirefoxManager {
         let browser_version = self.get_browser_version().to_string();
         let firefox_versions_url = self.create_firefox_details_url(endpoint);
         let firefox_versions =
-            parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+            parse_json_from_url::<Value>(self.get_http_client(), &firefox_versions_url)?;
 
         let versions_map = firefox_versions.as_object().unwrap();
         let filter_key = if browser_version.contains('.') {
@@ -220,7 +218,7 @@ impl SeleniumManager for FirefoxManager {
 
                 let driver_version = match parse_json_from_url::<GeckodriverReleases>(
                     self.get_http_client(),
-                    DRIVER_VERSIONS_URL.to_string(),
+                    DRIVER_VERSIONS_URL,
                 ) {
                     Ok(driver_releases) => {
                         let major_browser_version_int =
@@ -407,7 +405,7 @@ impl SeleniumManager for FirefoxManager {
 
         let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
         let firefox_versions =
-            parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+            parse_json_from_url::<Value>(self.get_http_client(), &firefox_versions_url)?;
         let browser_version = firefox_versions
             .get(FIREFOX_STABLE_LABEL)
             .unwrap()
@@ -430,7 +428,7 @@ impl SeleniumManager for FirefoxManager {
         if self.is_unstable(browser_version) {
             let firefox_versions_url = self.create_firefox_details_url(FIREFOX_VERSIONS_ENDPOINT);
             let firefox_versions =
-                parse_generic_json_from_url(self.get_http_client(), firefox_versions_url)?;
+                parse_json_from_url::<Value>(self.get_http_client(), &firefox_versions_url)?;
             let version_label = if self.is_beta(browser_version) {
                 FIREFOX_BETA_LABEL
             } else if self.is_dev(browser_version) {
@@ -480,7 +478,7 @@ impl SeleniumManager for FirefoxManager {
                 );
                 self.get_logger()
                     .trace(format!("Checking release URL: {}", release_url));
-                let content = read_content_from_link(self.get_http_client(), release_url)?;
+                let content = read_content_from_link(self.get_http_client(), &release_url)?;
                 if !content.contains("Not Found") {
                     return Ok(version.to_string());
                 }

--- a/rust/src/grid.rs
+++ b/rust/src/grid.rs
@@ -121,7 +121,7 @@ impl SeleniumManager for GridManager {
 
                 let selenium_releases = parse_json_from_url::<Vec<SeleniumRelease>>(
                     self.get_http_client(),
-                    MIRROR_URL.to_string(),
+                    MIRROR_URL,
                 )?;
 
                 let filtered_releases: Vec<SeleniumRelease> = selenium_releases

--- a/rust/src/iexplorer.rs
+++ b/rust/src/iexplorer.rs
@@ -134,7 +134,7 @@ impl SeleniumManager for IExplorerManager {
 
                 let selenium_releases = parse_json_from_url::<Vec<SeleniumRelease>>(
                     self.get_http_client(),
-                    MIRROR_URL.to_string(),
+                    MIRROR_URL,
                 )?;
 
                 let filtered_releases: Vec<SeleniumRelease> = selenium_releases


### PR DESCRIPTION
### Description
This PR enhances the logic related to JSON parsing to use a more descriptive message when error parsing JSON from online response. Example:

```
./selenium-manager --browser chrome --debug --driver-mirror-url https://googlechromelabs.github.io/chrome-for-testing/BAD
DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=119.0.6045.200\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 119.0.6045.200
DEBUG   Discovering versions from https://googlechromelabs.github.io/chrome-for-testing/BAD/known-good-versions-with-downloads.json
WARN    There was an error managing chromedriver (Error parsing JSON from URL https://googlechromelabs.github.io/chrome-for-testing/BAD/known-good-versions-with-downloads.json expected value at line 1 column 1); using driver found in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\119.0.6045.105\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

### Motivation and Context
Improve user experience, as reported in #12675.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
