### PR TITLE
[bidi][java][js] Add setFiles command of the Input Module

### DIFF
--- a/java/src/org/openqa/selenium/bidi/module/Input.java
+++ b/java/src/org/openqa/selenium/bidi/module/Input.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.bidi.BiDi;
 import org.openqa.selenium.bidi.Command;
 import org.openqa.selenium.bidi.HasBiDi;
+import org.openqa.selenium.bidi.script.RemoteReference;
 import org.openqa.selenium.interactions.Sequence;
 
 public class Input {
@@ -86,5 +87,25 @@ public class Input {
 
   public void release(String browsingContext) {
     bidi.send(new Command<>("input.releaseActions", Map.of("context", browsingContext)));
+  }
+
+  public void setFiles(String browsingContext, RemoteReference element, List<String> files) {
+    bidi.send(
+        new Command<>(
+            "input.setFiles",
+            Map.of("context", browsingContext, "element", element.toJson(), "files", files)));
+  }
+
+  public void setFiles(String browsingContext, String elementId, List<String> files) {
+    bidi.send(
+        new Command<>(
+            "input.setFiles",
+            Map.of(
+                "context",
+                browsingContext,
+                "element",
+                new RemoteReference(RemoteReference.Type.SHARED_ID, elementId).toJson(),
+                "files",
+                files)));
   }
 }

--- a/java/src/org/openqa/selenium/bidi/module/Input.java
+++ b/java/src/org/openqa/selenium/bidi/module/Input.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.bidi.module;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -107,5 +108,13 @@ public class Input {
                 new RemoteReference(RemoteReference.Type.SHARED_ID, elementId).toJson(),
                 "files",
                 files)));
+  }
+
+  public void setFiles(String browsingContext, RemoteReference element, String file) {
+    setFiles(browsingContext, element, Collections.singletonList(file));
+  }
+
+  public void setFiles(String browsingContext, String elementId, String file) {
+    setFiles(browsingContext, elementId, Collections.singletonList(file));
   }
 }

--- a/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
@@ -1,0 +1,105 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.bidi.input;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
+import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
+import static org.openqa.selenium.testing.drivers.Browser.IE;
+import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.bidi.module.Input;
+import org.openqa.selenium.bidi.script.RemoteReference;
+import org.openqa.selenium.environment.webserver.AppServer;
+import org.openqa.selenium.environment.webserver.NettyAppServer;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NotYetImplemented;
+
+public class SetFilesCommandTest extends JupiterTestBase {
+  private Input input;
+
+  private String windowHandle;
+
+  private AppServer server;
+
+  @BeforeEach
+  public void setUp() {
+    windowHandle = driver.getWindowHandle();
+    input = new Input(driver);
+    server = new NettyAppServer();
+    server.start();
+  }
+
+  @Test
+  @NotYetImplemented(SAFARI)
+  @NotYetImplemented(IE)
+  @NotYetImplemented(EDGE)
+  @NotYetImplemented(FIREFOX)
+  public void canSetFiles() throws IOException {
+    driver.get(pages.formPage);
+    WebElement uploadElement = driver.findElement(By.id("upload"));
+    assertThat(uploadElement.getAttribute("value")).isEmpty();
+
+    File file = File.createTempFile("test", "txt");
+    file.deleteOnExit();
+
+    List<String> paths = new ArrayList<>();
+    paths.add(file.getAbsolutePath());
+
+    input.setFiles(
+        windowHandle,
+        new RemoteReference(
+            RemoteReference.Type.SHARED_ID, ((RemoteWebElement) uploadElement).getId()),
+        paths);
+
+    assertThat(uploadElement.getAttribute("value")).endsWith(file.getName());
+  }
+
+  @Test
+  @NotYetImplemented(SAFARI)
+  @NotYetImplemented(IE)
+  @NotYetImplemented(EDGE)
+  @NotYetImplemented(FIREFOX)
+  public void canSetFilesWithElementId() throws IOException {
+    driver.get(pages.formPage);
+    WebElement uploadElement = driver.findElement(By.id("upload"));
+    assertThat(uploadElement.getAttribute("value")).isEmpty();
+
+    File file = File.createTempFile("test", "txt");
+    file.deleteOnExit();
+
+    List<String> paths = new ArrayList<>();
+    paths.add(file.getAbsolutePath());
+
+    input.setFiles(
+      windowHandle,
+      ((RemoteWebElement) uploadElement).getId(),
+      paths);
+
+    assertThat(uploadElement.getAttribute("value")).endsWith(file.getName());
+  }
+}

