### PR TITLE
[py] support wheel also to build sync actions

### DIFF
--- a/py/selenium/webdriver/common/action_chains.py
+++ b/py/selenium/webdriver/common/action_chains.py
@@ -111,8 +111,7 @@ class ActionChains:
             self.move_to_element(on_element)
 
         self.w3c_actions.pointer_action.click()
-        self.w3c_actions.key_action.pause()
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer', 2)
 
         return self
 
@@ -127,7 +126,7 @@ class ActionChains:
             self.move_to_element(on_element)
 
         self.w3c_actions.pointer_action.click_and_hold()
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer')
 
         return self
 
@@ -142,8 +141,7 @@ class ActionChains:
             self.move_to_element(on_element)
 
         self.w3c_actions.pointer_action.context_click()
-        self.w3c_actions.key_action.pause()
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer', 2)
 
         return self
 
@@ -158,8 +156,7 @@ class ActionChains:
             self.move_to_element(on_element)
 
         self.w3c_actions.pointer_action.double_click()
-        for _ in range(4):
-            self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer', 4)
 
         return self
 
@@ -206,7 +203,7 @@ class ActionChains:
             self.click(element)
 
         self.w3c_actions.key_action.key_down(value)
-        self.w3c_actions.pointer_action.pause()
+        self.w3c_actions.fill_pause_except('key')
 
         return self
 
@@ -226,7 +223,7 @@ class ActionChains:
             self.click(element)
 
         self.w3c_actions.key_action.key_up(value)
-        self.w3c_actions.pointer_action.pause()
+        self.w3c_actions.fill_pause_except('key')
 
         return self
 
@@ -239,7 +236,7 @@ class ActionChains:
         """
 
         self.w3c_actions.pointer_action.move_by(xoffset, yoffset)
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer')
 
         return self
 
@@ -251,7 +248,7 @@ class ActionChains:
         """
 
         self.w3c_actions.pointer_action.move_to(to_element)
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer')
 
         return self
 
@@ -266,15 +263,16 @@ class ActionChains:
         """
 
         self.w3c_actions.pointer_action.move_to(to_element, int(xoffset), int(yoffset))
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer')
 
         return self
 
     def pause(self, seconds: float | int) -> ActionChains:
         """Pause all inputs for the specified duration in seconds."""
 
-        self.w3c_actions.pointer_action.pause(seconds)
         self.w3c_actions.key_action.pause(seconds)
+        self.w3c_actions.pointer_action.pause(seconds)
+        self.w3c_actions.wheel_action.pause(seconds)
 
         return self
 
@@ -289,7 +287,7 @@ class ActionChains:
             self.move_to_element(on_element)
 
         self.w3c_actions.pointer_action.release()
-        self.w3c_actions.key_action.pause()
+        self.w3c_actions.fill_pause_except('pointer')
 
         return self
 
@@ -329,6 +327,8 @@ class ActionChains:
         """
 
         self.w3c_actions.wheel_action.scroll(origin=element)
+        self.w3c_actions.fill_pause_except('wheel')
+
         return self
 
     def scroll_by_amount(self, delta_x: int, delta_y: int) -> ActionChains:
