### PR TITLE
Update documentation link in readme

### DIFF
--- a/rb/README.md
+++ b/rb/README.md
@@ -10,7 +10,7 @@ This gem provides Ruby bindings for Selenium and supports MRI >= 3.0.
 
 * https://rubygems.org/gems/selenium-webdriver
 * https://www.selenium.dev/selenium/docs/api/rb/index.html
-* https://www.selenium.dev/documentation/
+* https://www.selenium.dev/documentation/?tab=ruby
 * https://github.com/SeleniumHQ/selenium/issues
 
 ## License

--- a/rb/README.md
+++ b/rb/README.md
@@ -10,7 +10,7 @@ This gem provides Ruby bindings for Selenium and supports MRI >= 3.0.
 
 * https://rubygems.org/gems/selenium-webdriver
 * https://www.selenium.dev/selenium/docs/api/rb/index.html
-* https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings
+* https://www.selenium.dev/documentation/
 * https://github.com/SeleniumHQ/selenium/issues
 
 ## License


### PR DESCRIPTION
The currently linked wiki page says it is outdated and directs to a new page.