--- a/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
@@ -59,7 +59,7 @@ public class SetFilesCommandTest extends JupiterTestBase {
   @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
-  public void canSetFiles() throws IOException {
+  void canSetFiles() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
     assertThat(uploadElement.getAttribute("value")).isEmpty();
@@ -95,10 +95,48 @@ public class SetFilesCommandTest extends JupiterTestBase {
     List<String> paths = new ArrayList<>();
     paths.add(file.getAbsolutePath());
 
+    input.setFiles(windowHandle, ((RemoteWebElement) uploadElement).getId(), paths);
+
+    assertThat(uploadElement.getAttribute("value")).endsWith(file.getName());
+  }
+
+  @Test
+  @NotYetImplemented(SAFARI)
+  @NotYetImplemented(IE)
+  @NotYetImplemented(EDGE)
+  @NotYetImplemented(FIREFOX)
+  void canSetFile() throws IOException {
+    driver.get(pages.formPage);
+    WebElement uploadElement = driver.findElement(By.id("upload"));
+    assertThat(uploadElement.getAttribute("value")).isEmpty();
+
+    File file = File.createTempFile("test", "txt");
+    file.deleteOnExit();
+
     input.setFiles(
-      windowHandle,
-      ((RemoteWebElement) uploadElement).getId(),
-      paths);
+        windowHandle,
+        new RemoteReference(
+            RemoteReference.Type.SHARED_ID, ((RemoteWebElement) uploadElement).getId()),
+        file.getAbsolutePath());
+
+    assertThat(uploadElement.getAttribute("value")).endsWith(file.getName());
+  }
+
+  @Test
+  @NotYetImplemented(SAFARI)
+  @NotYetImplemented(IE)
+  @NotYetImplemented(EDGE)
+  @NotYetImplemented(FIREFOX)
+  void canSetFileWithElementId() throws IOException {
+    driver.get(pages.formPage);
+    WebElement uploadElement = driver.findElement(By.id("upload"));
+    assertThat(uploadElement.getAttribute("value")).isEmpty();
+
+    File file = File.createTempFile("test", "txt");
+    file.deleteOnExit();
+
+    input.setFiles(
+        windowHandle, ((RemoteWebElement) uploadElement).getId(), file.getAbsolutePath());
 
     assertThat(uploadElement.getAttribute("value")).endsWith(file.getName());
   }

--- a/javascript/node/selenium-webdriver/bidi/input.js
+++ b/javascript/node/selenium-webdriver/bidi/input.js
@@ -60,9 +60,6 @@ class Input {
   }
 
   async setFiles(browsingContextId, element, files) {
-    if (!Array.isArray(files)) {
-      throw Error(`Pass in an array of file paths. Received: ${files}`)
-    }
 
     if (typeof element !== 'string' && !(element instanceof ReferenceValue)) {
       throw Error(`Pass in a WebElement id as a string or a ReferenceValue. Received: ${element}`)
@@ -76,11 +73,10 @@ class Input {
           typeof element === 'string'
             ? new ReferenceValue(RemoteReferenceType.SHARED_ID, element).asMap()
             : element.asMap(),
-        files: files,
+        files: typeof files === 'string' ? [files] : files,
       },
     }
     const response = await this.bidi.send(command)
-    console.log(response)
   }
 }
 

--- a/javascript/node/selenium-webdriver/bidi/input.js
+++ b/javascript/node/selenium-webdriver/bidi/input.js
@@ -76,7 +76,7 @@ class Input {
         files: typeof files === 'string' ? [files] : files,
       },
     }
-    const response = await this.bidi.send(command)
+    await this.bidi.send(command)
   }
 }
 

--- a/javascript/node/selenium-webdriver/bidi/input.js
+++ b/javascript/node/selenium-webdriver/bidi/input.js
@@ -18,7 +18,7 @@
 // type: module added to package.json
 // import { WebElement } from '../lib/webdriver'
 const { WebElement } = require('../lib/webdriver')
