### PR TITLE
[rust] Add timestamps to Selenium Manager logs

### DIFF
--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -17,7 +17,6 @@
 
 use crate::config::BooleanKey;
 use crate::metadata::now_unix_timestamp;
-use env_logger::fmt::Color;
 use env_logger::Target::Stdout;
 use env_logger::DEFAULT_FILTER_ENV;
 use log::Level;
@@ -26,9 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::env;
 use std::fmt::Display;
-use std::io::Write;
 use std::ops::Deref;
-use Color::{Blue, Cyan, Green, Red, Yellow};
 
 pub const DRIVER_PATH: &str = "Driver path: ";
 pub const BROWSER_PATH: &str = "Browser path: ";
@@ -99,22 +96,8 @@ impl Logger {
                     env_logger::Builder::new()
                         .filter_module(env!("CARGO_CRATE_NAME"), filter)
                         .target(Stdout)
-                        .format(|buf, record| {
-                            let mut level_style = buf.style();
-                            match record.level() {
-                                Level::Trace => level_style.set_color(Cyan),
-                                Level::Debug => level_style.set_color(Blue),
-                                Level::Info => level_style.set_color(Green),
-                                Level::Warn => level_style.set_color(Yellow),
-                                Level::Error => level_style.set_color(Red).set_bold(true),
-                            };
-                            writeln!(
-                                buf,
-                                "{}\t{}",
-                                level_style.value(record.level()),
-                                record.args()
-                            )
-                        })
+                        .format_target(false)
+                        .format_timestamp_millis()
                         .try_init()
                         .unwrap_or_default();
                 } else {


### PR DESCRIPTION
### Description
This PR allows to log the timestamp in the regular (`LOGGER`) output type, as follows:

```
./selenium-manager --browser chrome --debug
[2024-02-07T10:20:05.129Z DEBUG] chromedriver not found in PATH
[2024-02-07T10:20:05.130Z DEBUG] chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
[2024-02-07T10:20:05.132Z DEBUG] Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
[2024-02-07T10:20:05.214Z DEBUG] Output: "\r\r\n\r\r\nVersion=121.0.6167.140\r\r\n\r\r\n\r\r\n\r"
[2024-02-07T10:20:05.220Z DEBUG] Detected browser: chrome 121.0.6167.140
[2024-02-07T10:20:05.223Z DEBUG] Required driver: chromedriver 121.0.6167.85
[2024-02-07T10:20:05.223Z DEBUG] chromedriver 121.0.6167.85 already in the cache
[2024-02-07T10:20:05.224Z INFO ] Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\121.0.6167.85\chromedriver.exe
[2024-02-07T10:20:05.224Z INFO ] Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

### Motivation and Context
Requested in #13421.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
