### PR TITLE
[dotnet] Fix protocol cdp version for remote webdriver

### DIFF
--- a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
@@ -433,6 +433,11 @@ namespace OpenQA.Selenium.Remote
         /// <returns>The active session to use to communicate with the Developer Tools debugging protocol.</returns>
         public DevToolsSession GetDevToolsSession(DevToolsOptions options)
         {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             if (this.devToolsSession == null)
             {
                 if (!this.Capabilities.HasCapability(RemoteDevToolsEndPointCapabilityName))
@@ -453,6 +458,8 @@ namespace OpenQA.Selenium.Remote
                 {
                     throw new WebDriverException("Cannot parse protocol version from reported version string: " + version);
                 }
+
+                options.ProtocolVersion = devToolsProtocolVersion;
 
                 try
                 {

--- a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
@@ -445,21 +445,24 @@ namespace OpenQA.Selenium.Remote
                     throw new WebDriverException("Cannot find " + RemoteDevToolsEndPointCapabilityName + " capability for driver");
                 }
 
-                if (!this.Capabilities.HasCapability(RemoteDevToolsVersionCapabilityName))
+                if (!options.ProtocolVersion.HasValue || options.ProtocolVersion == DevToolsSession.AutoDetectDevToolsProtocolVersion)
                 {
-                    throw new WebDriverException("Cannot find " + RemoteDevToolsVersionCapabilityName + " capability for driver");
+                    if (!this.Capabilities.HasCapability(RemoteDevToolsVersionCapabilityName))
+                    {
+                        throw new WebDriverException("Cannot find " + RemoteDevToolsVersionCapabilityName + " capability for driver");
+                    }
+
+                    string debuggerAddress = this.Capabilities.GetCapability(RemoteDevToolsEndPointCapabilityName).ToString();
+                    string version = this.Capabilities.GetCapability(RemoteDevToolsVersionCapabilityName).ToString();
+
+                    bool versionParsed = int.TryParse(version.Substring(0, version.IndexOf(".")), out int devToolsProtocolVersion);
+                    if (!versionParsed)
+                    {
+                        throw new WebDriverException("Cannot parse protocol version from reported version string: " + version);
+                    }
+
+                    options.ProtocolVersion = devToolsProtocolVersion;
                 }
-
-                string debuggerAddress = this.Capabilities.GetCapability(RemoteDevToolsEndPointCapabilityName).ToString();
-                string version = this.Capabilities.GetCapability(RemoteDevToolsVersionCapabilityName).ToString();
-
-                bool versionParsed = int.TryParse(version.Substring(0, version.IndexOf(".")), out int devToolsProtocolVersion);
-                if (!versionParsed)
-                {
-                    throw new WebDriverException("Cannot parse protocol version from reported version string: " + version);
-                }
-
-                options.ProtocolVersion = devToolsProtocolVersion;
 
                 try
                 {

--- a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
@@ -445,14 +445,15 @@ namespace OpenQA.Selenium.Remote
                     throw new WebDriverException("Cannot find " + RemoteDevToolsEndPointCapabilityName + " capability for driver");
                 }
 
+                string debuggerAddress = this.Capabilities.GetCapability(RemoteDevToolsEndPointCapabilityName).ToString();
+
                 if (!options.ProtocolVersion.HasValue || options.ProtocolVersion == DevToolsSession.AutoDetectDevToolsProtocolVersion)
                 {
                     if (!this.Capabilities.HasCapability(RemoteDevToolsVersionCapabilityName))
                     {
                         throw new WebDriverException("Cannot find " + RemoteDevToolsVersionCapabilityName + " capability for driver");
                     }
-
-                    string debuggerAddress = this.Capabilities.GetCapability(RemoteDevToolsEndPointCapabilityName).ToString();
+                    
                     string version = this.Capabilities.GetCapability(RemoteDevToolsVersionCapabilityName).ToString();
 
                     bool versionParsed = int.TryParse(version.Substring(0, version.IndexOf(".")), out int devToolsProtocolVersion);


### PR DESCRIPTION
### Description
Regression issue, it fixes determination of cdp version, returned back to the remote webdriver in capabilities.

### Motivation and Context
Fixes https://github.com/SeleniumHQ/selenium/issues/13502

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
