### PR TITLE
[rb] implement toggle for BiDi and Classic implementations

### DIFF
--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -318,7 +318,8 @@ module Selenium
       attr_reader :bridge
 
       def create_bridge(caps:, url:, http_client: nil)
-        Remote::Bridge.new(http_client: http_client, url: url).tap do |bridge|
+        klass = caps['webSocketUrl'] ? Remote::BiDiBridge : Remote::Bridge
+        klass.new(http_client: http_client, url: url).tap do |bridge|
           bridge.create_session(caps)
         end
       end

--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -213,12 +213,10 @@ module Selenium
           http.close
         rescue *QUIT_ERRORS
           nil
-        ensure
-          @bidi&.close
         end
 
         def close
-          execute(:close_window).tap { |handles| @bidi&.close if handles.empty? }
+          execute :close_window
         end
 
         def refresh
@@ -605,10 +603,8 @@ module Selenium
         end
 
         def bidi
-          msg = 'this operation requires enabling BiDi by setting #web_socket_url to true in options class'
-          raise(WebDriver::Error::WebDriverError, msg) unless capabilities.web_socket_url
-
-          @bidi ||= Selenium::WebDriver::BiDi.new(url: capabilities[:web_socket_url])
+          msg = 'BiDi must be enabled by setting #web_socket_url to true in options class'
+          raise(WebDriver::Error::WebDriverError, msg)
         end
 
         def command_list

--- a/rb/spec/integration/selenium/webdriver/bidi/script_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/script_spec.rb
@@ -27,9 +27,8 @@ module Selenium
 
       it 'errors when bidi not enabled' do
         reset_driver!(web_socket_url: false) do |driver|
-          expect {
-            driver.script
-          }.to raise_error(WebDriver::Error::WebDriverError, /this operation requires enabling BiDi/)
+          msg = /BiDi must be enabled by setting #web_socket_url to true in options class/
+          expect { driver.script }.to raise_error(WebDriver::Error::WebDriverError, msg)
         end
       end
 

--- a/rb/spec/tests.bzl
+++ b/rb/spec/tests.bzl
@@ -207,7 +207,11 @@ def rb_integration_test(name, srcs, deps = [], data = [], browsers = BROWSERS.ke
             env = BROWSERS[browser]["env"] | {"WEBDRIVER_BIDI": "true"},
             main = "@bundle//bin:rspec",
             tags = COMMON_TAGS + BROWSERS[browser]["tags"] + tags + ["{}-bidi".format(browser)],
-            deps = ["//rb/spec/integration/selenium/webdriver:spec_helper"] + BROWSERS[browser]["deps"] + deps,
+            deps = depset(
+                ["//rb/spec/integration/selenium/webdriver:spec_helper", "//rb/lib/selenium/webdriver:bidi"] +
+                BROWSERS[browser]["deps"] +
+                deps,
+            ),
             visibility = ["//rb:__subpackages__"],
             target_compatible_with = BROWSERS[browser]["target_compatible_with"],
         )


### PR DESCRIPTION
### **User description**
This is a much simpler implementation of, and replaces #13126 

### Description
* Instead of extending the bridge dynamically, it uses a subclassed bridge
* We can do this by picking the bridge before starting the session, based on the capabilities being passed in; sending `"webSocketUrl": true` to the driver should give the right failure message if it is not supported, bindings don't have to work around it
* All BiDi usages in bridge are now in the BiDiBridge
* Calling `#bidi` on `Bridge` gives a warning that web_socket_url must be used to access BiDi (this is the real reason to pass the bridge to the BiDi classes and not just the bidi instance; the warning is in one place and works everywhere)

### Motivation and Context
This is a prerequisite for #13995


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `BiDiBridge` class to handle BiDi-specific logic.
- Modified `create_bridge` method to use `BiDiBridge` when `webSocketUrl` capability is true.
- Added autoload for `BiDiBridge` in the remote module.
- Refactored `Bridge` class to remove BiDi-specific logic and updated the `bidi` method to raise an error if `web_socket_url` is not enabled.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver.rb</strong><dd><code>Use `BiDiBridge` subclass based on `webSocketUrl` capability</code></dd></summary>
<hr>
      
rb/lib/selenium/webdriver/common/driver.rb

<li>Modified <code>create_bridge</code> method to use <code>BiDiBridge</code> subclass when <br><code>webSocketUrl</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14092/files#diff-ecf89969518aec5e73ce3aff22dc10e88185534845a8a17228952c92f1498cdd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>remote.rb</strong><dd><code>Autoload `BiDiBridge` in remote module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/remote.rb

- Added autoload for `BiDiBridge`.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14092/files#diff-8508e5626045769b4fff77bdc225df7fc68b5d086c29c7566ec62232604ad5a7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bidi_bridge.rb</strong><dd><code>Implement `BiDiBridge` class with session management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/remote/bidi_bridge.rb

<li>Added new <code>BiDiBridge</code> class inheriting from <code>Bridge</code>.<br> <li> Implemented <code>create_session</code>, <code>quit</code>, and <code>close</code> methods in <code>BiDiBridge</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14092/files#diff-812b66f6ce3688d462c12e405e4808ffc075e0b6b2b9804b236ca977539a46e7">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bridge.rb</strong><dd><code>Refactor `Bridge` class to remove BiDi logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rb/lib/selenium/webdriver/remote/bridge.rb

<li>Removed BiDi-specific logic from <code>Bridge</code> class.<br> <li> Updated <code>bidi</code> method to raise an error if <code>web_socket_url</code> is not <br>enabled.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14092/files#diff-42b562229083afc6ac8cc70a735fc1b24863402aa1404f08f60322b24cdfefc3">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

