### PR TITLE
[bidi] Add provide response command

### DIFF
--- a/java/src/org/openqa/selenium/bidi/module/Network.java
+++ b/java/src/org/openqa/selenium/bidi/module/Network.java
@@ -33,6 +33,7 @@ import org.openqa.selenium.bidi.network.BeforeRequestSent;
 import org.openqa.selenium.bidi.network.ContinueRequestParameters;
 import org.openqa.selenium.bidi.network.ContinueResponseParameters;
 import org.openqa.selenium.bidi.network.FetchError;
+import org.openqa.selenium.bidi.network.ProvideResponseParameters;
 import org.openqa.selenium.bidi.network.ResponseDetails;
 import org.openqa.selenium.internal.Require;
 
@@ -130,6 +131,10 @@ public class Network implements AutoCloseable {
 
   public void continueResponse(ContinueResponseParameters parameters) {
     this.bidi.send(new Command<>("network.continueResponse", parameters.toMap()));
+  }
+
+  public void provideResponse(ProvideResponseParameters parameters) {
+    this.bidi.send(new Command<>("network.provideResponse", parameters.toMap()));
   }
 
   public void onBeforeRequestSent(Consumer<BeforeRequestSent> consumer) {

--- a/java/src/org/openqa/selenium/bidi/network/ProvideResponseParameters.java
+++ b/java/src/org/openqa/selenium/bidi/network/ProvideResponseParameters.java
@@ -1,0 +1,64 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.bidi.network;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ProvideResponseParameters {
+  private final Map<String, Object> map = new HashMap<>();
+
+  public ProvideResponseParameters(String request) {
+    map.put("request", request);
+  }
+
+  public ProvideResponseParameters body(BytesValue value) {
+    map.put("body", value.toMap());
+    return this;
+  }
+
+  public ProvideResponseParameters cookies(List<SetCookieHeader> cookieHeaders) {
+    List<Map<String, Object>> cookies =
+        cookieHeaders.stream().map(SetCookieHeader::toMap).collect(Collectors.toList());
+    map.put("cookies", cookies);
+    return this;
+  }
+
+  public ProvideResponseParameters headers(List<Header> headers) {
+    List<Map<String, Object>> headerList =
+        headers.stream().map(Header::toMap).collect(Collectors.toList());
+    map.put("headers", headerList);
+    return this;
+  }
+
+  public ProvideResponseParameters reasonPhrase(String reasonPhrase) {
+    map.put("reasonPhrase", reasonPhrase);
+    return this;
+  }
+
+  public ProvideResponseParameters statusCode(int statusCode) {
+    map.put("statusCode", statusCode);
+    return this;
+  }
+
+  public Map<String, Object> toMap() {
+    return map;
+  }
+}

--- a/javascript/node/selenium-webdriver/bidi/network.js
+++ b/javascript/node/selenium-webdriver/bidi/network.js
@@ -19,6 +19,7 @@ const { BeforeRequestSent, ResponseStarted, FetchError } = require('./networkTyp
 const { AddInterceptParameters } = require('./addInterceptParameters')
 const { ContinueResponseParameters } = require('./continueResponseParameters')
 const { ContinueRequestParameters } = require('./continueRequestParameters')
+const { ProvideResponseParameters } = require('./provideResponseParameters')
 
 class Network {
   constructor(driver, browsingContextIds) {
@@ -190,6 +191,19 @@ class Network {
 
     const command = {
       method: 'network.continueResponse',
+      params: Object.fromEntries(params.asMap()),
+    }
+
+    await this.bidi.send(command)
+  }
+
+  async provideResponse(params) {
+    if (!(params instanceof ProvideResponseParameters)) {
+      throw new Error(`Params must be an instance of ProvideResponseParameters. Received:'${params}'`)
+    }
+
+    const command = {
+      method: 'network.provideResponse',
       params: Object.fromEntries(params.asMap()),
     }
 

--- a/javascript/node/selenium-webdriver/bidi/provideResponseParameters.js
+++ b/javascript/node/selenium-webdriver/bidi/provideResponseParameters.js
@@ -1,0 +1,83 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const { BytesValue, Header } = require('./networkTypes')
+
+class ProvideResponseParameters {
+  #map = new Map()
+
+  constructor(request) {
+    this.#map.set('request', request)
+  }
+
+  body(value) {
+    if (!(value instanceof BytesValue)) {
+      throw new Error(`Value must be an instance of BytesValue. Received: '${value})'`)
+    }
+    this.#map.set('body', Object.fromEntries(value.asMap()))
+    return this
+  }
+
+  cookies(cookieHeaders) {
+    const cookies = []
+    cookieHeaders.forEach((header) => {
+      if (!(header instanceof Header)) {
+        throw new Error(`CookieHeader must be an instance of Header. Received:'${header}'`)
+      }
+      cookies.push(Object.fromEntries(header.asMap()))
+    })
+
+    this.#map.set('cookies', cookies)
+    return this
+  }
+
+  headers(headers) {
+    const headerList = []
+    headers.forEach((header) => {
+      if (!(header instanceof Header)) {
+        throw new Error(`Header must be an instance of Header. Received:'${header}'`)
+      }
+      headerList.push(Object.fromEntries(header.asMap()))
+    })
+
+    this.#map.set('headers', headerList)
+    return this
+  }
+
+  reasonPhrase(reasonPhrase) {
+    if (typeof reasonPhrase !== 'string') {
+      throw new Error(`Reason phrase must be a string. Received: '${reasonPhrase})'`)
+    }
+    this.#map.set('reasonPhrase', reasonPhrase)
+    return this
+  }
+
+  statusCode(statusCode) {
+    if (!Number.isInteger(statusCode)) {
+      throw new Error(`Status must be an integer. Received:'${statusCode}'`)
+    }
+
+    this.#map.set('statusCode', statusCode)
+    return this
+  }
+
+  asMap() {
+    return this.#map
+  }
+}
+
+module.exports = { ProvideResponseParameters }

--- a/javascript/node/selenium-webdriver/bidi/provideResponseParameters.js
+++ b/javascript/node/selenium-webdriver/bidi/provideResponseParameters.js
@@ -26,7 +26,7 @@ class ProvideResponseParameters {
 
   body(value) {
     if (!(value instanceof BytesValue)) {
-      throw new Error(`Value must be an instance of BytesValue. Received: '${value})'`)
+      throw new Error(`Value must be an instance of BytesValue. Received: ${typeof value} with value: ${value}`)
     }
     this.#map.set('body', Object.fromEntries(value.asMap()))
     return this

--- a/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
@@ -27,6 +27,7 @@ const { InterceptPhase } = require('../../bidi/interceptPhase')
 const { until } = require('../../index')
 const { ContinueRequestParameters } = require('../../bidi/continueRequestParameters')
 const { ContinueResponseParameters } = require('../../bidi/continueResponseParameters')
+const { ProvideResponseParameters } = require('../../bidi/provideResponseParameters')
 
 suite(
   function (env) {
@@ -140,6 +141,21 @@ suite(
 
         await network.responseStarted(async (event) => {
           await network.continueResponse(new ContinueResponseParameters(event.request.request))
+          counter = counter + 1
+        })
+
+        await driver.get(Pages.logEntryAdded)
+
+        assert.strictEqual(counter, 1)
+      })
+
+      xit('can provide response', async function () {
+        await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
+
+        let counter = 0
+
+        await network.beforeRequestSent(async (event) => {
+          await network.provideResponse(new ProvideResponseParameters(event.request.request))
           counter = counter + 1
         })
 


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add provide response command of the BiDi Network module https://w3c.github.io/webdriver-bidi/#command-network-provideResponse in Java and JS bindings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Incrementally implement BiDI APIs. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, tests


___

## **Description**
- Added `provideResponse` command implementation in both Java and JavaScript bindings.
- Introduced `ProvideResponseParameters` class in Java and JavaScript for setting up response parameters.
- Added tests for the new `provideResponse` command in Java and JavaScript, including a disabled test for future comprehensive testing.
- This enhancement aims at incrementally implementing the BiDi APIs, specifically the network module's provide response command.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Network.java</strong><dd><code>Add Provide Response Command to Network Module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/module/Network.java

- Added `provideResponse` method to the `Network` class.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-e742aac674b88cc9d9b7d49a9adf66b4dd95c479327e712cf08a3f8c02a43e7f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProvideResponseParameters.java</strong><dd><code>Implement ProvideResponseParameters Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/network/ProvideResponseParameters.java

<li>Introduced <code>ProvideResponseParameters</code> class with methods to set request <br>parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-b852beb1023b8d48579128488c155a732a810e875cb0efa159f1dda940088140">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network.js</strong><dd><code>Add Provide Response Command to Network Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/network.js

- Added `provideResponse` method to the `Network` class.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-fb16b0c75e71305b0d870a4a16c59f87778593611a0205aa642a2e99d88c0a7a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>provideResponseParameters.js</strong><dd><code>Implement ProvideResponseParameters Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/provideResponseParameters.js

<li>Created <code>ProvideResponseParameters</code> class with methods for setting up <br>response parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-0a56a8f07817bcc5069f369d212e38ab5d4118a0e9b8c6bb36a474f078aaefa4">+83/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkCommandsTest.java</strong><dd><code>Add Tests for Provide Response Command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java

<li>Added tests for <code>provideResponse</code> method in <code>Network</code> class.<br> <li> Included a disabled test for future implementation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-56334c02fd23ebd6590a6ae6f44b2113bdbc325175c1273c4ef17a236119e517">+66/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_commands_test.js</strong><dd><code>Add Test for Provide Response Command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/network_commands_test.js

<li>Added a test for <code>provideResponse</code> method, currently marked as pending.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13708/files#diff-dea7f03b07f22d3628b93323b3ebe6ad2ca436ebeb1e660b8ece557a130bbf76">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

