### PR TITLE
[cdp][java] Continue requests without modification for know errors in NetworkInterceptor

### DIFF
--- a/java/src/org/openqa/selenium/devtools/idealized/Network.java
+++ b/java/src/org/openqa/selenium/devtools/idealized/Network.java
@@ -202,6 +202,7 @@ public abstract class Network<AUTHREQUIRED, REQUESTPAUSED> {
             String id = getRequestId(pausedRequest);
 
             if (hasErrorResponse(pausedRequest)) {
+              pendingResponses.remove(id);
               devTools.send(continueWithoutModification(pausedRequest));
               return;
             }

--- a/java/src/org/openqa/selenium/devtools/idealized/Network.java
+++ b/java/src/org/openqa/selenium/devtools/idealized/Network.java
@@ -200,6 +200,12 @@ public abstract class Network<AUTHREQUIRED, REQUESTPAUSED> {
         pausedRequest -> {
           try {
             String id = getRequestId(pausedRequest);
+
+            if (hasErrorResponse(pausedRequest)) {
+              devTools.send(continueWithoutModification(pausedRequest));
+              return;
+            }
+
             Either<HttpRequest, HttpResponse> message = createSeMessages(pausedRequest);
 
             if (message.isRight()) {
@@ -347,6 +353,8 @@ public abstract class Network<AUTHREQUIRED, REQUESTPAUSED> {
   protected abstract String getRequestId(REQUESTPAUSED pausedReq);
 
   protected abstract Either<HttpRequest, HttpResponse> createSeMessages(REQUESTPAUSED pausedReq);
+
+  protected abstract boolean hasErrorResponse(REQUESTPAUSED pausedReq);
 
   protected abstract Command<Void> continueWithoutModification(REQUESTPAUSED pausedReq);
 

--- a/java/src/org/openqa/selenium/devtools/v121/v121Network.java
+++ b/java/src/org/openqa/selenium/devtools/v121/v121Network.java
@@ -114,8 +114,7 @@ public class v121Network extends Network<AuthRequired, RequestPaused> {
 
   @Override
   public Either<HttpRequest, HttpResponse> createSeMessages(RequestPaused pausedReq) {
-    if (pausedReq.getResponseStatusCode().isPresent()
-        || pausedReq.getResponseErrorReason().isPresent()) {
+    if (pausedReq.getResponseStatusCode().isPresent()) {
       String body;
       boolean bodyIsBase64Encoded;
 
@@ -159,6 +158,11 @@ public class v121Network extends Network<AuthRequired, RequestPaused> {
             cdpReq.getMethod(), cdpReq.getUrl(), cdpReq.getHeaders(), cdpReq.getPostData());
 
     return Either.left(req);
+  }
+
+  @Override
+  protected boolean hasErrorResponse(RequestPaused pausedReq) {
+    return pausedReq.getResponseErrorReason().isPresent();
   }
 
   @Override

--- a/java/src/org/openqa/selenium/devtools/v122/v122Network.java
+++ b/java/src/org/openqa/selenium/devtools/v122/v122Network.java
@@ -114,8 +114,7 @@ public class v122Network extends Network<AuthRequired, RequestPaused> {
 
   @Override
   public Either<HttpRequest, HttpResponse> createSeMessages(RequestPaused pausedReq) {
-    if (pausedReq.getResponseStatusCode().isPresent()
-        || pausedReq.getResponseErrorReason().isPresent()) {
+    if (pausedReq.getResponseStatusCode().isPresent()) {
       String body;
       boolean bodyIsBase64Encoded;
 
@@ -159,6 +158,11 @@ public class v122Network extends Network<AuthRequired, RequestPaused> {
             cdpReq.getMethod(), cdpReq.getUrl(), cdpReq.getHeaders(), cdpReq.getPostData());
 
     return Either.left(req);
+  }
+
+  @Override
+  protected boolean hasErrorResponse(RequestPaused pausedReq) {
+    return pausedReq.getResponseErrorReason().isPresent();
   }
 
   @Override

--- a/java/src/org/openqa/selenium/devtools/v123/v123Network.java
+++ b/java/src/org/openqa/selenium/devtools/v123/v123Network.java
@@ -114,8 +114,7 @@ public class v123Network extends Network<AuthRequired, RequestPaused> {
 
   @Override
   public Either<HttpRequest, HttpResponse> createSeMessages(RequestPaused pausedReq) {
-    if (pausedReq.getResponseStatusCode().isPresent()
-        || pausedReq.getResponseErrorReason().isPresent()) {
+    if (pausedReq.getResponseStatusCode().isPresent()) {
       String body;
       boolean bodyIsBase64Encoded;
 
@@ -159,6 +158,11 @@ public class v123Network extends Network<AuthRequired, RequestPaused> {
             cdpReq.getMethod(), cdpReq.getUrl(), cdpReq.getHeaders(), cdpReq.getPostData());
 
     return Either.left(req);
+  }
+
+  @Override
+  protected boolean hasErrorResponse(RequestPaused pausedReq) {
+    return pausedReq.getResponseErrorReason().isPresent();
   }
 
   @Override

--- a/java/src/org/openqa/selenium/devtools/v85/V85Network.java
+++ b/java/src/org/openqa/selenium/devtools/v85/V85Network.java
@@ -124,8 +124,7 @@ public class V85Network extends Network<AuthRequired, RequestPaused> {
 
   @Override
   public Either<HttpRequest, HttpResponse> createSeMessages(RequestPaused pausedReq) {
-    if (pausedReq.getResponseStatusCode().isPresent()
-        || pausedReq.getResponseErrorReason().isPresent()) {
+    if (pausedReq.getResponseStatusCode().isPresent()) {
       String body;
       boolean bodyIsBase64Encoded;
 
@@ -169,6 +168,11 @@ public class V85Network extends Network<AuthRequired, RequestPaused> {
             cdpReq.getMethod(), cdpReq.getUrl(), cdpReq.getHeaders(), cdpReq.getPostData());
 
     return Either.left(req);
+  }
+
+  @Override
+  protected boolean hasErrorResponse(RequestPaused pausedReq) {
+    return pausedReq.getResponseErrorReason().isPresent();
   }
 
   @Override

--- a/java/test/org/openqa/selenium/devtools/NetworkInterceptorTest.java
+++ b/java/test/org/openqa/selenium/devtools/NetworkInterceptorTest.java
@@ -20,7 +20,8 @@ package org.openqa.selenium.devtools;
 import static com.google.common.net.MediaType.XHTML_UTF_8;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.openqa.selenium.remote.http.Contents.utf8String;
 import static org.openqa.selenium.testing.Safely.safelyCall;
@@ -35,7 +36,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.environment.webserver.NettyAppServer;
+import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.Filter;
 import org.openqa.selenium.remote.http.HttpMethod;
@@ -246,6 +249,16 @@ class NetworkInterceptorTest extends JupiterTestBase {
 
       String body = driver.findElement(By.tagName("body")).getText();
       assertThat(body).contains("Hello, World!");
+    }
+  }
+
+  @Test
+  @NoDriverBeforeTest
+  void shouldProceedAsNormalIfRequestResultInAnKnownError() {
+    Filter filter = next -> next;
+    try (NetworkInterceptor ignored = new NetworkInterceptor(driver, filter)) {
+      assertThatExceptionOfType(WebDriverException.class)
+          .isThrownBy(() -> driver.get("http://localhost:" + PortProber.findFreePort()));
     }
   }
 }


### PR DESCRIPTION
## **User description**
Related to #13774

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Selenium was returning an HTTP 200 response if CDP responded with an error parameter in the paused request. The changes fix this by adding a check and continuing the request without modification.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #13774 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Added error response handling in network request interception across multiple versions (v85, v121, v122, v123) to continue without modification when errors are detected.
- Enhanced the idealized network handling to improve the response to paused requests with errors.
- Updated tests to check the new behavior ensuring that requests with known errors are handled correctly.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Network.java</strong><dd><code>Enhance error handling in paused network requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/devtools/idealized/Network.java

<li>Added a check for error responses in paused requests and continue <br>without modification if an error is present.<br> <li> Enhanced the handling of paused requests by directly continuing them <br>when an error response is detected.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-e2eaccc33e555132eea5a90c621e9bc3f356dc3da108fa43ff0db0534946b4fd">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>v121Network.java</strong><dd><code>Implement error response handling in v121</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/devtools/v121/v121Network.java

<li>Implemented method to check for error responses in paused requests.<br> <li> Adjusted logic to only consider response status code for creating <br>messages.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-a5d6564d19b18aff33fea626ca28f1c734350c62f2a1b07dfe12f4b7d85eef60">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>v122Network.java</strong><dd><code>Add error handling in network requests for v122</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/devtools/v122/v122Network.java

<li>Added method to detect error responses in network requests.<br> <li> Modified message creation to ignore error reasons unless a status code <br>is present.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-07881f5d2a76a8bc4f996df0bce3df021793ee4c4c2eaf64ab76d9978791889f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>v123Network.java</strong><dd><code>Introduce error response handling in v123</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/src/org/openqa/selenium/devtools/v123/v123Network.java

<li>Introduced error response detection for paused network requests.<br> <li> Altered message creation logic to focus on status codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-a13835552724f8a6dc3631aee2e77d61a711deae7f335bb9248f5fd0f5a8ad98">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>V85Network.java</strong><dd><code>Simplify and enhance error handling in V85 network interception</code></dd></summary>
<hr>
      
java/src/org/openqa/selenium/devtools/v85/V85Network.java

<li>Added error response detection in network interception.<br> <li> Simplified message creation by focusing on status codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-7d2ede887b6d41abf418cc653aad842cdf24ae4fc6b61ffacb204ee63dc91f88">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkInterceptorTest.java</strong><dd><code>Update tests for new error handling in network requests</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/devtools/NetworkInterceptorTest.java

<li>Added a test to ensure proper handling when a known error occurs <br>during a network request.<br> <li> Modified existing tests to adapt to the new error handling mechanism.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13836/files#diff-3a210ca03f8e29c8097e6d7f9d056db7a17335a669c61a64e60e37f2158733d9">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

