### PR TITLE
[rb] Use Bazel JDK when starting server

### DIFF
--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -258,11 +258,11 @@ module Selenium
 
     def java_bin
       pp(ENV)
-      if ENV.key?('BAZEL_TEST') && ENV.key?('JAVA_HOME')
+      if ENV.key?('BAZEL_TEST') && (java_home = ENV.fetch('JAVA_HOME', nil))
         if WebDriver::Platform.windows?
-          "#{ENV['JAVA_HOME']}/bin/java.exe"
+          "#{java_home}/bin/java.exe"
         else
-          "#{ENV['JAVA_HOME']}/bin/java"
+          "#{java_home}/bin/java"
         end
       else
         'java'

--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -241,7 +241,7 @@ module Selenium
         # extract any additional_args that start with -D as options
         properties = @additional_args.dup - @additional_args.delete_if { |arg| arg[/^-D/] }
         args = ['-jar', @jar, @role, '--port', @port.to_s]
-        server_command = ['java'] + properties + args + @additional_args
+        server_command = [java_bin] + properties + args + @additional_args
         cp = WebDriver::ChildProcess.build(*server_command)
 
         if @log.is_a?(String)
@@ -253,6 +253,18 @@ module Selenium
         cp.detach = @background
 
         cp
+      end
+    end
+
+    def java_bin
+      if ENV.key?('BAZEL_TEST') && ENV.key?('JAVA_HOME')
+        if WebDriver::Platform.windows?
+          "#{ENV['JAVA_HOME']}/bin/java.exe"
+        else
+          "#{ENV['JAVA_HOME']}/bin/java"
+        end
+      else
+        'java'
       end
     end
 

--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -257,6 +257,7 @@ module Selenium
     end
 
     def java_bin
+      pp(ENV)
       if ENV.key?('BAZEL_TEST') && ENV.key?('JAVA_HOME')
         if WebDriver::Platform.windows?
           "#{ENV['JAVA_HOME']}/bin/java.exe"

--- a/rb/spec/unit/selenium/server_spec.rb
+++ b/rb/spec/unit/selenium/server_spec.rb
@@ -48,7 +48,7 @@ module Selenium
     it 'uses the given jar file and port' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
       allow(WebDriver::ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: 1234, background: true)
@@ -57,13 +57,13 @@ module Selenium
       server.start
       expect(File).to have_received(:exist?).with('selenium_server_deploy.jar')
       expect(WebDriver::ChildProcess).to have_received(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', '1234')
     end
 
     it 'waits for the server process by default' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
       allow(WebDriver::ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: port)
@@ -74,14 +74,14 @@ module Selenium
 
       expect(File).to have_received(:exist?).with('selenium_server_deploy.jar')
       expect(WebDriver::ChildProcess).to have_received(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
       expect(mock_process).to have_received(:wait)
     end
 
     it 'adds additional args' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
       allow(WebDriver::ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s, 'foo', 'bar')
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s, 'foo', 'bar')
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: port, background: true)
@@ -92,14 +92,14 @@ module Selenium
       server.start
       expect(File).to have_received(:exist?).with('selenium_server_deploy.jar')
       expect(WebDriver::ChildProcess).to have_received(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone',
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone',
               '--port', port.to_s, 'foo', 'bar')
     end
 
     it 'adds additional JAVA options args' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
       allow(WebDriver::ChildProcess).to receive(:build)
-        .with('java',
+        .with(a_string_ending_with('java'),
               '-Dwebdriver.chrome.driver=/bin/chromedriver',
               '-jar', 'selenium_server_deploy.jar',
               'standalone',
@@ -117,7 +117,7 @@ module Selenium
       server.start
       expect(File).to have_received(:exist?).with('selenium_server_deploy.jar')
       expect(WebDriver::ChildProcess).to have_received(:build)
-        .with('java',
+        .with(a_string_ending_with('java'),
               '-Dwebdriver.chrome.driver=/bin/chromedriver',
               '-jar', 'selenium_server_deploy.jar',
               'standalone',
@@ -194,7 +194,7 @@ module Selenium
     it 'raises Selenium::Server::Error if the server is not launched within the timeout' do
       allow(File).to receive(:exist?).with('selenium_server_deploy.jar').and_return(true)
       allow(WebDriver::ChildProcess).to receive(:build)
-        .with('java', '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
+        .with(a_string_ending_with('java'), '-jar', 'selenium_server_deploy.jar', 'standalone', '--port', port.to_s)
         .and_return(mock_process)
 
       poller = instance_double(WebDriver::SocketPoller)


### PR DESCRIPTION
## **User description**
This ensures the server is not started with a system JDK which might be missing, outdated or simply inaccessible due to Bazel test sandboxing.


___

## **Type**
enhancement


___

## **Description**
- Introduced a new method `java_bin` to dynamically select the Java binary based on the environment, specifically for Bazel tests.
- Modified the server initialization command to use the Java binary determined by `java_bin`, enhancing compatibility with Bazel's sandboxed environment.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rb</strong><dd><code>Use Bazel JDK for Selenium Server Initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/server.rb

<li>Modified server command to use <code>java_bin</code> method for determining Java <br>binary path.<br> <li> Added <code>java_bin</code> method to select Java binary from <code>JAVA_HOME</code> if <br><code>BAZEL_TEST</code> environment variable is set, otherwise defaults to 'java'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13771/files#diff-b79229af72183b83c001b2cebb5d6b26a49a807fea93c549b1ca11873dc672bb">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

