### PR TITLE
[build] create a stage release workflow for after the pre-release PR

### DIFF
--- a/.github/workflows/stage-release.yml
+++ b/.github/workflows/stage-release.yml
@@ -1,0 +1,59 @@
+name: Release Staging
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  github-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.repository_owner == 'seleniumhq' &&
+      startsWith(github.event.pull_request.head.ref, 'release-preparation-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Extract version from branch name
+        id: extract_version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=$(echo $BRANCH_NAME | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Prep git
+        run: |
+          git config --local user.email "selenium-ci@users.noreply.github.com"
+          git config --local user.name "Selenium CI Bot"
+      - name: Tag Release
+        run: |
+          git tag selenium-${{ env.VERSION }}
+          git push origin selenium-${{ env.VERSION }}
+      - name: Update Nightly Tag to Remove pre-release
+        run: |
+          git fetch --tags
+          git tag -d nightly || echo "Nightly tag not found"
+          git tag nightly
+          git push origin refs/tags/nightly --force
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - name: Build and Stage Packages
+        run: ./go all:package
+      - name: Generate Draft Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Selenium ${{ env.VERSION }}
+          body: |
+              ## Detailed Changelogs by Component
+              <img src="https://www.selenium.dev/images/programming/java.svg" width="20" height="20"> **[Java](https://github.com/SeleniumHQ/selenium/blob/trunk/java/CHANGELOG)** &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;<img src="https://www.selenium.dev/images/programming/python.svg" width="20" height="20"> **[Python](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES)** &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;<img src="https://www.selenium.dev/images/programming/csharp.svg" width="20" height="20"> **[DotNet](https://github.com/SeleniumHQ/selenium/blob/trunk/dotnet/CHANGELOG)** &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;<img src="https://www.selenium.dev/images/programming/ruby.svg" width="20" height="20"> **[Ruby](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES)** &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;<img src="https://www.selenium.dev/images/programming/javascript.svg" width="20" height="20"> **[JavaScript](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/CHANGES.md)** &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;<img src="https://www.selenium.dev/images/browsers/internet-explorer.svg" width="20" height="20"> **[IEDriver](https://github.com/SeleniumHQ/selenium/blob/trunk/cpp/iedriverserver/CHANGELOG)**
+              <br>
+          tag_name: selenium-${{ env.VERSION }}
+          draft: true
+          generate_release_notes: true
+          prerelease: false
+          files: build/dist/*.*

--- a/.github/workflows/stage-release.yml
+++ b/.github/workflows/stage-release.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Build and Stage Packages
-        run: ./go all:package
+        run: ./go all:package[--config=release]
       - name: Generate Draft Release
         uses: softprops/action-gh-release@v2
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -1035,11 +1035,19 @@ namespace :all do
     Rake::Task['node:build'].invoke(*args)
   end
 
+  desc 'Package or build stamped artifacts for all language bindings'
+  task :package do |_task, arguments|
+    args = arguments.to_a.compact
+    Rake::Task['java:package'].invoke(*args)
+    Rake::Task['dotnet:package'].invoke(*args)
+    Rake::Task['py:build'].invoke(*args)
+    Rake::Task['rb:build'].invoke(*args)
+    Rake::Task['node:build'].invoke(*args)
+  end
+
   desc 'Release all artifacts for all language bindings'
   task :release do |_task, arguments|
     Rake::Task['clean'].invoke
-    tag = @git.add_tag("selenium-#{java_version}")
-    @git.push('origin', tag.name)
 
     args = arguments.to_a.compact.empty? ? ['--stamp'] : arguments.to_a.compact
     Rake::Task['java:release'].invoke(*args)
@@ -1047,7 +1055,6 @@ namespace :all do
     Rake::Task['rb:release'].invoke(*args)
     Rake::Task['dotnet:release'].invoke(*args)
     Rake::Task['node:release'].invoke(*args)
-    Rake::Task['create_release_notes'].invoke
     Rake::Task['all:docs'].invoke
     Rake::Task['all:version'].invoke('nightly')
 
@@ -1138,39 +1145,6 @@ end
 
 at_exit do
   system 'sh', '.git-fixfiles' if File.exist?('.git') && !SeleniumRake::Checks.windows?
-end
-
-desc 'Create Release Notes for Minor Release'
-task :create_release_notes do
-  range = "#{previous_tag(java_version)}...HEAD"
-  format = '* [\\`%h\\`](http://github.com/seleniumhq/selenium/commit/%H) - %s :: %aN'
-  git_log_command = %(git --no-pager log "#{range}" --pretty=format:"#{format}" --reverse)
-  git_log_output = `#{git_log_command}`
-
-  release_notes = <<~RELEASE_NOTES
-    ### Changelog
-
-    For each component's detailed changelog, please check:
-    * [Ruby](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES)
-    * [Python](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES)
-    * [JavaScript](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/CHANGES.md)
-    * [Java](https://github.com/SeleniumHQ/selenium/blob/trunk/java/CHANGELOG)
-    * [DotNet](https://github.com/SeleniumHQ/selenium/blob/trunk/dotnet/CHANGELOG)
-    * [IEDriverServer](https://github.com/SeleniumHQ/selenium/blob/trunk/cpp/iedriverserver/CHANGELOG)
-
-    ### Commits in this release
-    <details>
-    <summary>Click to see all the commits included in this release</summary>
-
-    #{git_log_output}
-
-    </details>
-  RELEASE_NOTES
-
-  FileUtils.mkdir_p('build/dist')
-  release_notes_file = "build/dist/release_notes_#{java_version}.md"
-  File.write(release_notes_file, release_notes)
-  puts "Release notes have been generated at: #{release_notes_file}"
 end
 
 def updated_version(current, desired = nil, nightly = nil)

--- a/Rakefile
+++ b/Rakefile
@@ -1035,14 +1035,11 @@ namespace :all do
     Rake::Task['node:build'].invoke(*args)
   end
 
-  desc 'Package or build stamped artifacts for all language bindings'
+  desc 'Package or build stamped artifacts for distribution in GitHub Release assets'
   task :package do |_task, arguments|
     args = arguments.to_a.compact
     Rake::Task['java:package'].invoke(*args)
     Rake::Task['dotnet:package'].invoke(*args)
-    Rake::Task['py:build'].invoke(*args)
-    Rake::Task['rb:build'].invoke(*args)
-    Rake::Task['node:build'].invoke(*args)
   end
 
   desc 'Release all artifacts for all language bindings'


### PR DESCRIPTION
### **User description**
### User description
1. This is set to run after a release-preparation PR is merged. (I've verified that part works)
2. It tags the release from the merged commit
3. It builds assets with RBE (after this runs, if you execute `./go all:release[--config=release]` everything has already been built and you're pretty much just downloading the top-level generated assets for publishing
4. It creates a Draft GitHub Release
    * Populates Tag
    * Populates Body
    * Automatically uploads the built assets

~I can't get it to complete on my fork because it won't do the RBE portion on my fork, and it is too late for me to spend more time on this tonight.~

~Hmm, it would make more sense to have a `all:package` task in the Rakefile so we don't have to call each of these individually. I'll update that.~

We can theoretically have this "stage release" be a "full release", but this continues to require manual intervention for anything that can't be taken back. 😁 

~We definitely want to add document generation and nightly version updates to this next, so we don't have to deal with that locally. Nightly update probably doesn't need manual intervention, but the API docs changes can be one big PR that gets reviewed before merging....  Anyway, that's next steps..~

### Update

* I was able to prove out most of this on my fork (can't use --config=release from my fork, and the documentation PR is extremely unwieldily when referencing a different repo org).
* ~I did implement documentation updating. I put it in a different workflow in case there's an issue with the staging release workflow so we can do it separately (again, wasn't able to really compare this from my fork)~
* I'm not sure I'm doing the right thing with the nightly tag. We can discuss after this release
* ~This dramatically changes the `:docs` tasks in Rakefile, it isn't doing the complete flow with manual queries and pushes and checking out origin. It is just switching to gh-pages and making the commit. So if you're doing it manually you need to pay attention to it more.~

### Update 2
* I'm removing the documentation update pieces, I was unable to get this working properly and there's no reason to hold up a release for it.

___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added a new GitHub Actions workflow (`stage-release.yml`) for release staging, which triggers on closed pull requests and handles building and packaging for multiple languages (Java, .NET, Ruby, Python, Node).
- Configured the workflow to create a draft GitHub release with the generated assets.
- Simplified the release task in the `Rakefile` by removing the creation of release notes and focusing on building and packaging.
- Removed the `create_release_notes` task from the `Rakefile`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stage-release.yml</strong><dd><code>Add GitHub Actions workflow for release staging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/stage-release.yml

<li>Added a new GitHub Actions workflow for release staging.<br> <li> Configured the workflow to trigger on closed pull requests.<br> <li> Included steps for building and packaging Java, .NET, Ruby, Python, <br>and Node projects.<br> <li> Added steps to create a draft GitHub release with generated assets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14122/files#diff-7beae040710de3a234065211d66bf51c5bbfd1ccd6a8659966716fca0d955aa5">+81/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Simplify release task and remove release notes generation</code></dd></summary>
<hr>
      
Rakefile

<li>Removed the creation of release notes from the release task.<br> <li> Simplified the release task to focus on building and packaging.<br> <li> Removed the <code>create_release_notes</code> task.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14122/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+0/-36</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added a new GitHub Actions workflow (`stage-release.yml`) to automate the release staging process. This workflow triggers on PR merge, tags the release, builds assets, creates a draft GitHub Release, and updates the nightly tag.
- Updated the `Rakefile` to include a new task `all:package` for packaging artifacts. Modified the `all:release` task to use this new packaging task. Removed the `create_release_notes` task from the `Rakefile`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stage-release.yml</strong><dd><code>Add GitHub Actions workflow for release staging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/stage-release.yml

<li>Added a new GitHub Actions workflow for release staging.<br> <li> Workflow triggers on PR merge and tags the release.<br> <li> Builds assets and creates a draft GitHub Release.<br> <li> Updates nightly tag and sets up Java environment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14122/files#diff-7beae040710de3a234065211d66bf51c5bbfd1ccd6a8659966716fca0d955aa5">+59/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Update Rakefile with new packaging task and remove release notes task</code></dd></summary>
<hr>
      
Rakefile

<li>Added a new task <code>all:package</code> to package artifacts.<br> <li> Modified <code>all:release</code> task to include the new <code>all:package</code> task.<br> <li> Removed the <code>create_release_notes</code> task.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14122/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+7/-36</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

