### PR TITLE
[py] adds PyPI classifiers for Python 3.10 to 3.12

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -49,7 +49,10 @@ setup_args = {
                     'Topic :: Software Development :: Libraries',
                     'Programming Language :: Python',
                     'Programming Language :: Python :: 3.8',
-                    'Programming Language :: Python :: 3.9'],
+                    'Programming Language :: Python :: 3.9',
+                    'Programming Language :: Python :: 3.10',
+                    'Programming Language :: Python :: 3.11',
+                    'Programming Language :: Python :: 3.12'],
     'package_dir': {
         'selenium': 'selenium',
         'selenium.common': 'selenium/common',


### PR DESCRIPTION
### Description

Sync'ing PyPI page with what's actually supported. Closes https://github.com/SeleniumHQ/selenium/issues/13472.

### Motivation and Context

Helping people know what versions are supported

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
