### PR TITLE
Fix typo in setup.py

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -72,7 +72,7 @@ setup_args = {
                  'selenium.webdriver.support', ],
     'include_package_data': True,
     'install_requires': [
-        "typing_extensions~= 4.9",
+        "typing-extensions~= 4.9",
         "urllib3[socks]>=1.26,<3",
         "trio~=0.17",
         "trio-websocket~=0.9",


### PR DESCRIPTION
Fixes #13486.

The issue wasn't fixed by #13487. The package name is `typing-extensions`, not `typing_extensions`.

I validated that the wheel built with these changes does require `typing-extensions` now.

<!--- Provide a general summary of your changes in the Title above -->

### Description
Changing `typing_extensions` to `typing-extensions`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
