### PR TITLE
Add JSON serialization for ShadowRoot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ bazel-testlogs
 javascript/node/selenium-webdriver/.vscode/settings.json
 
 dotnet-bin
+.metadata/

--- a/java/spotbugs-excludes.xml
+++ b/java/spotbugs-excludes.xml
@@ -196,7 +196,12 @@
   </Match>
 
   <Match>
-    <Class name="org.openqa.selenium.remote.internal.WebElementToJsonConverter" />
+    <Class name="org.openqa.selenium.remote.WebElementToJsonConverter" />
     <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
+  </Match>
+
+  <Match>
+    <Class name="org.openqa.selenium.remote.internal.WebElementToJsonConverter" />
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
   </Match>
 </FindBugsFilter>

--- a/java/spotbugs-excludes.xml
+++ b/java/spotbugs-excludes.xml
@@ -194,4 +194,9 @@
     <Class name="org.openqa.selenium.testing.StaticResources"/>
     <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
   </Match>
+
+  <Match>
+    <Class name="org.openqa.selenium.remote.internal.WebElementToJsonConverter" />
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
+  </Match>
 </FindBugsFilter>

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -89,7 +89,6 @@ import org.openqa.selenium.print.PrintOptions;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.ConnectionFailedException;
 import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
 import org.openqa.selenium.remote.tracing.TracedHttpClient;
 import org.openqa.selenium.remote.tracing.Tracer;
 import org.openqa.selenium.remote.tracing.opentelemetry.OpenTelemetryTracer;

--- a/java/src/org/openqa/selenium/remote/WebElementToJsonConverter.java
+++ b/java/src/org/openqa/selenium/remote/WebElementToJsonConverter.java
@@ -1,0 +1,93 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote;
+
+import static java.util.stream.Collectors.toList;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.openqa.selenium.WrapsElement;
+
+/**
+ * Converts {@link RemoteWebElement} objects, which may be {@link WrapsElement wrapped}, into their
+ * JSON representation as defined by the WebDriver wire protocol. This class will recursively
+ * convert Lists and Maps to catch nested references.
+ *
+ * @see <a
+ *     href="https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object">
+ *     WebDriver JSON Wire Protocol</a>
+ */
+public class WebElementToJsonConverter implements Function<Object, Object> {
+  @Override
+  public Object apply(Object arg) {
+    if (arg == null || arg instanceof String || arg instanceof Boolean || arg instanceof Number) {
+      return arg;
+    }
+
+    while (arg instanceof WrapsElement) {
+      arg = ((WrapsElement) arg).getWrappedElement();
+    }
+
+    if (arg instanceof RemoteWebElement) {
+      return Map.of(Dialect.W3C.getEncodedElementKey(), ((RemoteWebElement) arg).getId());
+    }
+
+    if (arg instanceof ShadowRoot) {
+      return Map.of(Dialect.W3C.getShadowRootElementKey(), ((ShadowRoot) arg).getId());
+    }
+
+    if (arg.getClass().isArray()) {
+      arg = arrayToList(arg);
+    }
+
+    if (arg instanceof Collection<?>) {
+      Collection<?> args = (Collection<?>) arg;
+      return args.stream().map(this).collect(toList());
+    }
+
+    if (arg instanceof Map<?, ?>) {
+      Map<?, ?> args = (Map<?, ?>) arg;
+      Map<String, Object> converted = new HashMap<>(args.size());
+      for (Map.Entry<?, ?> entry : args.entrySet()) {
+        Object key = entry.getKey();
+        if (!(key instanceof String)) {
+          throw new IllegalArgumentException(
+              "All keys in Map script arguments must be strings: " + key.getClass().getName());
+        }
+        converted.put((String) key, apply(entry.getValue()));
+      }
+      return converted;
+    }
+
+    throw new IllegalArgumentException(
+        "Argument is of an illegal type: " + arg.getClass().getName());
+  }
+
+  private static List<Object> arrayToList(Object array) {
+    List<Object> list = new ArrayList<>();
+    for (int i = 0; i < Array.getLength(array); i++) {
+      list.add(Array.get(array, i));
+    }
+    return list;
+  }
+}

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -89,7 +89,7 @@ import java.util.stream.Stream;
 import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.codec.AbstractHttpCommandCodec;
