### PR TITLE
[rust] Selenium Manager decrease frequency of statistics reporting

### DIFF
--- a/rust/src/stats.rs
+++ b/rust/src/stats.rs
@@ -28,7 +28,7 @@ const SM_USER_AGENT: &str = "Selenium Manager {}";
 const APP_JSON: &str = "application/json";
 const PAGE_VIEW: &str = "pageview";
 const SELENIUM_DOMAIN: &str = "manager.selenium.dev";
-const SM_STATS_URL: &str = "https://{}/sm-stats";
+const SM_STATS_URL: &str = "https://{}/sm-usage";
 const REQUEST_TIMEOUT_SEC: u64 = 3;
 
 #[derive(Default, Serialize, Deserialize)]
@@ -39,7 +39,7 @@ pub struct Data {
     pub props: Props,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Props {
     pub browser: String,
     pub browser_version: String,


### PR DESCRIPTION
### Description
This PR makes SM decrease the frequency of statistics reporting, as requested and discussed on #13521.

To decrease this frequency, we rely on the value of TTL, one day by default. This way, when the same stats properties are used (i.e., the properties sent to Plausible: `browser`, `browser_version`, `os`, `arch`, `lang`, and `selenium_version`), the request to Plausible will be done only once. For that, the SM metadata file is used (`~/.cache/selenium/sm-metadata.json`). For example, when calling SM for the first time:

```
./selenium-manager --browser chrome --debug

DEBUG   Sending stats to Plausible: Props { browser: "chrome", browser_version: "", os: "windows", arch: "amd64", lang: "", selenium_version: "4.18-nightly" }
DEBUG   chromedriver not found in PATH
DEBUG   chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
DEBUG   Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
DEBUG   Output: "\r\r\n\r\r\nVersion=121.0.6167.140\r\r\n\r\r\n\r\r\n\r"
DEBUG   Detected browser: chrome 121.0.6167.140
DEBUG   Discovering versions from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
DEBUG   Required driver: chromedriver 121.0.6167.85
DEBUG   chromedriver 121.0.6167.85 already in the cache
INFO    Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\121.0.6167.85\chromedriver.exe
INFO    Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

After that, the metadata file will contain the following:

```
{
  "browsers": [],
  "drivers": [
    {
      "major_browser_version": "121",
      "driver_name": "chromedriver",
      "driver_version": "121.0.6167.85",
      "driver_ttl": 1707308646
    }
  ],
  "stats": [
    {
      "browser": "chrome",
      "browser_version": "",
      "os": "windows",
      "arch": "amd64",
      "lang": "",
      "selenium_version": "4.18-nightly",
      "stats_ttl": 1707308646
    }
  ]
}
```

The field `stats_ttl` is used in the following same calls (in terms of properties) to prevent requesting Plausible again. Only when `stats_ttl` is stale (i.e., in 1 day), the same properties will be sent to Plausible.

Note that, as discussed on Slack, the path for the new calls to Plausible is `/sm-usage`. Plausible already has counted my tests:

https://plausible.io/manager.selenium.dev

### Motivation and Context
This PR implements #13521.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
