### PR TITLE
Update script commands to fix the failing BiDi tests

### DIFF
--- a/java/src/org/openqa/selenium/bidi/module/Script.java
+++ b/java/src/org/openqa/selenium/bidi/module/Script.java
@@ -262,10 +262,17 @@ public class Script implements Closeable {
   }
 
   public String addPreloadScript(String functionDeclaration) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("functionDeclaration", functionDeclaration);
+
+    if (!browsingContextIds.isEmpty()) {
+      parameters.put("contexts", this.browsingContextIds);
+    }
+
     return this.bidi.send(
         new Command<>(
             "script.addPreloadScript",
-            Map.of("functionDeclaration", functionDeclaration, "contexts", this.browsingContextIds),
+            parameters,
             jsonInput -> {
               Map<String, Object> result = jsonInput.read(Map.class);
               return result.get("script").toString();
@@ -273,16 +280,18 @@ public class Script implements Closeable {
   }
 
   public String addPreloadScript(String functionDeclaration, List<ChannelValue> arguments) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("functionDeclaration", functionDeclaration);
+    parameters.put("arguments", arguments);
+
+    if (!browsingContextIds.isEmpty()) {
+      parameters.put("contexts", this.browsingContextIds);
+    }
+
     return this.bidi.send(
         new Command<>(
             "script.addPreloadScript",
-            Map.of(
-                "functionDeclaration",
-                functionDeclaration,
-                "contexts",
-                this.browsingContextIds,
-                "arguments",
-                arguments),
+            parameters,
             jsonInput -> {
               Map<String, Object> result = jsonInput.read(Map.class);
               return result.get("script").toString();
@@ -290,16 +299,19 @@ public class Script implements Closeable {
   }
 
   public String addPreloadScript(String functionDeclaration, String sandbox) {
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("functionDeclaration", functionDeclaration);
+    parameters.put("sandbox", sandbox);
+
+    if (!browsingContextIds.isEmpty()) {
+      parameters.put("contexts", this.browsingContextIds);
+    }
+
     return this.bidi.send(
         new Command<>(
             "script.addPreloadScript",
-            Map.of(
-                "functionDeclaration",
-                functionDeclaration,
-                "contexts",
-                this.browsingContextIds,
-                "sandbox",
-                sandbox),
+            parameters,
             jsonInput -> {
               Map<String, Object> result = jsonInput.read(Map.class);
               return result.get("script").toString();
@@ -308,18 +320,19 @@ public class Script implements Closeable {
 
   public String addPreloadScript(
       String functionDeclaration, List<ChannelValue> arguments, String sandbox) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("functionDeclaration", functionDeclaration);
+    parameters.put("arguments", arguments);
+    parameters.put("sandbox", sandbox);
+
+    if (!browsingContextIds.isEmpty()) {
+      parameters.put("contexts", this.browsingContextIds);
+    }
+
     return this.bidi.send(
         new Command<>(
             "script.addPreloadScript",
-            Map.of(
-                "functionDeclaration",
-                functionDeclaration,
-                "contexts",
-                this.browsingContextIds,
-                "arguments",
-                arguments,
-                "sandbox",
-                sandbox),
+            parameters,
             jsonInput -> {
               Map<String, Object> result = jsonInput.read(Map.class);
               return result.get("script").toString();

--- a/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
@@ -804,7 +803,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(FIREFOX)
   void canAddPreloadScript() throws ExecutionException, InterruptedException, TimeoutException {
     Script script = new Script(driver);
     String id = script.addPreloadScript("() => {{ console.log('{preload_script_console_text}') }}");
@@ -827,7 +825,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(FIREFOX)
   void canAddPreloadScriptWithArguments() {
     Script script = new Script(driver);
     String id =
@@ -839,7 +836,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(FIREFOX)
   void canAddPreloadScriptWithChannelOptions() {
     Script script = new Script(driver);
     SerializationOptions serializationOptions = new SerializationOptions();
@@ -853,7 +849,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(FIREFOX)
   void canAddPreloadScriptInASandbox() {
     Script script = new Script(driver);
     String id = script.addPreloadScript("() => { window.bar=2; }", "sandbox");

--- a/javascript/node/selenium-webdriver/bidi/scriptManager.js
+++ b/javascript/node/selenium-webdriver/bidi/scriptManager.js
@@ -32,13 +32,13 @@ class ScriptManager {
     this._driver = driver
   }
 
-  async init(browsingContextId) {
+  async init(browsingContextIds) {
     if (!(await this._driver.getCapabilities()).get('webSocketUrl')) {
       throw Error('WebDriver instance must support BiDi protocol')
     }
 
     this.bidi = await this._driver.getBidi()
-    this._browsingContextId = browsingContextId
+    this._browsingContextIds = browsingContextIds
   }
 
   async disownRealmScript(realmId, handles) {
@@ -171,6 +171,14 @@ class ScriptManager {
       functionDeclaration: functionDeclaration,
       arguments: argumentValueList,
       sandbox: sandbox,
+    }
+
+    if (Array.isArray(this._browsingContextIds) && this._browsingContextIds.length > 0) {
+      params.contexts = this._browsingContextIds
+    }
+
+    if (typeof this._browsingContextIds === 'string') {
+      params.contexts = new Array(this._browsingContextIds)
     }
 
     const command = {
@@ -331,8 +339,8 @@ class ScriptManager {
   }
 
   async subscribeAndHandleEvent(eventType, callback) {
-    if (this._browsingContextIds != null) {
-      await this.bidi.subscribe(eventType, this._browsingContextIds)
+    if (this.browsingContextIds != null) {
+      await this.bidi.subscribe(eventType, this.browsingContextIds)
     } else {
       await this.bidi.subscribe(eventType)
     }

--- a/javascript/node/selenium-webdriver/test/bidi/script_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/script_test.js
@@ -540,9 +540,9 @@ suite(
         assert.equal(windowRealm.browsingContext, windowId)
       })
 
-      it('can add preload script', async function () {
+      it('can add preload script test', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         await manager.addPreloadScript("() => { window.foo='bar'; }")
 
@@ -587,7 +587,7 @@ suite(
 
       it('can access preload script properties', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         await manager.addPreloadScript('() => { window.preloadScriptFunction = () => window.baz = 42; }')
 
@@ -603,7 +603,7 @@ suite(
 
       it('can add preload script to sandbox', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         await manager.addPreloadScript('() => { window.foo = 1; }')
         await manager.addPreloadScript('() => { window.bar = 2; }', [], 'sandbox')
@@ -639,7 +639,7 @@ suite(
 
       it('can remove properties set by preload script', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         await manager.addPreloadScript('() => { window.foo = 42; }')
         await manager.addPreloadScript('() => { window.foo = 50; }', [], 'sandbox_1')
@@ -658,7 +658,7 @@ suite(
 
       it('can remove preload script', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         let script = await manager.addPreloadScript("() => { window.foo='bar'; }")
 
@@ -683,7 +683,7 @@ suite(
 
       it('cannot remove same preload script twice', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         let script = await manager.addPreloadScript("() => { window.foo='bar'; }")
 
@@ -696,7 +696,7 @@ suite(
 
       it('can remove one of preload script', async function () {
         const id = await driver.getWindowHandle()
-        const manager = await ScriptManager(id, driver)
+        const manager = await ScriptManager([], driver)
 
         let script_1 = await manager.addPreloadScript("() => { window.bar='foo'; }")
 


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
W3C BiDi spec was updated to ensure the if browsing context is passed for adding the preload script command, it cannot be empty. This was implemented from Firefox 124 onwards. Updated the command accordingly. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Updated `Script.java` to dynamically include `contexts` in `addPreloadScript` commands based on non-empty `browsingContextIds`, enhancing flexibility and adherence to updated W3C BiDi spec.
- Enabled preload script tests for Firefox in `ScriptCommandsTest.java` by removing `@NotYetImplemented(FIREFOX)` annotations, indicating these features are now supported.
- Modified `scriptManager.js` in the JavaScript bindings to accept and handle multiple browsing context IDs, allowing for more versatile script management.
- Adjusted related tests in `script_test.js` to reflect these changes, ensuring consistency and correctness in testing.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Script.java</strong><dd><code>Refactor and Update Script Command for Browsing Contexts</code>&nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/module/Script.java

<li>Updated <code>addPreloadScript</code> methods to conditionally include <code>contexts</code> <br>parameter based on <code>browsingContextIds</code> being non-empty.<br> <li> Refactored method parameters into a <code>Map</code> for dynamic construction of <br>command parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13737/files#diff-50c1170fcf2a1d5799eca20bfbe0587e393b92bd5b590c921cb9f0b2ee8acdc8">+37/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scriptManager.js</strong><dd><code>Support Multiple Browsing Contexts in ScriptManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/scriptManager.js

<li>Modified <code>init</code> to accept multiple browsing context IDs.<br> <li> Adjusted preload script command to support multiple contexts.<br> <li> Fixed event subscription to use updated context IDs variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13737/files#diff-8b2c9869483a994b7a763bddd00c1e14d418da092015a460ce3977514ee9d736">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScriptCommandsTest.java</strong><dd><code>Enable Preload Script Tests for Firefox</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java

<li>Removed <code>@NotYetImplemented(FIREFOX)</code> annotations, indicating support <br>for Firefox in preload script tests.<br> <li> Minor adjustments to test assertions and parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13737/files#diff-37b21f83d3902764db9c61f46343f33fdaa3ade7b5a6f8e125a08e35ffcf466b">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script_test.js</strong><dd><code>Update ScriptManager Tests for Browsing Context Changes</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/script_test.js

<li>Updated tests to pass an array of browsing context IDs to <br><code>ScriptManager</code>.<br> <li> Renamed a test for clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13737/files#diff-d3c85e936faf208f80f0b174a8741245142c7fa8b0d998e7540cf66033bcea76">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

