### PR TITLE
[rb] Per-browser test targets and RBE

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -95,7 +95,7 @@ jobs:
           distribution: 'temurin'
       - name: Setup Bazel with caching
         if: inputs.caching
-        uses: bazel-contrib/setup-bazel@0.8.0
+        uses: bazel-contrib/setup-bazel@0.8.1
         with:
           bazelisk-cache: true
           bazelrc: common --color=yes
@@ -110,7 +110,7 @@ jobs:
           repository-cache: true
       - name: Setup Bazel without caching
         if: inputs.caching == false
-        uses: bazel-contrib/setup-bazel@0.8.0
+        uses: bazel-contrib/setup-bazel@0.8.1
         with:
           bazelrc: common --color=yes
       - name: Setup Fluxbox and Xvfb

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -56,7 +56,11 @@ jobs:
       cache-key: rb-unit-test-${{ matrix.ruby-version }}
       os: ${{ matrix.os }}
       ruby-version: ${{ matrix.ruby-version }}
-      run: bazel test //rb/spec/unit/...
+      run: >
+        bazel test
+        --build_tests_only
+        --test_size_filters small
+        //rb/spec/...
 
   integration-tests-local:
     name: Local Tests
@@ -90,10 +94,12 @@ jobs:
       os: ${{ matrix.os }}
       run: >
         bazel test
-        --define browser=${{ matrix.browser }}
+        --build_tests_only
         --flaky_test_attempts 3
         --local_test_jobs 1
-        //rb/spec/integration/...
+        --test_size_filters large
+        --test_tag_filters ${{ matrix.browser }}
+        //rb/spec/...
 
   integration-tests-remote:
     name: Remote Tests
@@ -119,8 +125,9 @@ jobs:
       java-version: 11
       run: >
         bazel test
-        --define browser=${{ matrix.browser }}
-        --define remote=true
+        --build_tests_only
         --flaky_test_attempts 3
         --local_test_jobs 1
-        //rb/spec/integration/...
+        --test_size_filters large
+        --test_tag_filters ${{ matrix.browser }}-remote
+        //rb/spec/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.8.0
+        uses: bazel-contrib/setup-bazel@0.8.1
         with:
           bazelisk-cache: true
           external-cache: |

--- a/.skipped-tests
+++ b/.skipped-tests
@@ -12,12 +12,17 @@
 -//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextTest-remote
 -//java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest
 -//java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+-//java/test/org/openqa/selenium/edge:EdgeDriverFunctionalTest
+-//java/test/org/openqa/selenium/edge:EdgeDriverFunctionalTest-edge
+-//java/test/org/openqa/selenium/edge:EdgeDriverFunctionalTest-remote
 -//java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest
 -//java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest
 -//java/test/org/openqa/selenium/grid/gridui:OverallGridTest
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-chrome
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-chrome-remote
+-//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-edge
+-//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-edge-remote
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-remote
 -//java/test/org/openqa/selenium/interactions:DefaultMouseTest
 -//java/test/org/openqa/selenium/interactions:DefaultMouseTest-remote

--- a/.skipped-tests
+++ b/.skipped-tests
@@ -1,5 +1,6 @@
 -//dotnet/test/common:DevTools/DevToolsNetworkTest-chrome
 -//dotnet/test/common:Interactions/BasicMouseInterfaceTest-chrome
+-//dotnet/test/common:Interactions/BasicMouseInterfaceTest-edge
 -//dotnet/test/common:Interactions/BasicMouseInterfaceTest-firefox
 -//dotnet/test/common:JavascriptEnabledBrowserTest-chrome
 -//dotnet/test/common:NetworkInterceptionTests-chrome
@@ -29,6 +30,7 @@
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverScreenshotTest-remote
 -//javascript/atoms:test-chrome
+-//javascript/atoms:test-edge
 -//javascript/atoms:test-firefox-beta
 -//javascript/atoms:test-firefox-dev
 -//py:common-chrome-test/selenium/webdriver/common/virtual_authenticator_tests.py

--- a/.skipped-tests
+++ b/.skipped-tests
@@ -31,6 +31,7 @@
 -//py:test-chrome-test/selenium/webdriver/chrome/chrome_service_tests.py
 -//py:test-chrome-test/selenium/webdriver/chrome/proxy_tests.py
 -//py:unit-test/unit/selenium/webdriver/common/cdp_module_fallback_tests.py
--//rb/spec/integration/selenium/webdriver/chrome:service
--//rb/spec/integration/selenium/webdriver/edge:service
--//rb/spec/integration/selenium/webdriver/firefox:service
+-//rb/spec/integration/selenium/webdriver/chrome:service-chrome
+-//rb/spec/integration/selenium/webdriver/edge:service-edge
+-//rb/spec/integration/selenium/webdriver/firefox:service-firefox
+-//rb/spec/integration/selenium/webdriver/firefox:service-firefox-beta

--- a/README.md
+++ b/README.md
@@ -334,36 +334,44 @@ bazel test //py:all
 
 Test targets:
 
-| Command                                                                              | Description                                    |
-|--------------------------------------------------------------------------------------|------------------------------------------------|
-| `bazel test //rb/...`                                                                | Run unit, integration tests (Chrome) and lint  |
-| `bazel test //rb:lint`                                                               | Run RuboCop linter                             |
-| `bazel test //rb/spec/...`                                                           | Run unit and integration tests (Chrome)        |
-| `bazel test --test_size_filters large //rb/...`                                      | Run integration tests using (Chrome)           |
-| `bazel test //rb/spec/integration/...`                                               | Run integration tests using (Chrome)           |
-| `bazel test //rb/spec/integration/... --define browser=firefox`                      | Run integration tests using (Firefox)          |
-| `bazel test //rb/spec/integration/... --define remote=true`                          | Run integration tests using (Chrome and Grid)  |
-| `bazel test //rb/spec/integration/... --define browser=firefox --define remote=true` | Run integration tests using (Firefox and Grid) |
-| `bazel test --test_size_filters small //rb/...`                                      | Run unit tests                                 |
-| `bazel test //rb/spec/unit/...`                                                      | Run unit tests                                 |
+| Command                                                                          | Description                                        |
+| -------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `bazel test //rb/...`                                                            | Run unit, all integration tests and lint           |
+| `bazel test //rb:lint`                                                           | Run RuboCop linter                                 |
+| `bazel test //rb/spec/...`                                                       | Run unit and integration tests for all browsers    |
+| `bazel test //rb/spec/... --test_size_filters small`                             | Run unit tests                                     |
+| `bazel test //rb/spec/unit/...`                                                  | Run unit tests                                     |
+| `bazel test //rb/spec/... --test_size_filters large`                             | Run integration tests for all browsers             |
+| `bazel test //rb/spec/integration/...`                                           | Run integration tests for all browsers             |
+| `bazel test //rb/spec/integration/... --test_tag_filters firefox`                | Run integration tests for local Firefox only       |
+| `bazel test //rb/spec/integration/... --test_tag_filters firefox-remote`         | Run integration tests for remote Firefox only      |
+| `bazel test //rb/spec/integration/... --test_tag_filters firefox,firefox-remote` | Run integration tests for local and remote Firefox |
 
-Ruby test modules have the same name as the spec file with `_spec.rb` removed, so you can run them individually:
+Ruby test targets have the same name as the spec file with `_spec.rb` removed, so you can run them individually.
+Integration tests targets also have a browser and remote suffix to control which browser to pick and whether to use Grid.
 
-| Test file                                                      | Test target                                              |
-|----------------------------------------------------------------|----------------------------------------------------------|
-| `rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver/chrome:driver` |
-| `rb/spec/unit/selenium/webdriver/proxy_spec.rb`                | `//rb/spec/unit/selenium/webdriver:proxy`                |
+| Test file                                               | Test target                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `rb/spec/unit/selenium/webdriver/proxy_spec.rb`         | `//rb/spec/unit/selenium/webdriver:proxy`                        |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome`         |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome-remote`  |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox`        |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox-remote` |
 
 Supported browsers:
 
 * `chrome`
 * `edge`
 * `firefox`
