### PR TITLE
[dotnet] Correct `ChromiumDriverService.AllowedIPAddresses` property name

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Globalization;
 using System.Text;
-using OpenQA.Selenium.Internal;
 
 namespace OpenQA.Selenium.Chromium
 {
@@ -33,7 +32,7 @@ namespace OpenQA.Selenium.Chromium
         private string logPath = string.Empty;
         private string urlPathPrefix = string.Empty;
         private string portServerAddress = string.Empty;
-        private string allowedIpAddresses = string.Empty;
+        private string allowedIPAddresses = string.Empty;
         private int adbPort = -1;
         private bool disableBuildCheck;
         private bool enableVerboseLogging;
@@ -122,11 +121,11 @@ namespace OpenQA.Selenium.Chromium
         /// connect to this instance of the Chrome driver. Defaults to an empty string,
         /// which means only the local loopback address can connect.
         /// </summary>
-        [Obsolete("Use AllowedIpAddresses")]
-        public string WhitelistedIpAddresses
+        [Obsolete($"Use {nameof(AllowedIPAddresses)}")]
+        public string WhitelistedIPAddresses
         {
-            get { return this.allowedIpAddresses; }
-            set { this.allowedIpAddresses = value; }
+            get { return this.allowedIPAddresses; }
+            set { this.allowedIPAddresses = value; }
         }
 
         /// <summary>
@@ -134,10 +133,10 @@ namespace OpenQA.Selenium.Chromium
         /// connect to this instance of the Chrome driver. Defaults to an empty string,
         /// which means only the local loopback address can connect.
         /// </summary>
-        public string AllowedIpAddresses
+        public string AllowedIPAddresses
         {
-            get { return this.allowedIpAddresses; }
-            set { this.allowedIpAddresses = value; }
+            get => this.allowedIPAddresses;
+            set => this.allowedIPAddresses = value;
         }
 
         /// <summary>
@@ -188,9 +187,9 @@ namespace OpenQA.Selenium.Chromium
                     argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --port-server={0}", this.portServerAddress);
                 }
 
-                if (!string.IsNullOrEmpty(this.allowedIpAddresses))
+                if (!string.IsNullOrEmpty(this.allowedIPAddresses))
                 {
-                    argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -allowed-ips={0}", this.allowedIpAddresses));
+                    argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -allowed-ips={0}", this.allowedIPAddresses));
                 }
 
                 return argsBuilder.ToString();


### PR DESCRIPTION
### Description

This is a correction of commit https://github.com/SeleniumHQ/selenium/commit/e7fb98b4d9b7423cbae55782ff349ca447bd3509 made in v4.18. If you check that commit changes, you should see that the old property `WhitelistedIPAddresses` actually was renamed, I believe accidentally, to `WhitelistedIpAddresses` marked with `[Obsolete]` attribute. `IP` -> `Ip`. So it turned to a breaking change that was not intended to be. So I renamed that old property back. Additionally, actual new `AllowedIpAddresses` property doesn't follow C# naming convention with `Ip`. So I corrected it to have `IP` as well.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
