### PR TITLE
[java] Allow `null` input in `FluentWait`

### DIFF
--- a/java/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -89,7 +89,7 @@ public class FluentWait<T> implements Wait<T> {
    * @param sleeper Used to put the thread to sleep between evaluation loops.
    */
   public FluentWait(T input, java.time.Clock clock, Sleeper sleeper) {
-    this.input = Require.nonNull("Input", input);
+    this.input = input;
     this.clock = Require.nonNull("Clock", clock);
     this.sleeper = Require.nonNull("Sleeper", sleeper);
   }


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
`input` in `FluentWait` should be handled by users in `Function<? super T, V> isTrue`.

### Motivation and Context
There is no reason to require `input` if `Function` implementation doesn't require such input. More generic solution is to overload the methods to allow to pass `Supplier` alongside with `Function`, but it will require changes in API.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
