### PR TITLE
Add devcontainer.json to ease local dev environment setup

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,8 +1,0 @@
-{
-  "name": "selenium-devcontainer",
-  "build": {
-    "dockerfile": "./scripts/dev-image/Dockerfile"
-  },
-  "runArgs": ["--name", "selenium_devcontainer"],
-  "initializeCommand" : "echo 'Starting Selenium Devcontainer'"
-}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "selenium-devcontainer",
+  "build": {
+    "dockerfile": "./scripts/dev-image/Dockerfile"
+  },
+  "runArgs": ["--name", "selenium_devcontainer"],
+  "initializeCommand" : "echo 'Starting Selenium Devcontainer'"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+// https://containers.dev/implementors/json_reference/
+
+{
+  "name": "selenium-devcontainer",
+  "build": {
+    "dockerfile": "../scripts/dev-image/Dockerfile"
+  },
+  "runArgs": ["--name", "selenium_devcontainer"]
+}

--- a/README.md
+++ b/README.md
@@ -103,11 +103,16 @@ Rather than creating your own local dev environment, GitPod provides a ready to 
 
 #### Using Dev Container
 
-You can also build a [Dev Container](https://containers.dev/) - basically a docker container - suitable
-for building and testing Selenium using the devcontainer.json in the
+As an alternative you can build a [Dev Container](https://containers.dev/) - basically a docker container -
+suitable for building and testing Selenium using the devcontainer.json in the
 [.devcontainer](.devcontainer/devcontainer.json) directory. Supporting IDEs like VS Code or IntelliJ IDEA
 should point you to how such a container can be created.
 
+#### Using Docker Image
+
+You can also build a Docker image suitable
+for building and testing Selenium using the Dockerfile in the
+[dev image](scripts/dev-image/Dockerfile) directory.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ Rather than creating your own local dev environment, GitPod provides a ready to 
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/SeleniumHQ/selenium)
 
-#### Using Docker Image
+#### Using Dev Container
 
-You can also build a Docker image suitable
-for building and testing Selenium using the Dockerfile in the
-[dev image](scripts/dev-image/Dockerfile) directory.
+You can also build a [Dev Container](https://containers.dev/) - basically a docker container - suitable
+for building and testing Selenium using the devcontainer.json in the
+[.devcontainer](.devcontainer/devcontainer.json) directory. Supporting IDEs like VS Code or IntelliJ IDEA
+should point you to how such a container can be created.
 
 
 ## Building


### PR DESCRIPTION
### Description
Adding a Dev Container configuration to ease local dev environment setup.

### Motivation and Context
I recently contributed to the Selenium project for the first time (see #13583). I opted for the Dev Container variant to set up my  local dev environment. This worked very well, but I had to create my own devcontainer.json to be able to work with my IDE and Dev Container. To make it easier to get started, especially for first time contributors, I would like to add a devcontainer.json to the Selenium project. This minimal devcontainer.json has two advantages:

1. IDEs will recognize that Dev Containers are supported when opening the project and may offer to create the container. Here is an example from Visual Studio Code:
![grafik](https://github.com/SeleniumHQ/selenium/assets/7973740/0697535c-35bc-4041-8824-740524084e86)

2. contributors who do not have much knowledge of Dev Containers can use the devcontainer.json and the documentation link it contains as a starting point for their local dev environment.

According to the [Dev Container documentation](https://containers.dev/implementors/spec/#devcontainerjson), I have placed the file in the preferred folder `.devcontainer`. Both IntelliJ IDEA and Visual Studio Code recognize this Dev Container configuration correctly.


### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
