### PR TITLE
[build] Remove features that are not w3c compliant

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -302,11 +302,13 @@ public class ChromiumDriver extends RemoteWebDriver
   }
 
   @Override
+  @Deprecated
   public Location location() {
     return locationContext.location();
   }
 
   @Override
+  @Deprecated
   public void setLocation(Location location) {
     Require.nonNull("Location", location);
     locationContext.setLocation(location);

--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -315,11 +315,13 @@ public class ChromiumDriver extends RemoteWebDriver
   }
 
   @Override
+  @Deprecated
   public ConnectionType getNetworkConnection() {
     return networkConnection.getNetworkConnection();
   }
 
   @Override
+  @Deprecated
   public ConnectionType setNetworkConnection(ConnectionType type) {
     Require.nonNull("Network Connection Type", type);
     return networkConnection.setNetworkConnection(type);

--- a/java/src/org/openqa/selenium/html5/Location.java
+++ b/java/src/org/openqa/selenium/html5/Location.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.html5;
 
 /** Represents the physical location of the browser. */
+@Deprecated
 public class Location {
 
   private final double latitude;

--- a/java/src/org/openqa/selenium/html5/LocationContext.java
+++ b/java/src/org/openqa/selenium/html5/LocationContext.java
@@ -17,6 +17,10 @@
 
 package org.openqa.selenium.html5;
 
+/**
+ * @deprecated This functionality is no longer supported
+ */
+@Deprecated
 public interface LocationContext {
 
   /**

--- a/java/src/org/openqa/selenium/mobile/NetworkConnection.java
+++ b/java/src/org/openqa/selenium/mobile/NetworkConnection.java
@@ -30,6 +30,7 @@ package org.openqa.selenium.mobile;
  * }
  * </pre>
  */
+@Deprecated
 public interface NetworkConnection {
 
   /**

--- a/java/src/org/openqa/selenium/remote/DriverCommand.java
+++ b/java/src/org/openqa/selenium/remote/DriverCommand.java
@@ -41,7 +41,6 @@ import org.openqa.selenium.print.PrintOptions;
  * @author jmleyba@gmail.com (Jason Leyba)
  */
 public interface DriverCommand {
-  String GET_ALL_SESSIONS = "getAllSessions";
   String GET_CAPABILITIES = "getCapabilities";
   String NEW_SESSION = "newSession";
   String STATUS = "status";
@@ -98,14 +97,12 @@ public interface DriverCommand {
   String GET_ELEMENT_VALUE_OF_CSS_PROPERTY = "getElementValueOfCssProperty";
   String GET_ELEMENT_ARIA_ROLE = "getElementAriaRole";
   String GET_ELEMENT_ACCESSIBLE_NAME = "getElementAccessibleName";
-  String ELEMENT_EQUALS = "elementEquals";
   String SCREENSHOT = "screenshot";
   String ELEMENT_SCREENSHOT = "elementScreenshot";
   String ACCEPT_ALERT = "acceptAlert";
   String DISMISS_ALERT = "dismissAlert";
   String GET_ALERT_TEXT = "getAlertText";
   String SET_ALERT_VALUE = "setAlertValue";
-  String SET_ALERT_CREDENTIALS = "setAlertCredentials";
   String GET_TIMEOUTS = "getTimeouts";
   String SET_TIMEOUT = "setTimeout";
   String PRINT_PAGE = "printPage";
@@ -114,10 +111,7 @@ public interface DriverCommand {
   String GET_LOCATION = "getLocation";
   String SET_LOCATION = "setLocation";
   String GET_APP_CACHE = "getAppCache";
-  String GET_APP_CACHE_STATUS = "getStatus";
   String CLEAR_APP_CACHE = "clearAppCache";
-  String IS_BROWSER_ONLINE = "isBrowserOnline";
-  String SET_BROWSER_ONLINE = "setBrowserOnline";
   String GET_LOCAL_STORAGE_ITEM = "getLocalStorageItem";
   String GET_LOCAL_STORAGE_KEYS = "getLocalStorageKeys";
   String SET_LOCAL_STORAGE_ITEM = "setLocalStorageItem";
@@ -149,7 +143,6 @@ public interface DriverCommand {
   // Logging API
   String GET_AVAILABLE_LOG_TYPES = "getAvailableLogTypes";
   String GET_LOG = "getLog";
-  String GET_SESSION_LOGS = "getSessionLogs";
   // Mobile API
   String GET_NETWORK_CONNECTION = "getNetworkConnection";
   String SET_NETWORK_CONNECTION = "setNetworkConnection";

--- a/java/src/org/openqa/selenium/remote/HttpCommandExecutor.java
+++ b/java/src/org/openqa/selenium/remote/HttpCommandExecutor.java
@@ -19,7 +19,6 @@ package org.openqa.selenium.remote;
 
 import static java.util.Collections.emptyMap;
 import static org.openqa.selenium.json.Json.JSON_UTF_8;
-import static org.openqa.selenium.remote.DriverCommand.GET_ALL_SESSIONS;
 import static org.openqa.selenium.remote.DriverCommand.NEW_SESSION;
 import static org.openqa.selenium.remote.DriverCommand.QUIT;
 import static org.openqa.selenium.remote.HttpSessionId.getSessionId;
@@ -148,7 +147,7 @@ public class HttpCommandExecutor implements CommandExecutor, NeedsLocalLogs {
       if (QUIT.equals(command.getName())) {
         return new Response();
       }
-      if (!GET_ALL_SESSIONS.equals(command.getName()) && !NEW_SESSION.equals(command.getName())) {
+      if (!NEW_SESSION.equals(command.getName())) {
         throw new NoSuchSessionException(
             "Session ID is null. Using WebDriver after calling quit()?");
       }

--- a/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
@@ -40,7 +40,6 @@ import static org.openqa.selenium.remote.DriverCommand.FULLSCREEN_CURRENT_WINDOW
 import static org.openqa.selenium.remote.DriverCommand.GET;
 import static org.openqa.selenium.remote.DriverCommand.GET_ACCOUNTS;
 import static org.openqa.selenium.remote.DriverCommand.GET_ALL_COOKIES;
-import static org.openqa.selenium.remote.DriverCommand.GET_AVAILABLE_LOG_TYPES;
 import static org.openqa.selenium.remote.DriverCommand.GET_CAPABILITIES;
 import static org.openqa.selenium.remote.DriverCommand.GET_CONTEXT_HANDLES;
 import static org.openqa.selenium.remote.DriverCommand.GET_COOKIE;
@@ -48,16 +47,13 @@ import static org.openqa.selenium.remote.DriverCommand.GET_CREDENTIALS;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_CONTEXT_HANDLE;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_URL;
 import static org.openqa.selenium.remote.DriverCommand.GET_DOWNLOADABLE_FILES;
-import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_RECT;
-import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_SIZE;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_TAG_NAME;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_TEXT;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_VALUE_OF_CSS_PROPERTY;
 import static org.openqa.selenium.remote.DriverCommand.GET_FEDCM_DIALOG_TYPE;
 import static org.openqa.selenium.remote.DriverCommand.GET_FEDCM_TITLE;
 import static org.openqa.selenium.remote.DriverCommand.GET_LOCATION;
-import static org.openqa.selenium.remote.DriverCommand.GET_LOG;
 import static org.openqa.selenium.remote.DriverCommand.GET_NETWORK_CONNECTION;
 import static org.openqa.selenium.remote.DriverCommand.GET_SCREEN_ORIENTATION;
 import static org.openqa.selenium.remote.DriverCommand.GET_SCREEN_ROTATION;
@@ -134,9 +130,6 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(GET_CAPABILITIES, get(sessionId));
     defineCommand(QUIT, delete(sessionId));
 
-    defineCommand(GET_LOG, post(sessionId + "/log"));  // Not w3c; overridden in W3CHttpCommandCodec
-    defineCommand(GET_AVAILABLE_LOG_TYPES, get(sessionId + "/log/types"));  // Not w3c; overridden in W3CHttpCommandCodec
-
     defineCommand(SWITCH_TO_FRAME, post(sessionId + "/frame"));
     defineCommand(SWITCH_TO_PARENT_FRAME, post(sessionId + "/frame/parent"));
 
@@ -167,10 +160,8 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(FIND_CHILD_ELEMENTS, post(elementId + "/elements"));
     defineCommand(IS_ELEMENT_ENABLED, get(elementId + "/enabled"));
     defineCommand(GET_ELEMENT_RECT, get(elementId + "/rect"));
-    defineCommand(GET_ELEMENT_LOCATION, get(elementId + "/location")); // Not w3c; Overridden in W3CHttpCommandCodec with rect
     defineCommand(GET_ELEMENT_TAG_NAME, get(elementId + "/name"));
     defineCommand(IS_ELEMENT_SELECTED, get(elementId + "/selected"));
-    defineCommand(GET_ELEMENT_SIZE, get(elementId + "/size")); // Not w3c; Overridden in W3CHttpCommandCodec with rect
     defineCommand(GET_ELEMENT_TEXT, get(elementId + "/text"));
     defineCommand(SEND_KEYS_TO_ELEMENT, post(elementId + "/value"));
 

--- a/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
@@ -31,7 +31,6 @@ import static org.openqa.selenium.remote.DriverCommand.DELETE_ALL_COOKIES;
 import static org.openqa.selenium.remote.DriverCommand.DELETE_COOKIE;
 import static org.openqa.selenium.remote.DriverCommand.DELETE_DOWNLOADABLE_FILES;
 import static org.openqa.selenium.remote.DriverCommand.DOWNLOAD_FILE;
-import static org.openqa.selenium.remote.DriverCommand.ELEMENT_EQUALS;
 import static org.openqa.selenium.remote.DriverCommand.ELEMENT_SCREENSHOT;
 import static org.openqa.selenium.remote.DriverCommand.FIND_CHILD_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.FIND_CHILD_ELEMENTS;
@@ -41,8 +40,6 @@ import static org.openqa.selenium.remote.DriverCommand.FULLSCREEN_CURRENT_WINDOW
 import static org.openqa.selenium.remote.DriverCommand.GET;
 import static org.openqa.selenium.remote.DriverCommand.GET_ACCOUNTS;
 import static org.openqa.selenium.remote.DriverCommand.GET_ALL_COOKIES;
-import static org.openqa.selenium.remote.DriverCommand.GET_ALL_SESSIONS;
-import static org.openqa.selenium.remote.DriverCommand.GET_APP_CACHE_STATUS;
 import static org.openqa.selenium.remote.DriverCommand.GET_AVAILABLE_LOG_TYPES;
 import static org.openqa.selenium.remote.DriverCommand.GET_CAPABILITIES;
 import static org.openqa.selenium.remote.DriverCommand.GET_CONTEXT_HANDLES;
@@ -64,13 +61,11 @@ import static org.openqa.selenium.remote.DriverCommand.GET_LOG;
 import static org.openqa.selenium.remote.DriverCommand.GET_NETWORK_CONNECTION;
 import static org.openqa.selenium.remote.DriverCommand.GET_SCREEN_ORIENTATION;
 import static org.openqa.selenium.remote.DriverCommand.GET_SCREEN_ROTATION;
-import static org.openqa.selenium.remote.DriverCommand.GET_SESSION_LOGS;
 import static org.openqa.selenium.remote.DriverCommand.GET_TIMEOUTS;
 import static org.openqa.selenium.remote.DriverCommand.GET_TITLE;
 import static org.openqa.selenium.remote.DriverCommand.GO_BACK;
 import static org.openqa.selenium.remote.DriverCommand.GO_FORWARD;
 import static org.openqa.selenium.remote.DriverCommand.IMPLICITLY_WAIT;
-import static org.openqa.selenium.remote.DriverCommand.IS_BROWSER_ONLINE;
 import static org.openqa.selenium.remote.DriverCommand.IS_ELEMENT_ENABLED;
 import static org.openqa.selenium.remote.DriverCommand.IS_ELEMENT_SELECTED;
 import static org.openqa.selenium.remote.DriverCommand.NEW_SESSION;
@@ -83,8 +78,6 @@ import static org.openqa.selenium.remote.DriverCommand.RESET_COOLDOWN;
 import static org.openqa.selenium.remote.DriverCommand.SCREENSHOT;
 import static org.openqa.selenium.remote.DriverCommand.SELECT_ACCOUNT;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ELEMENT;
-import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_CREDENTIALS;
-import static org.openqa.selenium.remote.DriverCommand.SET_BROWSER_ONLINE;
 import static org.openqa.selenium.remote.DriverCommand.SET_DELAY_ENABLED;
 import static org.openqa.selenium.remote.DriverCommand.SET_LOCATION;
 import static org.openqa.selenium.remote.DriverCommand.SET_NETWORK_CONNECTION;
@@ -137,14 +130,12 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
 
     String sessionId = "/session/:sessionId";
 
-    defineCommand(GET_ALL_SESSIONS, get("/sessions"));
     defineCommand(NEW_SESSION, post("/session"));
     defineCommand(GET_CAPABILITIES, get(sessionId));
     defineCommand(QUIT, delete(sessionId));
 
-    defineCommand(GET_SESSION_LOGS, post("/logs"));
-    defineCommand(GET_LOG, post(sessionId + "/log"));
-    defineCommand(GET_AVAILABLE_LOG_TYPES, get(sessionId + "/log/types"));
+    defineCommand(GET_LOG, post(sessionId + "/log"));  // Not w3c; overridden in W3CHttpCommandCodec
+    defineCommand(GET_AVAILABLE_LOG_TYPES, get(sessionId + "/log/types"));  // Not w3c; overridden in W3CHttpCommandCodec
 
     defineCommand(SWITCH_TO_FRAME, post(sessionId + "/frame"));
     defineCommand(SWITCH_TO_PARENT_FRAME, post(sessionId + "/frame/parent"));
@@ -161,8 +152,6 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(GO_FORWARD, post(sessionId + "/forward"));
     defineCommand(REFRESH, post(sessionId + "/refresh"));
 
-    defineCommand(SET_ALERT_CREDENTIALS, post(sessionId + "/alert/credentials"));
-
     defineCommand(SCREENSHOT, get(sessionId + "/screenshot"));
     defineCommand(ELEMENT_SCREENSHOT, get(sessionId + "/element/:id/screenshot"));
     defineCommand(GET_TITLE, get(sessionId + "/title"));
@@ -177,12 +166,11 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(FIND_CHILD_ELEMENT, post(elementId + "/element"));
     defineCommand(FIND_CHILD_ELEMENTS, post(elementId + "/elements"));
     defineCommand(IS_ELEMENT_ENABLED, get(elementId + "/enabled"));
-    defineCommand(ELEMENT_EQUALS, get(elementId + "/equals/:other"));
     defineCommand(GET_ELEMENT_RECT, get(elementId + "/rect"));
-    defineCommand(GET_ELEMENT_LOCATION, get(elementId + "/location"));
+    defineCommand(GET_ELEMENT_LOCATION, get(elementId + "/location")); // Not w3c; Overridden in W3CHttpCommandCodec with rect
     defineCommand(GET_ELEMENT_TAG_NAME, get(elementId + "/name"));
     defineCommand(IS_ELEMENT_SELECTED, get(elementId + "/selected"));
-    defineCommand(GET_ELEMENT_SIZE, get(elementId + "/size"));
+    defineCommand(GET_ELEMENT_SIZE, get(elementId + "/size")); // Not w3c; Overridden in W3CHttpCommandCodec with rect
     defineCommand(GET_ELEMENT_TEXT, get(elementId + "/text"));
     defineCommand(SEND_KEYS_TO_ELEMENT, post(elementId + "/value"));
 
@@ -199,23 +187,29 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(SET_SCRIPT_TIMEOUT, post(timeouts + "/async_script"));
     defineCommand(IMPLICITLY_WAIT, post(timeouts + "/implicit_wait"));
 
-    defineCommand(GET_APP_CACHE_STATUS, get(sessionId + "/application_cache/status"));
-    defineCommand(IS_BROWSER_ONLINE, get(sessionId + "/browser_connection"));
-    defineCommand(SET_BROWSER_ONLINE, post(sessionId + "/browser_connection"));
-    defineCommand(GET_LOCATION, get(sessionId + "/location"));
-    defineCommand(SET_LOCATION, post(sessionId + "/location"));
+    defineCommand(
+        GET_LOCATION, get(sessionId + "/location")); // Not w3c; used in RemoteLocationContext
+    defineCommand(
+        SET_LOCATION, post(sessionId + "/location")); // Not w3c; used in RemoteLocationContext
 
-    defineCommand(GET_SCREEN_ORIENTATION, get(sessionId + "/orientation"));
-    defineCommand(SET_SCREEN_ORIENTATION, post(sessionId + "/orientation"));
-    defineCommand(GET_SCREEN_ROTATION, get(sessionId + "/rotation"));
-    defineCommand(SET_SCREEN_ROTATION, post(sessionId + "/rotation"));
+    defineCommand(
+        GET_SCREEN_ORIENTATION, get(sessionId + "/orientation")); // Not w3c; used in Appium
+    defineCommand(
+        SET_SCREEN_ORIENTATION, post(sessionId + "/orientation")); // Not w3c; used in Appium
+    defineCommand(GET_SCREEN_ROTATION, get(sessionId + "/rotation")); // Not w3c; used in Appium
+    defineCommand(SET_SCREEN_ROTATION, post(sessionId + "/rotation")); // Not w3c; used in Appium
 
     // Mobile Spec
-    defineCommand(GET_NETWORK_CONNECTION, get(sessionId + "/network_connection"));
-    defineCommand(SET_NETWORK_CONNECTION, post(sessionId + "/network_connection"));
-    defineCommand(SWITCH_TO_CONTEXT, post(sessionId + "/context"));
-    defineCommand(GET_CURRENT_CONTEXT_HANDLE, get(sessionId + "/context"));
-    defineCommand(GET_CONTEXT_HANDLES, get(sessionId + "/contexts"));
+    defineCommand(
+        GET_NETWORK_CONNECTION,
+        get(sessionId + "/network_connection")); // Not w3c; used in RemoteNetworkConnection
+    defineCommand(
+        SET_NETWORK_CONNECTION,
+        post(sessionId + "/network_connection")); // Not w3c; used in RemoteNetworkConnection
+    defineCommand(SWITCH_TO_CONTEXT, post(sessionId + "/context")); // Not w3c; used in Appium
+    defineCommand(
+        GET_CURRENT_CONTEXT_HANDLE, get(sessionId + "/context")); // Not w3c; used in Appium
+    defineCommand(GET_CONTEXT_HANDLES, get(sessionId + "/contexts")); // Not w3c; used in Appium
 
     // Virtual Authenticator API
     String webauthn = sessionId + "/webauthn/authenticator";

--- a/java/src/org/openqa/selenium/remote/html5/RemoteLocationContext.java
+++ b/java/src/org/openqa/selenium/remote/html5/RemoteLocationContext.java
@@ -23,6 +23,10 @@ import org.openqa.selenium.html5.LocationContext;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ExecuteMethod;
 
+/**
+ * @deprecated This functionality is no longer supported
+ */
+@Deprecated
 public class RemoteLocationContext implements LocationContext {
   private final ExecuteMethod executeMethod;
 

--- a/java/src/org/openqa/selenium/remote/mobile/RemoteNetworkConnection.java
+++ b/java/src/org/openqa/selenium/remote/mobile/RemoteNetworkConnection.java
@@ -22,6 +22,10 @@ import org.openqa.selenium.mobile.NetworkConnection;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ExecuteMethod;
 
+/**
+ * @deprecated This functionality is no longer supported
+ */
+@Deprecated
 public class RemoteNetworkConnection implements NetworkConnection {
 
   private final ExecuteMethod executeMethod;
@@ -31,12 +35,14 @@ public class RemoteNetworkConnection implements NetworkConnection {
   }
 
   @Override
+  @Deprecated
   public ConnectionType getNetworkConnection() {
     return new ConnectionType(
         ((Number) executeMethod.execute(DriverCommand.GET_NETWORK_CONNECTION, null)).intValue());
   }
 
   @Override
+  @Deprecated
   public ConnectionType setNetworkConnection(ConnectionType type) {
     Map<String, ConnectionType> mode = Map.of("type", type);
     return new ConnectionType(


### PR DESCRIPTION
### Description
* Remove non-compliant commands that are not being used in Selenium code anywhere
    * GET_ALL_SESSIONS
    * ELEMENT_EQUALS
    * SET_ALERT_CREDENTIALS
    * GET_APP_CACHE_STATUS
    * IS_BROWSER_ONLINE
    * SET_BROWSER_ONLINE
    * GET_SESSION_LOGS
* Remove commands that are implemented by the single subclass (`W3CHttpCommandCodec`)
    * GET_AVAILABLE_LOG_TYPES
    * GET_ELEMENT_LOCATION
    * GET_ELEMENT_SIZE
    * GET_LOG
* Deprecate features that shouldn't work because the endpoints are no longer valid
    * Getting & Setting location (geo-location)
    * Getting & Setting network connection

### Motivation and Context
* Slowly removing things that don't work or at least are not compliant

### Future Considerations
* Need to contact Appium about things they need to implement so we can get rid of them (alternately we can change the namespacing on them to be w3c compliant; kind of depends on what we want to live where in the two code bases)
    * GET_SCREEN_ORIENTATION
    * SET_SCREEN_ORIENTATION
    * GET_SCREEN_ROTATION
    * SET_SCREEN_ROTATION
    * SWITCH_TO_CONTEXT
    * GET_CURRENT_CONTEXT_HANDLE
    * GET_CONTEXT_HANDLES
* Can we merge these classes since we no longer have multiple implementations? I don't think this would affect how we are moving to BiDi spec.
