### PR TITLE
[py] deprecate FirefoxBinary class

### DIFF
--- a/py/selenium/webdriver/firefox/firefox_binary.py
+++ b/py/selenium/webdriver/firefox/firefox_binary.py
@@ -23,10 +23,13 @@ from subprocess import DEVNULL
 from subprocess import STDOUT
 from subprocess import Popen
 
+from typing_extensions import deprecated
+
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common import utils
 
 
+@deprecated("Use binary_location property in Firefox Options to set location")
 class FirefoxBinary:
     NO_FOCUS_LIBRARY_NAME = "x_ignore_nofocus.so"
 

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -69,7 +69,7 @@ class Options(ArgOptions):
         """Sets the location of the browser binary by string."""
         if not isinstance(value, str):
             raise TypeError(self.BINARY_LOCATION_ERROR)
-        self.binary = value
+        self._binary_location = value
 
     @property
     def preferences(self) -> dict:

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -14,8 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import typing
 from typing import Union
+
+from typing_extensions import deprecated
 
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.options import ArgOptions
@@ -38,28 +39,30 @@ class Options(ArgOptions):
 
     def __init__(self) -> None:
         super().__init__()
-        self._binary: typing.Optional[FirefoxBinary] = None
+        self._binary_location = ""
         self._preferences: dict = {}
         self._profile = None
         self.log = Log()
 
     @property
+    @deprecated("use binary_location instead")
     def binary(self) -> FirefoxBinary:
         """Returns the FirefoxBinary instance."""
-        return self._binary
+        return FirefoxBinary(self._binary_location)
 
     @binary.setter
+    @deprecated("use binary_location instead")
     def binary(self, new_binary: Union[str, FirefoxBinary]) -> None:
         """Sets location of the browser binary, either by string or
         ``FirefoxBinary`` instance."""
-        if not isinstance(new_binary, FirefoxBinary):
-            new_binary = FirefoxBinary(new_binary)
-        self._binary = new_binary
+        if isinstance(new_binary, FirefoxBinary):
+            new_binary = new_binary._start_cmd
+        self.binary_location = new_binary
 
     @property
     def binary_location(self) -> str:
         """:Returns: The location of the binary."""
-        return self.binary._start_cmd
+        return self._binary_location
 
     @binary_location.setter  # noqa
     def binary_location(self, value: str) -> None:
@@ -102,8 +105,8 @@ class Options(ArgOptions):
         caps = self._caps
         opts = {}
 
-        if self._binary:
-            opts["binary"] = self._binary._start_cmd
+        if self._binary_location:
+            opts["binary"] = self._binary_location
         if self._preferences:
             opts["prefs"] = self._preferences
         if self._profile:

--- a/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
+++ b/py/test/unit/selenium/webdriver/firefox/firefox_options_tests.py
@@ -34,12 +34,12 @@ def options():
 def test_set_binary_with_firefox_binary(options):
     binary = FirefoxBinary("foo")
     options.binary = binary
-    assert options._binary == binary
+    assert options.binary_location == "foo"
 
 
 def test_set_binary_with_path(options):
     options.binary = "/foo"
-    assert options._binary._start_cmd == "/foo"
+    assert options.binary_location == "/foo"
 
 
 def test_get_binary(options):
@@ -49,11 +49,11 @@ def test_get_binary(options):
 
 def test_set_binary_location(options):
     options.binary_location = "/foo"
-    assert options._binary._start_cmd == "/foo"
+    assert options.binary_location == "/foo"
 
 
 def test_get_binary_location(options):
-    options._binary = FirefoxBinary("/foo")
+    options._binary_location = "/foo"
     assert options.binary_location == "/foo"
 
 
@@ -131,7 +131,7 @@ def test_set_log_level(options):
 def test_creates_capabilities(options):
     profile = FirefoxProfile()
     options._arguments = ["foo"]
-    options._binary = FirefoxBinary("/bar")
+    options._binary_location = "/bar"
     options._preferences = {"foo": "bar"}
     options.proxy = Proxy({"proxyType": ProxyType.MANUAL})
     options._profile = profile


### PR DESCRIPTION
### Description
Deprecates the class and the properties on Firefox Options that is the only place the class is used

### Motivation and Context
The class was created to manage starting and stopping the browser, which has not been necessary since the move to geckodriver. It is currently only used for storing the location of the browser, which is already duplicated behavior of binary_location() method.

Note: making use of the new deprecated annotation which is nice.