### PR TITLE
SeleniumManager python wrapper should check if architecture/platform combination is supported

### DIFF
--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -17,9 +17,9 @@
 import json
 import logging
 import os
+import platform
 import subprocess
 import sys
-import platform
 from pathlib import Path
 from typing import List
 

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 import sys
+import platform
 from pathlib import Path
 from typing import List
 
@@ -47,17 +48,19 @@ class SeleniumManager:
             return Path(path)
 
         dirs = {
-            "darwin": "macos",
-            "win32": "windows",
-            "cygwin": "windows",
-            "linux": "linux",
-            "freebsd": "linux",
-            "openbsd": "linux",
+            ("darwin", "any"): "macos",
+            ("win32", "any"): "windows",
+            ("cygwin", "any"): "windows",
+            ("linux", "x86_64"): "linux",
+            ("freebsd", "x86_64"): "linux",
+            ("openbsd", "x86_64"): "linux",
         }
 
-        directory = dirs.get(sys.platform)
+        arch = platform.machine() if sys.platform in ("linux", "freebsd", "openbsd") else "any"
+
+        directory = dirs.get((sys.platform, arch))
         if directory is None:
-            raise WebDriverException(f"Unsupported platform: {sys.platform}")
+            raise WebDriverException(f"Unsupported platform/architecture combination: {sys.platform}/{arch}")
 
         if sys.platform in ["freebsd", "openbsd"]:
             logger.warning("Selenium Manager binary may not be compatible with %s; verify settings", sys.platform)


### PR DESCRIPTION
### Description
SeleniumManager's get_binary() now checks if architecture/platform combination is supported (and not only if the platform is supported).

### Motivation and Context
Currently, when running selenium manager on unsupported architectures, best case scenario the user gets an OS level error message that's not necessarily clear, worst case scenario - the binary is completely missing and then the user gets a "Unable to obtain working Selenium Manager binary" message (for example, this happens on RP, since all RPG are set to install wheels from "piwheel" repo which seems to discard all executables that are not supported by RPs architectures).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
