### PR TITLE
[py] Fix type error in mypy

### DIFF
--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -418,7 +418,7 @@ class ArgOptions(BaseOptions):
         """:Returns: A list of arguments needed for the browser."""
         return self._arguments
 
-    def add_argument(self, argument):
+    def add_argument(self, argument) -> None:
         """Adds an argument to the list.
 
         :Args:


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Because the return type of the `add_argument` method was not specified, mypy generated a `no-untyped-call` error.
This error occurs when you call the `add_argument` method in a typed method.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will help you avoid unexpected errors that may be generated by typecheckers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
