### PR TITLE
[java] WebSocket NoVNC session against the grid URL contains trailing slash

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -838,7 +838,7 @@ public class LocalNode extends Node {
   private URI rewrite(String path) {
     try {
       String scheme = "https".equals(gridUri.getScheme()) ? "wss" : "ws";
-      if (gridUri.getPath() != null && !gridUri.getPath().isEmpty()) {
+      if (gridUri.getPath() != null && !gridUri.getPath().equals("/")) {
         path = gridUri.getPath() + path;
       }
       return new URI(


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
[java] WebSocket NoVNC session against the grid URL contains trailing slash

### Motivation and Context
We are going to the situation when `--grid-url` contains trailing slash, e.g. `http://my.domain.com/`
Based on the grid URL, others NoVNC, CDP, BiDi urls are constructed with double-slash `http://my.domain.com//session`, which caused a redirect issue (mentioned in https://github.com/SeleniumHQ/docker-selenium/issues/2075)
Users no longer have to worry about the trailing slash.
Fix: https://github.com/SeleniumHQ/docker-selenium/issues/2075

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
