### PR TITLE
[build] create workflow to PR changes to browser versions

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -140,3 +140,12 @@ jobs:
           title: "Nightly"
           prerelease: true
           files: ${{ inputs.nightly-release-files }}
+      - name: Save changes
+        run: |
+          git diff > changes.patch
+      - name: "Upload changes"
+        uses: actions/upload-artifact@v3
+        with:
+          name: patch-file
+          path: changes.patch
+          retention-days: 6

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -1,0 +1,46 @@
+name: Pin Browsers
+on:
+  schedule:
+    - cron: 10 0 * * *
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update Pinned Browsers
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Pin Browsers
+      cache-key: pin-browsers
+      run: bazel run //scripts:pinned_browsers
+
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: update
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download patch
+        uses: actions/download-artifact@v2
+        with:
+          name: patch-file
+      - name: Apply Patch
+        run: |
+          git apply changes.patch
+          rm changes.patch
+      - name: Check Changes
+        run: |
+          if [[ -n $(git status --porcelain common/repositories.bzl) ]]; then
+          echo "CHANGES_FOUND=true" >> $GITHUB_ENV
+          fi
+      - name: Create Pull Request
+        if: env.CHANGES_FOUND == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          add-paths: common/repositories.bzl
+          commit-message: Update pinned browser versions
+          committer: Selenium CI Bot <selenium-ci@users.noreply.github.com>
+          author: Selenium CI Bot <selenium-ci@users.noreply.github.com>
+          title: "Automated Browser Version Update"
+          body: "This is an automated pull request to update pinned browsers and drivers"
+          branch: "pinned-browser-updates"

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -18,9 +18,9 @@ jobs:
     needs: update
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download patch
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: patch-file
       - name: Apply Patch

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -14,6 +14,7 @@ jobs:
       run: bazel run //scripts:pinned_browsers
 
   pull-request:
+    if: github.repository_owner == 'seleniumhq'
     runs-on: ubuntu-latest
     needs: update
     steps:


### PR DESCRIPTION
This is set to run daily and create a PR with any changes.

The PR will look like this: https://github.com/titusfortner/selenium/pull/54

(I'm not sure why it was posted as me and not the CI bot, but it was posted by this action: https://github.com/titusfortner/selenium/actions/runs/7585149002)

I did this with patch files in case we want to use this approach for other things in the future.