### PR TITLE
[bidi][java] Deprecate using builder for Locate Node parameters. 

### DIFF
--- a/java/src/org/openqa/selenium/bidi/browsingcontext/LocateNodeParameters.java
+++ b/java/src/org/openqa/selenium/bidi/browsingcontext/LocateNodeParameters.java
@@ -29,11 +29,11 @@ import org.openqa.selenium.bidi.script.SerializationOptions;
 public class LocateNodeParameters {
 
   private final Locator locator;
-  private final Optional<Long> maxNodeCount;
-  private final Optional<ResultOwnership> ownership;
-  private final Optional<String> sandbox;
-  private final Optional<SerializationOptions> serializationOptions;
-  private final Optional<List<RemoteReference>> startNodes;
+  private Optional<Long> maxNodeCount = Optional.empty();
+  private Optional<ResultOwnership> ownership = Optional.empty();
+  private Optional<String> sandbox = Optional.empty();
+  private Optional<SerializationOptions> serializationOptions = Optional.empty();
+  private Optional<List<RemoteReference>> startNodes = Optional.empty();
 
   private LocateNodeParameters(Builder builder) {
     this.locator = builder.locator;
@@ -42,6 +42,35 @@ public class LocateNodeParameters {
     this.sandbox = Optional.ofNullable(builder.sandbox);
     this.serializationOptions = Optional.ofNullable(builder.serializationOptions);
     this.startNodes = Optional.ofNullable(builder.startNodes);
+  }
+
+  public LocateNodeParameters(Locator locator) {
+    this.locator = locator;
+  }
+
+  public LocateNodeParameters setMaxNodeCount(long maxNodeCount) {
+    this.maxNodeCount = Optional.of(maxNodeCount);
+    return this;
+  }
+
+  public LocateNodeParameters setOwnership(ResultOwnership ownership) {
+    this.ownership = Optional.of(ownership);
+    return this;
+  }
+
+  public LocateNodeParameters setSandbox(String sandbox) {
+    this.sandbox = Optional.of(sandbox);
+    return this;
+  }
+
+  public LocateNodeParameters setSerializationOptions(SerializationOptions options) {
+    this.serializationOptions = Optional.of(options);
+    return this;
+  }
+
+  public LocateNodeParameters setStartNodes(List<RemoteReference> startNodes) {
+    this.startNodes = Optional.of(startNodes);
+    return this;
   }
 
   public Map<String, Object> toMap() {
@@ -62,6 +91,12 @@ public class LocateNodeParameters {
     return map;
   }
 
+  /**
+   * @deprecated Use the chaining of LocateNodeParameters methods to add optional parameters. This
+   *     is in favor of keeping the usage pattern consistent for BiDi parameters. Use the {@link
+   *     LocateNodeParameters#LocateNodeParameters(Locator locator)} constructor and chain methods.
+   */
+  @Deprecated(since = "4.20", forRemoval = true)
   public static class Builder {
 
     private final Locator locator;

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -65,7 +65,7 @@ public class LocateNodesTest extends JupiterTestBase {
 
     driver.get(pages.xhtmlTestPage);
 
-    LocateNodeParameters parameters = new LocateNodeParameters.Builder(Locator.css("div")).build();
+    LocateNodeParameters parameters = new LocateNodeParameters(Locator.css("div"));
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(13);
@@ -113,9 +113,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("div.extraDiv, div.content"))
-            .setMaxNodeCount(1)
-            .build();
+        new LocateNodeParameters(Locator.css("div.extraDiv, div.content")).setMaxNodeCount(1);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isGreaterThanOrEqualTo(1);
@@ -141,9 +139,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.xpath("/html/body/div[2]"))
-            .setMaxNodeCount(1)
-            .build();
+        new LocateNodeParameters(Locator.xpath("/html/body/div[2]")).setMaxNodeCount(1);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isGreaterThanOrEqualTo(1);
@@ -170,9 +166,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.innerText("Spaced out"))
-            .setMaxNodeCount(1)
-            .build();
+        new LocateNodeParameters(Locator.innerText("Spaced out")).setMaxNodeCount(1);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isGreaterThanOrEqualTo(1);
@@ -194,7 +188,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("div")).setMaxNodeCount(4).build();
+        new LocateNodeParameters(Locator.css("div")).setMaxNodeCount(4);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(4);
@@ -212,9 +206,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("div"))
-            .setOwnership(ResultOwnership.NONE)
-            .build();
+        new LocateNodeParameters(Locator.css("div")).setOwnership(ResultOwnership.NONE);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(13);
@@ -233,9 +225,7 @@ public class LocateNodesTest extends JupiterTestBase {
     driver.get(pages.xhtmlTestPage);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("div"))
-            .setOwnership(ResultOwnership.ROOT)
-            .build();
+        new LocateNodeParameters(Locator.css("div")).setOwnership(ResultOwnership.ROOT);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(13);
@@ -276,10 +266,9 @@ public class LocateNodesTest extends JupiterTestBase {
                 new RemoteReference(RemoteReference.Type.SHARED_ID, value.getSharedId().get())));
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("input"))
+        new LocateNodeParameters(Locator.css("input"))
             .setStartNodes(startNodes)
-            .setMaxNodeCount(50)
-            .build();
+            .setMaxNodeCount(50);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(35);
@@ -298,10 +287,7 @@ public class LocateNodesTest extends JupiterTestBase {
     browsingContext.navigate(pages.xhtmlTestPage, ReadinessState.COMPLETE);
 
     LocateNodeParameters parameters =
-        new LocateNodeParameters.Builder(Locator.css("div"))
-            .setSandbox(sandbox)
-            .setMaxNodeCount(1)
-            .build();
+        new LocateNodeParameters(Locator.css("div")).setSandbox(sandbox).setMaxNodeCount(1);
 
     List<RemoteValue> elements = browsingContext.locateNodes(parameters);
     assertThat(elements.size()).isEqualTo(1);


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Deprecated using Builder and added chaining methods.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure consistency across BiDi parameters usage. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement


___

## **Description**
- Deprecated the use of Builder for constructing `LocateNodeParameters` and introduced chaining methods for setting optional parameters directly.
- Updated all instances in tests to utilize the new chaining methods, simplifying the instantiation process.
- This change aims to ensure consistency across BiDi parameters usage and improve the developer experience.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocateNodeParameters.java</strong><dd><code>Deprecate Builder and Introduce Chaining Methods for </code><br><code>LocateNodeParameters</code></dd></summary>
<hr>
      
java/src/org/openqa/selenium/bidi/browsingcontext/LocateNodeParameters.java

<li>Deprecated the Builder class for constructing LocateNodeParameters.<br> <li> Introduced chaining methods for setting optional parameters directly <br>on LocateNodeParameters instances.<br> <li> Changed fields from final to non-final to support the new chaining <br>methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13767/files#diff-bb179b9475dac7c3fe2a78fe06ee2f1bb8dc287100df412810d2c9fced579a51">+40/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocateNodesTest.java</strong><dd><code>Update Tests to Use New Chaining Methods for LocateNodeParameters</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java

<li>Updated tests to use the new chaining methods instead of the <br>deprecated Builder for LocateNodeParameters.<br> <li> Simplified the instantiation of LocateNodeParameters in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13767/files#diff-b63701b3cf1f898a95e4ef4d8b70e04724101885116b5287a447a0670a5a1ff3">+10/-24</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

