### PR TITLE
[rust] Use DEBUG level for WARN traces in offline mode

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -938,10 +938,13 @@ pub trait SeleniumManager {
                 .unwrap_or_default()
                 .unwrap_or_default();
             if best_browser_from_cache.exists() {
-                self.get_logger().warn(format!(
-                    "There was an error managing {}; using browser found in the cache",
-                    self.get_browser_name()
-                ));
+                self.get_logger().debug_or_warn(
+                    format!(
+                        "There was an error managing {}; using browser found in the cache",
+                        self.get_browser_name()
+                    ),
+                    self.is_offline(),
+                );
                 browser_path = path_to_string(best_browser_from_cache);
             }
         }

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -150,6 +150,11 @@ impl Logger {
         self.logger(message.to_string(), Level::Debug);
     }
 
+    pub fn debug_or_warn<T: Display>(&self, message: T, is_debug: bool) {
+        let level = if is_debug { Level::Debug } else { Level::Warn };
+        self.logger(message.to_string(), level);
+    }
+
     pub fn trace<T: Display>(&self, message: T) {
         self.logger(message.to_string(), Level::Trace);
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -245,11 +245,14 @@ fn main() {
             if let Some(best_driver_from_cache) =
                 selenium_manager.find_best_driver_from_cache().unwrap()
             {
-                log.warn(format!(
-                    "There was an error managing {} ({}); using driver found in the cache",
-                    selenium_manager.get_driver_name(),
-                    err
-                ));
+                log.debug_or_warn(
+                    format!(
+                        "There was an error managing {} ({}); using driver found in the cache",
+                        selenium_manager.get_driver_name(),
+                        err
+                    ),
+                    selenium_manager.is_offline(),
+                );
                 log_driver_and_browser_path(
                     log,
                     &best_driver_from_cache,


### PR DESCRIPTION
## **User description**
### Description
This PR changes the level of several WARN traces to DEBUG when the offline mode is enabled. Example:

```
./selenium-manager --browser firefox --debug --offline
[2024-04-12T09:33:30.755Z DEBUG] Offline flag set, but also asked not to avoid browser downloads. Honouring offline flag
[2024-04-12T09:33:30.756Z DEBUG] Using Selenium Manager in offline mode
[2024-04-12T09:33:30.774Z DEBUG] geckodriver not found in PATH
[2024-04-12T09:33:30.774Z DEBUG] firefox detected at C:\Program Files\Mozilla Firefox\firefox.exe
[2024-04-12T09:33:30.775Z DEBUG] Running command: wmic datafile where name='C:\\Program Files\\Mozilla Firefox\\firefox.exe' get Version /value
[2024-04-12T09:33:30.854Z DEBUG] Output: "\r\r\n\r\r\nVersion=124.0.2.8857\r\r\n\r\r\n\r\r\n\r"
[2024-04-12T09:33:30.859Z DEBUG] Detected browser: firefox 124.0.2.8857
[2024-04-12T09:33:30.906Z DEBUG] There was an error managing geckodriver (Unable to discover proper geckodriver version in offline mode); using driver found in the cache
[2024-04-12T09:33:30.907Z INFO ] Driver path: C:\Users\boni\.cache\selenium\geckodriver\win64\0.34.0\geckodriver.exe
[2024-04-12T09:33:30.908Z INFO ] Browser path: C:\Program Files\Mozilla Firefox\firefox.exe
```

### Motivation and Context
Requested in #13809.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
bug_fix


___

## **Description**
- Introduced a new logging method `debug_or_warn` in `logger.rs` to dynamically log messages as either DEBUG or WARN based on the offline mode flag.
- Utilized the new `debug_or_warn` method in `lib.rs` and `main.rs` to improve logging when the Selenium Manager operates in offline mode, specifically when falling back to using cached browsers or drivers.
- This change aims to provide more appropriate logging levels when in offline mode, reducing the verbosity of WARN logs when not necessary.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Use Debug or Warn Level Logging in Offline Mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/lib.rs

<li>Introduced <code>debug_or_warn</code> method usage for logging when using a browser <br>from the cache in offline mode.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13810/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logger.rs</strong><dd><code>Add Debug or Warn Logging Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/logger.rs

<li>Added a new method <code>debug_or_warn</code> to log messages as DEBUG or WARN <br>based on offline mode flag.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13810/files#diff-113e74fd25aff5a010b2d20e89babef5a738c58c0c5a3ce2f3e9984c1a37530f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Enhance Logging for Driver Cache Usage in Offline Mode</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/main.rs

<li>Utilized <code>debug_or_warn</code> for logging driver cache usage in offline mode.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13810/files#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

