### PR TITLE
[dotnet] use correct devtools session id after reinitialization

### DIFF
--- a/dotnet/test/common/DevTools/DevToolsTabsTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsTabsTest.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace OpenQA.Selenium.DevTools
+{
+    using CurrentCdpVersion = V123;
+
+    [TestFixture]
+    public class DevToolsTabsTest : DevToolsTestFixture
+    {
+
+        [Test]
+        [IgnoreBrowser(Selenium.Browser.IE, "IE does not support Chrome DevTools Protocol")]
+        [IgnoreBrowser(Selenium.Browser.Firefox, "Firefox does not support Chrome DevTools Protocol")]
+        [IgnoreBrowser(Selenium.Browser.Safari, "Safari does not support Chrome DevTools Protocol")]
+        public async Task ClosingTabDoesNotBreakDevToolsSession()
+        {
+            var domains = session.GetVersionSpecificDomains<CurrentCdpVersion.DevToolsSessionDomains>();
+            await domains.Console.Enable();
+            var oldWindowHandle = driver.CurrentWindowHandle;
+            driver.SwitchTo().NewWindow(WindowType.Tab);
+            driver.SwitchTo().Window(oldWindowHandle);
+            driver.Close();
+            Assert.That(
+                async () => {
+                    await domains.Console.Enable();
+                },
+                Throws.Nothing
+            );
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
### Description
After reinitialization of the dev tools session, that new active session id should be used.

### Motivation and Context
Fixes regression issue: https://github.com/SeleniumHQ/selenium/issues/13755

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
PLEASE double check: in case a `sessionId` is provided to `SendCommand()` I removed the check if `attachedTargetId == null` and  the reinitialization of the session. My assumption was in case the `sessionId` is given, we don't need a session re-initialization.

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

## **Type**
bug_fix, tests


___

## **Description**
- Enhanced DevTools session management by ensuring the session is reattached if not currently attached to a target before sending commands.
- Added a new test to ensure that closing a tab does not break the DevTools session, addressing regression issue #13755.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DevToolsSession.cs</strong><dd><code>Improve DevTools Session Management in Selenium WebDriver</code></dd></summary>
<hr>
      
dotnet/src/webdriver/DevTools/DevToolsSession.cs

<li>Modified <code>SendCommand</code> to reattach session if <code>attachedTargetId</code> is null <br>before sending a command.<br> <li> Removed redundant session reattachment logic from overloaded <br><code>SendCommand</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13768/files#diff-0beb90c52c9357d5c8b3d1b68279e46971b026839cb7122bb29c6022776bff56">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DevToolsTabsTest.cs</strong><dd><code>Add Test for Verifying DevTools Session After Closing Tab</code></dd></summary>
<hr>
      
dotnet/test/common/DevTools/DevToolsTabsTest.cs

<li>Added a new test <code>ClosingTabDoesNotBreakDevToolsSession</code> to verify <br>DevTools session remains active after closing a tab.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13768/files#diff-a328a58b82c2837def4cc21d9eaead2b4c1a471872e9fb7319924dcfa23f183e">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

