### PR TITLE
[grid][java]: dynamic grid re-fetch browser images if they were pruned during runtime

### DIFF
--- a/java/src/org/openqa/selenium/docker/ContainerConfig.java
+++ b/java/src/org/openqa/selenium/docker/ContainerConfig.java
@@ -84,6 +84,10 @@ public class ContainerConfig {
     this.hostConfig = hostConfig;
   }
 
+  public Image getImage() {
+    return this.image;
+  }
+
   public static ContainerConfig image(Image image) {
     return new ContainerConfig(
         image,

--- a/java/src/org/openqa/selenium/docker/v1_41/CreateContainer.java
+++ b/java/src/org/openqa/selenium/docker/v1_41/CreateContainer.java
@@ -52,6 +52,7 @@ class CreateContainer {
   }
 
   public Container apply(ContainerConfig info) {
+    this.protocol.getImage(info.getImage().getName());
     HttpResponse res =
         DockerMessages.throwIfNecessary(
             client.execute(


### PR DESCRIPTION
## **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fix: https://github.com/SeleniumHQ/docker-selenium/issues/1644

**Steps to reproduce:**
* launch Selenium Grid in dynamic grid mode (in our case, grid was deployed in docker stack, but this should not make a difference)
* spin up a browser node in dynamic grid and terminate it (image is persisted afterwards)
* perform `docker image prune -a`
* try to spin up the same browser node again

**Expected behavior:**
* browser node image is fetched again as it is missing locally
* browser node is launched successfully after image was fetched

**Actual behavior:**
Grid fails fatally trying to spin up a browser with the now missing image.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Added a new method `getImage()` in `ContainerConfig` to facilitate image retrieval.
- Enhanced the container creation process to automatically re-fetch browser images if they were pruned during runtime, addressing a fatal grid failure issue.
- Implemented a retry mechanism in the container creation process to handle cases where the Docker image is not found locally, by attempting to pull the image again before retrying.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContainerConfig.java</strong><dd><code>Add Method to Retrieve Image from ContainerConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/docker/ContainerConfig.java

<li>Added a method <code>getImage()</code> to retrieve the image from a <code>ContainerConfig</code> <br>object.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13821/files#diff-ef3399f1ef34da7c97a287ae43ca7feda14f6d23189602a4a1cf70acb8709040">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateContainer.java</strong><dd><code>Implement Image Re-fetch Logic for Docker Containers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/docker/v1_41/CreateContainer.java

<li>Implemented a retry mechanism in <code>apply</code> method to handle "No such <br>image" DockerException.<br> <li> Added a <code>createContainer</code> method to encapsulate container creation <br>logic.<br> <li> Utilized <code>PullImage</code> to fetch the image if it's not found locally before <br>retrying container creation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13821/files#diff-58369a3ec8da4db1b10dcdf9ff21a666d7da60508836db7cc94937618f576f57">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

