### PR TITLE
[rb] Deprecate WebStorage JS methods

### DIFF
--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -301,6 +301,7 @@ module Selenium
         #
 
         def local_storage_item(key, value = nil)
+          WebDriver.logger.deprecate('local_storage_item(key, value)', id: :local_storage_item)
           if value
             execute_script("localStorage.setItem('#{key}', '#{value}')")
           else
@@ -309,22 +310,27 @@ module Selenium
         end
 
         def remove_local_storage_item(key)
+          WebDriver.logger.deprecate('remove_local_storage_item(key)', id: :remove_local_storage_item)
           execute_script("localStorage.removeItem('#{key}')")
         end
 
         def local_storage_keys
+          WebDriver.logger.deprecate('local_storage_keys', id: :local_storage_keys)
           execute_script('return Object.keys(localStorage)')
         end
 
         def clear_local_storage
+          WebDriver.logger.deprecate('clear_local_storage', id: :clear_local_storage)
           execute_script('localStorage.clear()')
         end
 
         def local_storage_size
+          WebDriver.logger.deprecate('local_storage_size', id: :local_storage_size)
           execute_script('return localStorage.length')
         end
 
         def session_storage_item(key, value = nil)
+          WebDriver.logger.deprecate('session_storage_item(key, value)', id: :session_storage_item)
           if value
             execute_script("sessionStorage.setItem('#{key}', '#{value}')")
           else
@@ -333,18 +339,22 @@ module Selenium
         end
 
         def remove_session_storage_item(key)
+          WebDriver.logger.deprecate('remove_session_storage_item(key)', id: :remove_session_storage_item)
           execute_script("sessionStorage.removeItem('#{key}')")
         end
 
         def session_storage_keys
+          WebDriver.logger.deprecate('session_storage_keys', id: :session_storage_keys)
           execute_script('return Object.keys(sessionStorage)')
         end
 
         def clear_session_storage
+          WebDriver.logger.deprecate('clear_session_storage', id: :clear_session_storage)
           execute_script('sessionStorage.clear()')
         end
 
         def session_storage_size
+          WebDriver.logger.deprecate('session_storage_size', id: :session_storage_size)
           execute_script('return sessionStorage.length')
         end
 

--- a/rb/spec/integration/selenium/webdriver/storage_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/storage_spec.rb
@@ -99,6 +99,17 @@ module Selenium
               storage.fetch('no-such-key')
             }.to raise_error(IndexError, /missing key/)
           end
+
+          it 'logs a deprecated warning when calling a deprecated method' do
+            storage_type = storage.is_a?(HTML5::LocalStorage) ? 'local' : 'session'
+
+            expect { storage['foo'] }.to have_deprecated(:"#{storage_type}_storage_item")
+            expect { storage['foo'] = 'bar' }.to have_deprecated(:"#{storage_type}_storage_item")
+            expect { storage.delete('foo') }.to have_deprecated(:"remove_#{storage_type}_storage_item")
+            expect { storage.size }.to have_deprecated(:"#{storage_type}_storage_size")
+            expect { storage.clear }.to have_deprecated(:"clear_#{storage_type}_storage")
+            expect { storage.keys }.to have_deprecated(:"#{storage_type}_storage_keys")
+          end
         end
 
         describe 'local storage' do


### PR DESCRIPTION
### **User description**
### Description
Based on #10397 this PR tries to deprecated all the methods that uses JS to interact with the web storage

### Motivation and Context
It's important that all bindings interact with the web storage APIs in the same way, so the first step is to align on what should be deprecated or removed

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added deprecation warnings for various WebStorage JS methods in `rb/lib/selenium/webdriver/remote/bridge.rb`.
- Implemented tests in `rb/spec/integration/selenium/webdriver/storage_spec.rb` to verify that deprecation warnings are logged when deprecated methods are called.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bridge.rb</strong><dd><code>Add deprecation warnings for WebStorage JS methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/remote/bridge.rb

<li>Added deprecation warnings for <code>local_storage_item</code>, <br><code>remove_local_storage_item</code>, <code>local_storage_keys</code>, <code>clear_local_storage</code>, <br><code>local_storage_size</code>, <code>session_storage_item</code>, <code>remove_session_storage_item</code>, <br><code>session_storage_keys</code>, <code>clear_session_storage</code>, and <code>session_storage_size</code> <br>methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14276/files#diff-42b562229083afc6ac8cc70a735fc1b24863402aa1404f08f60322b24cdfefc3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage_spec.rb</strong><dd><code>Add tests for deprecated WebStorage methods warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/storage_spec.rb

<li>Added tests to ensure deprecation warnings are logged for deprecated <br>WebStorage methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14276/files#diff-53e2c087e5dccafc6a71191cd734de18c52fe5aa4cd6aca382fd088c38593ba4">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