-import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
+import org.openqa.selenium.remote.WebElementToJsonConverter;
 
 /**
  * A command codec that adheres to the W3C's WebDriver wire protocol.

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -88,8 +88,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.remote.codec.AbstractHttpCommandCodec;
 import org.openqa.selenium.remote.WebElementToJsonConverter;
+import org.openqa.selenium.remote.codec.AbstractHttpCommandCodec;
 
 /**
  * A command codec that adheres to the W3C's WebDriver wire protocol.

--- a/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
+++ b/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
@@ -23,5 +23,6 @@ package org.openqa.selenium.remote.internal;
  * @deprecated This class has moved to a {@link org.openqa.selenium.remote.WebElementToJsonConverter
  *     new location}.
  */
+@Deprecated
 public class WebElementToJsonConverter
     extends org.openqa.selenium.remote.WebElementToJsonConverter {}

--- a/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
+++ b/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
@@ -19,7 +19,9 @@ package org.openqa.selenium.remote.internal;
 
 /**
  * {@inheritDoc}
- * @deprecated This class has moved to a {@link org.openqa.selenium.remote.WebElementToJsonConverter new location}.
+ *
+ * @deprecated This class has moved to a {@link org.openqa.selenium.remote.WebElementToJsonConverter
+ *     new location}.
  */
-public class WebElementToJsonConverter extends org.openqa.selenium.remote.WebElementToJsonConverter {
-}
+public class WebElementToJsonConverter
+    extends org.openqa.selenium.remote.WebElementToJsonConverter {}

--- a/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
+++ b/java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java
@@ -17,75 +17,9 @@
 
 package org.openqa.selenium.remote.internal;
 
-import static java.util.stream.Collectors.toList;
-
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.remote.Dialect;
-import org.openqa.selenium.remote.RemoteWebElement;
-
 /**
- * Converts {@link RemoteWebElement} objects, which may be {@link WrapsElement wrapped}, into their
- * JSON representation as defined by the WebDriver wire protocol. This class will recursively
- * convert Lists and Maps to catch nested references.
- *
- * @see <a
- *     href="https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object">
- *     WebDriver JSON Wire Protocol</a>
+ * {@inheritDoc}
+ * @deprecated This class has moved to a {@link org.openqa.selenium.remote.WebElementToJsonConverter new location}.
  */
