### PR TITLE
[atoms] use css locators in dom.js

### DIFF
--- a/javascript/atoms/BUILD.bazel
+++ b/javascript/atoms/BUILD.bazel
@@ -119,10 +119,10 @@ closure_js_library(
     deps = [
         ":bot",
         ":color",
+        ":css",
         ":domcore",
         ":json",
         ":useragent",
-        ":xpath",
         "@io_bazel_rules_closure//closure/library",
     ],
 )
@@ -239,7 +239,7 @@ closure_js_library(
     name = "locators",
     srcs = glob(
         ["locators/*.js"],
-        exclude = ["locators/xpath.js"],
+        exclude = ["locators/css.js"],
     ),
     suppress = [
         "JSC_IMPLICITLY_NULLABLE_JSDOC",
@@ -250,11 +250,12 @@ closure_js_library(
     ],
     deps = [
         ":bot",
+        ":css",
         ":dom",
         ":errors",
         ":json",
         ":useragent",
-        ":xpath",
+        "//third_party/js/wgxpath",
         "@io_bazel_rules_closure//closure/library",
     ],
 )
@@ -289,8 +290,8 @@ closure_js_library(
 )
 
 closure_js_library(
-    name = "xpath",
-    srcs = ["locators/xpath.js"],
+    name = "css",
+    srcs = ["locators/css.js"],
     suppress = [
         "JSC_IMPLICITLY_NULLABLE_JSDOC",
         "JSC_STRICT_INEXISTENT_PROPERTY",
@@ -300,7 +301,7 @@ closure_js_library(
     deps = [
         ":bot",
         ":errors",
-        "//third_party/js/wgxpath",
+        ":useragent",
         "@io_bazel_rules_closure//closure/library",
     ],
 )
@@ -331,6 +332,7 @@ closure_js_deps(
         ":action",
         ":bot",
         ":color",
+        ":css",
         ":devices",
         ":dom",
         ":domcore",
@@ -343,7 +345,6 @@ closure_js_deps(
         ":test_util",
         ":useragent",
         ":window",
-        ":xpath",
     ],
 )
 

--- a/javascript/atoms/dom.js
+++ b/javascript/atoms/dom.js
@@ -24,7 +24,7 @@ goog.provide('bot.dom');
 goog.require('bot');
 goog.require('bot.color');
 goog.require('bot.dom.core');
-goog.require('bot.locators.xpath');
+goog.require('bot.locators.css');
 goog.require('bot.userAgent');
 goog.require('goog.array');
 goog.require('goog.dom');
@@ -878,15 +878,12 @@ bot.dom.maybeFindImageMap_ = function(elem) {
   if (map && map.name) {
     var mapDoc = goog.dom.getOwnerDocument(map);
 
-    // The "//*" XPath syntax can confuse the closure compiler, so we use
-    // the "/descendant::*" syntax instead.
-    // TODO: Try to find a reproducible case for the compiler bug.
     // TODO: Restrict to applet, img, input:image, and object nodes.
-    var imageXpath = '/descendant::*[@usemap = "#' + map.name + '"]';
+    var locator = '*[usemap="#' + map.name + '"]';
 
     // TODO: Break dependency of bot.locators on bot.dom,
     // so bot.locators.findElement can be called here instead.
-    image = bot.locators.xpath.single(imageXpath, mapDoc);
+    image = bot.locators.css.single(locator, mapDoc);
 
     if (image) {
       rect = bot.dom.getClientRect(image);


### PR DESCRIPTION
### Description
Using xpaths will need to transfer the complete `wicked-good-xpath`, this can easily be replaced by a css locator.

### Motivation and Context
This will reduce the size of the `isDisplayed.js` from ~43kb to ~17kb.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
