### PR TITLE
[java] set a timeout on joining threads after ending remote server

### DIFF
--- a/java/src/org/openqa/selenium/os/ExternalProcess.java
+++ b/java/src/org/openqa/selenium/os/ExternalProcess.java
@@ -265,6 +265,9 @@ public class ExternalProcess {
 
     if (exited) {
       worker.join(30000);
+      if (worker.isAlive()) {
+        worker.interrupt();
+      }
     }
 
     return exited;
@@ -295,6 +298,9 @@ public class ExternalProcess {
       try {
         if (process.waitFor(timeout.toMillis(), MILLISECONDS)) {
           worker.join(30000);
+          if (worker.isAlive()) {
+            worker.interrupt();
+          }
           return;
         }
       } catch (InterruptedException ex) {

--- a/java/src/org/openqa/selenium/os/ExternalProcess.java
+++ b/java/src/org/openqa/selenium/os/ExternalProcess.java
@@ -264,7 +264,7 @@ public class ExternalProcess {
     boolean exited = process.waitFor(duration.toMillis(), TimeUnit.MILLISECONDS);
 
     if (exited) {
-      worker.join();
+      worker.join(30000);
     }
 
     return exited;

--- a/java/src/org/openqa/selenium/os/ExternalProcess.java
+++ b/java/src/org/openqa/selenium/os/ExternalProcess.java
@@ -294,7 +294,7 @@ public class ExternalProcess {
 
       try {
         if (process.waitFor(timeout.toMillis(), MILLISECONDS)) {
-          worker.join();
+          worker.join(30000);
           return;
         }
       } catch (InterruptedException ex) {


### PR DESCRIPTION
### Description
Just adds a timeout value of 30 seconds (no idea what the right value is)

### Motivation and Context
This seems to keep the test from hanging at timing out after 30 minutes and then failing...

Running the tests to verify