### PR TITLE
Update license date for Ruby README

### DIFF
--- a/rb/README.md
+++ b/rb/README.md
@@ -15,7 +15,7 @@ This gem provides Ruby bindings for Selenium and supports MRI >= 3.0.
 
 ## License
 
-Copyright 2009-2023 Software Freedom Conservancy
+Copyright 2009-2024 Software Freedom Conservancy
 
 Licensed to the Software Freedom Conservancy (SFC) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Really simple PR to update the date from `2023` to `2024` in the README
