### PR TITLE
[dotnet] Don't use no-sandbox browser argument

### DIFF
--- a/dotnet/test/common/Environment/DriverFactory.cs
+++ b/dotnet/test/common/Environment/DriverFactory.cs
@@ -70,8 +70,9 @@ namespace OpenQA.Selenium.Environment
                 options = GetDriverOptions<ChromeOptions>(driverType, driverOptions);
                 options.UseWebSocketUrl = true;
 
-                //var chromeOptions = (ChromeOptions)options;
+                var chromeOptions = (ChromeOptions)options;
                 //chromeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
+                chromeOptions.AddArguments("--disable-dev-shm-usage");
 
                 service = CreateService<ChromeDriverService>();
                 if (!string.IsNullOrEmpty(this.browserBinaryLocation))
@@ -88,8 +89,9 @@ namespace OpenQA.Selenium.Environment
                 browser = Browser.Edge;
                 options = GetDriverOptions<EdgeOptions>(driverType, driverOptions);
 
-                //var edgeOptions = (EdgeOptions)options;
+                var edgeOptions = (EdgeOptions)options;
                 //edgeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
+                edgeOptions.AddArguments("--disable-dev-shm-usage");
 
                 service = CreateService<EdgeDriverService>();
                 if (!string.IsNullOrEmpty(this.browserBinaryLocation))
@@ -186,7 +188,7 @@ namespace OpenQA.Selenium.Environment
         }
 
 
-        private T MergeOptions<T>(object baseOptions, DriverOptions overriddenOptions) where T:DriverOptions, new()
+        private T MergeOptions<T>(object baseOptions, DriverOptions overriddenOptions) where T : DriverOptions, new()
         {
             // If the driver type has a static DefaultOptions property,
             // get the value of that property, which should be a valid
@@ -208,7 +210,7 @@ namespace OpenQA.Selenium.Environment
             return mergedOptions;
         }
 
-        private T CreateService<T>() where T:DriverService
+        private T CreateService<T>() where T : DriverService
         {
             T service = default(T);
             Type serviceType = typeof(T);
@@ -216,7 +218,7 @@ namespace OpenQA.Selenium.Environment
             MethodInfo createDefaultServiceMethod = serviceType.GetMethod("CreateDefaultService", BindingFlags.Public | BindingFlags.Static, null, new Type[] { }, null);
             if (createDefaultServiceMethod != null && createDefaultServiceMethod.ReturnType == serviceType)
             {
-                service = (T)createDefaultServiceMethod.Invoke(null, new object[] {});
+                service = (T)createDefaultServiceMethod.Invoke(null, new object[] { });
             }
 
             return service;

--- a/dotnet/test/common/Environment/DriverFactory.cs
+++ b/dotnet/test/common/Environment/DriverFactory.cs
@@ -70,8 +70,8 @@ namespace OpenQA.Selenium.Environment
                 options = GetDriverOptions<ChromeOptions>(driverType, driverOptions);
                 options.UseWebSocketUrl = true;
 
-                var chromeOptions = (ChromeOptions)options;
-                chromeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
+                //var chromeOptions = (ChromeOptions)options;
+                //chromeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
 
                 service = CreateService<ChromeDriverService>();
                 if (!string.IsNullOrEmpty(this.browserBinaryLocation))
@@ -88,8 +88,8 @@ namespace OpenQA.Selenium.Environment
                 browser = Browser.Edge;
                 options = GetDriverOptions<EdgeOptions>(driverType, driverOptions);
 
-                var edgeOptions = (EdgeOptions)options;
-                edgeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
+                //var edgeOptions = (EdgeOptions)options;
+                //edgeOptions.AddArguments("--no-sandbox", "--disable-dev-shm-usage");
 
                 service = CreateService<EdgeDriverService>();
                 if (!string.IsNullOrEmpty(this.browserBinaryLocation))


### PR DESCRIPTION
## **User description**
### Description
Use default browser argument for internal testing.

### Motivation and Context
Related to https://github.com/SeleniumHQ/selenium/issues/13656

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Removed the use of `--no-sandbox` and `--disable-dev-shm-usage` arguments for Chrome and Edge browsers to align with default browser configurations for internal testing.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverFactory.cs</strong><dd><code>Remove No-Sandbox Argument for Chrome and Edge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
dotnet/test/common/Environment/DriverFactory.cs

<li>Commented out the addition of <code>--no-sandbox</code> and <code>--disable-dev-shm-usage</code> <br>arguments for Chrome and Edge browsers.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13702/files#diff-59cddfb584518b63ddc54d300a3439eca9e7dafbaab64a53f08ddac2d6e1a20a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

