### PR TITLE
Ensure rules_proto comes from the module file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,9 +30,9 @@ http_archive(
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 
 rules_closure_dependencies(
-  omit_rules_java = True,
-  omit_rules_proto = True,
-  omit_rules_python = True,
+    omit_rules_java = True,
+    omit_rules_proto = True,
+    omit_rules_python = True,
 )
 
 rules_closure_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,11 @@ http_archive(
 
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 
-rules_closure_dependencies()
+rules_closure_dependencies(
+  omit_rules_java = True,
+  omit_rules_proto = True,
+  omit_rules_python = True,
+)
 
 rules_closure_toolchains()
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the `rules_closure_dependencies` in the WORKSPACE file to explicitly omit dependencies related to Java, Proto, and Python. This change ensures that these dependencies are managed more precisely, potentially to avoid conflicts or to streamline the build process.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WORKSPACE</strong><dd><code>Modify Closure Dependencies in WORKSPACE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
WORKSPACE

<li>Modified <code>rules_closure_dependencies</code> to omit rules for Java, Proto, and <br>Python.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/13879/files#diff-5493ff8e9397811510e780de47c57abb70137f1afe85d1519130dc3679d60ce5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

