### PR TITLE
[rust] Use pure Rust implementation for which command

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -35,7 +35,6 @@ jobs:
         include:
           - os: macos
           - os: ubuntu
-          - os: windows
     with:
       name: Tests (${{ matrix.os }})
       cache-key: rust-test

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -35,6 +35,7 @@ jobs:
         include:
           - os: macos
           - os: ubuntu
+          - os: windows
     with:
       name: Tests (${{ matrix.os }})
       cache-key: rust-test

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "14dbf17d9e872e55d0e978b15ce60660603017dfddf7a924539a1085d1255e3f",
+  "checksum": "2e41cb73375f93664a33a387f57c14d87cccc43361197a1b4f325e2bc05f6954",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -3713,6 +3713,52 @@
       ],
       "license_file": "LICENSE"
     },
+    "either 1.12.0": {
+      "name": "either",
+      "version": "1.12.0",
+      "package_url": "https://github.com/rayon-rs/either",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/either/1.12.0/download",
+          "sha256": "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "either",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "either",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "use_std"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.12.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "encoding_rs 0.8.34": {
       "name": "encoding_rs",
       "version": "0.8.34",
@@ -5806,6 +5852,56 @@
         },
         "edition": "2018",
         "version": "0.4.3"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "home 0.5.9": {
+      "name": "home",
+      "version": "0.5.9",
+      "package_url": "https://github.com/rust-lang/cargo",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/home/0.5.9/download",
+          "sha256": "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "home",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "home",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.52.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.5.9"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11582,10 +11678,6 @@
               "target": "infer"
             },
             {
-              "id": "is_executable 1.0.1",
-              "target": "is_executable"
-            },
-            {
               "id": "log 0.4.21",
               "target": "log"
             },
@@ -11630,6 +11722,10 @@
               "target": "walkdir"
             },
             {
+              "id": "which 6.0.1",
+              "target": "which"
+            },
+            {
               "id": "zip 1.3.0",
               "target": "zip"
             }
@@ -11641,6 +11737,10 @@
             {
               "id": "assert_cmd 2.0.14",
               "target": "assert_cmd"
+            },
+            {
+              "id": "is_executable 1.0.1",
+              "target": "is_executable"
             },
             {
               "id": "rstest 0.19.0",
@@ -16115,6 +16215,72 @@
       ],
       "license_file": "LICENSE"
     },
+    "which 6.0.1": {
+      "name": "which",
+      "version": "6.0.1",
+      "package_url": "https://github.com/harryfei/which-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/which/6.0.1/download",
+          "sha256": "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "which",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "which",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.12.0",
+              "target": "either"
+            }
+          ],
+          "selects": {
+            "cfg(any(unix, target_os = \"wasi\", target_os = \"redox\"))": [
+              {
+                "id": "rustix 0.38.34",
+                "target": "rustix"
+              }
+            ],
+            "cfg(any(windows, unix, target_os = \"redox\"))": [
+              {
+                "id": "home 0.5.9",
+                "target": "home"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "winsafe 0.0.19",
+                "target": "winsafe"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "6.0.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.txt"
+    },
     "winapi 0.3.9": {
       "name": "winapi",
       "version": "0.3.9",
@@ -16539,11 +16705,14 @@
             "Win32_Storage",
             "Win32_Storage_FileSystem",
             "Win32_System",
+            "Win32_System_Com",
             "Win32_System_Console",
             "Win32_System_IO",
             "Win32_System_SystemInformation",
             "Win32_System_Threading",
             "Win32_System_WindowsProgramming",
+            "Win32_UI",
+            "Win32_UI_Shell",
             "default"
           ],
           "selects": {}
@@ -17868,6 +18037,50 @@
       ],
       "license_file": "LICENSE"
     },
