### PR TITLE
[bidi][js] Add types for user prompt related events

### DIFF
--- a/javascript/node/selenium-webdriver/bidi/browsingContextInspector.js
+++ b/javascript/node/selenium-webdriver/bidi/browsingContextInspector.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-const { BrowsingContextInfo, NavigationInfo } = require('./browsingContextTypes')
+const { BrowsingContextInfo, NavigationInfo, UserPromptOpened, UserPromptClosed } = require('./browsingContextTypes')
 
 /**
  * Represents a browsing context related events.
@@ -127,8 +127,10 @@ class BrowsingContextInspector {
         let response = null
         if ('navigation' in params) {
           response = new NavigationInfo(params.context, params.navigation, params.timestamp, params.url)
+        } else if ('type' in params) {
+          response = new UserPromptOpened(params.context, params.type, params.message)
         } else if ('accepted' in params) {
-          /* Needs to be updated when browsers implement other events */
+          response = new UserPromptClosed(params.context, params.accepted, params.userText)
         } else {
           response = new BrowsingContextInfo(params.context, params.url, params.children, params.parent)
         }

--- a/javascript/node/selenium-webdriver/bidi/browsingContextTypes.js
+++ b/javascript/node/selenium-webdriver/bidi/browsingContextTypes.js
@@ -80,4 +80,20 @@ class NavigationInfo {
   }
 }
 
-module.exports = { BrowsingContextInfo, NavigationInfo }
+class UserPromptOpened {
+  constructor(browsingContextId, type, message) {
+    this.browsingContextId = browsingContextId
+    this.type = type
+    this.message = message
+  }
+}
+
+class UserPromptClosed {
+  constructor(browsingContextId, accepted, userText = undefined) {
+    this.browsingContextId = browsingContextId
+    this.accepted = accepted
+    this.userText = userText
+  }
+}
+
+module.exports = { BrowsingContextInfo, NavigationInfo, UserPromptOpened, UserPromptClosed }

--- a/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
@@ -158,52 +158,67 @@ suite(
         assert(navigationInfo.url.includes('linkToAnchorOnThisPage'))
       })
 
