### PR TITLE
[rust] Bump clap to version 4.5.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,7 +231,12 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains()
+rust_register_toolchains(
+    edition = "2021",
+    versions = [
+        "1.76.0"
+    ],
+)
 
 load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -234,7 +234,7 @@ rules_rust_dependencies()
 rust_register_toolchains(
     edition = "2021",
     versions = [
-        "1.76.0"
+        "1.76.0",
     ],
 )
 

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f7318189fb81fd26fcdc1b88f691d19f6a0501a1317b250f363fc6485a79faaf",
+  "checksum": "d5efddd0399bb2f2c3f5fd3b9bddccaca7bb166d27f72bc81487442cdadbfdcb",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4529f2854cf8e3949ad4c30256971bf8bbc9e48298e87f19f40dea2e43b76083",
+  "checksum": "f7318189fb81fd26fcdc1b88f691d19f6a0501a1317b250f363fc6485a79faaf",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -1524,13 +1524,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap 4.4.18": {
+    "clap 4.5.2": {
       "name": "clap",
-      "version": "4.4.18",
+      "version": "4.5.2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.4.18/download",
-          "sha256": "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+          "url": "https://static.crates.io/crates/clap/4.5.2/download",
+          "sha256": "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
         }
       },
       "targets": [
@@ -1566,7 +1566,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.4.18",
+              "id": "clap_builder 4.5.2",
               "target": "clap_builder"
             }
           ],
@@ -1576,23 +1576,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 4.4.7",
+              "id": "clap_derive 4.5.0",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "4.4.18"
+        "version": "4.5.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_builder 4.4.18": {
+    "clap_builder 4.5.2": {
       "name": "clap_builder",
-      "version": "4.4.18",
+      "version": "4.5.2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.4.18/download",
-          "sha256": "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.2/download",
+          "sha256": "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
         }
       },
       "targets": [
@@ -1634,28 +1634,28 @@
               "target": "anstyle"
             },
             {
-              "id": "clap_lex 0.6.0",
+              "id": "clap_lex 0.7.0",
               "target": "clap_lex"
             },
             {
-              "id": "strsim 0.10.0",
+              "id": "strsim 0.11.0",
               "target": "strsim"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.18"
+        "version": "4.5.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 4.4.7": {
+    "clap_derive 4.5.0": {
       "name": "clap_derive",
-      "version": "4.4.7",
+      "version": "4.5.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_derive/4.4.7/download",
-          "sha256": "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+          "url": "https://static.crates.io/crates/clap_derive/4.5.0/download",
+          "sha256": "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
         }
       },
       "targets": [
@@ -1702,17 +1702,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.7"
+        "version": "4.5.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_lex 0.6.0": {
+    "clap_lex 0.7.0": {
       "name": "clap_lex",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_lex/0.6.0/download",
-          "sha256": "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+          "url": "https://static.crates.io/crates/clap_lex/0.7.0/download",
+          "sha256": "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
         }
       },
       "targets": [
@@ -1732,7 +1732,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7739,7 +7739,7 @@
               "target": "bzip2"
             },
             {
-              "id": "clap 4.4.18",
+              "id": "clap 4.5.2",
               "target": "clap"
             },
             {
@@ -8591,13 +8591,13 @@
       },
       "license": "MIT"
     },
-    "strsim 0.10.0": {
+    "strsim 0.11.0": {
       "name": "strsim",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/strsim/0.10.0/download",
-          "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+          "url": "https://static.crates.io/crates/strsim/0.11.0/download",
+          "sha256": "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
         }
       },
       "targets": [
@@ -8617,7 +8617,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.10.0"
+        "version": "0.11.0"
       },
       "license": "MIT"
     },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle 1.0.6",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -1606,9 +1606,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ Selenium Manager is a CLI tool that automatically manages the browser/driver inf
 """
 
 [dependencies]
-clap = { version = "4.4.18", features = ["derive", "cargo"] }
+clap = { version = "4.5.2", features = ["derive", "cargo"] }
 log = "0.4.21"
 env_logger = "0.10.2"
 regex = "1.10.3"


### PR DESCRIPTION
## **User description**
### Description
This PR simply bumps the version of **clap** (a dependency in Selenium Manager) to **4.5.2**.

### Motivation and Context
This change is, in theory, harmless. But I'm doing it as a PR since it breaks the build. I don't know the cause, but it happens when Bazel is trying to compile Selenium Manager with clap 4.5.2. In particular, **clap_lex 0.7.0**, which is a transitive dependency of clap 4.5.2, cannot be compiled with Bazel:

```
ERROR: /home/runner/.bazel/external/crates__clap_lex-0.7.0/BUILD.bazel:20:13: Compiling Rust rlib clap_lex v0.7.0 (2 files) failed: (Exit 1): process_wrapper failed: error executing command (from target @crates__clap_lex-0.7.0//:clap_lex) 

...

error[E0599]: no method named `as_encoded_bytes` found for reference `&OsStr` in the current scope
   --> external/crates__clap_lex-0.7.0/src/ext.rs:186:26
```

I am not sure how Bazel compiles Rust. But using Cargo 1.7.6, this problem does not happen.

Any idea?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Updated the `clap` dependency in `rust/Cargo.toml` from version `4.4.18` to `4.5.2` to include new features and improvements.
- This update is part of enhancing Selenium Manager's CLI capabilities.
- The previous attempt to update caused build issues with Bazel due to a transitive dependency (`clap_lex 0.7.0`). This PR aims to address or highlight this issue for further investigation.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update `clap` dependency to version 4.5.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/Cargo.toml

- Bumped `clap` version from `4.4.18` to `4.5.2`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13699/files#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

