### PR TITLE
Refactor argument creation in DriverService classes

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -282,32 +282,7 @@ public class ChromeDriverService extends DriverService {
     @Override
     protected List<String> createArgs() {
       List<String> args = new ArrayList<>();
-      args.add(String.format("--port=%d", getPort()));
-
-      // Readable timestamp and append logs only work if log path is specified in args
-      // Cannot use logOutput because goog:loggingPrefs requires --log-path get sent
-      if (getLogFile() != null) {
-        args.add(String.format("--log-path=%s", getLogFile().getAbsolutePath()));
-        if (Boolean.TRUE.equals(readableTimestamp)) {
-          args.add("--readable-timestamp");
-        }
-        if (Boolean.TRUE.equals(appendLog)) {
-          args.add("--append-log");
-        }
-        withLogOutput(
-            OutputStream.nullOutputStream()); // Do not overwrite log file in getLogOutput()
-      }
-
-      if (logLevel != null) {
-        args.add(String.format("--log-level=%s", logLevel.toString().toUpperCase()));
-      }
-      if (allowedListIps != null) {
-        args.add(String.format("--allowed-ips=%s", allowedListIps));
-      }
-      if (Boolean.TRUE.equals(disableBuildCheck)) {
-        args.add("--disable-build-check");
-      }
-
+      super.createCommonArgs(readableTimestamp, appendLog, logLevel, allowedListIps, disableBuildCheck, args);
       return unmodifiableList(args);
     }
 

--- a/java/src/org/openqa/selenium/edge/EdgeDriverService.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverService.java
@@ -276,38 +276,13 @@ public class EdgeDriverService extends DriverService {
     @Override
     protected List<String> createArgs() {
       List<String> args = new ArrayList<>();
-      args.add(String.format("--port=%d", getPort()));
-
-      // Readable timestamp and append logs only work if log path is specified in args
-      // Cannot use logOutput because goog:loggingPrefs requires --log-path get sent
-      if (getLogFile() != null) {
-        args.add(String.format("--log-path=%s", getLogFile().getAbsolutePath()));
-        if (Boolean.TRUE.equals(readableTimestamp)) {
-          args.add("--readable-timestamp");
-        }
-        if (Boolean.TRUE.equals(appendLog)) {
-          args.add("--append-log");
-        }
-        withLogOutput(
-            OutputStream.nullOutputStream()); // Do not overwrite log file in getLogOutput()
-      }
-
-      if (logLevel != null) {
-        args.add(String.format("--log-level=%s", logLevel.toString().toUpperCase()));
-      }
+      super.createCommonArgs(readableTimestamp, appendLog, logLevel, allowedListIps, disableBuildCheck, args);
       if (Boolean.TRUE.equals(silent)) {
         args.add("--silent");
       }
       if (Boolean.TRUE.equals(verbose)) {
         args.add("--verbose");
       }
-      if (allowedListIps != null) {
-        args.add(String.format("--allowed-ips=%s", allowedListIps));
-      }
-      if (Boolean.TRUE.equals(disableBuildCheck)) {
-        args.add("--disable-build-check");
-      }
-
       return List.copyOf(args);
     }
 

--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -44,6 +44,7 @@ import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.net.UrlChecker;
@@ -518,5 +519,39 @@ public class DriverService implements Closeable {
 
     protected abstract DS createDriverService(
         File exe, int port, Duration timeout, List<String> args, Map<String, String> environment);
+
+    protected void createCommonArgs(Boolean readableTimestamp, Boolean appendLog,
+                                    ChromiumDriverLogLevel logLevel, String allowedListIps,
+                                    Boolean disableBuildCheck, List<String> args) {
+
+      args.add(String.format("--port=%d", getPort()));
+
+      if (getLogFile() != null) {
+        args.add(String.format("--log-path=%s", getLogFile().getAbsolutePath()));
+        if (Boolean.TRUE.equals(readableTimestamp)) {
+          args.add("--readable-timestamp");
+        }
+        if (Boolean.TRUE.equals(appendLog)) {
+          args.add("--append-log");
+        }
+        withLogOutput(
+          OutputStream.nullOutputStream()); // Do not overwrite log file in getLogOutput()
+      }
+
+      if (logLevel != null) {
+        args.add(String.format("--log-level=%s", logLevel.toString().toUpperCase()));
+      }
+      if (allowedListIps != null) {
+        args.add(String.format("--allowed-ips=%s", allowedListIps));
+      }
+      if (Boolean.TRUE.equals(disableBuildCheck)) {
+        args.add("--disable-build-check");
+      }
+    }
+
+   }
   }
-}
+
+
+
+


### PR DESCRIPTION
### Description
The argument creation process within EdgeDriverService, ChromeDriverService, and DriverService classes has been refactored to improve code readability and maintainability. Common argument creation code was abstracted into a new method named `createCommonArgs` in the base DriverService class. This eliminates code duplication across different classes and increases maintainability.

### Motivation and Context
The motivation behind this change was to enhance the readability and maintainability of the codebase by removing duplicated argument creation logic. The new method, `createCommonArgs`, centralizes common code, making it easier to manage and reducing the chances of inconsistencies.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