@@ -341,6 +341,8 @@ class ActionChains:
         """
 
         self.w3c_actions.wheel_action.scroll(delta_x=delta_x, delta_y=delta_y)
+        self.w3c_actions.fill_pause_except('wheel')
+
         return self
 
     def scroll_from_origin(self, scroll_origin: ScrollOrigin, delta_x: int, delta_y: int) -> ActionChains:
@@ -369,6 +371,8 @@ class ActionChains:
             delta_x=delta_x,
             delta_y=delta_y,
         )
+        self.w3c_actions.fill_pause_except('wheel')
+    
         return self
 
     # Context manager so ActionChains can be used in a 'with .. as' statements.

--- a/py/selenium/webdriver/common/actions/action_builder.py
+++ b/py/selenium/webdriver/common/actions/action_builder.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Dict
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Union
 
@@ -85,6 +87,17 @@ class ActionBuilder:
         new_input = WheelInput(name)
         self._add_input(new_input)
         return new_input
+    
+    def fill_pause_except(self, type: Literal["key", "pointer", "wheel"], ticks: int = 1) -> None:
+        actions: Dict[Literal["key", "pointer", "wheel"], Union[KeyActions, PointerActions, WheelActions]] = {
+            "key": self.key_action,
+            "pointer": self.pointer_action,
+            "wheel": self.wheel_action
+        }
+        del actions[type]
+        for action in actions.values():
+            for _ in range(ticks):
+                action.pause()
 
     def perform(self) -> None:
         enc = {"actions": []}

--- a/py/test/selenium/webdriver/common/interactions_tests.py
+++ b/py/test/selenium/webdriver/common/interactions_tests.py
@@ -207,15 +207,14 @@ def test_sending_keys_to_element(driver, pages):
     assert "abc" == e.get_attribute("value")
 
 
-def test_can_send_keys_between_clicks(driver, pages):
+def test_can_perform_actions_with_multiple_devices(driver, pages):
     """
     For W3C, ensures that the correct number of pauses are given to the other
     input device.
     """
     pages.load("javascriptPage.html")
     keyup = driver.find_element(By.ID, "keyUp")
-    keydown = driver.find_element(By.ID, "keyDown")
-    ActionChains(driver).click(keyup).send_keys("foobar").click(keydown).perform()
+    ActionChains(driver).click(keyup).scroll_by_amount(0, 100).send_keys("foobar").perform()
 
     assert "foobar" == keyup.get_attribute("value")
 

--- a/py/test/selenium/webdriver/common/interactions_with_device_tests.py
+++ b/py/test/selenium/webdriver/common/interactions_with_device_tests.py
@@ -193,18 +193,21 @@ def test_sending_keys_to_element_with_keyboard(driver, pages):
     assert "abc" == e.get_attribute("value")
 
 
-def test_can_send_keys_between_clicks_with_keyboard(driver, pages):
+def test_can_perform_actions_with_multiple_input_devices(driver, pages):
     """
     For W3C, ensures that the correct number of pauses are given to the other
     input device.
     """
     pages.load("javascriptPage.html")
     keyup = driver.find_element(By.ID, "keyUp")
-    keydown = driver.find_element(By.ID, "keyDown")
 
+    mouse = PointerInput(interaction.POINTER_MOUSE, "test mouse")
     key_board = KeyInput("test keyboard")
+    wheel = WheelInput("test wheel")
 
-    ActionChains(driver, devices=[key_board]).click(keyup).send_keys("foobar").click(keydown).perform()
+    devices = [mouse, key_board, wheel]
+
+    ActionChains(driver, devices=devices).click(keyup).scroll_by_amount(0, 100).send_keys("foobar").perform()
 
     assert "foobar" == keyup.get_attribute("value")
 


### PR DESCRIPTION
### Description

Make ActionChains.scroll_* functions fill pause to key, pointer actions queue each for building sync actions.
And make the other functions fill pause to scroll actions queue also.

### Motivation and Context

Problem:
When run the code below, pause actions are carried out differently than intended.
```python
actions = ActionChains(driver)
actions.scroll_...()
actions.pause(5)
actions.scroll_...()
actions.pause(5)
actions.scroll_...()
actions.perform()
```
Built actions:
```typescript
[
  { type: "pointer", .., actions: [{ type: "pause", duration: 5000 }, { type: "pause", duration: 5000 }],
  { type: "key", ......, actions: [{ type: "pause", duration: 5000 }, { type: "pause", duration: 5000 }],
  { type: "wheel", ...., actions: [{ type: "scroll", .. }, { type: "scroll", .. }, { type: "scroll", .. }]
]
```
Should be(simplified):
```typescript
[
  { type: "pointer", .., actions: [{ pause 0 }, { pause 5000 }, { pause 0 }, { pause 5000 }, { pause 0 }],
  { type: "key", ......, actions: [{ pause 0 }, { pause 5000 }, { pause 0 }, { pause 5000 }, { pause 0 }],
  { type: "wheel", ...., actions: [{ scroll }, { pause 5000 }, { scroll 0 }, { pause 5000 }, { scroll 0 }]
]
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

