### PR TITLE
[dotnet] Fix network response data encoding

### DIFF
--- a/dotnet/src/webdriver/DevTools/v119/V119Network.cs
+++ b/dotnet/src/webdriver/DevTools/v119/V119Network.cs
@@ -261,7 +261,7 @@ namespace OpenQA.Selenium.DevTools.V119
                     }
                     else
                     {
-                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(bodyResponse.Body);
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v119/V119Network.cs
+++ b/dotnet/src/webdriver/DevTools/v119/V119Network.cs
@@ -257,11 +257,11 @@ namespace OpenQA.Selenium.DevTools.V119
                 {
                     if (bodyResponse.Base64Encoded)
                     {
-                        responseData.Body = Encoding.UTF8.GetString(Convert.FromBase64String(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(Convert.FromBase64String(bodyResponse.Body));
                     }
                     else
                     {
-                        responseData.Body = bodyResponse.Body;
+                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v120/V120Network.cs
+++ b/dotnet/src/webdriver/DevTools/v120/V120Network.cs
@@ -257,11 +257,11 @@ namespace OpenQA.Selenium.DevTools.V120
                 {
                     if (bodyResponse.Base64Encoded)
                     {
-                        responseData.Body = Encoding.UTF8.GetString(Convert.FromBase64String(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(Convert.FromBase64String(bodyResponse.Body));
                     }
                     else
                     {
-                        responseData.Body = bodyResponse.Body;
+                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v120/V120Network.cs
+++ b/dotnet/src/webdriver/DevTools/v120/V120Network.cs
@@ -261,7 +261,7 @@ namespace OpenQA.Selenium.DevTools.V120
                     }
                     else
                     {
-                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(bodyResponse.Body);
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v121/V121Network.cs
+++ b/dotnet/src/webdriver/DevTools/v121/V121Network.cs
@@ -257,11 +257,11 @@ namespace OpenQA.Selenium.DevTools.V121
                 {
                     if (bodyResponse.Base64Encoded)
                     {
-                        responseData.Body = Encoding.UTF8.GetString(Convert.FromBase64String(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(Convert.FromBase64String(bodyResponse.Body));
                     }
                     else
                     {
-                        responseData.Body = bodyResponse.Body;
+                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v121/V121Network.cs
+++ b/dotnet/src/webdriver/DevTools/v121/V121Network.cs
@@ -261,7 +261,7 @@ namespace OpenQA.Selenium.DevTools.V121
                     }
                     else
                     {
-                        responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
+                        responseData.Content = new HttpResponseContent(bodyResponse.Body);
                     }
                 }
             }

--- a/dotnet/src/webdriver/DevTools/v85/V85Network.cs
+++ b/dotnet/src/webdriver/DevTools/v85/V85Network.cs
@@ -255,11 +255,11 @@ namespace OpenQA.Selenium.DevTools.V85
                 var bodyResponse = await fetch.GetResponseBody(new Fetch.GetResponseBodyCommandSettings() { RequestId = responseData.RequestId }).ConfigureAwait(false);
                 if (bodyResponse.Base64Encoded)
                 {
-                    responseData.Body = Encoding.UTF8.GetString(Convert.FromBase64String(bodyResponse.Body));
+                    responseData.Content = new HttpResponseContent(Convert.FromBase64String(bodyResponse.Body));
                 }
                 else
                 {
-                    responseData.Body = bodyResponse.Body;
+                    responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
                 }
             }
         }

--- a/dotnet/src/webdriver/DevTools/v85/V85Network.cs
+++ b/dotnet/src/webdriver/DevTools/v85/V85Network.cs
@@ -259,7 +259,7 @@ namespace OpenQA.Selenium.DevTools.V85
                 }
                 else
                 {
-                    responseData.Content = new HttpResponseContent(Encoding.UTF8.GetBytes(bodyResponse.Body));
+                    responseData.Content = new HttpResponseContent(bodyResponse.Body);
                 }
             }
         }

--- a/dotnet/src/webdriver/HttpResponseContent.cs
+++ b/dotnet/src/webdriver/HttpResponseContent.cs
@@ -1,0 +1,57 @@
+// <copyright file="HttpResponseContent.cs" company="WebDriver Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Text;
+
+namespace OpenQA.Selenium
+{
+    /// <summary>
+    /// Represents the content of an HTTP response.
+    /// </summary>
+    public class HttpResponseContent
+    {
+        private readonly byte[] content;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponseContent"/> class.
+        /// </summary>
+        /// <param name="content">The byte array representing the content of the response.</param>
+        public HttpResponseContent(byte[] content)
+        {
+            this.content = content;
+        }
+
+        /// <summary>
+        /// Reads the content of the response as a UTF8 encoded string.
+        /// </summary>
+        /// <returns>The content of the response as a string.</returns>
+        public string ReadAsString()
+        {
+            return Encoding.UTF8.GetString(content);
+        }
+
+        /// <summary>
+        /// Reads the content of the response as a byte array.
+        /// </summary>
+        /// <returns>The content of the response as a byte array.</returns>
+        public byte[] ReadAsBytes()
+        {
+            return content;
+        }
+    }
+}

--- a/dotnet/src/webdriver/HttpResponseContent.cs
+++ b/dotnet/src/webdriver/HttpResponseContent.cs
@@ -58,7 +58,7 @@ namespace OpenQA.Selenium
         /// Reads the content of the response as a byte array.
         /// </summary>
         /// <returns>The content of the response as a byte array.</returns>
-        public byte[] ReadAsBytes()
+        public byte[] ReadAsByteArray()
         {
             return content;
         }

--- a/dotnet/src/webdriver/HttpResponseContent.cs
+++ b/dotnet/src/webdriver/HttpResponseContent.cs
@@ -37,6 +37,15 @@ namespace OpenQA.Selenium
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponseContent"/> class.
+        /// </summary>
+        /// <param name="content">The UTF8 encoded string representing the content of the response.</param>
+        public HttpResponseContent(string content)
+        {
+            this.content = Encoding.UTF8.GetBytes(content);
+        }
+
+        /// <summary>
         /// Reads the content of the response as a UTF8 encoded string.
         /// </summary>
         /// <returns>The content of the response as a string.</returns>

--- a/dotnet/src/webdriver/HttpResponseData.cs
+++ b/dotnet/src/webdriver/HttpResponseData.cs
@@ -46,7 +46,17 @@ namespace OpenQA.Selenium
         /// <summary>
         /// Gets or sets the body of the HTTP response.
         /// </summary>
-        public string Body => this.Content?.ReadAsString();
+        public string Body
+        {
+            get
+            {
+                return this.Content?.ReadAsString();
+            }
+            set
+            {
+                this.Content = new HttpResponseContent(value);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the content of the HTTP response.

--- a/dotnet/src/webdriver/HttpResponseData.cs
+++ b/dotnet/src/webdriver/HttpResponseData.cs
@@ -16,10 +16,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Data.Common;
-using System.Text;
 
 namespace OpenQA.Selenium
 {
@@ -49,7 +46,12 @@ namespace OpenQA.Selenium
         /// <summary>
         /// Gets or sets the body of the HTTP response.
         /// </summary>
-        public string Body { get; set; }
+        public string Body => this.Content?.ReadAsString();
+
+        /// <summary>
+        /// Gets or sets the content of the HTTP response.
+        /// </summary>
+        public HttpResponseContent Content { get; set; }
 
         /// <summary>
         /// Gets or sets the type of resource for this response.

--- a/dotnet/src/webdriver/NetworkResponseReceivedEventArgs.cs
+++ b/dotnet/src/webdriver/NetworkResponseReceivedEventArgs.cs
@@ -29,7 +29,7 @@ namespace OpenQA.Selenium
         private readonly string requestId;
         private readonly string responseUrl;
         private readonly long responseStatusCode;
-        private readonly string responseBody;
+        private readonly HttpResponseContent responseContent;
         private readonly string responseResourceType;
         private readonly Dictionary<string, string> responseHeaders = new Dictionary<string, string>();
 
@@ -42,7 +42,7 @@ namespace OpenQA.Selenium
             this.requestId = responseData.RequestId;
             this.responseUrl = responseData.Url;
             this.responseStatusCode = responseData.StatusCode;
-            this.responseBody = responseData.Body;
+            this.responseContent = responseData.Content;
             this.responseResourceType = responseData.ResourceType;
             foreach (KeyValuePair<string, string> header in responseData.Headers)
             {
@@ -68,7 +68,15 @@ namespace OpenQA.Selenium
         /// <summary>
         /// Gets the body of the network response.
         /// </summary>
-        public string ResponseBody => this.responseBody;
+        /// <remarks>
+        /// This property is an alias for <see cref="ResponseContent"/>.ReadAsString() to keep backward compatibility.
+        /// </remarks>
+        public string ResponseBody => this.ResponseContent?.ReadAsString();
+
+        /// <summary>
+        /// Gets the content of the network response.
+        /// </summary>
+        public HttpResponseContent ResponseContent => this.responseContent;
 
         /// <summary>
         /// Gets the type of resource of the network response.


### PR DESCRIPTION
### Description
NetworkManager exposes HTTP response body data as `string` type. Not all responses have strings. In case if the response is bytes, selenium is doing extra convertion from `bytes` to `utf8 string`. It leads to data loosing, we cannot convert string back to bytes.

### Motivation and Context
Fix #11726 

### New approach to get data
```csharp
network.NetworkResponseReceived += (sender, e) =>
{
    if (e.ResponseResourceType == "Image")
    {
        Console.WriteLine($"{e.ResponseUrl} : {e.ResponseResourceType}");
        if (!string.IsNullOrEmpty(e.ResponseBody))
        {
            Console.WriteLine(Encoding.UTF8.GetBytes(e.ResponseBody).Length);
        }

        if (e.ResponseContent != null)
        {
            Console.WriteLine(e.ResponseContent.ReadAsByteArray().Length);
        }
    }
};

await network.StartMonitoring();

driver.Url = "https://selenium.dev";
```

And its output is:
```
https://www.selenium.dev/images/sponsors/saucelabs.png : Image
11191
6255
```

where `6255` is correct bytes of the image.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
