### PR TITLE
Fix 14278 and match ordering of dependencies

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -196,11 +196,11 @@ py_library(
     imports = ["."],
     visibility = ["//visibility:public"],
     deps = [
-        requirement("typing_extensions"),
+        requirement("urllib3"),
         requirement("trio"),
         requirement("trio_websocket"),
-        requirement("urllib3"),
         requirement("certifi"),
+        requirement("typing_extensions"),
         requirement("websocket-client"),
     ],
 )
@@ -295,8 +295,8 @@ py_wheel(
         "trio~=0.17",
         "trio-websocket~=0.9",
         "certifi>=2021.10.8",
-        "typing_extensions~=4.9.0",
-        "websocket-client==1.8.0",
+        "typing_extensions~=4.9",
+        "websocket-client~=1.8",
     ],
     strip_path_prefixes = [
         "py/",

--- a/py/setup.py
+++ b/py/setup.py
@@ -81,8 +81,8 @@ setup_args = {
         "trio~=0.17",
         "trio-websocket~=0.9",
         "certifi>=2021.10.8",
-        "typing_extensions~= 4.9.0",
-        "websocket-client==1.8.0",
+        "typing_extensions~=4.9",
+        "websocket-client~=1.8",
     ],
     'rust_extensions': [
         RustExtension(


### PR DESCRIPTION
### **User description**
## Fix 14278 and match ordering of dependencies

### Description
Fix 14278 and match ordering of dependencies

### Motivation and Context
This resolves https://github.com/SeleniumHQ/selenium/issues/14278

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated version constraints for `typing_extensions` and `websocket-client` dependencies in `setup.py` and `BUILD.bazel`.
- Reordered dependencies in `BUILD.bazel` to match the required order.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Update dependency versions in setup.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/setup.py

<li>Updated version constraints for <code>typing_extensions</code> and <code>websocket-client</code> <br>dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14297/files#diff-722aeeec2821793eb6adf0c529cc7439c4b27ce78937cbb8840e94d4fc1c4017">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Reorder and update dependencies in BUILD.bazel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/BUILD.bazel

<li>Reordered dependencies to match the required order.<br> <li> Updated version constraints for <code>typing_extensions</code> and <code>websocket-client</code> <br>dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14297/files#diff-3e8ff3a52e8e6c0b195ea328e17c50ba6d90abca1ce1624110607da20691d7a9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

