### PR TITLE
Use all provided options while merging them for Firefox

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
+++ b/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
@@ -171,6 +171,8 @@ public class SessionCapabilitiesMutator implements Function<Capabilities, Capabi
       Map<String, Object> stereotypeOptions, Map<String, Object> capsOptions) {
     Map<String, Object> toReturn = new HashMap<>(stereotypeOptions);
 
+    List<String> handledOptions = List.of("args", "prefs", "profile", "log", "binary");
+
     for (Map.Entry<String, Object> entry : capsOptions.entrySet()) {
       String name = entry.getKey();
       Object value = entry.getValue();
@@ -214,6 +216,14 @@ public class SessionCapabilitiesMutator implements Function<Capabilities, Capabi
         @SuppressWarnings("unchecked")
         Map<String, Object> logLevelMap = (Map<String, Object>) value;
         toReturn.put("log", logLevelMap);
+      }
+
+      if (name.equals("binary") && !stereotypeOptions.containsKey("binary")) {
+        toReturn.put(name, value);
+      }
+
+      if (!handledOptions.contains(name)) {
+        toReturn.put(name, value);
       }
     }
 

--- a/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
@@ -238,6 +238,7 @@ public class SessionCapabilitiesMutatorTest {
     stereotypeOptions.put("log", debugLog);
 
     stereotypeOptions.put("profile", "profile-string");
+    stereotypeOptions.put("androidDeviceSerial", "emulator-5556");
 
     stereotype =
         new ImmutableCapabilities(
@@ -260,6 +261,7 @@ public class SessionCapabilitiesMutatorTest {
     capabilityOptions.put("profile", "different-profile-string");
 
     capabilityOptions.put("binary", "/path/to/caps/binary");
+    capabilityOptions.put("androidPackage", "com.android.chrome");
 
     capabilities =
         new ImmutableCapabilities(
@@ -304,6 +306,20 @@ public class SessionCapabilitiesMutatorTest {
         .extractingByKey("profile")
         .asInstanceOf(STRING)
         .isEqualTo("different-profile-string");
+
+    assertThat(modifiedCapabilities)
+      .extractingByKey("moz:firefoxOptions")
+      .asInstanceOf(MAP)
+      .extractingByKey("androidDeviceSerial")
+      .asInstanceOf(STRING)
+      .isEqualTo("emulator-5556");
+
+    assertThat(modifiedCapabilities)
+      .extractingByKey("moz:firefoxOptions")
+      .asInstanceOf(MAP)
+      .extractingByKey("androidPackage")
+      .asInstanceOf(STRING)
+      .isEqualTo("com.android.chrome");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
@@ -308,18 +308,18 @@ public class SessionCapabilitiesMutatorTest {
         .isEqualTo("different-profile-string");
 
     assertThat(modifiedCapabilities)
-      .extractingByKey("moz:firefoxOptions")
-      .asInstanceOf(MAP)
-      .extractingByKey("androidDeviceSerial")
-      .asInstanceOf(STRING)
-      .isEqualTo("emulator-5556");
+        .extractingByKey("moz:firefoxOptions")
+        .asInstanceOf(MAP)
+        .extractingByKey("androidDeviceSerial")
+        .asInstanceOf(STRING)
+        .isEqualTo("emulator-5556");
 
     assertThat(modifiedCapabilities)
-      .extractingByKey("moz:firefoxOptions")
-      .asInstanceOf(MAP)
-      .extractingByKey("androidPackage")
-      .asInstanceOf(STRING)
-      .isEqualTo("com.android.chrome");
+        .extractingByKey("moz:firefoxOptions")
+        .asInstanceOf(MAP)
+        .extractingByKey("androidPackage")
+        .asInstanceOf(STRING)
+        .isEqualTo("com.android.chrome");
   }
 
   @Test


### PR DESCRIPTION
### Description
This fix addresses the discrepancy that we have in methods of processing browser options for Chromium(`mergeChromiumOptions`) and Firefox(`mergeFirefoxOptions`). In the case of Chromium, if the option name doesn't match any of previously processed, we add it anyway. It doesn't happen for Firefox. So in the case when one option is set in stereotype, but other is provided in capabilities this second one is missed from the result.

### Motivation and Context
We have observed different behavior with the same setup running tests for Chrome and Firefox. While for Chrome everything worked fine, in case of Firefox provided capability was missed while creating session so that we got an exceptions (in our case, missing `androidPackage` lead to error about missing Firefox binary, which wasn't expected in case of session for mobile device). Updated version of `shouldMergeFirefoxSpecificOptionsFromStereotypeAndCaps` unit test demonstrates this case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
