### PR TITLE
[rb] manage bidi instance on the bridge not the driver

### DIFF
--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -71,8 +71,8 @@ module Selenium
       def initialize(bridge: nil, listener: nil, **opts)
         @devtools = nil
         bridge ||= create_bridge(**opts)
-        add_extensions(bridge.browser)
         @bridge = listener ? Support::EventFiringBridge.new(bridge, listener) : bridge
+        add_extensions(@bridge.browser)
       end
 
       def inspect
@@ -180,7 +180,7 @@ module Selenium
       #
 
       def close
-        bridge.close
+        bridge&.close
       end
 
       #

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -70,7 +70,6 @@ module Selenium
 
       def initialize(bridge: nil, listener: nil, **opts)
         @devtools = nil
-        @bidi = nil
         bridge ||= create_bridge(**opts)
         add_extensions(bridge.browser)
         @bridge = listener ? Support::EventFiringBridge.new(bridge, listener) : bridge
@@ -174,7 +173,6 @@ module Selenium
       ensure
         @service_manager&.stop
         @devtools&.close
-        @bidi&.close
       end
 
       #
@@ -182,10 +180,7 @@ module Selenium
       #
 
       def close
-        # If no top-level browsing contexts are open after calling close,
-        # it indicates that the WebDriver session is closed.
-        # If the WebDriver session is closed, the BiDi session also needs to be closed.
-        bridge.close.tap { |handles| @bidi&.close if handles&.empty? }
+        bridge.close
       end
 
       #

--- a/rb/lib/selenium/webdriver/common/driver_extensions/has_bidi.rb
+++ b/rb/lib/selenium/webdriver/common/driver_extensions/has_bidi.rb
@@ -28,7 +28,7 @@ module Selenium
         #
 
         def bidi
-          @bidi ||= Selenium::WebDriver::BiDi.new(url: capabilities[:web_socket_url])
+          @bridge.bidi
         end
       end # HasBiDi
     end # DriverExtensions

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -214,11 +214,11 @@ module Selenium
         rescue *QUIT_ERRORS
           nil
         ensure
-          @bidi.close
+          @bidi&.close
         end
 
         def close
-          execute(:close_window).tap { |handles| @bidi.close if handles.empty? }
+          execute(:close_window).tap { |handles| @bidi&.close if handles.empty? }
         end
 
         def refresh

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -213,10 +213,12 @@ module Selenium
           http.close
         rescue *QUIT_ERRORS
           nil
+        ensure
+          @bidi.close
         end
 
         def close
-          execute :close_window
+          execute(:close_window).tap { |handles| @bidi.close if handles.empty? }
         end
 
         def refresh
@@ -600,6 +602,13 @@ module Selenium
 
         def user_verified(verified, authenticator_id)
           execute :set_user_verified, {authenticatorId: authenticator_id}, {isUserVerified: verified}
+        end
+
+        def bidi
+          msg = 'this operation requires enabling BiDi by setting #web_socket_url to true in options class'
+          raise(WebDriver::Error::WebDriverError, msg) unless capabilities.web_socket_url
+
+          @bidi ||= Selenium::WebDriver::BiDi.new(url: capabilities[:web_socket_url])
         end
 
         def command_list

--- a/rb/sig/lib/selenium/webdriver/common/driver.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/driver.rbs
@@ -5,7 +5,6 @@ module Selenium
 
       include TakesScreenshot
 
-      @bidi: untyped
       @devtools: untyped
       @navigate: untyped
 

--- a/rb/sig/lib/selenium/webdriver/remote/bridge.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/bridge.rbs
@@ -5,6 +5,7 @@ module Selenium
         include _CommandList
         include _Features
 
+        @bidi: WebDriver::BiDi
         @http: untyped
 
         @file_detector: untyped


### PR DESCRIPTION
### **User description**
### Description
Moves implementation of bidi away from the driver class and onto the bridge class
Should be a non-breaking change

### Motivation and Context
Classes that use BiDi should be initialized by a bridge instance not the driver instance.

I think we probably want to implement the conversion of WebDriver Classic to WebDriver BiDi as a separate Bridge, and this should make that easier.


___

### **PR Type**
enhancement


___

### **Description**
- Removed BiDi instance management from the driver class and delegated it to the bridge class.
- Updated `quit` and `close` methods in the driver class to remove BiDi handling.
- Added BiDi instance management to the bridge class, including updates to `quit` and `close` methods.
- Updated method signatures to reflect the changes in BiDi instance management.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver.rb</strong><dd><code>Remove BiDi instance management from driver class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/common/driver.rb

<li>Removed BiDi instance management from the driver class.<br> <li> Updated <code>quit</code> and <code>close</code> methods to remove BiDi handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14071/files#diff-ecf89969518aec5e73ce3aff22dc10e88185534845a8a17228952c92f1498cdd">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>has_bidi.rb</strong><dd><code>Delegate BiDi instance management to bridge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/common/driver_extensions/has_bidi.rb

- Updated `bidi` method to delegate to the bridge.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14071/files#diff-9a197301fbaa7cc8b4225b9f32a60cadbe1fc72ed002cb217f2aafcdbf4058b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bridge.rb</strong><dd><code>Add BiDi instance management to bridge class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/remote/bridge.rb

<li>Added BiDi instance management to the bridge class.<br> <li> Updated <code>quit</code> and <code>close</code> methods to handle BiDi instance.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14071/files#diff-42b562229083afc6ac8cc70a735fc1b24863402aa1404f08f60322b24cdfefc3">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>driver.rbs</strong><dd><code>Remove BiDi instance variable from driver signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/sig/lib/selenium/webdriver/common/driver.rbs

- Removed BiDi instance variable declaration.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14071/files#diff-91b084e4330efe2794c17d5b79d203958bd89469087f9455069256e9ec846bda">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bridge.rbs</strong><dd><code>Add BiDi instance variable to bridge signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/sig/lib/selenium/webdriver/remote/bridge.rbs

- Added BiDi instance variable declaration.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14071/files#diff-beea6e4d56cd705f023d4c2ae2582ba9fd27da7007a5d803d8e6e793f18b87b0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

