### PR TITLE
[dotnet] toggle starting test server with Java if Runfiles are not available

### DIFF
--- a/dotnet/test/common/Environment/EnvironmentManager.cs
+++ b/dotnet/test/common/Environment/EnvironmentManager.cs
@@ -24,9 +24,10 @@ namespace OpenQA.Selenium.Environment
         private EnvironmentManager()
         {
             string dataFilePath;
-            var runfiles = Runfiles.Create();
+            Runfiles runfiles = null;
             try
             {
+                runfiles = Runfiles.Create();
                 dataFilePath = runfiles.Rlocation("_main/dotnet/test/common/appconfig.json");
             }
             catch (FileNotFoundException)
@@ -143,6 +144,8 @@ namespace OpenQA.Selenium.Environment
             try
             {
                 string managerFilePath = "";
+                runfiles ??= Runfiles.Create();
+
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     managerFilePath = runfiles.Rlocation("_main/dotnet/src/webdriver/manager/windows/selenium-manager.exe");

--- a/dotnet/test/common/Environment/TestWebServer.cs
+++ b/dotnet/test/common/Environment/TestWebServer.cs
@@ -49,7 +49,14 @@ namespace OpenQA.Selenium.Environment
                 catch (FileNotFoundException)
                 {
                     var baseDirectory = AppContext.BaseDirectory;
-                    standaloneTestJar = Path.Combine(baseDirectory, "../../../../../../bazel-bin/java/test/org/openqa/selenium/environment/appserver_deploy.jar");
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        standaloneTestJar = Path.Combine(baseDirectory, "../../../../../../bazel-bin/java/test/org/openqa/selenium/environment/appserver.exe");
+                    }
+                    else
+                    {
+                        standaloneTestJar = Path.Combine(baseDirectory, "../../../../../../bazel-bin/java/test/org/openqa/selenium/environment/appserver_deploy.jar");
+                    }
                 }
 
                 Console.Write("Standalone jar is " + standaloneTestJar);


### PR DESCRIPTION
### **User description**
### Description
This allows users to run .NET tests with bazel (both pinned and unpinned browsers), as well as locally with Java using dotnet on Mac. @nvborisenko can you verify this works on Windows? I can spin up a VM if I need to.

This might be more of a hack than the right solution, but it's the best I know how to do. Feedback appreciated.

### Motivation and Context
Current code does not work on Mac to run tests locally


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved `Runfiles` handling in `EnvironmentManager` by adding null checks and adjusting logic for `FileNotFoundException`.
- Enhanced `TestWebServer` startup logic:
  - Added fallback to `JAVA_HOME` environment variable.
  - Refactored platform-specific executable path handling.
  - Improved error handling for missing Java executable.
  - Simplified process start logic and environment variable setup.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnvironmentManager.cs</strong><dd><code>Improve `Runfiles` handling in `EnvironmentManager`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
dotnet/test/common/Environment/EnvironmentManager.cs

<li>Added null check for <code>Runfiles</code> creation.<br> <li> Adjusted logic to handle <code>FileNotFoundException</code> when <code>Runfiles</code> are not <br>available.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14010/files#diff-75436dc8c8dced10f6b96f66e3e3a5d6b31ec7e64ae11a0187b48877d82c3972">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TestWebServer.cs</strong><dd><code>Enhance `TestWebServer` startup logic and error handling</code>&nbsp; </dd></summary>
<hr>
      
dotnet/test/common/Environment/TestWebServer.cs

<li>Added fallback to <code>JAVA_HOME</code> environment variable if <code>javaHomeDirectory</code> <br>is not set.<br> <li> Refactored <code>Start</code> method to handle different platforms and executable <br>paths.<br> <li> Improved error handling for missing Java executable.<br> <li> Simplified process start logic and environment variable setup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14010/files#diff-9b1522ed8b7052b3c0e172fa95173cec4340245fe34caf1ca94cf17376a10dca">+46/-54</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