-      xit('can listen to user prompt opened event', async function () {
-        let userpromptOpened = null
-        const browsingConextInspector = await BrowsingContextInspector(driver)
+      ignore(env.browsers(Browser.EDGE, Browser.CHROME)).it(
+        'can listen to user prompt opened event',
+        async function () {
+          let userpromptOpened = null
+          const browsingcontextInspector = await BrowsingContextInspector(driver)
 
-        const browsingContext = await BrowsingContext(driver, {
-          browsingContextId: await driver.getWindowHandle(),
-        })
+          const browsingContext = await BrowsingContext(driver, {
+            browsingContextId: await driver.getWindowHandle(),
+          })
 
-        await driver.get(Pages.alertsPage)
+          await browsingcontextInspector.onUserPromptOpened((entry) => {
+            userpromptOpened = entry
+          })
 
-        await driver.findElement(By.id('alert')).click()
+          await driver.get(Pages.alertsPage)
 
-        await driver.wait(until.alertIsPresent())
+          await driver.findElement(By.id('alert')).click()
 
-        await browsingConextInspector.onUserPromptOpened((entry) => {
-          userpromptOpened = entry
-        })
+          await driver.wait(until.alertIsPresent())
 
-        assert.equal(userpromptOpened.browsingContextId, browsingContext.id)
-        assert.equal(userpromptOpened.type, 'alert')
-      })
+          await browsingContext.handleUserPrompt(true)
 
-      xit('can listen to user prompt closed event', async function () {
-        let userpromptClosed = null
-        const browsingConextInspector = await BrowsingContextInspector(driver)
+          // Chrome/Edge do not return the window's browsing context id as per the spec.
+          // This assertion fails.
+          // It is probably a bug in the Chrome/Edge driver.
+          assert.equal(userpromptOpened.browsingContextId, browsingContext.id)
+          assert.equal(userpromptOpened.type, 'alert')
+        },
+      )
 
-        const browsingContext = await BrowsingContext(driver, {
-          browsingContextId: await driver.getWindowHandle(),
-        })
+      ignore(env.browsers(Browser.EDGE, Browser.CHROME)).it(
+        'can listen to user prompt closed event',
+        async function () {
+          const windowHandle = await driver.getWindowHandle()
+          let userpromptClosed = null
+          const browsingcontextInspector = await BrowsingContextInspector(driver, windowHandle)
 
-        await driver.get(Pages.alertsPage)
+          const browsingContext = await BrowsingContext(driver, {
+            browsingContextId: windowHandle,
+          })
 
-        await driver.findElement(By.id('prompt')).click()
+          await driver.get(Pages.alertsPage)
 
-        await driver.wait(until.alertIsPresent())
+          await driver.findElement(By.id('prompt')).click()
 
-        await browsingConextInspector.onUserPromptClosed((entry) => {
-          userpromptClosed = entry
-        })
+          await driver.wait(until.alertIsPresent())
 
-        await browsingContext.handleUserPrompt(true, 'selenium')
+          await browsingcontextInspector.onUserPromptClosed((entry) => {
+            userpromptClosed = entry
+          })
 
-        assert.equal(userpromptClosed.browsingContextId, browsingContext.id)
-        assert.equal(userpromptClosed.accepted, true)
-        assert.equal(userpromptClosed.userText, 'selenium')
-      })
+          await browsingContext.handleUserPrompt(true, 'selenium')
+
+          // Chrome/Edge do not return the window's browsing context id as per the spec.
+          // This assertion fails.
+          // It is probably a bug in the Chrome/Edge driver.
+          assert.equal(userpromptClosed.browsingContextId, browsingContext.id)
+          assert.equal(userpromptClosed.accepted, true)
+          assert.equal(userpromptClosed.userText, 'selenium')
+        },
+      )
     })
   },
   { browsers: [Browser.FIREFOX, Browser.CHROME, Browser.EDGE] },


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add user prompt types for events "UserPromptOpened" and "UserPromptClosed". Else it was defaulting to the wrong type.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added handling for `UserPromptOpened` and `UserPromptClosed` events in `browsingContextInspector.js`.
- Defined new classes `UserPromptOpened` and `UserPromptClosed` in `browsingContextTypes.js`.
- Added tests for `UserPromptOpened` and `UserPromptClosed` events in `browsingcontext_inspector_test.js`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browsingContextInspector.js</strong><dd><code>Add handling for user prompt events in browsing context inspector</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/browsingContextInspector.js

<li>Added imports for <code>UserPromptOpened</code> and <code>UserPromptClosed</code>.<br> <li> Implemented handling for <code>UserPromptOpened</code> and <code>UserPromptClosed</code> events.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14097/files#diff-7fbbddd435d48230ba46bb41098623933971e58ee2dd073d0a0f8995633b495d">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>browsingContextTypes.js</strong><dd><code>Define classes for user prompt events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
javascript/node/selenium-webdriver/bidi/browsingContextTypes.js

<li>Added <code>UserPromptOpened</code> class.<br> <li> Added <code>UserPromptClosed</code> class.<br> <li> Exported new classes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14097/files#diff-0c65ec6304c400b7d144c63e0bc86f13cae0c98cfe1bbd493e474724de11b908">+17/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browsingcontext_inspector_test.js</strong><dd><code>Add tests for user prompt events in browsing context inspector</code></dd></summary>
<hr>
      
javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js

<li>Added tests for <code>UserPromptOpened</code> event.<br> <li> Added tests for <code>UserPromptClosed</code> event.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14097/files#diff-5a795b4366203e58bdf8bb6749ce666b85a150f2ca2b8d3e9970039347f5881a">+47/-32</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

