### PR TITLE
[dotnet] Make some classes in internal folder as really to be internal

### DIFF
--- a/dotnet/src/webdriver/Internal/Base64UrlEncoder.cs
+++ b/dotnet/src/webdriver/Internal/Base64UrlEncoder.cs
@@ -23,7 +23,7 @@ namespace OpenQA.Selenium.Internal
     /// <summary>
     /// Encodes and Decodes strings as Base64Url encoding.
     /// </summary>
-    public static class Base64UrlEncoder
+    internal static class Base64UrlEncoder
     {
         private const char base64PadCharacter = '=';
         private const string doubleBase64PadCharacter = "==";

--- a/dotnet/src/webdriver/Internal/IWebDriverObjectReference.cs
+++ b/dotnet/src/webdriver/Internal/IWebDriverObjectReference.cs
@@ -16,10 +16,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OpenQA.Selenium.Internal
 {

--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -24,7 +24,7 @@ namespace OpenQA.Selenium.Internal
     /// <summary>
     /// Encapsulates methods for working with ports.
     /// </summary>
-    public static class PortUtilities
+    internal static class PortUtilities
     {
         /// <summary>
         /// Finds a random, free port to be listened on.

--- a/dotnet/src/webdriver/Internal/ResourceUtilities.cs
+++ b/dotnet/src/webdriver/Internal/ResourceUtilities.cs
@@ -16,9 +16,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;

--- a/dotnet/src/webdriver/Internal/ReturnedCookie.cs
+++ b/dotnet/src/webdriver/Internal/ReturnedCookie.cs
@@ -24,7 +24,7 @@ namespace OpenQA.Selenium.Internal
     /// <summary>
     /// Represents a cookie returned to the driver by the browser.
     /// </summary>
-    public class ReturnedCookie : Cookie
+    internal class ReturnedCookie : Cookie
     {
 
         /// <summary>


### PR DESCRIPTION
### Description
Internal stuff should be internal.

### Motivation and Context
Sometimes selenium's classes appears in IDE suggestions, and these classes are supposed to be for internal usage. Like `PortUtilities` class.. I don't think Selenium is created for networking.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
