### PR TITLE
[rust] Select release with artifact when filtering Edge response

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -447,7 +447,15 @@ impl SeleniumManager for EdgeManager {
             return self.unavailable_discovery();
         }
 
-        let release = releases.first().unwrap();
+        let releases_with_artifacts: Vec<&Release> = releases
+            .into_iter()
+            .filter(|r| !r.artifacts.is_empty())
+            .collect();
+        if releases_with_artifacts.is_empty() {
+            return self.unavailable_discovery();
+        }
+
+        let release = releases_with_artifacts.first().unwrap();
         let artifacts: Vec<&Artifact> = release
             .artifacts
             .iter()

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -18,10 +18,9 @@
 use crate::config::OS;
 use crate::config::OS::WINDOWS;
 use crate::{
-    format_one_arg, format_three_args, format_two_args, run_shell_command_by_os,
-    run_shell_command_with_log, Command, Logger, CP_VOLUME_COMMAND, HDIUTIL_ATTACH_COMMAND,
-    HDIUTIL_DETACH_COMMAND, MACOS, MSIEXEC_INSTALL_COMMAND, MV_PAYLOAD_COMMAND,
-    MV_PAYLOAD_OLD_VERSIONS_COMMAND, PKGUTIL_COMMAND,
+    format_one_arg, format_three_args, format_two_args, run_shell_command_by_os, Command, Logger,
+    CP_VOLUME_COMMAND, HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS,
+    MSIEXEC_INSTALL_COMMAND, MV_PAYLOAD_COMMAND, MV_PAYLOAD_OLD_VERSIONS_COMMAND, PKGUTIL_COMMAND,
 };
 use anyhow::anyhow;
 use anyhow::Error;
@@ -200,7 +199,7 @@ pub fn uncompress_pkg(
         &out_folder,
     ));
     log.trace(format!("Running command: {}", command.display()));
-    run_shell_command_with_log(&log, os, command)?;
+    run_shell_command_by_os(os, command)?;
 
     fs::create_dir_all(target)?;
     let target_folder = path_to_string(target);

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -18,9 +18,10 @@
 use crate::config::OS;
 use crate::config::OS::WINDOWS;
 use crate::{
-    format_one_arg, format_three_args, format_two_args, run_shell_command_by_os, Command, Logger,
-    CP_VOLUME_COMMAND, HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS,
-    MSIEXEC_INSTALL_COMMAND, MV_PAYLOAD_COMMAND, MV_PAYLOAD_OLD_VERSIONS_COMMAND, PKGUTIL_COMMAND,
+    format_one_arg, format_three_args, format_two_args, run_shell_command_by_os,
+    run_shell_command_with_log, Command, Logger, CP_VOLUME_COMMAND, HDIUTIL_ATTACH_COMMAND,
+    HDIUTIL_DETACH_COMMAND, MACOS, MSIEXEC_INSTALL_COMMAND, MV_PAYLOAD_COMMAND,
+    MV_PAYLOAD_OLD_VERSIONS_COMMAND, PKGUTIL_COMMAND,
 };
 use anyhow::anyhow;
 use anyhow::Error;
@@ -199,7 +200,7 @@ pub fn uncompress_pkg(
         &out_folder,
     ));
     log.trace(format!("Running command: {}", command.display()));
-    run_shell_command_by_os(os, command)?;
+    run_shell_command_with_log(&log, os, command)?;
 
     fs::create_dir_all(target)?;
     let target_folder = path_to_string(target);


### PR DESCRIPTION
## **User description**
### Description
This PR makes the filtering process used by Selenium Manager more robust in discovering the proper Edge release to download.

### Motivation and Context
It seems the responses provided by the [Edge products API](https://edgeupdates.microsoft.com/api/products/) has recently changed, since now, it can provide releases with empty artifacts. As a result, Selenium Manager fails discovering Edge, as it happens in some tests (e.g. [here](https://github.com/SeleniumHQ/selenium/actions/runs/8420832610/job/23056676931?pr=13725#step:16:1981)). This PR should prevent that.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
Bug fix


___

## **Description**
- Filters out Edge releases without artifacts to ensure proper discovery of Edge releases.
- Fixes an issue where Selenium Manager could fail to discover Edge due to releases with empty artifacts.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge.rs</strong><dd><code>Improve Edge Release Filtering in Selenium Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/edge.rs

<li>Filters Edge releases to only consider those with non-empty artifacts.<br> <li> Returns an unavailable discovery result if no releases with artifacts <br>are found.<br> <li> Ensures that the selected release has at least one artifact.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13735/files#diff-dcd62c3bd133281f5bd97d8a876bcf753d7a4f3edd6ccbacf44eff3e9fcc484e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

