### PR TITLE
[dotnet] Specify the dll as nuget content explicitly

### DIFF
--- a/dotnet/src/support/WebDriver.Support.StrongNamed.nuspec
+++ b/dotnet/src/support/WebDriver.Support.StrongNamed.nuspec
@@ -31,6 +31,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="**" target="." exclude="obj\**;*.csproj;*.config"/>
+    <file src="lib/netstandard2.0/WebDriver.Support.dll" target="lib/netstandard2.0/WebDriver.Support.dll" />
+    <file src="lib/netstandard2.0/WebDriver.Support.pdb" target="lib/netstandard2.0/WebDriver.Support.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.Support.xml" target="lib/netstandard2.0/WebDriver.Support.xml" />
+
+    <file src="icon.png" />
   </files>
 </package>

--- a/dotnet/src/support/WebDriver.Support.StrongNamed.nuspec
+++ b/dotnet/src/support/WebDriver.Support.StrongNamed.nuspec
@@ -31,9 +31,9 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="lib/netstandard2.0/WebDriver.Support.dll" target="lib/netstandard2.0/WebDriver.Support.dll" />
-    <file src="lib/netstandard2.0/WebDriver.Support.pdb" target="lib/netstandard2.0/WebDriver.Support.pdb" />
-    <file src="lib/netstandard2.0/WebDriver.Support.xml" target="lib/netstandard2.0/WebDriver.Support.xml" />
+    <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.dll" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.dll" />
+    <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.pdb" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.xml" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.xml" />
 
     <file src="icon.png" />
   </files>

--- a/dotnet/src/support/WebDriver.Support.nuspec
+++ b/dotnet/src/support/WebDriver.Support.nuspec
@@ -31,6 +31,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="**" target="." exclude="obj\**;*.csproj;*.config"/>
+    <file src="lib/netstandard2.0/WebDriver.Support.dll" target="lib/netstandard2.0/WebDriver.Support.dll" />
+    <file src="lib/netstandard2.0/WebDriver.Support.pdb" target="lib/netstandard2.0/WebDriver.Support.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.Support.xml" target="lib/netstandard2.0/WebDriver.Support.xml" />
+
+    <file src="icon.png" />
   </files>
 </package>

--- a/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
+++ b/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
@@ -32,6 +32,18 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="**" target="." exclude="obj\**;*.csproj;*.config"/>
+    <file src="lib/netstandard2.0/WebDriver.dll" target="lib/netstandard2.0/WebDriver.dll" />
+    <file src="lib/netstandard2.0/WebDriver.pdb" target="lib/netstandard2.0/WebDriver.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.xml" target="lib/netstandard2.0/WebDriver.xml" />
+
+    <file src="build/Selenium.WebDriver.targets" target="build/Selenium.WebDriver.targets"/>
+    <file src="buildTransitive/Selenium.WebDriver.targets" target="buildTransitive/Selenium.WebDriver.targets"/>
+
+    <file src="manager/linux/selenium-manager" target="manager/linux/selenium-manager" />
+    <file src="manager/macos/selenium-manager" target="manager/macos/selenium-manager" />
+    <file src="manager/windows/selenium-manager.exe" target="manager/windows/selenium-manager.exe" />
+
+    <file src="icon.png" />
+    <file src="README.md" />
   </files>
 </package>

--- a/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
+++ b/dotnet/src/webdriver/WebDriver.StrongNamed.nuspec
@@ -32,12 +32,12 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="lib/netstandard2.0/WebDriver.dll" target="lib/netstandard2.0/WebDriver.dll" />
-    <file src="lib/netstandard2.0/WebDriver.pdb" target="lib/netstandard2.0/WebDriver.pdb" />
-    <file src="lib/netstandard2.0/WebDriver.xml" target="lib/netstandard2.0/WebDriver.xml" />
+    <file src="lib/netstandard2.0/WebDriver.StrongNamed.dll" target="lib/netstandard2.0/WebDriver.StrongNamed.dll" />
+    <file src="lib/netstandard2.0/WebDriver.StrongNamed.pdb" target="lib/netstandard2.0/WebDriver.StrongNamed.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.StrongNamed.xml" target="lib/netstandard2.0/WebDriver.StrongNamed.xml" />
 
-    <file src="build/Selenium.WebDriver.targets" target="build/Selenium.WebDriver.targets"/>
-    <file src="buildTransitive/Selenium.WebDriver.targets" target="buildTransitive/Selenium.WebDriver.targets"/>
+    <file src="build/Selenium.WebDriver.StrongNamed.targets" target="build/Selenium.WebDriver.StrongNamed.targets"/>
+    <file src="buildTransitive/Selenium.WebDriver.StrongNamed.targets" target="buildTransitive/Selenium.WebDriver.StrongNamed.targets"/>
 
     <file src="manager/linux/selenium-manager" target="manager/linux/selenium-manager" />
     <file src="manager/macos/selenium-manager" target="manager/macos/selenium-manager" />

--- a/dotnet/src/webdriver/WebDriver.nuspec
+++ b/dotnet/src/webdriver/WebDriver.nuspec
@@ -32,6 +32,9 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="**" target="." exclude="obj\**;*.csproj;*.config"/>
+    <file src="lib/netstandard2.0/WebDriver.dll" target="lib/netstandard2.0/WebDriver.dll" />
+
+    <file src="icon.png" />
+    <file src="README.md" />
   </files>
 </package>

--- a/dotnet/src/webdriver/WebDriver.nuspec
+++ b/dotnet/src/webdriver/WebDriver.nuspec
@@ -33,6 +33,15 @@
   </metadata>
   <files>
     <file src="lib/netstandard2.0/WebDriver.dll" target="lib/netstandard2.0/WebDriver.dll" />
+    <file src="lib/netstandard2.0/WebDriver.pdb" target="lib/netstandard2.0/WebDriver.pdb" />
+    <file src="lib/netstandard2.0/WebDriver.xml" target="lib/netstandard2.0/WebDriver.xml" />
+
+    <file src="build/Selenium.WebDriver.targets" target="build/Selenium.WebDriver.targets"/>
+    <file src="buildTransitive/Selenium.WebDriver.targets" target="buildTransitive/Selenium.WebDriver.targets"/>
+
+    <file src="manager/linux/selenium-manager" target="manager/linux/selenium-manager" />
+    <file src="manager/macos/selenium-manager" target="manager/macos/selenium-manager" />
+    <file src="manager/windows/selenium-manager.exe" target="manager/windows/selenium-manager.exe" />
 
     <file src="icon.png" />
     <file src="README.md" />


### PR DESCRIPTION
### Description
Let's see how we can avoid [[🐛 Bug]: Unpredictable nuget package structure while releasing a package](https://github.com/SeleniumHQ/selenium/issues/13272) in future.

### Motivation and Context
This is a try to fix #13272 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
