### PR TITLE
Use PrivateAssets=compile to avoid exposing Newtonsoft.json to downstream consumers

### DIFF
--- a/dotnet/src/webdriver/WebDriver.csproj
+++ b/dotnet/src/webdriver/WebDriver.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" PrivateAssets="compile" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Description

Use PrivateAssets=compile to avoid exposing Newtonsoft.json to downstream consumers. 

### Motivation and Context

Currently, the Newtonsoft.json public API surface is exposed to all consumers whether they want to use it or not. With this change consumers will only see the API as being available if it is referenced on purpose.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Only a breaking change in that consuming projects would need to add a direct reference to Newtonsoft.json if they want to use it and it isn't referenced elsewhere.**

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

