### PR TITLE
[ci] automatically close issues marked awaiting answer

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,11 +16,18 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 280 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
           stale-issue-label: 'I-stale'
           days-before-stale: 280
           days-before-close: 14
-          operations-per-run: 200
+      - uses: actions/stale@v9
+        with:
+          close-issue-message: 'This issue was closed because we did not receive any additional information after 14 days.'
+          stale-issue-label: 'R-awaiting answer'
+          days-before-stale: -1
+          days-before-close: 14
+          labels-to-add-when-unstale: 'needs-triaging'
+


### PR DESCRIPTION
## **User description**
We (well, Diego) spend a lot of time going back and closing issues when we don't hear back from the author. It would save time (and feel less personal) if this were made automatic. To work it uses the stale github action to remove the `awaiting-answer` label and restore the `needs-triage` label if any additional comment is made. This has the added benefit of allowing us to filter the needs-triage labels to see only issues with new information.


___

## **Type**
enhancement


___

## **Description**
- Upgraded GitHub stale action to version 9 for better performance and features.
- Introduced a new automated process to close issues marked 'R-awaiting answer' after 14 days of inactivity, improving issue management efficiency.
- Configured to automatically add 'needs-triaging' label to issues that receive updates after being marked as stale, facilitating easier tracking and management.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stale.yml</strong><dd><code>Enhance Issue Management with Automated Closing for Awaiting Answer</code></dd></summary>
<hr>
      
.github/workflows/stale.yml

<li>Updated the stale GitHub action to version 9.<br> <li> Added a new stale action specifically for issues labeled 'R-awaiting <br>answer'.<br> <li> Configured the new action to close issues after 14 days if no <br>additional information is provided.<br> <li> Set the action to add 'needs-triaging' label when an issue becomes <br>unstale.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13668/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

