### PR TITLE
Update Ruby BiDi script structs to match spec (as of 2024-07-08)

### DIFF
--- a/rb/lib/selenium/webdriver/bidi/log_handler.rb
+++ b/rb/lib/selenium/webdriver/bidi/log_handler.rb
@@ -21,8 +21,8 @@ module Selenium
   module WebDriver
     class BiDi
       class LogHandler
-        ConsoleLogEntry = BiDi::Struct.new(:level, :text, :timestamp, :method, :args, :type)
-        JavaScriptLogEntry = BiDi::Struct.new(:level, :text, :timestamp, :stack_trace, :type)
+        ConsoleLogEntry = BiDi::Struct.new(:level, :text, :timestamp, :stack_trace, :type, :source, :method, :args)
+        JavaScriptLogEntry = BiDi::Struct.new(:level, :text, :timestamp, :stack_trace, :type, :source)
 
         def initialize(bidi)
           @bidi = bidi


### PR DESCRIPTION
### **User description**
### Description

This updates the structs used by the BiDi `Script` and `LogHandler` classes to represent JS logs and errors so that they match the W3C spec as of 2024-07-08. This is meant to resolve the [discussion about the *context* of JS Logs and errors from #13992](https://github.com/SeleniumHQ/selenium/issues/13992#issuecomment-2193786922).

There are a couple open questions here:

1. These structs include some complex collections that have defined types in the spec, but are represented here as hashes, rather than other structs. Should they be structs instead? (For context, this PR was motivated by a desire to get at the information in `log_entry_instance.source['context']`, which would be nicer to get as `log_entry_instance.source.context`.)

    Caveat: `args` and `stack_trace` already existed as arrays of hashes and hashes of arrays of hashes respectively, so maybe making nice structs would be too much of a breaking change?

2. The spec now has a `GenericLogEntry` type for things that aren’t JS logs or exceptions (I *think* this is for various warnings and errors logged by the browser itself, like CORS blocking or content integrity problems). That’s not handled here; should I try to add it? Happy to do that work here or in a separate PR if desired.

    It’s not currently a *problem* since `Script` doesn’t ever add handlers for other types of messages that would show up this way, but someone could theoretically subscribe to them via an instance of `LogHandler` and that might not work out so well.


### Motivation and Context

The BiDi spec has added more fields since `LogHandler` was first implemented, and the current functionality is missing important information, like the ID of the browser context a log entry came from (in `entry.source.context`). This just updates the structs with the fields currently expected by the spec.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. **(I couldn’t get all tests to pass locally even before I touched things, but all tests that I expect could have been affected were passing and still are.)**
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Updated the `ConsoleLogEntry` and `JavaScriptLogEntry` structs in `LogHandler` to include the `source` field, aligning with the W3C spec as of 2024-07-08.
- Added `method`, `args`, and `stack_trace` fields to `ConsoleLogEntry` struct.
- Introduced a helper method `a_stack_frame` in the test suite to match `script.StackFrame` objects.
- Enhanced existing tests to validate the new fields in `ConsoleLogEntry` and `JavaScriptLogEntry`, including detailed checks for `source`, `args`, and `stack_trace`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log_handler.rb</strong><dd><code>Update BiDi log entry structs to match W3C spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/bidi/log_handler.rb

<li>Updated <code>ConsoleLogEntry</code> and <code>JavaScriptLogEntry</code> structs to include <br><code>source</code>.<br> <li> Added <code>method</code>, <code>args</code>, and <code>stack_trace</code> to <code>ConsoleLogEntry</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14236/files#diff-255281b194a6769984ac959abce6e066d00fbfc11e43f8b21363695d0dd652b8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>script_spec.rb</strong><dd><code>Enhance BiDi script tests for updated log entry structs</code>&nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/bidi/script_spec.rb

<li>Added helper method <code>a_stack_frame</code> for matching <code>script.StackFrame</code> <br>objects.<br> <li> Enhanced tests to check for new fields in <code>ConsoleLogEntry</code> and <br><code>JavaScriptLogEntry</code>.<br> <li> Added detailed expectations for <code>source</code>, <code>args</code>, and <code>stack_trace</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14236/files#diff-511fb8dd07c92b6e7a8767aafc8f3008f7fb18799fd027b9ee9b4e45d9cbea33">+46/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

