### PR TITLE
[java] ensure the original RemoteNode stays DOWN #13646

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -279,6 +279,12 @@ public class RemoteNode extends Node implements Closeable {
       try {
         NodeStatus status = getStatus();
 
+        if (!Objects.equals(getId(), status.getNodeId())) {
+          // ensure the original RemoteNode stays DOWN when it has been restarted and registered
+          // again as another RemoteNode with the same externalUri
+          return new Result(DOWN, externalUri + " has unexpected node id");
+        }
+
         switch (status.getAvailability()) {
           case DOWN:
             return new Result(DOWN, externalUri + " is down");


### PR DESCRIPTION
### Motivation and Context
Will fix #13646 and prevent a restarted node from reporting the original RemoteNode UP.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
