### PR TITLE
[bidi][java] Add continueRequest and continueResponse command

### DIFF
--- a/java/src/org/openqa/selenium/bidi/module/Network.java
+++ b/java/src/org/openqa/selenium/bidi/module/Network.java
@@ -30,6 +30,8 @@ import org.openqa.selenium.bidi.Event;
 import org.openqa.selenium.bidi.HasBiDi;
 import org.openqa.selenium.bidi.network.AddInterceptParameters;
 import org.openqa.selenium.bidi.network.BeforeRequestSent;
+import org.openqa.selenium.bidi.network.ContinueRequestParameters;
+import org.openqa.selenium.bidi.network.ContinueResponseParameters;
 import org.openqa.selenium.bidi.network.FetchError;
 import org.openqa.selenium.bidi.network.ResponseDetails;
 import org.openqa.selenium.internal.Require;
@@ -120,6 +122,14 @@ public class Network implements AutoCloseable {
 
   public void failRequest(String requestId) {
     this.bidi.send(new Command<>("network.failRequest", Map.of("request", requestId)));
+  }
+
+  public void continueRequest(ContinueRequestParameters parameters) {
+    this.bidi.send(new Command<>("network.continueRequest", parameters.toMap()));
+  }
+
+  public void continueResponse(ContinueResponseParameters parameters) {
+    this.bidi.send(new Command<>("network.continueResponse", parameters.toMap()));
   }
 
   public void onBeforeRequestSent(Consumer<BeforeRequestSent> consumer) {

--- a/java/src/org/openqa/selenium/bidi/network/BytesValue.java
+++ b/java/src/org/openqa/selenium/bidi/network/BytesValue.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium.bidi.network;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.openqa.selenium.json.JsonInput;
 
 public class BytesValue {
@@ -76,5 +78,13 @@ public class BytesValue {
 
   public String getValue() {
     return value;
+  }
+
+  public Map<String, String> toMap() {
+    Map<String, String> map = new HashMap<>();
+    map.put("type", type.toString());
+    map.put("value", value);
+
+    return map;
   }
 }

--- a/java/src/org/openqa/selenium/bidi/network/ContinueRequestParameters.java
+++ b/java/src/org/openqa/selenium/bidi/network/ContinueRequestParameters.java
@@ -1,0 +1,64 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.bidi.network;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ContinueRequestParameters {
+  private final Map<String, Object> map = new HashMap<>();
+
+  public ContinueRequestParameters(String request) {
+    map.put("request", request);
+  }
+
+  public ContinueRequestParameters body(BytesValue value) {
+    map.put("body", value.toMap());
+    return this;
+  }
+
+  public ContinueRequestParameters cookies(List<Header> cookieHeaders) {
+    List<Map<String, Object>> cookies =
+        cookieHeaders.stream().map(Header::toMap).collect(Collectors.toList());
+    map.put("cookies", cookies);
+    return this;
+  }
+
+  public ContinueRequestParameters headers(List<Header> headers) {
+    List<Map<String, Object>> headerList =
+        headers.stream().map(Header::toMap).collect(Collectors.toList());
+    map.put("headers", headerList);
+    return this;
+  }
+
+  public ContinueRequestParameters method(String method) {
+    map.put("method", method);
+    return this;
+  }
+
+  public ContinueRequestParameters url(String url) {
+    map.put("url", url);
+    return this;
+  }
+
+  public Map<String, Object> toMap() {
+    return map;
+  }
+}

--- a/java/src/org/openqa/selenium/bidi/network/ContinueResponseParameters.java
+++ b/java/src/org/openqa/selenium/bidi/network/ContinueResponseParameters.java
@@ -1,0 +1,66 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.bidi.network;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.openqa.selenium.UsernameAndPassword;
+
+public class ContinueResponseParameters {
+  private final Map<String, Object> map = new HashMap<>();
+
+  public ContinueResponseParameters(String request) {
+    map.put("request", request);
+  }
+
+  public ContinueResponseParameters cookies(List<SetCookieHeader> cookieHeaders) {
+    List<Map<String, Object>> cookies =
+        cookieHeaders.stream().map(SetCookieHeader::toMap).collect(Collectors.toList());
+    map.put("cookies", cookies);
+    return this;
+  }
+
+  public ContinueResponseParameters credentials(UsernameAndPassword credentials) {
+    map.put(
+        "credentials", Map.of("type", "password", credentials.password(), credentials.username()));
+    return this;
+  }
+
+  public ContinueResponseParameters headers(List<Header> headers) {
+    List<Map<String, Object>> headerList =
+        headers.stream().map(Header::toMap).collect(Collectors.toList());
+    map.put("headers", headerList);
+    return this;
+  }
+
+  public ContinueResponseParameters reasonPhrase(String reasonPhrase) {
+    map.put("reasonPhrase", reasonPhrase);
+    return this;
+  }
+
+  public ContinueResponseParameters statusCode(int statusCode) {
+    map.put("statusCode", statusCode);
+    return this;
+  }
+
+  public Map<String, Object> toMap() {
+    return map;
+  }
+}

--- a/java/src/org/openqa/selenium/bidi/network/Cookie.java
+++ b/java/src/org/openqa/selenium/bidi/network/Cookie.java
@@ -16,6 +16,8 @@
 // under the License.
 package org.openqa.selenium.bidi.network;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.openqa.selenium.json.JsonInput;
 
@@ -165,5 +167,21 @@ public class Cookie {
 
   public Optional<Long> getExpiry() {
     return expiry;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("name", getName());
+    map.put("value", getValue().toMap());
+    map.put("domain", getDomain());
+    map.put("path", getPath());
+    map.put("size", getSize());
+    map.put("secure", isSecure());
+    map.put("httpOnly", isHttpOnly());
+    map.put("sameSite", getSameSite().toString());
+
+    getExpiry().ifPresent(expiryValue -> map.put("expiry", expiryValue));
+
+    return map;
   }
 }

--- a/java/src/org/openqa/selenium/bidi/network/SetCookieHeader.java
+++ b/java/src/org/openqa/selenium/bidi/network/SetCookieHeader.java
@@ -14,58 +14,56 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 package org.openqa.selenium.bidi.network;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.openqa.selenium.json.JsonInput;
 
-public class Header {
-  private final String name;
-  private final BytesValue value;
+public class SetCookieHeader {
 
-  private Header(String name, BytesValue value) {
-    this.name = name;
-    this.value = value;
+  private final Map<String, Object> map = new HashMap<>();
+
+  public SetCookieHeader(String name, BytesValue value) {
+    map.put("name", name);
+    map.put("value", value);
   }
 
-  public static Header fromJson(JsonInput input) {
-    String name = null;
-    BytesValue value = null;
-
-    input.beginObject();
-    while (input.hasNext()) {
-      switch (input.nextName()) {
-        case "name":
-          name = input.read(String.class);
-          break;
-        case "value":
-          value = input.read(BytesValue.class);
-          break;
-        default:
-          input.skipValue();
-      }
-    }
-
-    input.endObject();
-
-    return new Header(name, value);
+  public SetCookieHeader domain(String domain) {
+    map.put("domain", domain);
+    return this;
   }
 
-  public String getName() {
-    return name;
+  public SetCookieHeader path(String path) {
+    map.put("path", path);
+    return this;
   }
 
-  public BytesValue getValue() {
-    return value;
+  public SetCookieHeader maxAge(long maxAge) {
+    map.put("maxAge", maxAge);
+    return this;
+  }
+
+  public SetCookieHeader httpOnly(boolean httpOnly) {
+    map.put("httpOnly", httpOnly);
+    return this;
+  }
+
+  public SetCookieHeader secure(boolean secure) {
+    map.put("secure", secure);
+    return this;
+  }
+
+  public SetCookieHeader sameSite(Cookie.SameSite sameSite) {
+    map.put("sameSite", sameSite.toString());
+    return this;
+  }
+
+  public SetCookieHeader expiry(long expiry) {
+    map.put("expiry", expiry);
+    return this;
   }
 
   public Map<String, Object> toMap() {
-    Map<String, Object> map = new HashMap<>();
-    map.put("name", this.name);
-    map.put("value", this.value.toMap());
-
     return map;
   }
 }


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add continueRequest and continueResponse command from the Network module

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Added `continueRequest` and `continueResponse` methods in `Network.java` to support continuing paused network requests and responses.
- Introduced new classes (`ContinueRequestParameters`, `ContinueResponseParameters`, `SetCookieHeader`) to encapsulate various parameters for network operations.
- Enhanced `BytesValue`, `Cookie`, and `Header` classes with `toMap` methods for easier conversion to Map representations.
- Added unit tests for the new `continueRequest` and `continueResponse` functionalities in the `NetworkCommandsTest.java`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Network.java</strong><dd><code>Add Methods for Continuing Paused Requests and Responses</code>&nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/module/Network.java

<li>Added <code>continueRequest</code> method to send a command for continuing a paused <br>request.<br> <li> Added <code>continueResponse</code> method to send a command for continuing a <br>paused response.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-e742aac674b88cc9d9b7d49a9adf66b4dd95c479327e712cf08a3f8c02a43e7f">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BytesValue.java</strong><dd><code>Enhance BytesValue with toMap Conversion Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/BytesValue.java

<li>Added <code>toMap</code> method to convert <code>BytesValue</code> instances to a Map <br>representation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-6262d5516735fcce3e9bb2f28a18b4f31d5997a57ab12dd63598c5c3cf821f30">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ContinueRequestParameters.java</strong><dd><code>Introduce ContinueRequestParameters Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/ContinueRequestParameters.java

<li>Introduced <code>ContinueRequestParameters</code> class to encapsulate parameters <br>for continuing a paused request.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-644e95262b087e5d0bd38fd776445a45f5000611a273a89ce32906728c3b0b59">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ContinueResponseParameters.java</strong><dd><code>Introduce ContinueResponseParameters Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/ContinueResponseParameters.java

<li>Introduced <code>ContinueResponseParameters</code> class to encapsulate parameters <br>for continuing a paused response.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-cbd6efdbde7cea33f63def7ddaf8eb77d85d08ff0fc9154e818c664321f67ba1">+66/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cookie.java</strong><dd><code>Enhance Cookie with toMap Conversion Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/Cookie.java

<li>Added <code>toMap</code> method to convert <code>Cookie</code> instances to a Map <br>representation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-246c2d6b1b02ecbf6d1430fdacfe6fbd90e69b06a1ff6f93bab8415d3e9d9b5e">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Header.java</strong><dd><code>Enhance Header with toMap Conversion Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/Header.java

<li>Added <code>toMap</code> method to convert <code>Header</code> instances to a Map <br>representation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-f3a176aa5f3e2c9b2e3ae148c3fb4c9150efcdc18babecf6c04ae1d0f45ca0ff">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetCookieHeader.java</strong><dd><code>Introduce SetCookieHeader Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/SetCookieHeader.java

<li>Introduced <code>SetCookieHeader</code> class to encapsulate parameters for setting <br>a cookie.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-57fa56c2639ae939f5f749aea7365c46c0f423eee6d9ae80b08a4133c491bc08">+69/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkCommandsTest.java</strong><dd><code>Add Tests for ContinueRequest and ContinueResponse Methods</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java

<li>Added tests for <code>continueRequest</code> and <code>continueResponse</code> methods in the <br><code>Network</code> module.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13692/files#diff-56334c02fd23ebd6590a6ae6f44b2113bdbc325175c1273c4ef17a236119e517">+67/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