-public class WebElementToJsonConverter implements Function<Object, Object> {
-  @Override
-  public Object apply(Object arg) {
-    if (arg == null || arg instanceof String || arg instanceof Boolean || arg instanceof Number) {
-      return arg;
-    }
-
-    while (arg instanceof WrapsElement) {
-      arg = ((WrapsElement) arg).getWrappedElement();
-    }
-
-    if (arg instanceof RemoteWebElement) {
-      return Map.of(Dialect.W3C.getEncodedElementKey(), ((RemoteWebElement) arg).getId());
-    }
-
-    if (arg.getClass().isArray()) {
-      arg = arrayToList(arg);
-    }
-
-    if (arg instanceof Collection<?>) {
-      Collection<?> args = (Collection<?>) arg;
-      return args.stream().map(this).collect(toList());
-    }
-
-    if (arg instanceof Map<?, ?>) {
-      Map<?, ?> args = (Map<?, ?>) arg;
-      Map<String, Object> converted = new HashMap<>(args.size());
-      for (Map.Entry<?, ?> entry : args.entrySet()) {
-        Object key = entry.getKey();
-        if (!(key instanceof String)) {
-          throw new IllegalArgumentException(
-              "All keys in Map script arguments must be strings: " + key.getClass().getName());
-        }
-        converted.put((String) key, apply(entry.getValue()));
-      }
-      return converted;
-    }
-
-    throw new IllegalArgumentException(
-        "Argument is of an illegal type: " + arg.getClass().getName());
-  }
-
-  private static List<Object> arrayToList(Object array) {
-    List<Object> list = new ArrayList<>();
-    for (int i = 0; i < Array.getLength(array); i++) {
-      list.add(Array.get(array, i));
-    }
-    return list;
-  }
+public class WebElementToJsonConverter extends org.openqa.selenium.remote.WebElementToJsonConverter {
 }

--- a/java/test/org/openqa/selenium/remote/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/BUILD.bazel
@@ -29,6 +29,7 @@ java_test_suite(
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/remote",
         "//java/src/org/openqa/selenium/support",
+        "//java/test/org/openqa/selenium:helpers",
         "//java/test/org/openqa/selenium/testing:annotations",
         artifact("org.assertj:assertj-core"),
         artifact("com.google.guava:guava"),

--- a/java/test/org/openqa/selenium/remote/WebElementToJsonConverterTest.java
+++ b/java/test/org/openqa/selenium/remote/WebElementToJsonConverterTest.java
@@ -223,8 +223,8 @@ class WebElementToJsonConverterTest {
     ShadowRoot context = new ShadowRoot(createIdleDriver(), "abc123");
     Object value = CONVERTER.apply(new Object[] {context});
     assertContentsInOrder(
-      new ArrayList<>((Collection<?>) value),
-      ImmutableMap.of(Dialect.W3C.getShadowRootElementKey(), "abc123"));
+        new ArrayList<>((Collection<?>) value),
+        ImmutableMap.of(Dialect.W3C.getShadowRootElementKey(), "abc123"));
   }
 
   private static WrappedWebElement wrapElement(WebElement element) {

--- a/java/test/org/openqa/selenium/remote/WebElementToJsonConverterTest.java
+++ b/java/test/org/openqa/selenium/remote/WebElementToJsonConverterTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.openqa.selenium.remote.internal;
+package org.openqa.selenium.remote;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,10 +27,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrappedWebElement;
-import org.openqa.selenium.remote.Dialect;
-import org.openqa.selenium.remote.RemoteWebElement;
 
 class WebElementToJsonConverterTest {
 
@@ -218,6 +218,15 @@ class WebElementToJsonConverterTest {
         ImmutableMap.of(Dialect.W3C.getEncodedElementKey(), "abc123"));
   }
 
+  @Test
+  void shouldConvertShadowRoots() {
+    ShadowRoot context = new ShadowRoot(createIdleDriver(), "abc123");
+    Object value = CONVERTER.apply(new Object[] {context});
+    assertContentsInOrder(
+      new ArrayList<>((Collection<?>) value),
+      ImmutableMap.of(Dialect.W3C.getShadowRootElementKey(), "abc123"));
+  }
+
   private static WrappedWebElement wrapElement(WebElement element) {
     return new WrappedWebElement(element);
   }
@@ -234,5 +243,14 @@ class WebElementToJsonConverterTest {
   private static void assertContentsInOrder(List<?> list, Object... expectedContents) {
     List<Object> expected = asList(expectedContents);
     assertThat(list).isEqualTo(expected);
+  }
+
+  private static RemoteWebDriver createIdleDriver() {
+    return new RemoteWebDriver(cmd -> new Response(), new ImmutableCapabilities()) {
+      @Override
+      protected void startSession(Capabilities capabilities) {
+        // Do nothing
+      }
+    };
   }
 }

--- a/java/test/org/openqa/selenium/remote/internal/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/internal/BUILD.bazel
@@ -30,22 +30,3 @@ java_library(
         artifact("io.netty:netty-transport"),
     ] + JUNIT5_DEPS,
 )
-
-java_test_suite(
-    name = "SmallTests",
-    size = "small",
-    srcs = glob(["*Test.java"]),
-    tags = [
-        "no-sandbox",
-    ],
-    deps = [
-        ":test-lib",
-        "//java/src/org/openqa/selenium:core",
-        "//java/src/org/openqa/selenium/remote",
-        "//java/src/org/openqa/selenium/remote/http",
-        "//java/test/org/openqa/selenium:helpers",
-        artifact("org.assertj:assertj-core"),
-        artifact("com.google.guava:guava"),
-        artifact("org.junit.jupiter:junit-jupiter-api"),
-    ] + JUNIT5_DEPS,
-)

--- a/java/test/org/openqa/selenium/remote/internal/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/internal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//java:defs.bzl", "JUNIT5_DEPS", "java_library", "java_test_suite")
+load("//java:defs.bzl", "JUNIT5_DEPS", "java_library")
 
 java_library(
     name = "test-lib",

--- a/java/test/org/openqa/selenium/support/pagefactory/UsingPageFactoryTest.java
+++ b/java/test/org/openqa/selenium/support/pagefactory/UsingPageFactoryTest.java
@@ -27,7 +27,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
-import org.openqa.selenium.remote.internal.WebElementToJsonConverter;
+import org.openqa.selenium.remote.WebElementToJsonConverter;
 import org.openqa.selenium.support.ByIdOrName;
 import org.openqa.selenium.support.CacheLookup;
 import org.openqa.selenium.support.FindBy;


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


Currently, attempts to specify **ShadowRoot** objects as arguments for JavaScript fragments via the `executeScript()` function fail with this exception:

```
java.lang.IllegalArgumentException: Argument is of an illegal type: org.openqa.selenium.remote.ShadowRoot
	at org.openqa.selenium.remote.internal.WebElementToJsonConverter.apply(WebElementToJsonConverter.java:81)
```

Examination of the `apply()` function confirms that no support is provided for **ShadowRoot**.

### Description
This PR adds support for specifying **ShadowRoot** objects as script arguments in `executeScript()` calls.

### Motivation and Context
It's currently impossible to provide a **ShadowRoot** search context as an argument to a JavaScript fragment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Added support for JSON serialization of `ShadowRoot` objects in Selenium, allowing them to be used as arguments in `executeScript()` calls.
- Implemented a new `WebElementToJsonConverter` class to handle JSON serialization of `RemoteWebElement` and `ShadowRoot`.
- Deprecated the old `WebElementToJsonConverter` class and updated references across the project to use the new class.
- Updated tests to reflect changes in `WebElementToJsonConverter` usage.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Remove Deprecated Import in RemoteWebDriver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<li>Removed import for <code>WebElementToJsonConverter</code> from <br><code>org.openqa.selenium.remote.internal</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>W3CHttpCommandCodec.java</strong><dd><code>Update Import to New WebElementToJsonConverter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java

<li>Updated import to use the new <code>WebElementToJsonConverter</code> from <br><code>org.openqa.selenium.remote</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-d3ee2e9bb5279f45d35691b5fe24402e8b9d1b795b293ace7a5e4c4ec144d5f4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebElementToJsonConverter.java</strong><dd><code>Add JSON Serialization Support for ShadowRoot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/remote/WebElementToJsonConverter.java

<li>Added a new <code>WebElementToJsonConverter</code> class supporting JSON <br>serialization for <code>RemoteWebElement</code> and <code>ShadowRoot</code>.<br> <li> Implemented conversion logic for various types including primitives, <br>collections, maps, and specifically <code>ShadowRoot</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-761294da4d931402be0f031b4752f4e418de4ad2345f19928d0793cfbbd724df">+93/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WebElementToJsonConverter.java</strong><dd><code>Deprecate Old WebElementToJsonConverter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/remote/internal/WebElementToJsonConverter.java

<li>Deprecated the old <code>WebElementToJsonConverter</code> class.<br> <li> Redirected usage to the new <code>WebElementToJsonConverter</code> location.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-7c81ecc58a5070ded707b937f5e62decd62194e6088c5553791d3063d7325dbc">+3/-69</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebElementToJsonConverterTest.java</strong><dd><code>Update Tests for New WebElementToJsonConverter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/remote/internal/WebElementToJsonConverterTest.java

- Updated test to use the new `WebElementToJsonConverter`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-89be983c822f12d091a29c64cdb6f6939678120dda541358ecaa4e0f7e5308b1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>UsingPageFactoryTest.java</strong><dd><code>Update PageFactory Test Imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/support/pagefactory/UsingPageFactoryTest.java

- Updated import to use the new `WebElementToJsonConverter`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13680/files#diff-5094dc193a99151e98e401de25fe84ffba49bb419acdf8341f40329527b5f3be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

