### PR TITLE
This commit changes the following boolean flags in BaseServerFlags to…

### DIFF
--- a/java/src/org/openqa/selenium/grid/server/BaseServerFlags.java
+++ b/java/src/org/openqa/selenium/grid/server/BaseServerFlags.java
@@ -57,7 +57,7 @@ public class BaseServerFlags implements HasRoles {
               + " external IP or hostname (e.g. inside a Docker container).",
       arity = 1)
   @ConfigValue(section = SERVER_SECTION, name = "bind-host", example = "true")
-  private Boolean bindHost = true;
+  private final Boolean bindHost = true;
 
   @Parameter(
       description =
@@ -81,7 +81,7 @@ public class BaseServerFlags implements HasRoles {
           "Whether the Selenium server should allow web browser connections from any host",
       arity = 1)
   @ConfigValue(section = SERVER_SECTION, name = "allow-cors", example = "true")
-  private Boolean allowCORS = false;
+  private final Boolean allowCORS = false;
 
   @Parameter(
       description =
@@ -114,7 +114,7 @@ public class BaseServerFlags implements HasRoles {
       names = "--self-signed-https",
       hidden = true)
   @ConfigValue(section = SERVER_SECTION, name = "https-self-signed", example = "false")
-  private Boolean isSelfSigned = false;
+  private final Boolean isSelfSigned = false;
 
   @Override
   public Set<Role> getRoles() {


### PR DESCRIPTION
## **User description**
… final:

bindHost
allowCORS
isSelfSigned
These flags are intended to be constant values and shouldn't be modified after initialization. Making them final enforces this behavior and improves code clarity.

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
This pull request modifies the following boolean flags in BaseServerFlags to be final:

**bindHost

allowCORS

isSelfSigned**

These flags represent configuration options for the server and are intended to be constant values set during initialization. Making them final enforces this behavior, preventing accidental modifications throughout the code's execution.

### Motivation and Context
here are several reasons for making these flags final:

Immutability: These flags define core server configuration and shouldn't change after initialization. final enforces this, ensuring consistent behavior.

Clarity: Using final explicitly indicates the intended constant nature of these flags, improving code readability for developers.
Maintainability: Accidental modifications can lead to unexpected behavior. final helps prevent such issues, making the code more maintainable in the long run.

Currently, these flags are declared as simple Boolean variables. While they haven't caused issues yet, making them final is a proactive measure to prevent potential problems in the future and improve code quality.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Made `bindHost`, `allowCORS`, and `isSelfSigned` boolean flags final in `BaseServerFlags` to ensure they remain constant after initialization, enhancing code clarity and maintainability.
- This change enforces the immutability of critical server configuration flags, preventing accidental modifications and ensuring consistent server behavior.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseServerFlags.java</strong><dd><code>Enforce Immutability of Server Configuration Flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/grid/server/BaseServerFlags.java

<li>Made <code>bindHost</code>, <code>allowCORS</code>, and <code>isSelfSigned</code> flags final to enforce <br>immutability.<br> <li> These flags are now initialized with their default values and cannot <br>be modified after.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13701/files#diff-1c32fe51485b07b3be1ae22ea7d6338cefb8b637f871ef13dd02c787f447d76b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