+    "winsafe 0.0.19": {
+      "name": "winsafe",
+      "version": "0.0.19",
+      "package_url": "https://github.com/rodrigocfd/winsafe",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/winsafe/0.0.19/download",
+          "sha256": "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "winsafe",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "winsafe",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "kernel"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.19"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.md"
+    },
     "x509-certificate 0.23.1": {
       "name": "x509-certificate",
       "version": "0.23.1",
@@ -18837,6 +19050,62 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
+    "cfg(any(unix, target_os = \"wasi\", target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
+    "cfg(any(windows, unix, target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
     "cfg(fuzzing)": [],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
       "aarch64-apple-darwin",
@@ -19124,7 +19393,6 @@
     "exitcode 1.1.2",
     "flate2 1.0.30",
     "infer 0.15.0",
-    "is_executable 1.0.1",
     "log 0.4.21",
     "regex 1.10.4",
     "reqwest 0.12.4",
@@ -19136,10 +19404,12 @@
     "tokio 1.37.0",
     "toml 0.8.13",
     "walkdir 2.5.0",
+    "which 6.0.1",
     "zip 1.3.0"
   ],
   "direct_dev_deps": [
     "assert_cmd 2.0.14",
+    "is_executable 1.0.1",
     "rstest 0.19.0"
   ]
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -607,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +897,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -1828,6 +1843,7 @@ dependencies = [
  "tokio",
  "toml",
  "walkdir",
+ "which",
  "zip",
 ]
 
@@ -2484,6 +2500,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2718,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "x509-certificate"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,6 @@ flate2 = "1.0.30"
 tar = "0.4.40"
 infer = "0.15.0"
 exitcode = "1.1.2"
-is_executable = "1.0.1"
 toml = "0.8.13"
 bzip2 = "0.4.4"
 sevenz-rust = "0.6.0"
@@ -35,10 +34,12 @@ walkdir = "2.5.0"
 debpkg = "0.6.0"
 anyhow = { version = "1.0.84", default-features = false, features = ["backtrace", "std"] }
 apple-flat-package = "0.18.0"
+which = "6.0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
 rstest = "0.19.0"
+is_executable = "1.0.1"
 
 [profile.release]
 opt-level = 'z'     # Optimize for size

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -96,10 +96,7 @@ pub fn run_shell_command(shell: &str, flag: &str, command: Command) -> Result<St
         }
     }
     let output = process.output()?;
-    Ok(
-        strip_trailing_newline(String::from_utf8_lossy(&output.stdout).to_string().as_str())
-            .to_string(),
-    )
+    Ok(strip_trailing_newline(&String::from_utf8_lossy(&output.stdout)).to_string())
 }
 
 pub fn strip_trailing_newline(input: &str) -> &str {


### PR DESCRIPTION
### **User description**
### Description
This PR includes the use of the [which](https://crates.io/crates/which) crate in Selenium Manager.

As reported in #14066, when a driver is found in the `PATH` and the path of that driver contains special characters (e.g., Japanese), SM is unable to parse the full path of the driver, giving an error in response.

After much digging into this issue, I have found that it is caused by the execution of the command `where` in Windows through Selenium Manager. The solution I found is to use a pure Rust crate implementing the`which` command. This should work both in Windows, Linux, and macOS.

Thanks to adding this crate, another existing crate (called `is_executable`) is not required anymore. So, the size of the resulting SM binaries does not change.

### Motivation and Context
Fix for #14066.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced the custom implementation of the `which` and `where` commands with the `which` crate to handle special characters in paths more robustly.
- Removed the `is_executable` crate from the main dependencies as it is no longer needed.
- Simplified the `run_shell_command` function to improve code readability.
- Updated `Cargo.toml` to include the `which` crate and moved `is_executable` to `dev-dependencies`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Use `which` crate for command execution and simplify logic</code></dd></summary>
<hr>
      
rust/src/lib.rs

<li>Replaced custom <code>which</code> and <code>where</code> command execution with the <code>which</code> <br>crate.<br> <li> Removed the <code>is_executable</code> crate usage.<br> <li> Simplified the <code>execute_which_in_shell</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14114/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+5/-29</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>shell.rs</strong><dd><code>Simplify `run_shell_command` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/src/shell.rs

- Simplified the `run_shell_command` function.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14114/files#diff-30b27717f4f675841032bd3834252f387d5cd629687d921db22b37bc16962a9d">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update dependencies in Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rust/Cargo.toml

<li>Added <code>which</code> crate dependency.<br> <li> Moved <code>is_executable</code> crate to <code>dev-dependencies</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14114/files#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

