### PR TITLE
[py] Allow overriding 'browserName' in WPEWebKit

### DIFF
--- a/py/selenium/webdriver/wpewebkit/options.py
+++ b/py/selenium/webdriver/wpewebkit/options.py
@@ -57,6 +57,9 @@ class Options(ArgOptions):
 
         caps[Options.KEY] = browser_options
 
+        if self.browser_name:
+            caps["browserName"] = self.browser_name
+
         return caps
 
     @property


### PR DESCRIPTION
## **User description**
By default the `browserName` capability for WPEWebKit is set to `MiniBrowser`. However, `MiniBrowser` is not the only browser supported to run WebDriver tests in WPEWebKit. Another supported browser is `Cog`.

Since `browserName: "Minibrowser"` is the default for WPEWebKit [1], when launching a remote connection setting the `binary` browser option to a path pointing to Cog, the connection will refuse to start. 

Consider the following script: https://gist.github.com/lauromoura/f3f424164b45820e2e33b75a8d661a25

```
$ ./mvt.py --browser /app/webkit/WebKitBuild/WPE/Release/Tools/cog-prefix/src/cog-build/launcher/cog --platform gtk4 127.0.0.1:8088
Connecting to remote driver...
Traceback (most recent call last):
  File "/home/dpino/webkit/./mvt.py", line 159, in <module>
	main()
  File "/home/dpino/webkit/./mvt.py", line 123, in main
	driver = webdriver.Remote(
			 ^^^^^^^^^^^^^^^^^
  File "/home/dpino/.local/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 208, in init
	self.start_session(capabilities)
  File "/home/dpino/.local/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 294, in start_session
	response = self.execute(Command.NEW_SESSION, caps)["value"]
			   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dpino/.local/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 349, in execute
	self.error_handler.check_response(response)
  File "/home/dpino/.local/lib/python3.11/site-packages/selenium/webdriver/remote/errorhandler.py", line 229, in check_response
	raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.SessionNotCreatedException: Message: Failed to match capabilities
```

This is because capabilities `browserName` and the basename of `binary` must match. This can be solved if developers are allowed to override the `browserName` capability. 

[1] https://github.com/SeleniumHQ/selenium/blob/ea73d44c00ef35ceca29b122c08003d40d080f34/py/selenium/webdriver/common/desired_capabilities.py#L99


___

## **Type**
enhancement


___

## **Description**
- Added the ability to override the `browserName` capability in both WebKitGTK and WPEWebKit Selenium bindings.
- This change allows users to specify a different browser, such as `Cog`, instead of the default `MiniBrowser`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options.py</strong><dd><code>Allow overriding browserName in WebKitGTK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
py/selenium/webdriver/webkitgtk/options.py

<li>Added capability to override the default <code>browserName</code> in capabilities <br>if <code>browser_name</code> is set.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13855/files#diff-c2cfb661a575d652121ca4eae33166ffdf21d1b4323c212ee6300c57c853dc39">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>options.py</strong><dd><code>Allow overriding browserName in WPEWebKit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
py/selenium/webdriver/wpewebkit/options.py

<li>Added capability to override the default <code>browserName</code> in capabilities <br>if <code>browser_name</code> is set.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13855/files#diff-328aa76538eefc1145f9a680697666ac3e36ed0c11cad17b5a22ca91ed00fa95">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

