### PR TITLE
[java] Deprecate `ContextAware` interface

### DIFF
--- a/java/src/org/openqa/selenium/ContextAware.java
+++ b/java/src/org/openqa/selenium/ContextAware.java
@@ -23,6 +23,7 @@ import java.util.Set;
  * Some implementations of WebDriver, notably those that support native testing, need the ability to
  * switch between the native and web-based contexts. This can be achieved by using this interface.
  */
+@Deprecated
 public interface ContextAware {
 
   /**


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Context management endpoints were removed in https://github.com/SeleniumHQ/selenium/commit/1b66415adf2bcce266d5acdd457378c4e6d07340, so it seems `ContextAware` interface becomes redundant.

### Motivation and Context
Open questions:
 - should `ContextAware` interface be deprecated or removed?
 - should `NoSuchContextException` be deprecated/removed as well?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
