### PR TITLE
[ci] automatically update PRs with format fixes

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -51,11 +51,17 @@ on:
         required: false
         type: string
         default: 'ignore-artifacts'
+      ignore-failure:
+        description: Ignore failure
+        required: false
+        type: string
+        default: false
 
 jobs:
   bazel:
     name: ${{ inputs.name }}
     runs-on: ${{ inputs.os }}-latest
+    continue-on-error: ${{ inputs.ignore-failure == 'true' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SEL_M2_USER: ${{ secrets.SEL_M2_USER }}

--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -6,11 +6,13 @@ on:
     branches:
       - trunk
   workflow_dispatch:
+  issues:
+    types: [ labeled ]
 
 jobs:
   format:
     name: Format
-    if: github.repository_owner == 'seleniumhq'
+    if: github.repository_owner == 'seleniumhq' && github.event_name != 'issues'
     uses: ./.github/workflows/bazel.yml
     with:
       name: Check format script run
@@ -18,12 +20,13 @@ jobs:
       ruby-version: jruby-9.4.5.0
       run: ./scripts/github-actions/check-format.sh
       artifact-name: format-fixes
+      ignore-failure: true
 
   push_fixes:
     name: Push changes
     runs-on: ubuntu-latest
     needs: format
-    if: github.event_name != 'push' && ${{ failure() }}
+    if: github.event_name != 'push' && ${{ failure() }} && github.event_name != 'issues'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,10 +54,49 @@ jobs:
         with:
           github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
           branch: ${{ github.head_ref }}
+      - name: Add label
+        uses: actions/github-script@v7
+        with:
+          github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['rerun-tests']
+            })
+
+  re_format:
+    name: Format Fixed
+    if: github.repository_owner == 'seleniumhq' && (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Check format script run
+      cache-key: rbe
+      ruby-version: jruby-9.4.5.0
+      run: ./scripts/github-actions/check-format.sh
+      artifact-name: format-fixes
+
+  remove_label:
+    name: Remove Label
+    needs: re_format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        uses: actions/github-script@v7
+        with:
+          github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          script: |
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['rerun-tests']
+            })
 
   test:
     name: Test