-const { RemoteValue, RemoteReferenceType, ReferenceValue } = require('./protocolValue')
+const { RemoteReferenceType, ReferenceValue } = require('./protocolValue')
 
 class Input {
   constructor(driver) {

--- a/javascript/node/selenium-webdriver/bidi/input.js
+++ b/javascript/node/selenium-webdriver/bidi/input.js
@@ -18,6 +18,7 @@
 // type: module added to package.json
 // import { WebElement } from '../lib/webdriver'
 const { WebElement } = require('../lib/webdriver')
+const { RemoteValue, RemoteReferenceType, ReferenceValue } = require('./protocolValue')
 
 class Input {
   constructor(driver) {
@@ -56,6 +57,30 @@ class Input {
       },
     }
     return await this.bidi.send(command)
+  }
+
+  async setFiles(browsingContextId, element, files) {
+    if (!Array.isArray(files)) {
+      throw Error(`Pass in an array of file paths. Received: ${files}`)
+    }
+
+    if (typeof element !== 'string' && !(element instanceof ReferenceValue)) {
+      throw Error(`Pass in a WebElement id as a string or a ReferenceValue. Received: ${element}`)
+    }
+
+    const command = {
+      method: 'input.setFiles',
+      params: {
+        context: browsingContextId,
+        element:
+          typeof element === 'string'
+            ? new ReferenceValue(RemoteReferenceType.SHARED_ID, element).asMap()
+            : element.asMap(),
+        files: files,
+      },
+    }
+    const response = await this.bidi.send(command)
+    console.log(response)
   }
 }
 

--- a/javascript/node/selenium-webdriver/bidi/protocolValue.js
+++ b/javascript/node/selenium-webdriver/bidi/protocolValue.js
@@ -160,23 +160,27 @@ class RemoteValue {
 }
 
 class ReferenceValue {
+  #handle
+  #sharedId
   constructor(handle, sharedId) {
     if (handle === RemoteReferenceType.HANDLE) {
-      this.handle = sharedId
+      this.#handle = sharedId
+    } else if (handle === RemoteReferenceType.SHARED_ID) {
+      this.#sharedId = sharedId
     } else {
-      this.handle = handle
-      this.sharedId = sharedId
+      this.#handle = handle
+      this.#sharedId = sharedId
     }
   }
 
   asMap() {
     const toReturn = {}
-    if (this.handle != null) {
-      toReturn[RemoteReferenceType.HANDLE] = this.handle
+    if (this.#handle != null) {
+      toReturn[RemoteReferenceType.HANDLE] = this.#handle
     }
 
-    if (this.sharedId != null) {
-      toReturn[RemoteReferenceType.SHARED_ID] = this.sharedId
+    if (this.#sharedId != null) {
+      toReturn[RemoteReferenceType.SHARED_ID] = this.#sharedId
     }
 
     return toReturn

--- a/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
@@ -1,0 +1,96 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+const assert = require('assert')
+require('../../lib/test/fileserver')
+const firefox = require('../../firefox')
+const { Pages, suite } = require('../../lib/test')
+const { Browser, By } = require('../..')
+const Input = require('../../bidi/input')
+const io = require('../../io')
+const fs = require('node:fs')
+const { ReferenceValue, RemoteReferenceType } = require('../../bidi/protocolValue')
+
+suite(
+  function (env) {
+    describe('Input Set Files', function () {
+      const FILE_HTML = '<!DOCTYPE html><div>' + 'Hello' + '</div>'
+      let driver
+
+      let _fp
+      before(function () {
+        return (_fp = io.tmpFile().then(function (fp) {
+          fs.writeFileSync(fp, FILE_HTML)
+          return fp
+        }))
+      })
+
+      beforeEach(async function () {
+        driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      })
+
+      afterEach(function () {
+        return driver.quit()
+      })
+
+      xit('can set files', async function () {
+        const browsingContextId = await driver.getWindowHandle()
+        const input = await Input(driver)
+        await driver.get(Pages.formPage)
+
+        var fp1 = await io.tmpFile().then(function (fp) {
+          fs.writeFileSync(fp, FILE_HTML)
+          return fp
+        })
+
+        const webElement = await driver.findElement(By.id('upload'))
+
+        assert.strictEqual(await webElement.getAttribute('value'), '')
+
+        const webElementId = await webElement.getId()
+
+        await input.setFiles(browsingContextId, new ReferenceValue(RemoteReferenceType.SHARED_ID, webElementId), [fp1])
+
+        assert.notEqual(await webElement.getAttribute('value'), '')
+      })
+
+      xit('can set files with element id', async function () {
+        const browsingContextId = await driver.getWindowHandle()
+        const input = await Input(driver)
+        await driver.get(Pages.formPage)
+
+        var fp1 = await io.tmpFile().then(function (fp) {
+          fs.writeFileSync(fp, FILE_HTML)
+          return fp
+        })
+
+        const webElement = await driver.findElement(By.id('upload'))
+
+        assert.strictEqual(await webElement.getAttribute('value'), '')
+
+        const webElementId = await webElement.getId()
+
+        await input.setFiles(browsingContextId, webElementId, [fp1])
+
+        assert.notEqual(await webElement.getAttribute('value'), '')
+      })
+    })
+  },
+  { browsers: [Browser.FIREFOX] },
+)

--- a/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
@@ -54,7 +54,7 @@ suite(
         const input = await Input(driver)
         await driver.get(Pages.formPage)
 
-        var fp1 = await io.tmpFile().then(function (fp) {
+        const filePath = await io.tmpFile().then(function(fp) {
           fs.writeFileSync(fp, FILE_HTML)
           return fp
         })
@@ -65,7 +65,7 @@ suite(
 
         const webElementId = await webElement.getId()
 
-        await input.setFiles(browsingContextId, new ReferenceValue(RemoteReferenceType.SHARED_ID, webElementId), [fp1])
+        await input.setFiles(browsingContextId, new ReferenceValue(RemoteReferenceType.SHARED_ID, webElementId), [filePath])
 
         assert.notEqual(await webElement.getAttribute('value'), '')
       })
@@ -75,7 +75,7 @@ suite(
         const input = await Input(driver)
         await driver.get(Pages.formPage)
 
-        var fp1 = await io.tmpFile().then(function (fp) {
+        const filePath = await io.tmpFile().then(function(fp) {
           fs.writeFileSync(fp, FILE_HTML)
           return fp
         })
@@ -86,7 +86,7 @@ suite(
 
         const webElementId = await webElement.getId()
 
-        await input.setFiles(browsingContextId, webElementId, [fp1])
+        await input.setFiles(browsingContextId, webElementId, filePath)
 
         assert.notEqual(await webElement.getAttribute('value'), '')
       })


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add setFiles command of the Input Module as described in the BiDi spec https://w3c.github.io/webdriver-bidi/#command-input-setFiles

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Added `setFiles` method overloads to the `Input` class in Java for setting files on input elements, along with tests.
- Implemented and tested the `setFiles` method in the JavaScript BiDi protocol implementation.
- Refactored `ReferenceValue` class in JavaScript to use private fields, enhancing encapsulation.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Input.java</strong><dd><code>Add setFiles Method Overloads to Input Module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/module/Input.java

<li>Added <code>setFiles</code> method overloads to the <code>Input</code> class for setting files <br>on input elements.<br> <li> One overload accepts a <code>RemoteReference</code> and a list of file paths, and <br>the other accepts an element ID and a list of file paths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13711/files#diff-96f7ec19af2b8cb39e6cde4e761a905ea4e2525808f67dc11c7b02e1bb03cfc2">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>input.js</strong><dd><code>Implement setFiles Method in Input Class for BiDi Protocol</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/input.js

<li>Implemented <code>setFiles</code> method in the <code>Input</code> class for setting files on <br>input elements.<br> <li> Validates input types and constructs the appropriate command for the <br>BiDi protocol.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13711/files#diff-c0e4b742bedcd4b96771c4ab01c3384a748b4143d72e2023f8bc5c7e773155cf">+25/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>protocolValue.js</strong><dd><code>Refactor ReferenceValue Class in BiDi Protocol Implementation</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/protocolValue.js

<li>Refactored <code>ReferenceValue</code> class to use private fields for handle and <br>sharedId.<br> <li> Adjusted <code>asMap</code> method to work with the new private field structure.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13711/files#diff-c974d726a6ddf9ffbe2f1f2789bd9cbce1b9fdb97e6aaa065d1b28d934511950">+11/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SetFilesCommandTest.java</strong><dd><code>Test Coverage for setFiles Method in Input Module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java

<li>Introduced tests for the newly added <code>setFiles</code> method in the <code>Input</code> <br>module.<br> <li> Tests cover scenarios with both <code>RemoteReference</code> and element ID.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13711/files#diff-289f98a8f44edcaadef7f408831a9be69ebc845ef0873d3696d525153180437f">+105/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>setFiles_command_test.js</strong><dd><code>Test Coverage for setFiles Method in BiDi Protocol</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js

<li>Added tests for the <code>setFiles</code> method in the BiDi protocol <br>implementation.<br> <li> Tests include scenarios for setting files using both a <code>ReferenceValue</code> <br>and an element ID.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13711/files#diff-121225b5ff0dd52bd73de0c89fc82781c81442e2b9e11591ebe00e235ac39945">+96/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

