### PR TITLE
[java][bidi] Remove non-relevant annotations

### DIFF
--- a/java/test/org/openqa/selenium/bidi/BiDiSessionTest.java
+++ b/java/test/org/openqa/selenium/bidi/BiDiSessionTest.java
@@ -18,19 +18,14 @@
 package org.openqa.selenium.bidi;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 
 class BiDiSessionTest extends JupiterTestBase {
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void shouldBeAbleToCreateABiDiSession() {
     BiDi biDi = ((HasBiDi) driver).getBiDi();
 

--- a/java/test/org/openqa/selenium/bidi/BiDiTest.java
+++ b/java/test/org/openqa/selenium/bidi/BiDiTest.java
@@ -20,8 +20,6 @@ package org.openqa.selenium.bidi;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -54,8 +52,6 @@ class BiDiTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canNavigateAndListenToErrors()
       throws ExecutionException, InterruptedException, TimeoutException {

--- a/java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java
@@ -29,7 +29,6 @@ import org.openqa.selenium.bidi.module.Browser;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 
 class BrowserCommandsTest extends JupiterTestBase {
 
@@ -44,8 +43,6 @@ class BrowserCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateAUserContext() {
     String userContext = browser.createUserContext();
 
@@ -55,8 +52,6 @@ class BrowserCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canGetUserContexts() {
     String userContext1 = browser.createUserContext();
     String userContext2 = browser.createUserContext();
@@ -69,8 +64,6 @@ class BrowserCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canRemoveUserContext() {
     String userContext1 = browser.createUserContext();
     String userContext2 = browser.createUserContext();

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
@@ -47,8 +47,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToWindowBrowsingContextCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -69,8 +67,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToBrowsingContextDestroyedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -92,8 +88,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToTabBrowsingContextCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -113,8 +107,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToDomContentLoadedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -131,8 +123,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToBrowsingContextLoadedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -149,8 +139,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canListenToNavigationStartedEvent()
@@ -169,8 +157,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToFragmentNavigatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -191,8 +177,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToUserPromptOpenedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -212,8 +196,6 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   // TODO: This test is flaky for comparing the browsing context id for Chrome and Edge. Fix flaky
   // test.
   void canListenToUserPromptClosedEvent()

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
@@ -24,8 +24,6 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -57,8 +55,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateABrowsingContextForGivenId() {
     String id = driver.getWindowHandle();
     BrowsingContext browsingContext = new BrowsingContext(driver, id);
@@ -66,16 +62,12 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateAWindow() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.WINDOW);
     assertThat(browsingContext.getId()).isNotEmpty();
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateAWindowWithAReferenceContext() {
     BrowsingContext browsingContext =
         new BrowsingContext(
@@ -86,16 +78,12 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateATab() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
     assertThat(browsingContext.getId()).isNotEmpty();
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateATabWithAReferenceContext() {
     BrowsingContext browsingContext =
         new BrowsingContext(
@@ -105,8 +93,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCreateAContextWithAllParameters() {
     Browser browser = new Browser(driver);
     String userContextId = browser.createUserContext();
@@ -123,8 +109,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canNavigateToAUrl() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
@@ -136,8 +120,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canNavigateToAUrlWithReadinessState() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
@@ -149,8 +131,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canGetTreeWithAChild() {
     String referenceContextId = driver.getWindowHandle();
     BrowsingContext parentWindow = new BrowsingContext(driver, referenceContextId);
@@ -169,8 +149,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canGetTreeWithDepth() {
     String referenceContextId = driver.getWindowHandle();
     BrowsingContext parentWindow = new BrowsingContext(driver, referenceContextId);
@@ -188,8 +166,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canGetAllTopLevelContexts() {
     BrowsingContext window1 = new BrowsingContext(driver, driver.getWindowHandle());
     BrowsingContext window2 = new BrowsingContext(driver, WindowType.WINDOW);
@@ -200,8 +176,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCloseAWindow() {
     BrowsingContext window1 = new BrowsingContext(driver, WindowType.WINDOW);
     BrowsingContext window2 = new BrowsingContext(driver, WindowType.WINDOW);
@@ -212,8 +186,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCloseATab() {
     BrowsingContext tab1 = new BrowsingContext(driver, WindowType.TAB);
     BrowsingContext tab2 = new BrowsingContext(driver, WindowType.TAB);
@@ -224,8 +196,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canActivateABrowsingContext() {
     BrowsingContext window1 = new BrowsingContext(driver, driver.getWindowHandle());
     // 2nd window is focused
@@ -243,8 +213,6 @@ class BrowsingContextTest extends JupiterTestBase {
   // Refer: https://github.com/w3c/webdriver-bidi/issues/187
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canReloadABrowsingContext() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
@@ -257,8 +225,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canReloadWithReadinessState() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
@@ -272,8 +238,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canHandleUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -288,8 +252,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canAcceptUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -304,8 +266,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canDismissUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -320,8 +280,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canPassUserTextToUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -338,8 +296,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canAcceptUserPromptWithUserText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -356,8 +312,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canDismissUserPromptWithUserText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -381,8 +335,6 @@ class BrowsingContextTest extends JupiterTestBase {
   // TODO: A potential solution can be replicating classic WebDriver screenshot tests.
   // Meanwhile, trusting the browsers to do the right thing.
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCaptureScreenshot() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -394,8 +346,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCaptureScreenshotWithAllParameters() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -421,8 +371,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCaptureScreenshotOfViewport() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -439,8 +387,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCaptureElementScreenshot() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -455,8 +401,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canSetViewport() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     driver.get(appServer.whereIs("formPage.html"));
@@ -473,8 +417,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(FIREFOX)
   void canSetViewportWithDevicePixelRatio() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -497,8 +439,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canPrintPage() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -516,8 +456,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canNavigateBackInTheBrowserHistory() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     browsingContext.navigate(pages.formPage, ReadinessState.COMPLETE);
@@ -530,8 +468,6 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canNavigateForwardInTheBrowserHistory() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     browsingContext.navigate(pages.formPage, ReadinessState.COMPLETE);

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -18,8 +18,7 @@ package org.openqa.selenium.bidi.browsingcontext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
-import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
+import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -18,7 +18,6 @@ package org.openqa.selenium.bidi.browsingcontext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
-import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 
@@ -53,6 +52,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodes() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -66,6 +66,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodesWithJustLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -77,6 +78,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNode() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -88,6 +90,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodesWithCSSLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -110,6 +113,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodesWithXPathLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -132,6 +136,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   void canLocateNodesWithInnerText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -151,6 +156,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodesWithMaxNodeCount() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -205,6 +211,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canLocateNodesInAGivenSandbox() {
     String sandbox = "sandbox";
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -248,6 +255,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NotYetImplemented(EDGE)
   void canFindElement() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -53,8 +53,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodes() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -68,8 +66,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodesWithJustLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -81,8 +77,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNode() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -94,8 +88,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodesWithCSSLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -118,8 +110,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodesWithXPathLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -142,8 +132,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   void canLocateNodesWithInnerText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -163,8 +151,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodesWithMaxNodeCount() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -219,8 +205,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canLocateNodesInAGivenSandbox() {
     String sandbox = "sandbox";
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -264,8 +248,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(CHROME)
-  @NotYetImplemented(EDGE)
   void canFindElement() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -21,8 +21,6 @@ import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,8 +53,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodes() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -71,8 +68,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesWithJustLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -85,8 +81,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNode() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -99,8 +94,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesWithCSSLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -124,8 +118,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesWithXPathLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -149,8 +142,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   void canLocateNodesWithInnerText() {
@@ -171,8 +163,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesWithMaxNodeCount() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -188,8 +179,6 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesGivenStartNodes() {
@@ -230,8 +219,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canLocateNodesInAGivenSandbox() {
     String sandbox = "sandbox";
@@ -276,8 +264,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
+  @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void canFindElement() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());

--- a/java/test/org/openqa/selenium/bidi/input/CombinedInputActionsTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/CombinedInputActionsTest.java
@@ -66,8 +66,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testPlainClickingOnMultiSelectionList() {
     driver.get(pages.formSelectionPage);
 
@@ -89,8 +87,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testShiftClickingOnMultiSelectionList() {
     driver.get(pages.formSelectionPage);
 
@@ -112,8 +108,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(FIREFOX)
   public void testMultipleInputs() {
     driver.get(pages.formSelectionPage);
@@ -143,8 +137,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testControlClickingOnMultiSelectionList() {
     assumeFalse(
         getEffectivePlatform(driver).is(Platform.MAC), "FIXME: macs don't have CONTROL key");
@@ -172,8 +164,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testControlClickingOnCustomMultiSelectionList() {
     driver.get(pages.selectableItemsPage);
     Keys key = getEffectivePlatform(driver).is(Platform.MAC) ? Keys.COMMAND : Keys.CONTROL;
@@ -204,8 +194,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(FIREFOX)
   public void testControlClickingWithMultiplePointers() {
     driver.get(pages.selectableItemsPage);
@@ -247,8 +235,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
 
   @SwitchToTopAfterTest
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canMoveMouseToAnElementInAnIframeAndClick() {
@@ -290,15 +276,11 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testCanClickOnLinks() {
     navigateToClicksPageAndClickLink();
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testCanClickOnLinksWithAnOffset() {
     driver.get(pages.clicksPage);
 
@@ -312,8 +294,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testClickAfterMoveToAnElementWithAnOffsetShouldUseLastMousePosition() {
     driver.get(pages.clickEventPage);
 
@@ -355,8 +335,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
    * driver keeps the wrong state, mouse movement will end up at the wrong coordinates.
    */
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMouseMovementWorksWhenNavigatingToAnotherPage() {
     navigateToClicksPageAndClickLink();
 
@@ -368,8 +346,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
@@ -409,8 +385,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testCombiningShiftAndClickResultsInANewWindow() {
     driver.get(pages.linkedImage);
     WebElement link = driver.findElement(By.id("link"));
@@ -434,8 +408,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testHoldingDownShiftKeyWhileClicking() {
     driver.get(pages.clickEventPage);
 
@@ -450,8 +422,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void canClickOnASuckerFishStyleMenu() throws InterruptedException {
     driver.get(pages.javascriptPage);
 
@@ -477,8 +447,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testCanClickOnSuckerFishMenuItem() {
     driver.get(pages.javascriptPage);
 

--- a/java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java
@@ -57,8 +57,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testBasicKeyboardInput() {
     driver.get(appServer.whereIs("single_text_input.html"));
 
@@ -72,8 +70,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(SAFARI)
   public void testSendingKeyDownOnly() {
     driver.get(appServer.whereIs("key_logger.html"));
@@ -94,8 +90,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(SAFARI)
   public void testSendingKeyUp() {
     driver.get(appServer.whereIs("key_logger.html"));
@@ -123,8 +117,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
 
   @Test
   @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
-  @NotYetImplemented(SAFARI)
   public void testSendingKeysWithShiftPressed() {
     driver.get(pages.javascriptPage);
 
@@ -150,8 +142,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(value = SAFARI, reason = "getText does not normalize spaces")
   public void testSendingKeysToActiveElement() {
     driver.get(pages.bodyTypingPage);
@@ -163,8 +153,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(SAFARI)
   public void testBasicKeyboardInputOnActiveElement() {
     driver.get(pages.javascriptPage);
@@ -179,8 +167,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canGenerateKeyboardShortcuts() {
     driver.get(appServer.whereIs("keyboard_shortcut.html"));
 
@@ -210,8 +196,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testSelectionSelectBySymbol() {
     driver.get(appServer.whereIs("single_text_input.html"));
 
@@ -237,8 +221,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @Ignore(IE)
   public void testSelectionSelectByWord() {
     assumeFalse(getEffectivePlatform(driver).is(Platform.MAC), "MacOS has alternative keyboard");
@@ -267,8 +249,6 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testSelectionSelectAll() {
     assumeFalse(getEffectivePlatform(driver).is(Platform.MAC), "MacOS has alternative keyboard");
 

--- a/java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java
@@ -28,7 +28,6 @@ import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -109,8 +108,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testDraggingElementWithMouseMovesItToAnotherList() {
     performDragAndDropWithMouse();
     WebElement dragInto = driver.findElement(By.id("sortable1"));
@@ -120,8 +117,6 @@ class DefaultMouseTest extends JupiterTestBase {
   // This test is very similar to testDraggingElementWithMouse. The only
   // difference is that this test also verifies the correct events were fired.
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testDraggingElementWithMouseFiresEvents() {
     performDragAndDropWithMouse();
     WebElement dragReporter = driver.findElement(By.id("dragging_reports"));
@@ -139,8 +134,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testDoubleClickThenGet() {
     // Fails in ff3 if WebLoadingListener removes browser listener
     driver.get(pages.javascriptPage);
@@ -153,8 +146,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testDragAndDrop() throws InterruptedException {
     driver.get(pages.droppableItems);
 
@@ -189,8 +180,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testDoubleClick() {
     driver.get(pages.javascriptPage);
 
@@ -202,8 +191,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testContextClick() {
     driver.get(pages.javascriptPage);
 
@@ -220,8 +207,6 @@ class DefaultMouseTest extends JupiterTestBase {
   @Ignore(value = FIREFOX, gitHubActions = true)
   @Ignore(value = CHROME, gitHubActions = true)
   @Ignore(value = EDGE, gitHubActions = true)
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testMoveToLocation() {
     driver.get(pages.mouseInteractionPage);
 
@@ -237,8 +222,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testMoveAndClick() {
     driver.get(pages.javascriptPage);
 
@@ -254,8 +237,6 @@ class DefaultMouseTest extends JupiterTestBase {
 
   @SwitchToTopAfterTest
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   void testShouldClickElementInIFrame() {
@@ -294,8 +275,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testShouldAllowUsersToHoverOverElements() {
     driver.get(pages.javascriptPage);
 
@@ -312,8 +291,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testHoverPersists() throws Exception {
     driver.get(pages.javascriptPage);
     // Move to a different element to make sure the mouse is not over the
@@ -337,8 +314,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMovingMouseByRelativeOffset() {
     driver.get(pages.mouseTrackerPage);
 
@@ -355,8 +330,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMovingMouseToRelativeElementOffset() {
     driver.get(pages.mouseTrackerPage);
 
@@ -374,8 +347,6 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMovingMouseToRelativeZeroElementOffset() {
     driver.get(pages.mouseTrackerPage);
 
@@ -391,8 +362,6 @@ class DefaultMouseTest extends JupiterTestBase {
 
   @NeedsFreshDriver({IE, CHROME, FIREFOX, EDGE})
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMoveRelativeToBody() {
     try {
       driver.get(pages.mouseTrackerPage);
@@ -411,8 +380,6 @@ class DefaultMouseTest extends JupiterTestBase {
 
   @Test
   @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testMoveMouseByOffsetOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
 
@@ -455,8 +422,6 @@ class DefaultMouseTest extends JupiterTestBase {
 
   @Test
   @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testCanMoveOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
 

--- a/java/test/org/openqa/selenium/bidi/input/DefaultWheelTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DefaultWheelTest.java
@@ -23,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,8 +56,6 @@ class DefaultWheelTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -77,8 +73,6 @@ class DefaultWheelTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -99,8 +93,6 @@ class DefaultWheelTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -120,8 +112,6 @@ class DefaultWheelTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void throwErrorWhenElementOriginIsOutOfViewport() {
@@ -142,8 +132,6 @@ class DefaultWheelTest extends JupiterTestBase {
 
   @NeedsFreshDriver
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void shouldScrollFromViewportByGivenAmount() {
     driver.get(
         appServer.whereIs("scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html"));
@@ -163,8 +151,6 @@ class DefaultWheelTest extends JupiterTestBase {
 
   @NeedsFreshDriver
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void shouldScrollFromViewportByGivenAmountFromOrigin() {
     driver.get(appServer.whereIs("scrolling_tests/frame_with_nested_scrolling_frame.html"));
     WheelInput.ScrollOrigin scrollOrigin = WheelInput.ScrollOrigin.fromViewport(10, 10);
@@ -185,8 +171,6 @@ class DefaultWheelTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void throwErrorWhenOriginOffsetIsOutOfViewport() {
     assertThrows(
         BiDiException.class,

--- a/java/test/org/openqa/selenium/bidi/input/DragAndDropTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DragAndDropTest.java
@@ -23,8 +23,6 @@ import static org.openqa.selenium.WaitingConditions.elementLocationToBe;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,8 +60,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testDragAndDropRelative() {
     driver.get(pages.dragAndDropPage);
     WebElement img = driver.findElement(By.id("test1"));
@@ -79,8 +75,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testDragAndDropToElement() {
     driver.get(pages.dragAndDropPage);
     WebElement img1 = driver.findElement(By.id("test1"));
@@ -91,8 +85,6 @@ class DragAndDropTest extends JupiterTestBase {
 
   @SwitchToTopAfterTest
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -112,8 +104,6 @@ class DragAndDropTest extends JupiterTestBase {
 
   @SwitchToTopAfterTest
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -134,8 +124,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testElementInDiv() {
     driver.get(pages.dragAndDropPage);
     WebElement img = driver.findElement(By.id("test3"));
@@ -145,8 +133,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   // BiDi in Chrome does not throw an error in case of target out of bounds
@@ -174,8 +160,6 @@ class DragAndDropTest extends JupiterTestBase {
   // window, otherwise we are stuck with a small window for the rest of the tests.
   // TODO(dawagner): Remove @NoDriverAfterTest when we can reliably do window resizing
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testShouldAllowUsersToDragAndDropToElementsOffTheCurrentViewPort() {
     driver.get(pages.dragAndDropPage);
 
@@ -195,8 +179,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void testDragAndDropOnJQueryItems() {
     driver.get(pages.droppableItems);
 
@@ -227,8 +209,6 @@ class DragAndDropTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @Ignore(FIREFOX)
   @NotYetImplemented(CHROME)

--- a/java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java
@@ -18,8 +18,6 @@
 package org.openqa.selenium.bidi.input;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.List;
 import java.util.Map;
@@ -33,7 +31,6 @@ import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 
 public class ReleaseCommandTest extends JupiterTestBase {
   private Input input;
@@ -51,8 +48,6 @@ public class ReleaseCommandTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void testReleaseInBrowsingContext() {
     driver.get(server.whereIs("/bidi/release_action.html"));
 

--- a/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
@@ -18,8 +18,6 @@
 package org.openqa.selenium.bidi.input;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +33,6 @@ import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 
 public class SetFilesCommandTest extends JupiterTestBase {
   private Input input;
@@ -53,8 +50,6 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canSetFiles() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -76,8 +71,6 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   public void canSetFilesWithElementId() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -95,8 +88,6 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canSetFile() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -115,8 +106,6 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canSetFileWithElementId() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));

--- a/java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java
@@ -20,8 +20,6 @@ package org.openqa.selenium.bidi.network;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -44,8 +42,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddInterceptPhase() {
     try (Network network = new Network(driver)) {
@@ -56,8 +52,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddInterceptPhases() {
     try (Network network = new Network(driver)) {
@@ -70,8 +64,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddStringUrlPattern() {
     try (Network network = new Network(driver)) {
@@ -84,8 +76,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddStringUrlPatterns() {
     try (Network network = new Network(driver)) {
@@ -101,8 +91,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddUrlPattern() {
     try (Network network = new Network(driver)) {
@@ -122,8 +110,6 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canAddUrlPatterns() {
     try (Network network = new Network(driver)) {

--- a/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
@@ -53,8 +53,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canAddIntercept() {
@@ -66,8 +64,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueRequest() throws InterruptedException {
@@ -101,8 +97,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueResponse() throws InterruptedException {
@@ -131,8 +125,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canProvideResponse() throws InterruptedException {
@@ -160,8 +152,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Disabled
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(FIREFOX)
   @NotYetImplemented(CHROME)
@@ -197,8 +187,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canRemoveIntercept() {
@@ -212,8 +200,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueWithAuthCredentials() {
@@ -232,8 +218,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueWithoutAuthCredentials() {
@@ -252,8 +236,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canCancelAuth() {
@@ -271,8 +253,6 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canFailRequest() {

--- a/java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java
@@ -49,8 +49,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canListenToBeforeRequestSentEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
@@ -71,8 +69,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canListenToResponseStartedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
@@ -95,8 +91,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canListenToResponseCompletedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
@@ -119,8 +113,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   void canListenToResponseCompletedEventWithCookie()
       throws ExecutionException, InterruptedException, TimeoutException {
@@ -143,8 +135,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canListenToOnAuthRequiredEvent()
@@ -168,8 +158,6 @@ class NetworkEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canListenToFetchError() throws ExecutionException, InterruptedException, TimeoutException {

--- a/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
@@ -47,8 +47,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithDeclaration() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -123,8 +121,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithArguments() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -151,8 +147,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionToGetIFrameBrowsingContext() {
     String url = appServer.whereIs("click_too_big_in_frame.html");
     driver.get(url);
@@ -186,8 +180,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionToGetElement() {
     String url = appServer.whereIs("/bidi/logEntryAdded.html");
     driver.get(url);
@@ -215,8 +207,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithAwaitPromise() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -243,8 +233,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithAwaitPromiseFalse() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -269,8 +257,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithThisParameter() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -296,8 +282,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithOwnershipRoot() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -317,8 +301,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithOwnershipNone() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -364,8 +346,6 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionInASandBox() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {

--- a/java/test/org/openqa/selenium/bidi/script/LocalValueTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/LocalValueTest.java
@@ -18,8 +18,6 @@
 package org.openqa.selenium.bidi.script;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,13 +30,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.bidi.module.Script;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 
 class LocalValueTest extends JupiterTestBase {
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithUndefinedArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -69,8 +64,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithNullArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -101,8 +94,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithMinusZeroArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -135,8 +126,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithInfinityArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -169,8 +158,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithMinusInfinityArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -204,8 +191,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithNumberArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -238,8 +223,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithBooleanArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -272,8 +255,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithBigIntArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -306,8 +287,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithArrayArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -346,8 +325,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithSetArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -386,8 +363,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithDateArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -421,8 +396,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithMapArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -463,8 +436,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithObjectArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -505,8 +476,6 @@ class LocalValueTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithRegExpArgument() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);

--- a/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
@@ -20,8 +20,6 @@ package org.openqa.selenium.bidi.script;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openqa.selenium.testing.Safely.safelyCall;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
-import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +44,6 @@ import org.openqa.selenium.bidi.module.Script;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.Pages;
 
 public class ScriptCommandsTest extends JupiterTestBase {
@@ -59,8 +56,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithDeclaration() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -79,8 +74,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithArguments() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -110,8 +103,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionToGetIFrameBrowsingContext() {
     String url = appServer.whereIs("click_too_big_in_frame.html");
     driver.get(url);
@@ -145,8 +136,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionToGetElement() {
     String url = appServer.whereIs("/bidi/logEntryAdded.html");
     driver.get(url);
@@ -176,8 +165,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithAwaitPromise() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -205,8 +192,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithAwaitPromiseFalse() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -232,8 +217,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithThisParameter() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -261,8 +244,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithOwnershipRoot() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -285,8 +266,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionWithOwnershipNone() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -309,8 +288,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionThatThrowsException() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -336,8 +313,6 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canCallFunctionInASandBox() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);

--- a/java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java
@@ -47,8 +47,6 @@ public class ScriptEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToChannelMessage()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Script script = new Script(driver)) {
@@ -76,8 +74,6 @@ public class ScriptEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   void canListenToRealmCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Script script = new Script(driver)) {
@@ -94,8 +90,6 @@ public class ScriptEventsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)

--- a/java/test/org/openqa/selenium/bidi/storage/StorageCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/storage/StorageCommandsTest.java
@@ -60,8 +60,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void canGetCookieByName() {
     String key = generateUniqueKey();
@@ -81,8 +79,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(EDGE)
   public void canGetCookieInDefaultUserContext() {
@@ -129,8 +125,6 @@ class StorageCommandsTest extends JupiterTestBase {
   public void canGetCookieInAUserContext() {}
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void canAddCookie() {
     String key = generateUniqueKey();
@@ -150,8 +144,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   public void canAddAndGetCookie() {
@@ -217,8 +209,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void canGetAllCookies() {
     String key1 = generateUniqueKey();
@@ -247,8 +237,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void canDeleteAllCookies() {
     addCookieOnServerSide(new Cookie("foo", "set"));
@@ -263,8 +251,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void canDeleteCookieWithName() {
     String key1 = generateUniqueKey();
@@ -287,8 +273,6 @@ class StorageCommandsTest extends JupiterTestBase {
   }
 
   @Test
-  @NotYetImplemented(SAFARI)
-  @NotYetImplemented(IE)
   @NotYetImplemented(EDGE)
   public void testAddCookiesWithDifferentPathsThatAreRelatedToOurs() {
     driver.get(appServer.whereIs("/common/animals"));


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
BiDi tests are run again Firefox, Chrome and Edge. There were annotations that marked not implemented for IE and Safari. Removed those, since the tests were not run in those browsers. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Removed `@NotYetImplemented` annotations for Safari and IE from multiple test files.
- Ensured that the tests are only run against supported browsers (Firefox, Chrome, and Edge).



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiSessionTest.java</strong><dd><code>Remove non-relevant annotations from BiDiSessionTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/BiDiSessionTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-2feb21a9c40126d90af8e22457a2cdd3e9bc4157e4bf4aef50ec0e7170c64f0b">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BiDiTest.java</strong><dd><code>Remove non-relevant annotations from BiDiTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/BiDiTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-4a91048e9c253491777254c74e64c71d5740cc11b649d31b9534692b4b3f54a7">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowserCommandsTest.java</strong><dd><code>Remove non-relevant annotations from BrowserCommandsTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-f2240b0d878ce01529b1809cc726a1482f55bfb895a811c759428cf883f82cec">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextInspectorTest.java</strong><dd><code>Remove non-relevant annotations from BrowsingContextInspectorTest</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-7e31cdee71aec8f625eef511eb299619a501aab66ee1bf937eedec82921ad7e9">+0/-18</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextTest.java</strong><dd><code>Remove non-relevant annotations from BrowsingContextTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-f33a246a757eda5a55a8c9939d94f577af17d34ded65badfda87cff2da956c5c">+0/-64</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LocateNodesTest.java</strong><dd><code>Remove non-relevant annotations from LocateNodesTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-b63701b3cf1f898a95e4ef4d8b70e04724101885116b5287a447a0670a5a1ff3">+9/-22</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CombinedInputActionsTest.java</strong><dd><code>Remove non-relevant annotations from CombinedInputActionsTest</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/CombinedInputActionsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-823129e36a5a933b2bc61bb1ff805dad7e139de04933ed52b4b9e078fb063db8">+0/-32</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultKeyboardTest.java</strong><dd><code>Remove non-relevant annotations from DefaultKeyboardTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-a4b533150d3d228d69ab0c5228e98b5479bd1b1bf3267fade1f5ac429a60e583">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultMouseTest.java</strong><dd><code>Remove non-relevant annotations from DefaultMouseTest</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-73693f52d08caad34072a0088cf7e5e3d6ad8809138e1b1a655c3f67c624ddc2">+0/-35</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultWheelTest.java</strong><dd><code>Remove non-relevant annotations from DefaultWheelTest</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/DefaultWheelTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-57eece5ae0b0549572803d67df1c5a1fb58943456f98d02fdaf4e6a7ffaa7c38">+0/-16</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DragAndDropTest.java</strong><dd><code>Remove non-relevant annotations from DragAndDropTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/DragAndDropTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-90c0c33bc3197e19668e269d8a92517b75ad8c1801f9ee0e68099a19bf0ba7f9">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReleaseCommandTest.java</strong><dd><code>Remove non-relevant annotations from ReleaseCommandTest</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-4769925ca68216ad07a68b8d649eed68d3c6e64ff4b88e839ee0619a10d2d36a">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetFilesCommandTest.java</strong><dd><code>Remove non-relevant annotations from SetFilesCommandTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-289f98a8f44edcaadef7f408831a9be69ebc845ef0873d3696d525153180437f">+0/-11</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AddInterceptParametersTest.java</strong><dd><code>Remove non-relevant annotations from AddInterceptParametersTest</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-b353be8d10c38461f2f4da0949661c40f80fcc879bc402aba63ca519449ec76f">+0/-14</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NetworkCommandsTest.java</strong><dd><code>Remove non-relevant annotations from NetworkCommandsTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-56334c02fd23ebd6590a6ae6f44b2113bdbc325175c1273c4ef17a236119e517">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NetworkEventsTest.java</strong><dd><code>Remove non-relevant annotations from NetworkEventsTest</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-d8a2f31c89a869b962bef54fdb254806ca6416d6d60323844e54b9855720cf0e">+0/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.java</strong><dd><code>Remove non-relevant annotations from CallFunctionParameterTest</code></dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-07986bca9cc97288db15330752e456cc04874783fd72c14f0a4110676a53bfaa">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LocalValueTest.java</strong><dd><code>Remove non-relevant annotations from LocalValueTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/script/LocalValueTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-fa3d8e825e6fb0192df24f667748ee04bd4acda7e8a6fd3d7feb8e323cdb0302">+0/-31</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ScriptCommandsTest.java</strong><dd><code>Remove non-relevant annotations from ScriptCommandsTest</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-37b21f83d3902764db9c61f46343f33fdaa3ade7b5a6f8e125a08e35ffcf466b">+0/-25</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ScriptEventsTest.java</strong><dd><code>Remove non-relevant annotations from ScriptEventsTest</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-da82a5780c17157064dcb1830a9c3b66a2d78862162728ea959c96961cac7f79">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StorageCommandsTest.java</strong><dd><code>Remove non-relevant annotations from StorageCommandsTest</code>&nbsp; </dd></summary>
<hr>
      
java/test/org/openqa/selenium/bidi/storage/StorageCommandsTest.java

- Removed `@NotYetImplemented` annotations for Safari and IE.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14013/files#diff-d194cb6bfaa95b8cdc7b7b02c349082742a38ba5c4f641ef715705c4f93e2b09">+0/-16</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

