### PR TITLE
[bidi][js] Enable tests for Edge and Chrome

### DIFF
--- a/javascript/node/selenium-webdriver/bidi/scriptManager.js
+++ b/javascript/node/selenium-webdriver/bidi/scriptManager.js
@@ -237,7 +237,10 @@ class ScriptManager {
     const params = {
       functionDeclaration: functionDeclaration,
       arguments: argumentValueList,
-      sandbox: sandbox,
+    }
+
+    if (sandbox !== null) {
+      params.sandbox = sandbox
     }
 
     if (Array.isArray(this._browsingContextIds) && this._browsingContextIds.length > 0) {

--- a/javascript/node/selenium-webdriver/package.json
+++ b/javascript/node/selenium-webdriver/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\"",
     "lint:fix": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\" --fix",
-    "test": "mocha -t 600000 --recursive test",
+    "test": "npm run lint && mocha -t 600000 --recursive test",
     "test-jasmine": "bazel test //javascript/node/selenium-webdriver:tests"
   },
   "mocha": {

--- a/javascript/node/selenium-webdriver/package.json
+++ b/javascript/node/selenium-webdriver/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\"",
     "lint:fix": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\" --fix",
-    "test": "npm run lint && mocha -t 600000 --recursive test",
+    "test": "mocha -t 600000 --recursive test --grep 'bidi'",
     "test-jasmine": "bazel test //javascript/node/selenium-webdriver:tests"
   },
   "mocha": {

--- a/javascript/node/selenium-webdriver/package.json
+++ b/javascript/node/selenium-webdriver/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\"",
     "lint:fix": "eslint --ignore-pattern node_modules --ignore-pattern generator --ext js lib/http.js \"**/*.js\" --fix",
-    "test": "mocha -t 600000 --recursive test --grep 'bidi'",
+    "test": "mocha -t 600000 --recursive test",
     "test-jasmine": "bazel test //javascript/node/selenium-webdriver:tests"
   },
   "mocha": {

--- a/javascript/node/selenium-webdriver/test/bidi/add_intercept_parameters_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/add_intercept_parameters_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { suite } = require('../../lib/test')
 const Network = require('../../bidi/network')
@@ -31,7 +30,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -106,5 +105,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/bidi_session_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/bidi_session_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { suite } = require('../../lib/test')
 
@@ -27,7 +26,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -44,5 +43,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/bidi_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/bidi_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { Pages, suite } = require('../../lib/test')
 const logInspector = require('../../bidi/logInspector')
@@ -30,7 +29,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {

--- a/javascript/node/selenium-webdriver/test/bidi/browser_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browser_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { suite } = require('../../lib/test')
 const { Browser } = require('../..')
 const BrowserBiDi = require('../../bidi/browser')
@@ -29,14 +28,14 @@ suite(
       let driver
 
       beforeEach(async function () {
-        driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+        driver = await env.builder().build()
       })
 
       afterEach(function () {
         return driver.quit()
       })
 
-      xit('can create a user context', async function () {
+      it('can create a user context', async function () {
         const browser = await BrowserBiDi(driver)
 
         const userContext = await browser.createUserContext()
@@ -46,7 +45,7 @@ suite(
         await browser.removeUserContext(userContext)
       })
 
-      xit('can get user contexts', async function () {
+      it('can get user contexts', async function () {
         const browser = await BrowserBiDi(driver)
 
         const userContext1 = await browser.createUserContext()
@@ -60,7 +59,7 @@ suite(
         await browser.removeUserContext(userContext2)
       })
 
-      xit('can remove user context', async function () {
+      it('can remove user context', async function () {
         const browser = await BrowserBiDi(driver)
 
         const userContext1 = await browser.createUserContext()
@@ -81,5 +80,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
@@ -18,9 +18,8 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser, By } = require('../../')
-const { Pages, suite } = require('../../lib/test')
+const { Pages, suite, ignore } = require('../../lib/test')
 const BrowsingContext = require('../../bidi/browsingContext')
 const BrowsingContextInspector = require('../../bidi/browsingContextInspector')
 const until = require('../../lib/until')
@@ -30,7 +29,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -119,23 +118,26 @@ suite(
         assert(navigationInfo.url.includes('/bidi/logEntryAdded.html'))
       })
 
-      xit('can listen to navigation started event', async function () {
-        let navigationInfo = null
-        const browsingConextInspector = await BrowsingContextInspector(driver)
+      ignore(env.browsers(Browser.CHROME, Browser.EDGE)).it(
+        'can listen to navigation started event',
+        async function () {
+          let navigationInfo = null
+          const browsingConextInspector = await BrowsingContextInspector(driver)
 
-        await browsingConextInspector.onNavigationStarted((entry) => {
-          navigationInfo = entry
-        })
+          await browsingConextInspector.onNavigationStarted((entry) => {
+            navigationInfo = entry
+          })
 
-        const browsingContext = await BrowsingContext(driver, {
-          browsingContextId: await driver.getWindowHandle(),
-        })
+          const browsingContext = await BrowsingContext(driver, {
+            browsingContextId: await driver.getWindowHandle(),
+          })
 
-        await browsingContext.navigate(Pages.logEntryAdded, 'complete')
+          await browsingContext.navigate(Pages.logEntryAdded, 'complete')
 
-        assert.equal(navigationInfo.browsingContextId, browsingContext.id)
-        assert(navigationInfo.url.includes('/bidi/logEntryAdded.html'))
-      })
+          assert.equal(navigationInfo.browsingContextId, browsingContext.id)
+          assert(navigationInfo.url.includes('/bidi/logEntryAdded.html'))
+        },
+      )
 
       it('can listen to fragment navigated event', async function () {
         let navigationInfo = null
@@ -204,5 +206,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/browsingcontext_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browsingcontext_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser, By } = require('../../')
 const { Pages, suite, ignore } = require('../../lib/test')
 const BrowsingContext = require('../../bidi/browsingContext')

--- a/javascript/node/selenium-webdriver/test/bidi/browsingcontext_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browsingcontext_test.js
@@ -20,7 +20,7 @@
 const assert = require('assert')
 const firefox = require('../../firefox')
 const { Browser, By } = require('../../')
-const { Pages, suite } = require('../../lib/test')
+const { Pages, suite, ignore } = require('../../lib/test')
 const BrowsingContext = require('../../bidi/browsingContext')
 const until = require('../../lib/until')
 const { Origin, CaptureScreenshotParameters } = require('../../bidi/captureScreenshotParameters')
@@ -31,7 +31,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -403,7 +403,7 @@ suite(
         assert(result.url.includes('/bidi/logEntryAdded.html'))
       })
 
-      xit('can reload with readiness state', async function () {
+      it('can reload with readiness state', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -431,7 +431,7 @@ suite(
         assert.equal(result[1], 300)
       })
 
-      xit('can set viewport with device pixel ratio', async function () {
+      ignore(env.browsers(Browser.FIREFOX)).it('can set viewport with device pixel ratio', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -462,5 +462,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/input_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/input_test.js
@@ -31,7 +31,7 @@ suite(
       let driver
 
       beforeEach(async function () {
-        driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+        driver = await env.builder().build()
       })
 
       afterEach(function () {
@@ -168,7 +168,7 @@ suite(
         assert.strictEqual(await slide.getCssValue('left'), '101px')
       })
 
-      ignore(env.browsers(Browser.FIREFOX)).it('can move to and click element in an iframe', async function () {
+      xit('can move to and click element in an iframe', async function () {
         const browsingContextId = await driver.getWindowHandle()
         const input = await Input(driver)
         await driver.get(fileServer.whereIs('click_tests/click_in_iframe.html'))
@@ -275,7 +275,7 @@ suite(
         assert.strictEqual(await el.getAttribute('value'), 'foobar')
       })
 
-      ignore(env.browsers(Browser.SAFARI)).it('can scroll with the wheel input', async function () {
+      it('can scroll with the wheel input', async function () {
         const browsingContextId = await driver.getWindowHandle()
         const input = await Input(driver)
         await driver.get(Pages.scrollingPage)
@@ -323,5 +323,5 @@ suite(
       }
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/input_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/input_test.js
@@ -19,7 +19,6 @@
 
 const assert = require('assert')
 const fileServer = require('../../lib/test/fileserver')
-const firefox = require('../../firefox')
 const { ignore, Pages, suite } = require('../../lib/test')
 const { Key, Origin } = require('../../lib/input')
 const { Browser, By, until } = require('../..')

--- a/javascript/node/selenium-webdriver/test/bidi/local_value_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/local_value_test.js
@@ -33,7 +33,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -418,5 +418,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/local_value_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/local_value_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { suite } = require('../../lib/test')
 

--- a/javascript/node/selenium-webdriver/test/bidi/locate_nodes_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/locate_nodes_test.js
@@ -41,7 +41,7 @@ suite(
     })
 
     describe('Locate Nodes', function () {
-      xit('can locate nodes', async function () {
+      it('can locate nodes', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -53,7 +53,7 @@ suite(
         assert.strictEqual(element.length, 13)
       })
 
-      xit('can locate node', async function () {
+      it('can locate node', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -65,7 +65,7 @@ suite(
         assert.strictEqual(element.type, 'node')
       })
 
-      xit('can locate node with css locator', async function () {
+      it('can locate node with css locator', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -128,7 +128,7 @@ suite(
         assert.strictEqual(elements.length, 4)
       })
 
-      xit('can locate node with none ownership value', async function () {
+      it('can locate node with none ownership value', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -141,7 +141,7 @@ suite(
         assert.strictEqual(elements[0].handle, null)
       })
 
-      xit('can locate node with root ownership value', async function () {
+      it('can locate node with root ownership value', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -195,7 +195,7 @@ suite(
         assert.strictEqual(elements.length, 35)
       })
 
-      xit('can locate nodes in a given sandbox', async function () {
+      it('can locate nodes in a given sandbox', async function () {
         const sandbox = 'sandbox'
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
@@ -234,7 +234,7 @@ suite(
         assert.strictEqual(sharedId.value, nodeId)
       })
 
-      xit('can find element', async function () {
+      it('can find element', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,
@@ -247,7 +247,7 @@ suite(
         assert.strictEqual(elementText, 'Open new window')
       })
 
-      xit('can find elements', async function () {
+      it('can find elements', async function () {
         const id = await driver.getWindowHandle()
         const browsingContext = await BrowsingContext(driver, {
           browsingContextId: id,

--- a/javascript/node/selenium-webdriver/test/bidi/log_inspector_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/log_inspector_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { Pages, suite } = require('../../lib/test')
 const logInspector = require('../../bidi/logInspector')

--- a/javascript/node/selenium-webdriver/test/bidi/log_inspector_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/log_inspector_test.js
@@ -29,7 +29,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {

--- a/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser, By } = require('../../')
 const { Pages, suite } = require('../../lib/test')
 const Network = require('../../bidi/network')

--- a/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/network_commands_test.js
@@ -35,7 +35,7 @@ suite(
     let network
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
 
       network = await Network(driver)
     })
@@ -46,12 +46,12 @@ suite(
     })
 
     describe('Network commands', function () {
-      xit('can add intercept', async function () {
+      it('can add intercept', async function () {
         const intercept = await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
         assert.notEqual(intercept, null)
       })
 
-      xit('can remove intercept', async function () {
+      it('can remove intercept', async function () {
         const network = await Network(driver)
         const intercept = await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
         assert.notEqual(intercept, null)
@@ -59,7 +59,7 @@ suite(
         await network.removeIntercept(intercept)
       })
 
-      xit('can continue with auth credentials ', async function () {
+      it('can continue with auth credentials ', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.AUTH_REQUIRED))
 
         await network.authRequired(async (event) => {
@@ -72,7 +72,7 @@ suite(
         assert.equal(source.includes('Access granted'), true)
       })
 
-      xit('can continue without auth credentials ', async function () {
+      it('can continue without auth credentials ', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.AUTH_REQUIRED))
 
         await network.authRequired(async (event) => {
@@ -88,7 +88,7 @@ suite(
         assert.equal(source.includes('Access denied'), true)
       })
 
-      xit('can cancel auth ', async function () {
+      it('can cancel auth ', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.AUTH_REQUIRED))
 
         await network.authRequired(async (event) => {
@@ -102,7 +102,7 @@ suite(
         }
       })
 
-      xit('can fail request', async function () {
+      it('can fail request', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
 
         await network.beforeRequestSent(async (event) => {
@@ -119,7 +119,7 @@ suite(
         }
       })
 
-      xit('can continue request', async function () {
+      it('can continue request', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
 
         let counter = 0
@@ -134,7 +134,7 @@ suite(
         assert.strictEqual(counter, 1)
       })
 
-      xit('can continue response', async function () {
+      it('can continue response', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.RESPONSE_STARTED))
 
         let counter = 0
@@ -149,7 +149,7 @@ suite(
         assert.strictEqual(counter, 1)
       })
 
-      xit('can provide response', async function () {
+      it('can provide response', async function () {
         await network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT))
 
         let counter = 0

--- a/javascript/node/selenium-webdriver/test/bidi/network_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/network_test.js
@@ -18,9 +18,8 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
-const { Pages, suite } = require('../../lib/test')
+const { Pages, suite, ignore } = require('../../lib/test')
 const Network = require('../../bidi/network')
 const until = require('../../lib/until')
 
@@ -29,7 +28,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -81,7 +80,7 @@ suite(
         assert.equal(beforeRequestEvent.request.cookies[1].value.value, 'dosa')
       })
 
-      it('can redirect http equiv', async function () {
+      ignore(env.browsers(Browser.CHROME, Browser.EDGE)).it('can redirect http equiv', async function () {
         let beforeRequestEvent = []
         const network = await Network(driver)
         await network.beforeRequestSent(function (event) {
@@ -155,7 +154,7 @@ suite(
         assert.equal(onResponseCompleted[0].redirectCount, 0)
       })
 
-      xit('can listen to auth required event', async function () {
+      ignore(env.browsers(Browser.CHROME, Browser.EDGE)).it('can listen to auth required event', async function () {
         let authRequiredEvent = null
         const network = await Network(driver)
         await network.authRequired(function (event) {
@@ -174,7 +173,7 @@ suite(
         assert.equal(authRequiredEvent.response.url.includes('basicAuth'), true)
       })
 
-      xit('can listen to fetch error event', async function () {
+      it('can listen to fetch error event', async function () {
         let fetchErrorEvent = null
         const network = await Network(driver)
         await network.fetchError(function (event) {
@@ -192,7 +191,7 @@ suite(
         assert.equal(fetchErrorEvent.request.method, 'GET')
         assert.equal(url.includes('valid_url'), true)
         assert.equal(fetchErrorEvent.request.headers.length > 1, true)
-        assert.equal(fetchErrorEvent.errorText, 'NS_ERROR_UNKNOWN_HOST')
+        assert.notEqual(fetchErrorEvent.errorText, null)
       })
 
       it('test response completed mime type', async function () {
@@ -217,5 +216,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/script_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/script_test.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const assert = require('assert')
-const firefox = require('../../firefox')
 const { Browser } = require('../../')
 const { Pages, suite } = require('../../lib/test')
 const BrowsingContext = require('../../bidi/browsingContext')

--- a/javascript/node/selenium-webdriver/test/bidi/script_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/script_test.js
@@ -35,7 +35,7 @@ suite(
     let driver
 
     beforeEach(async function () {
-      driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+      driver = await env.builder().build()
     })
 
     afterEach(async function () {
@@ -215,7 +215,7 @@ suite(
         assert.notEqual(result.realmId, null)
 
         assert.equal(result.exceptionDetails.exception.type, 'error')
-        assert.equal(result.exceptionDetails.text, "SyntaxError: expected expression, got ')'")
+        assert.equal(result.exceptionDetails.text.includes('SyntaxError:'), true)
         assert.equal(result.exceptionDetails.columnNumber, 39)
         assert.equal(result.exceptionDetails.stackTrace.callFrames.length, 0)
       })
@@ -320,7 +320,7 @@ suite(
         assert.notEqual(result.realmId, null)
 
         assert.equal(result.exceptionDetails.exception.type, 'error')
-        assert.equal(result.exceptionDetails.text, "SyntaxError: expected expression, got ')'")
+        assert.equal(result.exceptionDetails.text.includes('SyntaxError:'), true)
         assert.equal(result.exceptionDetails.columnNumber, 39)
         assert.equal(result.exceptionDetails.stackTrace.callFrames.length, 0)
       })
@@ -797,7 +797,7 @@ suite(
         assert.equal(realmInfo.realmType, RealmType.WINDOW)
       })
 
-      xit('can listen to realm destroyed message', async function () {
+      it('can listen to realm destroyed message', async function () {
         const manager = await ScriptManager(undefined, driver)
 
         let realmInfo = null
@@ -819,5 +819,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/script_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/script_test.js
@@ -215,7 +215,7 @@ suite(
 
         assert.equal(result.exceptionDetails.exception.type, 'error')
         assert.equal(result.exceptionDetails.text.includes('SyntaxError:'), true)
-        assert.equal(result.exceptionDetails.columnNumber, 39)
+        assert.notEqual(result.exceptionDetails.columnNumber, null)
         assert.equal(result.exceptionDetails.stackTrace.callFrames.length, 0)
       })
 
@@ -320,7 +320,7 @@ suite(
 
         assert.equal(result.exceptionDetails.exception.type, 'error')
         assert.equal(result.exceptionDetails.text.includes('SyntaxError:'), true)
-        assert.equal(result.exceptionDetails.columnNumber, 39)
+        assert.notEqual(result.exceptionDetails.columnNumber, null)
         assert.equal(result.exceptionDetails.stackTrace.callFrames.length, 0)
       })
 
@@ -796,7 +796,7 @@ suite(
         assert.equal(realmInfo.realmType, RealmType.WINDOW)
       })
 
-      it('can listen to realm destroyed message', async function () {
+      xit('can listen to realm destroyed message', async function () {
         const manager = await ScriptManager(undefined, driver)
 
         let realmInfo = null

--- a/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js
@@ -19,13 +19,13 @@
 
 const assert = require('assert')
 require('../../lib/test/fileserver')
-const firefox = require('../../firefox')
 const { Pages, suite } = require('../../lib/test')
 const { Browser, By } = require('../..')
 const Input = require('../../bidi/input')
 const io = require('../../io')
 const { ReferenceValue, RemoteReferenceType } = require('../../bidi/protocolValue')
 const fs = require('fs')
+const { ignore } = require('../../testing')
 
 suite(
   function (env) {
@@ -42,14 +42,14 @@ suite(
       })
 
       beforeEach(async function () {
-        driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+        driver = await env.builder().build()
       })
 
       afterEach(function () {
         return driver.quit()
       })
 
-      xit('can set files', async function () {
+      ignore(env.browsers(Browser.FIREFOX)).it('can set files', async function () {
         const browsingContextId = await driver.getWindowHandle()
         const input = await Input(driver)
         await driver.get(Pages.formPage)
@@ -72,7 +72,7 @@ suite(
         assert.notEqual(await webElement.getAttribute('value'), '')
       })
 
-      xit('can set files with element id', async function () {
+      ignore(env.browsers(Browser.FIREFOX)).it('can set files with element id', async function () {
         const browsingContextId = await driver.getWindowHandle()
         const input = await Input(driver)
         await driver.get(Pages.formPage)
@@ -94,5 +94,5 @@ suite(
       })
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/test/bidi/storage_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/storage_test.js
@@ -19,7 +19,6 @@
 
 const assert = require('assert')
 require('../../lib/test/fileserver')
-const firefox = require('../../firefox')
 const { suite } = require('../../lib/test')
 const { Browser } = require('../..')
 const Storage = require('../../bidi/storage')
@@ -35,7 +34,7 @@ suite(
       let driver
 
       beforeEach(async function () {
-        driver = await env.builder().setFirefoxOptions(new firefox.Options().enableBidi()).build()
+        driver = await env.builder().build()
         await driver.get(fileserver.Pages.ajaxyPage)
         await driver.manage().deleteAllCookies()
         return assertHasCookies()
@@ -45,7 +44,7 @@ suite(
         return driver.quit()
       })
 
-      xit('can get cookie by name', async function () {
+      it('can get cookie by name', async function () {
         const cookie = createCookieSpec()
 
         await driver.manage().addCookie(cookie)
@@ -94,7 +93,7 @@ suite(
         assert.strictEqual(partitionKey.userContext, 'default')
       })
 
-      xit('can add cookie', async function () {
+      it('can add cookie', async function () {
         const cookie = createCookieSpec()
 
         const storage = await Storage(driver)
@@ -112,7 +111,7 @@ suite(
         assert.strictEqual(result.cookies[0].value.value, cookie.value)
       })
 
-      xit('can add and get cookie with all parameters', async function () {
+      it('can add and get cookie with all parameters', async function () {
         const cookie = createCookieSpec()
 
         const storage = await Storage(driver)
@@ -144,16 +143,16 @@ suite(
 
         assert.strictEqual(resultCookie.name, cookie.name)
         assert.strictEqual(resultCookie.value.value, cookie.value)
-        assert.strictEqual(resultCookie.domain, fileserver.whereIs('/'))
+        assert.strictEqual(resultCookie.domain.includes('http'), true)
         assert.strictEqual(resultCookie.path, '/ajaxy_page.html')
         assert.strictEqual(resultCookie.size > 0, true)
         assert.strictEqual(resultCookie.httpOnly, true)
         assert.strictEqual(resultCookie.secure, false)
         assert.strictEqual(resultCookie.sameSite, SameSite.LAX)
-        assert.strictEqual(resultCookie.expires, expiry)
+        assert.notEqual(resultCookie.expires, null)
       })
 
-      xit('can get all cookies', async function () {
+      it('can get all cookies', async function () {
         const cookie1 = createCookieSpec()
         const cookie2 = createCookieSpec()
 
@@ -249,5 +248,5 @@ suite(
       }
     })
   },
-  { browsers: [Browser.FIREFOX] },
+  { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },
 )

--- a/javascript/node/selenium-webdriver/testing/index.js
+++ b/javascript/node/selenium-webdriver/testing/index.js
@@ -302,6 +302,11 @@ class Environment {
         builder.setCapability('moz:debuggerAddress', true)
       }
 
+      // Enable BiDi for supporting browsers.
+      if (browser.name === Browser.FIREFOX || browser.name === Browser.CHROME || browser.name === Browser.EDGE) {
+        builder.setCapability('webSocketUrl', true)
+      }
+
       if (typeof urlOrServer === 'string') {
         builder.usingServer(urlOrServer)
       } else if (urlOrServer) {


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Enable tests for Edge and Chrome for BiDi APIs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, tests


___

## **Description**
- Enabled BiDi tests for Chrome and Edge in addition to Firefox across various test files.
- Added null check for `sandbox` parameter in `scriptManager.js`.
- Fixed and enabled previously skipped tests related to user contexts and browsing contexts for multiple browsers.
- Updated tests to support BiDi in Firefox, Chrome, and Edge for input, local value, locate nodes, log inspector, network commands, network, script, setFiles command, and storage.
- Added capability to enable BiDi for Firefox, Chrome, and Edge in `testing/index.js`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>scriptManager.js</strong><dd><code>Add null check for sandbox parameter in addPreloadScript</code>&nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/scriptManager.js

<li>Added a check to only include <code>sandbox</code> parameter if it's not null in <br><code>addPreloadScript</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-8b2c9869483a994b7a763bddd00c1e14d418da092015a460ce3977514ee9d736">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>add_intercept_parameters_test.js</strong><dd><code>Enable BiDi tests for Chrome and Edge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/add_intercept_parameters_test.js

<li>Enabled tests for Chrome and Edge in addition to Firefox.<br> <li> Removed unused import.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-683fbb762e2a1dfb83896bce7d4cb8f00ebc6c72d3a535011659bda38eef0cef">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bidi_session_test.js</strong><dd><code>Enable BiDi session tests for multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/bidi_session_test.js

- Enabled BiDi session tests for Chrome and Edge browsers.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-d19bd3738973475a11c59b5f9c82480d2d6c265f9c1c452233679071e41aab2b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>browser_test.js</strong><dd><code>Enable user context tests for BiDi in multiple browsers</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/browser_test.js

<li>Enabled previously skipped tests for creating, getting, and removing <br>user contexts.<br> <li> Tests are now enabled for Firefox, Chrome, and Edge.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-34e1dd2b823d3bfd66a861a6a696e4f02313df50cc7885e216a2412dcc8fa197">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>browsingcontext_inspector_test.js</strong><dd><code>Update browsing context inspector tests for BiDi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js

<li>Enabled navigation started event test for all browsers except Chrome <br>and Edge.<br> <li> Other tests enabled for Firefox, Chrome, and Edge.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-5a795b4366203e58bdf8bb6749ce666b85a150f2ca2b8d3e9970039347f5881a">+19/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>browsingcontext_test.js</strong><dd><code>Enable browsing context tests for BiDi in multiple browsers</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/browsingcontext_test.js

<li>Enabled various browsing context tests for Firefox, Chrome, and Edge.<br> <li> Added ignore for set viewport test on Firefox.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-d5e20be6a19ac8040a6e6e4988cd74172e5ea9027e82ac01adad2c2df240f34a">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>input_test.js</strong><dd><code>Enable input tests for BiDi in multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/input_test.js

<li>Enabled input tests for Firefox, Chrome, and Edge.<br> <li> Marked move to and click element in an iframe test as ignored.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-1b9a20ed234d11350ce21fa778053776be5802e8b1a2b728b6852a9bc284ef37">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local_value_test.js</strong><dd><code>Enable local value tests for BiDi in multiple browsers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/local_value_test.js

- Enabled local value tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-a62d6cbfd9d08a2acd1182619821b44fb300d96b5ccab2d6a5465260bdea9b35">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>locate_nodes_test.js</strong><dd><code>Enable locate nodes tests for BiDi in multiple browsers</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/locate_nodes_test.js

- Enabled various locate nodes tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-d69c46b8235285967e4b9734bfd4b1b4d7a401f4c80086cb2663cef1f43c8298">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_inspector_test.js</strong><dd><code>Enable log inspector tests for BiDi in multiple browsers</code>&nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/log_inspector_test.js

- Enabled log inspector tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-f172e17060711f9511bdc0830aac9fba714639b13d06cffcc01988e611aa7862">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_commands_test.js</strong><dd><code>Enable network commands tests for BiDi in multiple browsers</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/network_commands_test.js

- Enabled network commands tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-dea7f03b07f22d3628b93323b3ebe6ad2ca436ebeb1e660b8ece557a130bbf76">+10/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_test.js</strong><dd><code>Enable network tests for BiDi in multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/network_test.js

<li>Enabled network tests for Firefox, Chrome, and Edge.<br> <li> Added ignore for redirect http equiv test on Chrome and Edge.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-a1ac20c340d17a8704b987b95d05c636b80f46115b238ba891902ddf69141138">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script_test.js</strong><dd><code>Enable script tests for BiDi in multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/script_test.js

- Enabled script tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-d3c85e936faf208f80f0b174a8741245142c7fa8b0d998e7540cf66033bcea76">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>setFiles_command_test.js</strong><dd><code>Enable set files command tests for BiDi in Chrome and Edge</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/setFiles_command_test.js

<li>Enabled set files command tests for Chrome and Edge, ignoring Firefox.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-121225b5ff0dd52bd73de0c89fc82781c81442e2b9e11591ebe00e235ac39945">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_test.js</strong><dd><code>Enable storage tests for BiDi in multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/storage_test.js

- Enabled storage tests for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-3e22d9fd2cdd6724cb058752747d4d393d269761ced2731dee7bcc6d663bb521">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Enable BiDi capability for multiple browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/testing/index.js

- Added capability to enable BiDi for Firefox, Chrome, and Edge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13790/files#diff-a73b91b68f7208515f860a1e2558954d2c8cfbb516a78bf0e272082da96f079f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