-    if: github.repository_owner == 'seleniumhq'
+    if: github.repository_owner == 'seleniumhq' && (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
     uses: ./.github/workflows/bazel.yml
     with:
       # TODO: experiment with turning off caches

--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Add label
         uses: actions/github-script@v7
         with:
-          github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,
@@ -68,7 +67,7 @@ jobs:
 
   re_format:
     name: Format Fixed
-    if: github.repository_owner == 'seleniumhq' && (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
+    if: github.repository_owner == 'seleniumhq' && github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'rerun-tests')
     uses: ./.github/workflows/bazel.yml
     with:
       name: Check format script run
@@ -85,7 +84,6 @@ jobs:
       - name: Remove label
         uses: actions/github-script@v7
         with:
-          github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
           script: |
             github.issues.removeLabel({
               issue_number: context.issue.number,

--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -17,6 +17,40 @@ jobs:
       cache-key: rbe
       ruby-version: jruby-9.4.5.0
       run: ./scripts/github-actions/check-format.sh
+      artifact-name: format-fixes
+
+  push_fixes:
+    name: Push changes
+    runs-on: ubuntu-latest
+    needs: format
+    if: github.event_name != 'push' && ${{ failure() }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Download patch
+        uses: actions/download-artifact@v4
+        with:
+          name: format-fixes
+      - name: Apply Patch
+        run: |
+          git apply changes.patch
+          rm changes.patch
+      - name: Commit files
+        id: git
+        run: |
+          export CHANGES=$(git status -s)
+          if [ -n "$CHANGES" ]; then
+            git config --local user.email "selenium-ci@users.noreply.github.com"
+            git config --local user.name "Selenium CI Bot"
+            git commit -am "fix formatting errors"
+          fi
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          branch: ${{ github.head_ref }}
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "0 */12 * * *"
   workflow_dispatch:
+  issues:
+    types: [ labeled ]
 
 jobs:
   check:
@@ -43,55 +45,59 @@ jobs:
     needs: check
     uses: ./.github/workflows/ci-dotnet.yml
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//dotnet') ||
       contains(join(github.event.commits.*.message), '[dotnet]') ||
-      contains(github.event.pull_request.title, '[dotnet]')
-
+      contains(github.event.pull_request.title, '[dotnet]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
   java:
     name: Java
     needs: check
     uses: ./.github/workflows/ci-java.yml
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//java') ||
       contains(join(github.event.commits.*.message), '[java]') ||
-      contains(github.event.pull_request.title, '[java]')
+      contains(github.event.pull_request.title, '[java]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
 
   javascript:
     name: JavaScript
     needs: check
     uses: ./.github/workflows/ci-javascript.yml
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//javascript') ||
       contains(join(github.event.commits.*.message), '[js]') ||
-      contains(github.event.pull_request.title, '[js]')
+      contains(github.event.pull_request.title, '[js]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
 
   python:
     name: Python
     needs: check
     uses: ./.github/workflows/ci-python.yml
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//py') ||
       contains(join(github.event.commits.*.message), '[py]') ||
-      contains(github.event.pull_request.title, '[py]')
+      contains(github.event.pull_request.title, '[py]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
 
   ruby:
     name: Ruby
     needs: check
     uses: ./.github/workflows/ci-ruby.yml
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//rb') ||
       contains(join(github.event.commits.*.message), '[rb]') ||
-      contains(github.event.pull_request.title, '[rb]')
+      contains(github.event.pull_request.title, '[rb]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))
 
   rust:
     name: Rust
@@ -100,8 +106,9 @@ jobs:
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
     if: >
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(needs.check.outputs.targets, '//rust') ||
       contains(join(github.event.commits.*.message), '[rust]') ||
-      contains(github.event.pull_request.title, '[rust]')
+      contains(github.event.pull_request.title, '[rust]')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'rerun-tests'))

--- a/java/src/org/openqa/selenium/chromium/AddHasCasting.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasCasting.java
@@ -59,10 +59,12 @@ public abstract class AddHasCasting
 
       @Override
       public void selectCastSink(String deviceName) {
-        Require.nonNull("Device Name", deviceName);
+                Require.nonNull("Device Name", deviceName);
 
         executeMethod.execute(SET_CAST_SINK_TO_USE, Map.of("sinkName", deviceName));
       }
+
+
 
       @Override
       public void startDesktopMirroring(String deviceName) {

--- a/java/src/org/openqa/selenium/chromium/AddHasCasting.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasCasting.java
@@ -59,12 +59,10 @@ public abstract class AddHasCasting
 
       @Override
       public void selectCastSink(String deviceName) {
-                Require.nonNull("Device Name", deviceName);
+        Require.nonNull("Device Name", deviceName);
 
         executeMethod.execute(SET_CAST_SINK_TO_USE, Map.of("sinkName", deviceName));
       }
-
-
 
       @Override
       public void startDesktopMirroring(String deviceName) {

--- a/scripts/github-actions/check-format.sh
+++ b/scripts/github-actions/check-format.sh
@@ -17,8 +17,4 @@ else
   # Fail the build if the format script needs to be re-run
   ./scripts/format.sh
   git diff --exit-code
-
-  # Now we're made it out, reapply changes made by the build
-  # runner
-  git reset --soft HEAD^
 fi


### PR DESCRIPTION
### Status
Well, now I'm trying to see if I can do something complicated and add a label to rerun tests if there has been an automatic reformatting. It's set up so that it shouldn't end up in a loop. Not sure it is worth going this far, though.

### Description
Uses what was done for automatically pinning browsers
Creates a patch file with format changes
In a new job applies the patch file and commits it
pushes the resulting commit back to the PR

### Motivation and Context
It's a pain to ask people to fix formatting in their PRs

I introduced formatting bugs in the PR so this should push to the PR. 🤞 

There we go, it works!
https://github.com/SeleniumHQ/selenium/pull/13514/commits/36ccb886d4d4a99972f8159193fed0ebf2d6e04c