### PR TITLE
EdgeOptions.useWebView to return "this"

### DIFF
--- a/java/src/org/openqa/selenium/edge/EdgeOptions.java
+++ b/java/src/org/openqa/selenium/edge/EdgeOptions.java
@@ -61,6 +61,7 @@ public class EdgeOptions extends ChromiumOptions<EdgeOptions> {
    * automation of WebView2 apps with Microsoft Edge WebDriver </a>
    *
    * @param enable boolean flag to enable or disable the 'webview2' usage
+   * @return this {@link EdgeOptions} object with added WebView2 capability
    */
   public EdgeOptions useWebView(boolean enable) {
     String browserName = enable ? WEBVIEW2_BROWSER_NAME : EDGE.browserName();

--- a/java/src/org/openqa/selenium/edge/EdgeOptions.java
+++ b/java/src/org/openqa/selenium/edge/EdgeOptions.java
@@ -62,9 +62,10 @@ public class EdgeOptions extends ChromiumOptions<EdgeOptions> {
    *
    * @param enable boolean flag to enable or disable the 'webview2' usage
    */
-  public void useWebView(boolean enable) {
+  public EdgeOptions useWebView(boolean enable) {
     String browserName = enable ? WEBVIEW2_BROWSER_NAME : EDGE.browserName();
     setCapability(CapabilityType.BROWSER_NAME, browserName);
+    return this;
   }
 
   @Override


### PR DESCRIPTION
### **User description**
All ChromiumOptions methods return `this`
This commit makes EdgeOptions.useWebView behave the same as other Options methods

**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
All ChromiumOptions methods return `this`
This commit makes EdgeOptions.useWebView behave the same as other Options methods

### Motivation and Context
All ChromiumOptions methods return `this`
This commit makes EdgeOptions.useWebView behave the same as other Options methods

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Modified the `useWebView` method in `EdgeOptions` class to return the `EdgeOptions` instance (`this`) instead of void.
- Ensures consistency with other `ChromiumOptions` methods that return `this`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EdgeOptions.java</strong><dd><code>Modify `useWebView` method to return `EdgeOptions` instance</code></dd></summary>
<hr>
      
java/src/org/openqa/selenium/edge/EdgeOptions.java

<li>Modified <code>useWebView</code> method to return <code>EdgeOptions</code> instead of void.<br> <li> Added a return statement to return <code>this</code> in the <code>useWebView</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14157/files#diff-2a19705afa93cc28103a6935b7f549605f8bcc8dc6b45f351d0e1cc97d273593">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

