### PR TITLE
[rust] Enhance logic to uncompress DEB files and set toolchain version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -239,7 +239,12 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains()
+rust_register_toolchains(
+    edition = "2021",
+    versions = [
+        "1.77.0",
+    ],
+)
 
 load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -239,12 +239,7 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains(
-    edition = "2021",
-    versions = [
-        "1.77.0",
-    ],
-)
+rust_register_toolchains()
 
 load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ad22e2c56bec9cc2899d923af26cb07afe691cb81013d741f8588252270397a5",
+  "checksum": "d36b984c23f29915721adf9a17dd692393c70efc1b1f8aa1ddbe9e0862eaecac",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d36b984c23f29915721adf9a17dd692393c70efc1b1f8aa1ddbe9e0862eaecac",
+  "checksum": "ad22e2c56bec9cc2899d923af26cb07afe691cb81013d741f8588252270397a5",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -273,8 +273,10 @@ pub fn uncompress_deb(
         opt_edge_str, target_str
     ));
     create_parent_path_if_not_exists(target)?;
-    let output = run_shell_command_by_os(os, command)?;
-    if output.is_empty() {
+    run_shell_command_by_os(os, command)?;
+    let target_path = Path::new(target);
+    if target_path.parent().unwrap().read_dir()?.next().is_none() {
+        println!("IS EMPTY");
         fs::rename(&opt_edge_str, &target_str)?;
     }
 


### PR DESCRIPTION
## **User description**
### Description
This PR improves the logic to extract Deb files (e.g., Edge), which was causing problems in Fedora. Also, this PR specifies a fixed version of the Rust compiler in the WORKSPACE file. 

### Motivation and Context
Currently, a warning is displayed in Fedora.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced the logic for uncompressing DEB files in `rust/src/files.rs` to better handle empty target directories, improving compatibility with Fedora.
- Set a fixed Rust compiler version (1.77.0) and specified Rust edition as "2021" in the `WORKSPACE` file to ensure consistent toolchain usage.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>files.rs</strong><dd><code>Enhance DEB File Uncompression Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/files.rs

<li>Modified the logic to check if the target directory is empty after <br>attempting to uncompress DEB files.<br> <li> Removed unnecessary output check for emptiness after running shell <br>command.<br> <li> Added a print statement to indicate when the target directory is <br>empty.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13741/files#diff-64844fef0537ed5f6fd38575be93920c99efacb3fd4c317ed6ff1ce243c2e1f1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WORKSPACE</strong><dd><code>Set Fixed Rust Toolchain Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
WORKSPACE

<li>Specified Rust edition as "2021".<br> <li> Set Rust compiler version to "1.77.0" explicitly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13741/files#diff-5493ff8e9397811510e780de47c57abb70137f1afe85d1519130dc3679d60ce5">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

