### PR TITLE
[java] deprecate all html5 offline storage implementations See #10397

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -292,11 +292,13 @@ public class ChromiumDriver extends RemoteWebDriver
   }
 
   @Override
+  @Deprecated
   public LocalStorage getLocalStorage() {
     return webStorage.getLocalStorage();
   }
 
   @Override
+  @Deprecated
   public SessionStorage getSessionStorage() {
     return webStorage.getSessionStorage();
   }

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -254,11 +254,13 @@ public class FirefoxDriver extends RemoteWebDriver
   }
 
   @Override
+  @Deprecated
   public LocalStorage getLocalStorage() {
     return webStorage.getLocalStorage();
   }
 
   @Override
+  @Deprecated
   public SessionStorage getSessionStorage() {
     return webStorage.getSessionStorage();
   }

--- a/java/src/org/openqa/selenium/html5/AppCacheStatus.java
+++ b/java/src/org/openqa/selenium/html5/AppCacheStatus.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.html5;
 
 /** Represents the application cache status. */
+@Deprecated
 public enum AppCacheStatus {
   UNCACHED(0),
   IDLE(1),

--- a/java/src/org/openqa/selenium/html5/LocalStorage.java
+++ b/java/src/org/openqa/selenium/html5/LocalStorage.java
@@ -21,4 +21,5 @@ package org.openqa.selenium.html5;
  * Represents the local storage for the site currently opened in the browser. Each site has its own
  * separate storage area.
  */
+@Deprecated
 public interface LocalStorage extends Storage {}

--- a/java/src/org/openqa/selenium/html5/SessionStorage.java
+++ b/java/src/org/openqa/selenium/html5/SessionStorage.java
@@ -23,4 +23,5 @@ package org.openqa.selenium.html5;
  * unique set of session storage, one for each origin. Sites can add data to the session storage and
  * it will be accessible to any page from the same site opened in that window.
  */
+@Deprecated
 public interface SessionStorage extends Storage {}

--- a/java/src/org/openqa/selenium/html5/Storage.java
+++ b/java/src/org/openqa/selenium/html5/Storage.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.html5;
 import java.util.Set;
 
 /** Represents common operations available for all web storage types (session or local). */
+@Deprecated
 public interface Storage {
 
   String getItem(String key);

--- a/java/src/org/openqa/selenium/html5/WebStorage.java
+++ b/java/src/org/openqa/selenium/html5/WebStorage.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.html5;
 
+@Deprecated
 public interface WebStorage {
 
   LocalStorage getLocalStorage();

--- a/java/src/org/openqa/selenium/remote/html5/RemoteLocalStorage.java
+++ b/java/src/org/openqa/selenium/remote/html5/RemoteLocalStorage.java
@@ -25,7 +25,13 @@ import org.openqa.selenium.html5.LocalStorage;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ExecuteMethod;
 
-/** Executes the commands to access HTML5 localStorage on the remote webdriver server. */
+/**
+ * Executes the commands to access HTML5 localStorage on the remote webdriver server.
+ *
+ * @deprecated LocalStorage can be managed by executing JavaScript. @see #executeScript(String,
+ *     Object...)
+ */
+@Deprecated
 public class RemoteLocalStorage implements LocalStorage {
   private final ExecuteMethod executeMethod;
 

--- a/java/src/org/openqa/selenium/remote/html5/RemoteSessionStorage.java
+++ b/java/src/org/openqa/selenium/remote/html5/RemoteSessionStorage.java
@@ -25,7 +25,13 @@ import org.openqa.selenium.html5.SessionStorage;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ExecuteMethod;
 
-/** Executes the commands to access HTML5 sessionStorage on the remote webdriver server. */
+/**
+ * Executes the commands to access HTML5 sessionStorage on the remote webdriver server.
+ *
+ * @deprecated LocalStorage can be managed by executing JavaScript. @see #executeScript(String,
+ *     Object...)
+ */
+@Deprecated
 public class RemoteSessionStorage implements SessionStorage {
   private final ExecuteMethod executeMethod;
 


### PR DESCRIPTION
### Description
Deprecates all LocalStorage and WebStorage implementations
Also deprecates `AppCacheStatus` enum which isn't being used anywhere and we probably could just delete

### Motivation and Context
See #10397

Here is the JavaScript equivalent of the methods being deprecated:
https://github.com/SeleniumHQ/selenium/blob/22dcb1796d5c791c1f6d5dde947b11fe5bd03748/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java#L220-L266

Do we want to put this in our docs somewhere and point people to it, or just tell them to find what they need online?