### PR TITLE
Fixing NPE when "se:downloadsEnabled" not set

### DIFF
--- a/java/src/org/openqa/selenium/HasDownloads.java
+++ b/java/src/org/openqa/selenium/HasDownloads.java
@@ -33,7 +33,7 @@ public interface HasDownloads {
    * @throws WebDriverException if capability to enable downloads is not set
    */
   default void requireDownloadsEnabled(Capabilities capabilities) {
-    boolean downloadsEnabled = (boolean) capabilities.getCapability("se:downloadsEnabled");
+    boolean downloadsEnabled = capabilities.is("se:downloadsEnabled");
     if (!downloadsEnabled) {
       throw new WebDriverException(
           "You must enable downloads in order to work with downloadable files.");


### PR DESCRIPTION
### Description
Fixes the NPE described in https://github.com/SeleniumHQ/selenium/issues/13578. I'm using `capabilities.is("se:downloadsEnabled")` because this function already checks for possible `null` values and casts to `boolean` using `Boolean.parseBoolean()`.

### Motivation and Context
Fixes the NPE described in https://github.com/SeleniumHQ/selenium/issues/13578.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.