### PR TITLE
[rb] Add `logger` gem as a runtime dependency

### DIFF
--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.22.0.nightly)
       base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/rb/selenium-webdriver.gemspec
+++ b/rb/selenium-webdriver.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'base64', ['~> 0.2']
+  s.add_runtime_dependency 'logger', ['~> 1.4']
   s.add_runtime_dependency 'rexml', ['~> 3.2', '>= 3.2.5']
   s.add_runtime_dependency 'rubyzip', ['>= 1.2.2', '< 3.0']
   s.add_runtime_dependency 'websocket', ['~> 1.0']


### PR DESCRIPTION
### **User description**
This is getting the same treatment as the `base64` gem, starting with Ruby 3.4. Also see #13454

Closes #14081

I've chosen `~>1.4` as the constraint since that was the minor version available when Ruby 3.0 released (the currently minimum supported ruby version)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `logger` gem as a runtime dependency with version constraint `~> 1.4`.
- This change aligns with the treatment of the `base64` gem, starting with Ruby 3.4.
- Ensures compatibility with the minimum supported Ruby version 3.0.
- Closes issue #14081.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium-webdriver.gemspec</strong><dd><code>Add `logger` gem as a runtime dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/selenium-webdriver.gemspec

<li>Added <code>logger</code> gem as a runtime dependency with version constraint <code>~> </code><br><code>1.4</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14082/files#diff-f7c3979ae889cfb6e1b2386569a8bcd4f45e9a7e03d8c13bad52eb502a240aad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