+* `firefox-beta`
 * `ie`
-* `safari` (cannot be run in parallel - use `--local_test_jobs 1`)
-* `safari-preview` (cannot be run in parallel - use `--local_test_jobs 1`)
+* `safari`
+* `safari-preview`
 
 Useful command line options:
+
+* `--pin_browsers` - use browsers and drivers downloaded by Bazel
+* `--headless` - run browsers in headless mode (supported be Chrome, Edge and Firefox)
 
 In addition to the [Common Options Examples](#common-options-examples), here are some additional Ruby specific ones:
 * `--test_arg "-tfocus"` - test only [focused specs](https://relishapp.com/rspec/rspec-core/v/3-12/docs/filtering/inclusion-filters)
@@ -380,8 +388,11 @@ Supported environment variables for use with `--test_env`:
 - `HEADLESS` - for chrome, edge and firefox; runs tests in headless mode
 - `DISABLE_BUILD_CHECK` - for chrome and edge; whether to ignore driver and browser version mismatches (allows testing Canary builds)
 - `CHROME_BINARY` - path to test specific Chrome browser
+- `CHROMEDRIVER_BINARY` - path to test specific ChromeDriver
 - `EDGE_BINARY` - path to test specific Edge browser
+- `MSEDGEDRIVER_BINARY` - path to test specific msedgedriver
 - `FIREFOX_BINARY` - path to test specific Firefox browser
+- `GECKODRIVER_BINARY` - path to test specific GeckoDriver
 
 To run with a specific version of Ruby you can change the version in `rb/.ruby-version` or from command line:
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ There are a number of bazel configurations specific for testing.
 ### Common Options Examples
 
 Here are examples of arguments we make use of in testing the Selenium code:
-* `--pin_browsers=true` - run specific browser versions defined in the build (versions are updated regularly)
+* `--pin_browsers` - run specific browser versions defined in the build (versions are updated regularly)
+* `--headless` - run browsers in headless mode (supported be Chrome, Edge and Firefox)
 * `--flaky_test_attempts 3` - re-run failed tests up to 3 times
 * `--local_test_jobs 1` - control parallelism of tests
 * `--cache_test_results=no`, `-t-` - disable caching of test results and re-runs all of them
@@ -367,11 +368,6 @@ Supported browsers:
 * `ie`
 * `safari`
 * `safari-preview`
-
-Useful command line options:
-
-* `--pin_browsers` - use browsers and drivers downloaded by Bazel
-* `--headless` - run browsers in headless mode (supported be Chrome, Edge and Firefox)
 
 In addition to the [Common Options Examples](#common-options-examples), here are some additional Ruby specific ones:
 * `--test_arg "-tfocus"` - test only [focused specs](https://relishapp.com/rspec/rspec-core/v/3-12/docs/filtering/inclusion-filters)

--- a/common/browsers.bzl
+++ b/common/browsers.bzl
@@ -1,5 +1,8 @@
 COMMON_TAGS = [
     "browser-test",
+    # We have to use no-sandbox at the moment because Firefox crashes
+    # when run under sandbox: https://bugzilla.mozilla.org/show_bug.cgi?id=1382498.
+    # For Chromium-based browser, we can just pass `--no-sandbox` flag.
     "no-sandbox",
     "requires-network",
 ]

--- a/common/browsers.bzl
+++ b/common/browsers.bzl
@@ -30,6 +30,9 @@ chrome_data = select({
 }) + chromedriver_data
 
 edgedriver_data = select({
+    "@selenium//common:use_pinned_linux_edge": [
+        "@linux_edgedriver//:msedgedriver",
+    ],
     "@selenium//common:use_pinned_macos_edge": [
         "@mac_edgedriver//:msedgedriver",
     ],
@@ -38,6 +41,10 @@ edgedriver_data = select({
 })
 
 edge_data = select({
+    "@selenium//common:use_pinned_linux_edge": [
+        "@linux_edge//:files",
+        "@linux_edge//:opt/microsoft/msedge/microsoft-edge",
+    ],
     "@selenium//common:use_pinned_macos_edge": [
         "@mac_edge//:Edge.app",
     ],

--- a/common/extensions/BUILD.bazel
+++ b/common/extensions/BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
         "//java/test/org/openqa/selenium/firefox:__pkg__",
         "//javascript/node/selenium-webdriver:__pkg__",
         "//py:__pkg__",
-        "//rb:__pkg__",
+        "//rb/spec:__subpackages__",
     ],
 )
 

--- a/common/private/deb_archive.bzl
+++ b/common/private/deb_archive.bzl
@@ -1,0 +1,36 @@
+def _deb_archive_impl(repository_ctx):
+    url = repository_ctx.attr.url
+
+    attrs = {}
+    if repository_ctx.attr.sha256:
+        attrs.update({"sha256": repository_ctx.attr.sha256})
+
+    repository_ctx.download_and_extract(
+        url,
+        **attrs
+    )
+
+    repository_ctx.extract(
+        archive = "data.tar.xz",
+        stripPrefix = repository_ctx.attr.strip_prefix,
+        output = repository_ctx.attr.output,
+    )
+    repository_ctx.delete("data.tar.xz")
+
+    repository_ctx.file(
+        "BUILD.bazel",
+        repository_ctx.attr.build_file_content,
+    )
+
+deb_archive = repository_rule(
+    _deb_archive_impl,
+    attrs = {
+        "url": attr.string(
+            mandatory = True,
+        ),
+        "sha256": attr.string(),
+        "strip_prefix": attr.string(),
+        "output": attr.string(),
+        "build_file_content": attr.string(),
+    },
+)

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -1,6 +1,7 @@
 # This file has been generated using `bazel run scripts:pinned_browsers`
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//common/private:deb_archive.bzl", "deb_archive")
 load("//common/private:dmg_archive.bzl", "dmg_archive")
 load("//common/private:drivers.bzl", "local_drivers")
 load("//common/private:pkg_archive.bzl", "pkg_archive")
@@ -96,12 +97,29 @@ exports_files(
 
     pkg_archive(
         name = "mac_edge",
-        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/9c227984-0429-48e9-bade-ba93774a430a/MicrosoftEdge-122.0.2365.80.pkg",
-        sha256 = "4fca764d70068e29d1b4657fb4c8b28bfcd8aebc295368bb49e7560f19af0716",
+        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/61b13da3-c921-482a-9166-743689310b71/MicrosoftEdge-122.0.2365.92.pkg",
+        sha256 = "304243a7ef631781b707c0d9cb8fd35e718cebad91c29078e389bb4e813afef9",
         move = {
-            "MicrosoftEdge-122.0.2365.80.pkg/Payload/Microsoft Edge.app": "Edge.app",
+            "MicrosoftEdge-122.0.2365.92.pkg/Payload/Microsoft Edge.app": "Edge.app",
         },
         build_file_content = "exports_files([\"Edge.app\"])",
+    )
+
+    deb_archive(
+        name = "linux_edge",
+        url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_122.0.2365.92-1_amd64.deb",
+        sha256 = "eab115c454b669dbc42f83b6b9ccc94ec4f2df5a2cf6be762069c75f18f703e8",
+        build_file_content = """
+filegroup(
+    name = "files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["opt/microsoft/msedge/microsoft-edge"],
+)
+""",
     )
 
     http_archive(
@@ -120,8 +138,8 @@ exports_files(
 
     http_archive(
         name = "linux_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/linux64/chrome-linux64.zip",
-        sha256 = "b059c80216abd74f25a35c08c6ad601a30dfdb09588af27828a9bc7adde65bd3",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.128/linux64/chrome-linux64.zip",
+        sha256 = "d20be2808665743423536a2ce030ffa8f6092b9dd9a29f72cd8999ef71955700",
         build_file_content = """
 filegroup(
     name = "files",
@@ -137,8 +155,8 @@ exports_files(
 
     http_archive(
         name = "mac_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/mac-x64/chrome-mac-x64.zip",
-        sha256 = "4754c5793fec0080e29c6df1720d09c4052b447a14239a55682948635612c0e8",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.128/mac-x64/chrome-mac-x64.zip",
+        sha256 = "f4efaa5dbe4e02d5d324ac862427be2facbca1bed1c75c5bacaa4c922ab5b643",
         strip_prefix = "chrome-mac-x64",
         patch_cmds = [
             "mv 'Google Chrome for Testing.app' Chrome.app",
@@ -149,16 +167,16 @@ exports_files(
 
     http_archive(
         name = "linux_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/linux64/chromedriver-linux64.zip",
-        sha256 = "a73431662c53100171823855de88aea4191c66262c9f61b9829f7ecddc76b754",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.128/linux64/chromedriver-linux64.zip",
+        sha256 = "40aaf6063c9d88fe43dd3e5b79cc101de1662b42ccac81616ecb0310ba921103",
         strip_prefix = "chromedriver-linux64",
         build_file_content = "exports_files([\"chromedriver\"])",
     )
 
     http_archive(
         name = "mac_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/mac-x64/chromedriver-mac-x64.zip",
-        sha256 = "16d7e9b92808cd8193fb00ded4c805744bfe0f89cbb647b3ddd1450226ec9212",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.128/mac-x64/chromedriver-mac-x64.zip",
+        sha256 = "41d2fd29a9a5b955fa908218e85ef3c4a2f997b72586c13b416196c3861152d3",
         strip_prefix = "chromedriver-mac-x64",
         build_file_content = "exports_files([\"chromedriver\"])",
     )

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -10,8 +10,8 @@ def pin_browsers():
 
     http_archive(
         name = "linux_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/en-US/firefox-122.0.1.tar.bz2",
-        sha256 = "1c502c15f71bb729e6506667c32de525849d6571f4a3a21e5b02fc08312b20e7",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0.1/linux-x86_64/en-US/firefox-123.0.1.tar.bz2",
+        sha256 = "3b8534ecd870f25434fc7ac8b7a26470492484f24fefe3be8eed0b41db52fe43",
         build_file_content = """
 filegroup(
     name = "files",
@@ -27,15 +27,15 @@ exports_files(
 
     dmg_archive(
         name = "mac_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/122.0.1/mac/en-US/Firefox%20122.0.1.dmg",
-        sha256 = "42721425ca279d48b729eab8e443ce2ad83465ada46dee367d84a103791deb2a",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0.1/mac/en-US/Firefox%20123.0.1.dmg",
+        sha256 = "35885bacbe7c838c8de476ced3aa2dc0f8642d613c0db5b462e919da1b6cf8c7",
         build_file_content = "exports_files([\"Firefox.app\"])",
     )
 
     http_archive(
         name = "linux_beta_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0b9/linux-x86_64/en-US/firefox-123.0b9.tar.bz2",
-        sha256 = "c29d96875b8eb03d37e948e3f62cd4505300fce85f0e09dfae6a4443d3878607",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/124.0b9/linux-x86_64/en-US/firefox-124.0b9.tar.bz2",
+        sha256 = "80208d269dc8d251a7f9f292a7a6ea9ad217189a01075ff6d77326cb0352c1db",
         build_file_content = """
 filegroup(
     name = "files",
@@ -51,15 +51,15 @@ exports_files(
 
     dmg_archive(
         name = "mac_beta_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0b9/mac/en-US/Firefox%20123.0b9.dmg",
-        sha256 = "6addddfd288a16c08dc59a88c8f9fe252d7d608b83bc2458f139e77fda4ddab8",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/124.0b9/mac/en-US/Firefox%20124.0b9.dmg",
+        sha256 = "c716240f5fd76937cccbe93e9ffdb681782fbacb9af1face7416351a6e71a1a3",
         build_file_content = "exports_files([\"Firefox.app\"])",
     )
 
     http_archive(
         name = "linux_dev_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0b9/linux-x86_64/en-US/firefox-123.0b9.tar.bz2",
-        sha256 = "c29d96875b8eb03d37e948e3f62cd4505300fce85f0e09dfae6a4443d3878607",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/124.0b9/linux-x86_64/en-US/firefox-124.0b9.tar.bz2",
+        sha256 = "80208d269dc8d251a7f9f292a7a6ea9ad217189a01075ff6d77326cb0352c1db",
         build_file_content = """
 filegroup(
     name = "files",
@@ -75,8 +75,8 @@ exports_files(
 
     dmg_archive(
         name = "mac_dev_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/123.0b9/mac/en-US/Firefox%20123.0b9.dmg",
-        sha256 = "6addddfd288a16c08dc59a88c8f9fe252d7d608b83bc2458f139e77fda4ddab8",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/124.0b9/mac/en-US/Firefox%20124.0b9.dmg",
+        sha256 = "c716240f5fd76937cccbe93e9ffdb681782fbacb9af1face7416351a6e71a1a3",
         build_file_content = "exports_files([\"Firefox.app\"])",
     )
 
@@ -96,32 +96,32 @@ exports_files(
 
     pkg_archive(
         name = "mac_edge",
-        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/7d455fa7-376b-4ff4-a83c-e74664b24a02/MicrosoftEdge-121.0.2277.128.pkg",
-        sha256 = "a9b0e772ab1d5545349e312a94526bd3376b9deaa159f13dce070f713c793261",
+        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/9c227984-0429-48e9-bade-ba93774a430a/MicrosoftEdge-122.0.2365.80.pkg",
+        sha256 = "4fca764d70068e29d1b4657fb4c8b28bfcd8aebc295368bb49e7560f19af0716",
         move = {
-            "MicrosoftEdge-121.0.2277.128.pkg/Payload/Microsoft Edge.app": "Edge.app",
+            "MicrosoftEdge-122.0.2365.80.pkg/Payload/Microsoft Edge.app": "Edge.app",
         },
         build_file_content = "exports_files([\"Edge.app\"])",
     )
 
     http_archive(
         name = "linux_edgedriver",
-        url = "https://msedgedriver.azureedge.net/121.0.2277.128/edgedriver_linux64.zip",
-        sha256 = "9375569e62132ebf68bbe18af7415d572198bc027e15273e8d979c8083ae156a",
+        url = "https://msedgedriver.azureedge.net/122.0.2365.80/edgedriver_linux64.zip",
+        sha256 = "ce49a0e62695ae10226903c00bb15bd296d563a009f03544394228bedf250ab5",
         build_file_content = "exports_files([\"msedgedriver\"])",
     )
 
     http_archive(
         name = "mac_edgedriver",
-        url = "https://msedgedriver.azureedge.net/121.0.2277.128/edgedriver_mac64.zip",
-        sha256 = "bdf456bf444e2878a672f3eebb3211ca05a10a896ca57d70ccfe9d1dc3e90100",
+        url = "https://msedgedriver.azureedge.net/122.0.2365.80/edgedriver_mac64.zip",
+        sha256 = "a12f5030963240e0838670e4cbaf826bd9e5a92565e5efa2e0066729cb34b523",
         build_file_content = "exports_files([\"msedgedriver\"])",
     )
 
     http_archive(
         name = "linux_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.39/linux64/chrome-linux64.zip",
-        sha256 = "22af92803b1c7dec09b12c857a116dee765cf355f212af2f6762fe94c9e26050",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/linux64/chrome-linux64.zip",
+        sha256 = "b059c80216abd74f25a35c08c6ad601a30dfdb09588af27828a9bc7adde65bd3",
         build_file_content = """
 filegroup(
     name = "files",
@@ -137,8 +137,8 @@ exports_files(
 
     http_archive(
         name = "mac_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.39/mac-x64/chrome-mac-x64.zip",
-        sha256 = "0144c2cba9eb4deaa5c53040784653f07f56619108559f2e67bf32c5625be950",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/mac-x64/chrome-mac-x64.zip",
+        sha256 = "4754c5793fec0080e29c6df1720d09c4052b447a14239a55682948635612c0e8",
         strip_prefix = "chrome-mac-x64",
         patch_cmds = [
             "mv 'Google Chrome for Testing.app' Chrome.app",
@@ -149,16 +149,16 @@ exports_files(
 
     http_archive(
         name = "linux_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.39/linux64/chromedriver-linux64.zip",
-        sha256 = "03bb90ffde549f9370dcdf2d2bf97783b484545aa8e5b1cbe28b2477028e02f3",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/linux64/chromedriver-linux64.zip",
+        sha256 = "a73431662c53100171823855de88aea4191c66262c9f61b9829f7ecddc76b754",
         strip_prefix = "chromedriver-linux64",
         build_file_content = "exports_files([\"chromedriver\"])",
     )
 
     http_archive(
         name = "mac_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.39/mac-x64/chromedriver-mac-x64.zip",
-        sha256 = "93325da65b13de4dfc1e5695c61d4e5bfc16263bf1102d6ce48bc12884b4bfee",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.111/mac-x64/chromedriver-mac-x64.zip",
+        sha256 = "16d7e9b92808cd8193fb00ded4c805744bfe0f89cbb647b3ddd1450226ec9212",
         strip_prefix = "chromedriver-mac-x64",
         build_file_content = "exports_files([\"chromedriver\"])",
     )

--- a/dotnet/private/dotnet_nunit_test_suite.bzl
+++ b/dotnet/private/dotnet_nunit_test_suite.bzl
@@ -32,6 +32,10 @@ _BROWSERS = {
         "args": [
             "--params=ActiveDriverConfig=Edge",
         ] + select({
+            "@selenium//common:use_pinned_linux_edge": [
+                "--params=DriverServiceLocation=$(location @linux_edgedriver//:msedgedriver)",
+                "--params=BrowserLocation=$(location @linux_edge//:opt/microsoft/msedge/microsoft-edge)",
+            ],
             "@selenium//common:use_pinned_macos_edge": [
                 "--params=DriverServiceLocation=$(location @mac_edgedriver//:msedgedriver)",
                 "\"--params=BrowserLocation=$(location @mac_edge//:Edge.app)/Contents/MacOS/Microsoft Edge\"",
@@ -42,7 +46,7 @@ _BROWSERS = {
             ],
         }),
         "data": edge_data,
-        "tags": ["skip-remote"],
+        "tags": [],
     },
     "firefox": {
         "args": [

--- a/dotnet/test/common/Environment/DriverFactory.cs
+++ b/dotnet/test/common/Environment/DriverFactory.cs
@@ -87,6 +87,10 @@ namespace OpenQA.Selenium.Environment
             {
                 browser = Browser.Edge;
                 options = GetDriverOptions<EdgeOptions>(driverType, driverOptions);
+
+                var edgeOptions = (EdgeOptions)options;
+                edgeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
+
                 service = CreateService<EdgeDriverService>();
                 if (!string.IsNullOrEmpty(this.browserBinaryLocation))
                 {

--- a/java/browsers.bzl
+++ b/java/browsers.bzl
@@ -27,6 +27,9 @@ chrome_jvm_flags = select({
 }) + chromedriver_jvm_flags
 
 edgedriver_jvm_flags = select({
+    "@selenium//common:use_pinned_linux_edge": [
+        "-Dwebdriver.edge.driver=$(location @linux_edgedriver//:msedgedriver)",
+    ],
     "@selenium//common:use_pinned_macos_edge": [
         "-Dwebdriver.edge.driver=$(location @mac_edgedriver//:msedgedriver)",
     ],
@@ -34,6 +37,9 @@ edgedriver_jvm_flags = select({
 })
 
 edge_jvm_flags = select({
+    "@selenium//common:use_pinned_linux_edge": [
+        "-Dwebdriver.edge.binary=$(location @linux_edge//:opt/microsoft/msedge/microsoft-edge)",
+    ],
     "@selenium//common:use_pinned_macos_edge": [
         "-Dwebdriver.edge.binary=\"$(location @mac_edge//:Edge.app)/Contents/MacOS/Microsoft Edge\"",
     ],

--- a/java/private/selenium_test.bzl
+++ b/java/private/selenium_test.bzl
@@ -30,7 +30,7 @@ BROWSERS = {
         "deps": ["//java/src/org/openqa/selenium/edge"],
         "jvm_flags": ["-Dselenium.browser=edge"] + edge_jvm_flags,
         "data": edge_data,
-        "tags": COMMON_TAGS + ["edge", "skip-remote"],
+        "tags": COMMON_TAGS + ["edge"],
     },
     "firefox": {
         "deps": ["//java/src/org/openqa/selenium/firefox"],

--- a/java/test/org/openqa/selenium/CookieImplementationTest.java
+++ b/java/test/org/openqa/selenium/CookieImplementationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.openqa.selenium.testing.drivers.Browser.ALL;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
@@ -205,6 +206,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Test
   @Ignore(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void testGetCookiesInAFrame() {
     driver.get(domainHelper.getUrlForFirstValidHostname("/common/animals"));
@@ -301,6 +303,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Test
   @NotYetImplemented(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void testShouldWalkThePathToDeleteACookie() {
     Cookie cookie1 = new Cookie.Builder("fish", "cod").build();
@@ -348,6 +351,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Test
   @NotYetImplemented(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void testCookieEqualityAfterSetAndGet() {
     driver.get(domainHelper.getUrlForFirstValidHostname("animals"));
@@ -394,6 +398,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Ignore(IE)
   @Ignore(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void canHandleSecureCookie() {
     driver.get(domainHelper.getSecureUrlForFirstValidHostname("animals"));
@@ -412,6 +417,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Ignore(IE)
   @Ignore(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void testRetainsCookieSecure() {
     driver.get(domainHelper.getSecureUrlForFirstValidHostname("animals"));
@@ -430,6 +436,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Test
   @Ignore(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void canHandleHttpOnlyCookie() {
     Cookie addedCookie =
@@ -445,6 +452,7 @@ class CookieImplementationTest extends JupiterTestBase {
   @Test
   @Ignore(SAFARI)
   @NotWorkingInRemoteBazelBuilds(CHROME)
+  @NotWorkingInRemoteBazelBuilds(EDGE)
   @NotWorkingInRemoteBazelBuilds(FIREFOX)
   public void testRetainsHttpOnlyFlag() {
     Cookie addedCookie =

--- a/java/test/org/openqa/selenium/ExecutingAsyncJavascriptTest.java
+++ b/java/test/org/openqa/selenium/ExecutingAsyncJavascriptTest.java
@@ -50,6 +50,7 @@ class ExecutingAsyncJavascriptTest extends JupiterTestBase {
 
   @Test
   @NotYetImplemented(value = CHROME, reason = "Default to 5s")
+  @NotYetImplemented(value = EDGE, reason = "Default to 5s")
   @NotYetImplemented(value = FIREFOX, reason = "Default to 5s")
   @NotYetImplemented(value = SAFARI, reason = "Default to 5s")
   public void shouldSetAndGetScriptTimeout() {

--- a/java/test/org/openqa/selenium/ExecutingJavascriptTest.java
+++ b/java/test/org/openqa/selenium/ExecutingJavascriptTest.java
@@ -491,6 +491,7 @@ class ExecutingJavascriptTest extends JupiterTestBase {
   @Test
   @Ignore(IE)
   @Ignore(value = CHROME, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=4395")
+  @Ignore(value = EDGE, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=4395")
   public void testShouldBeAbleToReturnADateObject() throws ParseException {
     driver.get(pages.simpleTestPage);
 

--- a/java/test/org/openqa/selenium/PageLoadingTest.java
+++ b/java/test/org/openqa/selenium/PageLoadingTest.java
@@ -25,6 +25,7 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElemen
 import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
@@ -72,6 +73,7 @@ class PageLoadingTest extends JupiterTestBase {
 
   @Test
   @NotYetImplemented(CHROME)
+  @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   public void testShouldReturnWhenGettingAUrlThatDoesNotResolve() {
     assertThatCode(() -> driver.get("http://www.thisurldoesnotexist.comx/"))
@@ -93,6 +95,7 @@ class PageLoadingTest extends JupiterTestBase {
 
   @Test
   @NotYetImplemented(CHROME)
+  @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   public void testShouldReturnWhenGettingAUrlThatDoesNotConnect() {
     // Here's hoping that there's nothing here. There shouldn't be

--- a/java/test/org/openqa/selenium/ProxySettingTest.java
+++ b/java/test/org/openqa/selenium/ProxySettingTest.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openqa.selenium.remote.CapabilityType.PROXY;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
@@ -111,6 +112,7 @@ class ProxySettingTest extends JupiterTestBase {
   @NoDriverAfterTest
   @Ignore(value = FIREFOX, travis = true)
   @Ignore(value = CHROME, reason = "Flaky")
+  @Ignore(value = EDGE, reason = "Flaky")
   public void canUsePACThatOnlyProxiesCertainHosts()
       throws URISyntaxException, InterruptedException {
     try (SimpleHttpServer helloServer =

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -59,7 +59,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodes() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -77,7 +76,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithJustLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -93,7 +91,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNode() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -109,7 +106,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithCSSLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -138,7 +134,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithXPathLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -192,7 +187,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithMaxNodeCount() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -211,7 +205,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithNoneOwnershipParameter() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -233,7 +226,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesWithRootOwnershipParameter() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -255,7 +247,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesGivenStartNodes() {
     String handle = driver.getWindowHandle();
     BrowsingContext browsingContext = new BrowsingContext(driver, handle);
@@ -299,7 +290,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canLocateNodesInAGivenSandbox() {
     String sandbox = "sandbox";
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -350,7 +340,6 @@ public class LocateNodesTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
-  @NotYetImplemented(FIREFOX)
   void canFindElement() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 
 import java.time.Duration;
 import java.util.List;
@@ -39,6 +40,7 @@ import org.openqa.selenium.chromium.HasNetworkConditions;
 import org.openqa.selenium.chromium.HasPermissions;
 import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.http.ClientConfig;
+import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
 import org.openqa.selenium.testing.NoDriverBeforeTest;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
@@ -93,6 +95,7 @@ class EdgeDriverFunctionalTest extends JupiterTestBase {
   }
 
   @Test
+  @Ignore(value = EDGE, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=4350")
   void canSetPermission() {
     HasPermissions permissions = (HasPermissions) driver;
 

--- a/java/test/org/openqa/selenium/edge/EdgeDriverInfoTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverInfoTest.java
@@ -57,7 +57,7 @@ class EdgeDriverInfoTest {
     assertThat(new EdgeDriverInfo())
         .is(supporting(new ImmutableCapabilities(EdgeOptions.CAPABILITY, Collections.emptyMap())));
     assertThat(new EdgeDriverInfo())
-        .is(supporting(new ImmutableCapabilities("edgeOptions", Collections.emptyMap())));
+        .is(supporting(new ImmutableCapabilities("ms:edgeOptions", Collections.emptyMap())));
   }
 
   private Condition<EdgeDriverInfo> supporting(Capabilities capabilities) {

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -36,7 +36,6 @@ drivers = (
     "remote",
     "safari",
     "webkitgtk",
-    "chromiumedge",
     "wpewebkit",
 )
 
@@ -169,16 +168,13 @@ def get_options(driver_class, config):
     headless = bool(config.option.headless)
     options = None
 
-    if driver_class == "ChromiumEdge":
-        options = getattr(webdriver, "EdgeOptions")()
-
     if browser_path or browser_args:
         if not options:
             options = getattr(webdriver, f"{driver_class}Options")()
         if driver_class == "WebKitGTK":
             options.overlay_scrollbars_enabled = False
         if browser_path is not None:
-            options.binary_location = browser_path
+            options.binary_location = browser_path.strip("'")
         if browser_args is not None:
             for arg in browser_args.split():
                 options.add_argument(arg)

--- a/py/private/browsers.bzl
+++ b/py/private/browsers.bzl
@@ -28,6 +28,12 @@ chrome_args = select({
 }) + headless_args
 
 edge_args = select({
+    "@selenium//common:use_pinned_linux_edge": [
+        "--driver-binary=$(location @linux_edgedriver//:msedgedriver)",
+        "--browser-binary=$(location @linux_edge//:opt/microsoft/msedge/microsoft-edge)",
+        "--browser-args=--disable-dev-shm-usage",
+        "--browser-args=--no-sandbox",
+    ],
     "@selenium//common:use_pinned_macos_edge": [
         "--driver-binary=$(location @mac_edgedriver//:msedgedriver)",
         "--browser-binary='$(location @mac_edge//:Edge.app)/Contents/MacOS/Microsoft Edge'",
@@ -56,7 +62,7 @@ BROWSERS = {
     "edge": {
         "args": ["--driver=edge"] + edge_args,
         "data": edge_data,
-        "tags": COMMON_TAGS + ["edge", "skip-remote"],
+        "tags": COMMON_TAGS + ["edge"],
     },
     "firefox": {
         "args": ["--driver=firefox"] + firefox_args,

--- a/py/pytest.ini
+++ b/py/pytest.ini
@@ -5,7 +5,7 @@ log_cli = True
 trio_mode = true
 markers =
     xfail_chrome: Tests expected to fail in Chrome
-    xfail_chromiumedge: Tests expected to fail in Chromium Edge
+    xfail_edge: Tests expected to fail in Edge
     xfail_firefox: Tests expected to fail in Firefox
     xfail_ie: Tests expected to fail in IE
     xfail_remote: Tests expected to fail with Remote webdriver

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1046,7 +1046,7 @@ class WebDriver(BaseWebDriver):
         _firefox = False
         if self.caps.get("browserName") == "chrome":
             debugger_address = self.caps.get("goog:chromeOptions").get("debuggerAddress")
-        elif self.caps.get("browserName") == "msedge":
+        elif self.caps.get("browserName") == "MicrosoftEdge":
             debugger_address = self.caps.get("ms:edgeOptions").get("debuggerAddress")
         else:
             _firefox = True

--- a/py/test/selenium/webdriver/common/alerts_tests.py
+++ b/py/test/selenium/webdriver/common/alerts_tests.py
@@ -141,7 +141,7 @@ def test_setting_the_value_of_an_alert_throws(driver, pages):
 @pytest.mark.xfail_chrome(
     condition=sys.platform == "darwin", reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=26", run=False
 )
-@pytest.mark.xfail_chromiumedge(
+@pytest.mark.xfail_edge(
     condition=sys.platform == "darwin", reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=26", run=False
 )
 def test_alert_should_not_allow_additional_commands_if_dimissed(driver, pages):
@@ -250,7 +250,7 @@ def test_should_handle_alert_on_page_load_using_get(driver, pages):
 
 
 @pytest.mark.xfail_chrome(reason="Non W3C conformant")
-@pytest.mark.xfail_chromiumedge(reason="Non W3C conformant")
+@pytest.mark.xfail_edge(reason="Non W3C conformant")
 def test_should_handle_alert_on_page_before_unload(driver, pages):
     pages.load("pageWithOnBeforeUnloadMessage.html")
 
@@ -293,6 +293,7 @@ def test_alert_should_not_allow_additional_commands_if_dismissed(driver, pages):
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1279211")
 @pytest.mark.xfail_remote(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1279211")
 @pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
 def test_unexpected_alert_present_exception_contains_alert_text(driver, pages):
     pages.load("alerts.html")
     driver.find_element(by=By.ID, value="alert").click()

--- a/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -360,7 +360,7 @@ def test_finding_alink_by_xpath_using_contains_keyword_should_work(driver, pages
 
 
 # @pytest.mark.xfail_chrome(raises=InvalidSelectorException)
-# @pytest.mark.xfail_chromiumedge(raises=InvalidSelectorException)
+# @pytest.mark.xfail_edge(raises=InvalidSelectorException)
 # @pytest.mark.xfail_firefox(raises=InvalidSelectorException)
 # @pytest.mark.xfail_remote(raises=InvalidSelectorException)
 # @pytest.mark.xfail_safari(raises=NoSuchElementException)

--- a/py/test/selenium/webdriver/common/element_attribute_tests.py
+++ b/py/test/selenium/webdriver/common/element_attribute_tests.py
@@ -270,6 +270,7 @@ def test_should_return_true_for_present_boolean_attributes(driver, pages):
 
 
 @pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_safari
 @pytest.mark.xfail_remote
@@ -280,6 +281,7 @@ def test_should_get_unicode_chars_from_attribute(driver, pages):
 
 
 @pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_safari
 @pytest.mark.xfail_remote

--- a/py/test/selenium/webdriver/common/frame_switching_tests.py
+++ b/py/test/selenium/webdriver/common/frame_switching_tests.py
@@ -230,6 +230,7 @@ def test_should_continue_to_refer_to_the_same_frame_once_it_has_been_selected(dr
 @pytest.mark.xfail_remote(raises=WebDriverException, reason="https://github.com/mozilla/geckodriver/issues/610")
 @pytest.mark.xfail_safari
 @pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
 def test_should_focus_on_the_replacement_when_aframe_follows_alink_to_a_top_targeted_page(driver, pages):
     pages.load("frameset.html")
     driver.switch_to.frame(0)
@@ -383,7 +384,7 @@ def test_should_be_able_to_switch_to_the_top_if_the_frame_is_deleted_from_under_
 
 
 # @pytest.mark.xfail_chrome(raises=NoSuchElementException)
-# @pytest.mark.xfail_chromiumedge(raises=NoSuchElementException)
+# @pytest.mark.xfail_edge(raises=NoSuchElementException)
 # @pytest.mark.xfail_firefox(raises=WebDriverException,
 #                            reason='https://github.com/mozilla/geckodriver/issues/614')
 # @pytest.mark.xfail_remote(raises=WebDriverException,

--- a/py/test/selenium/webdriver/common/page_loading_tests.py
+++ b/py/test/selenium/webdriver/common/page_loading_tests.py
@@ -121,7 +121,7 @@ def test_should_wait_for_document_to_be_loaded(driver, pages):
 # @pytest.mark.xfail_firefox(run=False)
 # @pytest.mark.xfail_remote(run=False)
 # @pytest.mark.xfail_chrome(run=False)
-# @pytest.mark.xfail_chromiumedge(run=False)
+# @pytest.mark.xfail_edge(run=False)
 # def test_should_not_hang_if_document_open_call_is_never_followed_by_document_close_call(driver, pages):
 #     pages.load("document_write_in_onload.html")
 #     driver.find_element(By.XPATH, "//body")

--- a/py/test/selenium/webdriver/common/position_and_size_tests.py
+++ b/py/test/selenium/webdriver/common/position_and_size_tests.py
@@ -63,7 +63,7 @@ def test_should_scroll_page_and_get_coordinates_of_an_element_that_is_out_of_vie
 
 
 @pytest.mark.xfail_chrome
-@pytest.mark.xfail_chromiumedge
+@pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_remote
 @pytest.mark.xfail_safari
@@ -76,7 +76,7 @@ def test_should_get_coordinates_of_an_element_in_aframe(driver, pages):
 
 
 @pytest.mark.xfail_chrome
-@pytest.mark.xfail_chromiumedge
+@pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_remote
 @pytest.mark.xfail_safari

--- a/py/test/selenium/webdriver/common/upload_tests.py
+++ b/py/test/selenium/webdriver/common/upload_tests.py
@@ -58,6 +58,7 @@ def test_can_upload_two_files(driver, pages, get_local_path):
 
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
 @pytest.mark.xfail_safari
 def test_file_is_uploaded_to_remote_machine_on_select(driver, pages, get_local_path):
     uploaded_files = []

--- a/py/test/selenium/webdriver/common/window_tests.py
+++ b/py/test/selenium/webdriver/common/window_tests.py
@@ -21,7 +21,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support.wait import WebDriverWait
 
 # @pytest.mark.xfail_ie
-# @pytest.mark.xfail_chromiumedge(reason="Fails on Travis")
+# @pytest.mark.xfail_edge(reason="Fails on Travis")
 # @pytest.mark.xfail_firefox(reason="Fails on Travis")
 # @pytest.mark.xfail_remote(reason="Fails on Travis")
 # def test_should_maximize_the_window(driver):

--- a/rake_tasks/selenium_rake/browsers.rb
+++ b/rake_tasks/selenium_rake/browsers.rb
@@ -18,9 +18,6 @@ module SeleniumRake
       'chrome' => {
         driver: 'Chrome',
       },
-      'chromiumedge' => {
-        driver: 'ChromiumEdge',
-      },
       'remote_firefox' => {
         driver: 'Remote',
         deps: [

--- a/rb/spec/BUILD.bazel
+++ b/rb/spec/BUILD.bazel
@@ -8,14 +8,14 @@ rb_library(
 )
 
 # List of dependencies can be gathered by running:
-# bazel query 'kind("rb_.* rule", //rb/spec/...) except //rb/spec:spec' | xargs -I{} echo '"{}",'
+# bazel query 'kind("rb_.* rule", //rb/spec/...) except attr(tags, "browser-test", //rb/spec/...) except //rb/spec:spec' | xargs -I{} echo '"{}",'
 
 rb_library(
     name = "spec",
     testonly = True,
     visibility = ["//rb:__pkg__"],
     deps = [
-        ":rspec_matchers",
+        "//rb/spec:rspec_matchers",
         "//rb/spec/integration/selenium/webdriver:action_builder",
         "//rb/spec/integration/selenium/webdriver:bidi",
         "//rb/spec/integration/selenium/webdriver:devtools",
@@ -52,6 +52,7 @@ rb_library(
         "//rb/spec/integration/selenium/webdriver/remote:driver",
         "//rb/spec/integration/selenium/webdriver/remote:element",
         "//rb/spec/integration/selenium/webdriver/safari:driver",
+        "//rb/spec/unit/selenium:devtools",
         "//rb/spec/unit/selenium:server",
         "//rb/spec/unit/selenium/devtools:cdp_client_generator",
         "//rb/spec/unit/selenium/webdriver:file_reaper",
@@ -67,6 +68,7 @@ rb_library(
         "//rb/spec/unit/selenium/webdriver/chrome:service",
         "//rb/spec/unit/selenium/webdriver/common:action_builder",
         "//rb/spec/unit/selenium/webdriver/common:credentials",
+        "//rb/spec/unit/selenium/webdriver/common:driver_finder",
         "//rb/spec/unit/selenium/webdriver/common:logger",
         "//rb/spec/unit/selenium/webdriver/common:selenium_manager",
         "//rb/spec/unit/selenium/webdriver/common:service",

--- a/rb/spec/integration/selenium/webdriver/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/BUILD.bazel
@@ -12,10 +12,7 @@ rb_library(
         "//rb:manager-linux",
         "//rb:manager-macos",
         "//rb:manager-windows",
-    ] + select({
-        "//rb/spec/integration:remote": ["//java/src/org/openqa/selenium/grid:selenium_server_deploy.jar"],
-        "//conditions:default": [],
-    }),
+    ],
     visibility = ["//rb/spec:__subpackages__"],
     deps = [
         "//rb/lib:selenium-webdriver",
@@ -27,14 +24,7 @@ rb_library(
         "//rb/lib/selenium/webdriver:remote",
         "//rb/spec:rspec_matchers",
         "@bundle",
-    ] + select({
-        "//rb/spec/integration:edge": ["//rb/lib/selenium/webdriver:edge"],
-        "//rb/spec/integration:firefox": ["//rb/lib/selenium/webdriver:firefox"],
-        "//rb/spec/integration:ie": ["//rb/lib/selenium/webdriver:ie"],
-        "//rb/spec/integration:safari": ["//rb/lib/selenium/webdriver:safari"],
-        "//rb/spec/integration:safari-preview": ["//rb/lib/selenium/webdriver:safari"],
-        "//conditions:default": ["//rb/lib/selenium/webdriver:chrome"],
-    }),
+    ],
 )
 
 [
@@ -79,25 +69,9 @@ rb_integration_test(
 rb_integration_test(
     name = "driver",
     srcs = ["driver_spec.rb"],
-    deps = [
-        "//rb/lib/selenium/webdriver:chrome",
-        "//rb/lib/selenium/webdriver:edge",
-        "//rb/lib/selenium/webdriver:firefox",
-        "//rb/lib/selenium/webdriver:ie",
-        "//rb/lib/selenium/webdriver:remote",
-        "//rb/lib/selenium/webdriver:safari",
-    ],
 )
 
 rb_integration_test(
     name = "element",
     srcs = ["element_spec.rb"],
-    deps = [
-        "//rb/lib/selenium/webdriver:chrome",
-        "//rb/lib/selenium/webdriver:edge",
-        "//rb/lib/selenium/webdriver:firefox",
-        "//rb/lib/selenium/webdriver:ie",
-        "//rb/lib/selenium/webdriver:remote",
-        "//rb/lib/selenium/webdriver:safari",
-    ],
 )

--- a/rb/spec/integration/selenium/webdriver/chrome/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/chrome/BUILD.bazel
@@ -4,7 +4,7 @@ load("//rb/spec:tests.bzl", "rb_integration_test")
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
-        deps = ["//rb/lib/selenium/webdriver:chrome"],
+        browsers = ["chrome"],  # No need to run in other browsers.
     )
     for file in glob(["*_spec.rb"])
 ]

--- a/rb/spec/integration/selenium/webdriver/edge/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/edge/BUILD.bazel
@@ -4,7 +4,7 @@ load("//rb/spec:tests.bzl", "rb_integration_test")
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
-        deps = ["//rb/lib/selenium/webdriver:edge"],
+        browsers = ["edge"],  # No need to run in other browsers.
     )
     for file in glob(["*_spec.rb"])
 ]

--- a/rb/spec/integration/selenium/webdriver/firefox/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/firefox/BUILD.bazel
@@ -4,7 +4,12 @@ load("//rb/spec:tests.bzl", "rb_integration_test")
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
-        deps = ["//rb/lib/selenium/webdriver:firefox"],
+        # No need to run in other browsers.
+        browsers = [
+            "firefox",
+            "firefox-beta",
+        ],
+        data = ["//common/extensions"],
     )
     for file in glob(["*_spec.rb"])
 ]

--- a/rb/spec/integration/selenium/webdriver/remote/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/remote/BUILD.bazel
@@ -4,7 +4,6 @@ load("//rb/spec:tests.bzl", "rb_integration_test")
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
-        deps = ["//rb/lib/selenium/webdriver:remote"],
     )
     for file in glob(["*_spec.rb"])
 ]

--- a/rb/spec/integration/selenium/webdriver/safari/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/safari/BUILD.bazel
@@ -4,7 +4,11 @@ load("//rb/spec:tests.bzl", "rb_integration_test")
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
-        deps = ["//rb/lib/selenium/webdriver:safari"],
+        # No need to run in other browsers.
+        browsers = [
+            "safari",
+            "safari-preview",
+        ],
     )
     for file in glob(["*_spec.rb"])
 ]

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -251,6 +251,8 @@ module Selenium
         def edge_options(args: [], **opts)
           opts[:binary] ||= ENV['EDGE_BINARY'] if ENV.key?('EDGE_BINARY')
           args << '--headless=chrome' if ENV['HEADLESS']
+          args << '--no-sandbox'
+          args << '--disable-gpu'
           WebDriver::Options.edge(browser_version: 'stable', args: args, **opts)
         end
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -217,13 +217,15 @@ module Selenium
           service ||= WebDriver::Service.edge
           service.args << '--disable-build-check' if ENV['DISABLE_BUILD_CHECK']
           service.args << '--verbose' if WebDriver.logger.debug?
+          service.executable_path = ENV['MSEDGEDRIVER_BINARY'] if ENV.key?('MSEDGEDRIVER_BINARY')
           WebDriver::Driver.for(:edge, service: service, **opts)
         end
 
         def firefox_driver(service: nil, **opts)
           service ||= WebDriver::Service.firefox
           service.args.push('--log', 'trace') if WebDriver.logger.debug?
-          WebDriver::Driver.for(:firefox, **opts)
+          service.executable_path = ENV['GECKODRIVER_BINARY'] if ENV.key?('GECKODRIVER_BINARY')
+          WebDriver::Driver.for(:firefox, service: service, **opts)
         end
 
         def safari_driver(**opts)
@@ -255,7 +257,7 @@ module Selenium
         def firefox_options(args: [], **opts)
           opts[:binary] ||= ENV['FIREFOX_BINARY'] if ENV.key?('FIREFOX_BINARY')
           args << '--headless' if ENV['HEADLESS']
-          WebDriver::Options.firefox(browser_version: 'stable', args: args, **opts)
+          WebDriver::Options.firefox(args: args, **opts)
         end
 
         def ie_options(**opts)

--- a/rb/spec/tests.bzl
+++ b/rb/spec/tests.bzl
@@ -35,14 +35,16 @@ BROWSERS = {
     "edge": {
         "data": edge_data,
         "deps": ["//rb/lib/selenium/webdriver:edge"],
-        "tags": [
-            "skip-remote",  # TODO: Add Linux version of Edge to pinned browsers.
-        ],
+        "tags": [],
         "target_compatible_with": [],
         "env": {
             "WD_REMOTE_BROWSER": "edge",
             "WD_SPEC_DRIVER": "edge",
         } | select({
+            "@selenium//common:use_pinned_linux_edge": {
+                "EDGE_BINARY": "$(location @linux_edge//:opt/microsoft/msedge/microsoft-edge)",
+                "MSEDGEDRIVER_BINARY": "$(location @linux_edgedriver//:msedgedriver)",
+            },
             "@selenium//common:use_pinned_macos_edge": {
                 "EDGE_BINARY": "$(location @mac_edge//:Edge.app)/Contents/MacOS/Microsoft\\ Edge",
                 "MSEDGEDRIVER_BINARY": "$(location @mac_edgedriver//:msedgedriver)",

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -141,11 +141,14 @@ exports_files(
 
 
 def edge():
+    content = ""
     r = http.request("GET", "https://edgeupdates.microsoft.com/api/products")
     all_data = json.loads(r.data)
 
-    edge = None
-    hash = None
+    linux = None
+    linux_hash = None
+    mac = None
+    mac_hash = None
     version = None
 
     for data in all_data:
@@ -155,12 +158,17 @@ def edge():
             if "MacOS" == release.get("Platform"):
                 for artifact in release["Artifacts"]:
                     if "pkg" == artifact["ArtifactName"]:
-                        edge = artifact["Location"]
-                        hash = artifact["Hash"]
-                        version = release["ProductVersion"]
+                        mac = artifact["Location"]
+                        mac_hash = artifact["Hash"]
+                        mac_version = release["ProductVersion"]
+            elif "Linux" == release.get("Platform"):
+                for artifact in release["Artifacts"]:
+                    if "deb" == artifact["ArtifactName"]:
+                        linux = artifact["Location"]
+                        linux_hash = artifact["Hash"]
 
-    if edge and hash:
-        return """
+    if mac and mac_hash:
+        content += """
     pkg_archive(
         name = "mac_edge",
         url = "%s",
@@ -171,12 +179,35 @@ def edge():
         build_file_content = "exports_files([\\"Edge.app\\"])",
     )
 """ % (
-            edge,
-            hash.lower(),
-            version,
+            mac,
+            mac_hash.lower(),
+            mac_version,
         )
 
-    return ""
+    if linux and linux_hash:
+        content += """
+    deb_archive(
+        name = "linux_edge",
+        url = "%s",
+        sha256 = "%s",
+        build_file_content = \"\"\"
+filegroup(
+    name = "files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["opt/microsoft/msedge/microsoft-edge"],
+)
+\"\"\",
+    )
+""" % (
+            linux,
+            linux_hash.lower()
+        )
+
+    return content
 
 
 def edgedriver():
@@ -333,6 +364,7 @@ if __name__ == "__main__":
     content = """# This file has been generated using `bazel run scripts:pinned_browsers`
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//common/private:deb_archive.bzl", "deb_archive")
 load("//common/private:dmg_archive.bzl", "dmg_archive")
 load("//common/private:drivers.bzl", "local_drivers")
 load("//common/private:pkg_archive.bzl", "pkg_archive")


### PR DESCRIPTION
## **User description**
Follow up to #13661.

This PR generates per-browser test targets in Bazel and hooks them into RBE. See documentation in README for how targets are generated from RSpec files.


___

## **Type**
enhancement, tests


___

## **Description**
- Updated Firefox versions and SHA256 checksums for Linux and macOS.
- Updated Edge versions and SHA256 checksums for macOS.
- Updated Chrome versions and SHA256 checksums for Linux and macOS.
- Refactored to generate per-browser test targets for Ruby integration tests.
- Added support for specifying browsers and handling remote execution.
- Updated GitHub Actions workflows to use `setup-bazel` action version `0.8.1`.
- Modified Ruby CI workflow to use `--build_tests_only` and `--test_size_filters`.
- Updated skipped test entries for Ruby integration tests with new naming convention.
- Updated Ruby test commands and descriptions to reflect new test target generation logic.
- Added new environment variables for custom driver paths.
- Removed `@NotYetImplemented(FIREFOX)` annotations from multiple Java test methods, enabling tests for Firefox.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>LocateNodesTest.java</strong><dd><code>Enable LocateNodes Tests for Firefox in Bidi BrowsingContext</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java

<li>Removed <code>@NotYetImplemented(FIREFOX)</code> annotations from multiple test <br>methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-b63701b3cf1f898a95e4ef4d8b70e04724101885116b5287a447a0670a5a1ff3">+0/-11</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NetworkEventsTest.java</strong><dd><code>Enable NetworkEvents Test for Firefox</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java

<li>Removed <code>@NotYetImplemented(FIREFOX)</code> annotation from <br><code>canListenToFetchError</code> test method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-d8a2f31c89a869b962bef54fdb254806ca6416d6d60323844e54b9855720cf0e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Restrict Chrome Integration Tests to Chrome Browser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/chrome/BUILD.bazel

<li>Specified <code>chrome</code> as the only browser for Chrome-specific integration <br>tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-5c6fcc442a425970a5b84682927afa426fc2de3f352c5f115b0cb4ef870042e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Restrict Edge Integration Tests to Edge Browser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/edge/BUILD.bazel

<li>Specified <code>edge</code> as the only browser for Edge-specific integration <br>tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-61d4eb872738f4d005fd3e4ace0f641cf796c9e6b99247938ba5e74c5157eeb2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Restrict Firefox Integration Tests to Firefox Browsers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/firefox/BUILD.bazel

<li>Specified <code>firefox</code> and <code>firefox-beta</code> as the browsers for <br>Firefox-specific integration tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-423944062b5c95c528d9ae06c1f40bd07cc8e4b354cea561f50f294fb1c64865">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Restrict Safari Integration Tests to Safari Browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/safari/BUILD.bazel

<li>Specified <code>safari</code> and <code>safari-preview</code> as the browsers for <br>Safari-specific integration tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-6ef3a2e5ae3d59e1a676f46aa46e7ac792dd96b9ad731e2387c27b2c5fcc7197">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Support Custom Edge and Firefox Driver Paths in Ruby Tests</code></dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<li>Added environment variable checks for <code>MSEDGEDRIVER_BINARY</code> and <br><code>GECKODRIVER_BINARY</code>.<br> <li> Modified <code>firefox_options</code> to not specifically set <code>browser_version</code> to <br>'stable'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tests.bzl</strong><dd><code>Generate Per-Browser Test Targets for Ruby Integration Tests</code></dd></summary>
<hr>
      
rb/spec/tests.bzl

<li>Refactored to generate per-browser test targets for Ruby integration <br>tests.<br> <li> Added support for specifying browsers and handling remote execution.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-0b035bed60fc62ad1db7c3548fa4df1aa1cd0ebe7b3c50cf5643a34929d8cb68">+174/-61</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>browsers.bzl</strong><dd><code>Document `no-sandbox` Usage for Firefox in Bazel Config</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
common/browsers.bzl

<li>Added comments regarding the use of <code>no-sandbox</code> for Firefox due to a <br>bug.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-3cd9e4c7ec8b7f01b7bc189a00bf080d0553912a63eb561c871f32a280cd3a3b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Ruby Test Commands and Environment Variables in README</code></dd></summary>
<hr>
      
README.md

<li>Updated Ruby test commands and descriptions to reflect new test target <br>generation logic.<br> <li> Added new environment variables for custom driver paths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+32/-21</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.bzl</strong><dd><code>Update Pinned Browser Versions and Checksums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
common/repositories.bzl

<li>Updated Firefox versions and SHA256 checksums for Linux and macOS.<br> <li> Updated Edge versions and SHA256 checksums for macOS.<br> <li> Updated Chrome versions and SHA256 checksums for Linux and macOS.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-25d82cd18102fed27d3202000e1f1b3a56a85ad2848236d91989cd30a3952401">+28/-28</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bazel.yml</strong><dd><code>Update GitHub Actions Workflow for Bazel Setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/bazel.yml

- Updated `setup-bazel` action version to `0.8.1`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-85e6e6bfc3047eb4fe69bf0f06238ddd442edf74266ad3a964ebfba26f46923c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ci-ruby.yml</strong><dd><code>Refine Ruby CI Workflow Commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/ci-ruby.yml

<li>Modified Ruby CI workflow to use <code>--build_tests_only</code> and <br><code>--test_size_filters</code>.<br> <li> Adjusted test command to include all Ruby specs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-e71b669ae33da2f4e6f9e0858c13b326eaea0388934d0a21e3ebc31005b7aa90">+13/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Update GitHub Actions Workflow for Bazel Setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/ci.yml

- Updated `setup-bazel` action version to `0.8.1`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>.skipped-tests</strong><dd><code>Update Skipped Tests List with New Naming Convention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.skipped-tests

<li>Updated skipped test entries for Ruby integration tests with new <br>naming convention.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-f5b9e26559bdc4671c8a6fd4013e376a76cbdac0a1661ffbe585b7533c4700f7">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Adjust Visibility for Ruby Spec Subpackages in Bazel Build File</code></dd></summary>
<hr>
      
common/extensions/BUILD.bazel

- Modified visibility for `//rb/spec:__subpackages__`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-c4603199396fae77404942287b31d1856af23b8e5baafa7f6290488ee4cd079d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update Dependencies for Ruby Spec Library Target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/spec/BUILD.bazel

- Updated dependencies for the Ruby `spec` library target.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-84fe633f14fd5f6b5d1a0640312340dd03dfcf6a2bc4a9a8d98442e8824f5fdc">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Simplify Dependencies for Ruby WebDriver Integration Tests</code></dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/BUILD.bazel

<li>Removed explicit dependencies from <code>driver</code> and <code>element</code> test targets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-57ea1da3218aa513701799d1c90da4a709215c7c8dd8e2e70e346b1ccf63951c">+2/-28</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Simplify Dependencies for Ruby Remote WebDriver Integration Tests</code></dd></summary>
<hr>
      
rb/spec/integration/selenium/webdriver/remote/BUILD.bazel

<li>Removed explicit dependencies from remote WebDriver integration test <br>targets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13683/files#diff-cd45be7d7e9ce730dfb1fdaa796cbeb4b815e249e03cb5a89164e872fe7a1ea2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

