### PR TITLE
[ci] upgrade upload and download actions to v4

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ''
+      artifact-name:
+        description: Name of artifact to upload
+        required: false
+        type: string
+        default: 'ignore-artifacts'
 
 jobs:
   bazel:
@@ -141,11 +146,13 @@ jobs:
           prerelease: true
           files: ${{ inputs.nightly-release-files }}
       - name: Save changes
+        if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
         run: |
           git diff > changes.patch
       - name: "Upload changes"
-        uses: actions/upload-artifact@v3
+        if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
+        uses: actions/upload-artifact@v4
         with:
-          name: patch-file
+          name: ${{ inputs.artifact-name }}
           path: changes.patch
           retention-days: 6

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "Rename binary"
         run: mv rust/target/release/selenium-manager.exe selenium-manager-windows.exe
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-windows
           path: selenium-manager-windows.exe
@@ -83,7 +83,7 @@ jobs:
       - name: "Rename binary"
         run: mv rust/target/debug/selenium-manager.exe selenium-manager-windows-debug.exe
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-windows-debug
           path: selenium-manager-windows-debug.exe
@@ -111,7 +111,7 @@ jobs:
       - name: "Rename binary"
         run: mv rust/target/x86_64-unknown-linux-musl/release/selenium-manager selenium-manager-linux
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-linux
           path: selenium-manager-linux
@@ -140,7 +140,7 @@ jobs:
           tar -cvf ../../../../selenium-manager-linux-debug.tar selenium-manager
         working-directory: rust
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-linux-debug
           path: selenium-manager-linux-debug.tar
@@ -170,7 +170,7 @@ jobs:
             target/x86_64-apple-darwin/release/selenium-manager
         working-directory: rust
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-macos
           path: rust/target/selenium-manager-macos
@@ -202,7 +202,7 @@ jobs:
           tar -cvf ../../selenium-manager-macos-debug.tar selenium-manager
         working-directory: rust
       - name: "Upload release binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-manager-macos-debug
           path: selenium-manager-macos-debug.tar
@@ -220,7 +220,7 @@ jobs:
           token: ${{ secrets.SELENIUM_CI_TOKEN }}
           repository: SeleniumHQ/selenium_manager_artifacts
       - name: "Download Artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: "Prepare and Commit"

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -12,6 +12,7 @@ jobs:
       name: Pin Browsers
       cache-key: pin-browsers
       run: bazel run //scripts:pinned_browsers
+      artifact-name: pinned-browsers
 
   pull-request:
     if: github.repository_owner == 'seleniumhq'
@@ -23,7 +24,7 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v4
         with:
-          name: patch-file
+          name: pinned-browsers
       - name: Apply Patch
         run: |
           git apply changes.patch


### PR DESCRIPTION
### Description
* update upload and download actions to v4
* pass in artifact name since v4 does not allow the same artifact with multiple names
* don't save or upload if not requested

### Motivation and Context
Trying to do more things with these artifact uploads and there are problems...
(#13513 & #13514)
Also notice that pinned_browser action stopped working because of the upgrade Alex requested I make to v4
