### PR TITLE
[CI] Update logic for which tests get run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,11 @@ jobs:
               pypi__pip: py/requirements_lock.txt
               rules_ruby_dist: rb/ruby_version.bzl
           repository-cache: true
-      - name: Get second parent of the merge commit
-        if: github.event_name == 'pull_request'
-        id: sha-parent
-        run: |
-          echo "PARENT_SHA=$(git rev-parse ${{ github.sha }}^2)" >> $GITHUB_ENV
-      - name: Set COMMIT_RANGE for pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "COMMIT_RANGE=${{ github.event.pull_request.base.sha }}..$PARENT_SHA" >> $GITHUB_ENV
-      - name: Set COMMIT_RANGE for non-pull request events
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "COMMIT_RANGE=${{ github.event.before }}..${{ github.sha }}" >> $GITHUB_ENV
       - name: Check Bazel targets
         id: check-targets
         run: ./scripts/github-actions/check-bazel-targets.sh
+        env:
+          COMMIT_RANGE: ${{ github.event.pull_request.base.sha || github.event.before }}..${{ github.event.pull_request.head.sha || github.sha }}
 
   dotnet:
     name: .NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,22 @@ jobs:
               pypi__pip: py/requirements_lock.txt
               rules_ruby_dist: rb/ruby_version.bzl
           repository-cache: true
+      - name: Get second parent of the merge commit
+        if: github.event_name == 'pull_request'
+        id: sha-parent
+        run: |
+          echo "PARENT_SHA=$(git rev-parse ${{ github.sha }}^2)" >> $GITHUB_ENV
+      - name: Set COMMIT_RANGE for pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "COMMIT_RANGE=${{ github.event.pull_request.base.sha }}..$PARENT_SHA" >> $GITHUB_ENV
+      - name: Set COMMIT_RANGE for non-pull request events
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "COMMIT_RANGE=${{ github.event.before }}..${{ github.sha }}" >> $GITHUB_ENV
       - name: Check Bazel targets
         id: check-targets
         run: ./scripts/github-actions/check-bazel-targets.sh
-        env:
-          COMMIT_RANGE: ${{ github.event.pull_request.base.sha || github.event.before }}..${{ github.sha }}
 
   dotnet:
     name: .NET


### PR DESCRIPTION
For instance I have this PR:
https://github.com/SeleniumHQ/selenium/pull/13452/commits

The GitHub Workflow evaluates as:
https://github.com/SeleniumHQ/selenium/actions/runs/7572844428/job/20623620638#step:4:7

Which you can see includes things that were added to trunk since the PR was made:
https://github.com/SeleniumHQ/selenium/compare/6127b5f8493c9e96792484254bacd0eb4fd1f47a...ac3be186b9e8b13197b39713348f1d96a2182a11

The commit getting used (`github.event.pull_request.base.sha`) is the merge commit. This PR gets the parent of that commit and uses that instead. If it isn't a PR it keeps current behavior.

Example of this PR in same context:
https://github.com/SeleniumHQ/selenium/actions/runs/7574277822/job/20628303353#step:7:8
which shows just the commits we want:
https://github.com/SeleniumHQ/selenium/compare/6127b5f8493c9e96792484254bacd0eb4fd1f47a...1d4472470c980f6901b7cd42a8e4dde0907781df

This has the advantage of not running extra tests based on what has been added to trunk since the PR was created and/or not requiring clicking the "update branch" button. I can't think of a scenario where this isn't what we want to do, but maybe I'm missing something? 