### PR TITLE
install_addon() didn't take into account dir paths with trailing slashes

### DIFF
--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -125,7 +125,10 @@ class WebDriver(RemoteWebDriver):
 
         if os.path.isdir(path):
             fp = BytesIO()
-            path_root = len(path) + 1  # account for trailing slash
+            # filter all trailing slash found in path
+            path = path.rstrip(os.sep)
+            # account for trailing slash that will be added by os.walk()
+            path_root = len(path) + 1
             with zipfile.ZipFile(fp, "w", zipfile.ZIP_DEFLATED) as zipped:
                 for base, _, files in os.walk(path):
                     for fyle in files:

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -126,7 +126,7 @@ class WebDriver(RemoteWebDriver):
         if os.path.isdir(path):
             fp = BytesIO()
             # filter all trailing slash found in path
-            path = path.rstrip(os.sep)
+            path = os.path.normpath(path)
             # account for trailing slash that will be added by os.walk()
             path_root = len(path) + 1
             with zipfile.ZipFile(fp, "w", zipfile.ZIP_DEFLATED) as zipped:


### PR DESCRIPTION
## **User description**
If install_addon() was called with a path argument pointing to to an extension directory and the path argument value itself ended with a trailing slash, install_addon() would eat the first character of each file it would be adding to the synthetized xpi file.

Fixes #13685

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description

install_addon() can be called given either a path to an xpi file or the path to the source code of an extension. 
In the second case, install_addon() will create a temporary xpi file itself. 

In the second case, if the given path ended with a slash, install_addon() would eat the first character 
of each file that it was adding to  the temporary xpi file.

The patch removes all trailing slashes from the path before processing, thus letting install_addon() work 
regardless of whether a path pointing to a dir ends with a slash.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If the path ended with a slash, install_addon() would eat the first character of each file that it was adding to 
the temporary xpi file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
bug_fix


___

## **Description**
- Fixes an issue in `install_addon` where paths with trailing slashes caused the first character of each file to be omitted when creating a temporary xpi file.
- Ensures `install_addon` works correctly regardless of whether a directory path ends with a slash by stripping trailing slashes and adjusting path root calculation.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Fix Trailing Slash Issue in install_addon Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
py/selenium/webdriver/firefox/webdriver.py

<li>Removes trailing slashes from the path before processing in <br><code>install_addon</code>.<br> <li> Adjusts <code>path_root</code> calculation to account for the removal of trailing <br>slashes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13694/files#diff-89ba579445647535b74423c7bf4b8be79ef1ce33847a2768e623c3083a33545d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

