### PR TITLE
Update remote_connection.py to allow proxy_url argument

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -248,7 +248,7 @@ class RemoteConnection:
 
         return urllib3.PoolManager(**pool_manager_init_args)
 
-    def __init__(self, remote_server_addr: str, keep_alive: bool = False, ignore_proxy: bool = False):
+    def __init__(self, remote_server_addr: str, keep_alive: bool = False, ignore_proxy: bool = False, proxy_url: str = None):
         self.keep_alive = keep_alive
         self._url = remote_server_addr
 
@@ -271,7 +271,7 @@ class RemoteConnection:
                         ignore_proxy = True
                         break
 
-        self._proxy_url = self._get_proxy_url() if not ignore_proxy else None
+        self._proxy_url = proxy_url if proxy_url else self._get_proxy_url() if not ignore_proxy else None
         if keep_alive:
             self._conn = self._get_connection_manager()
         self._commands = remote_commands


### PR DESCRIPTION
### **User description**
There are network topologies and configurations where a proxy for the remote connection makes sense, and you do not want to set a system-wide proxy using environment variables. This small PR allows this with the smallest possible change and effort, instead of requiring users to subclass RemoteConnection, e.g.

```
"""A simple extension of Selenium RemoteConnection that allows a parameterized proxy instead of
solely setting a proxy via global ENV vars"""
from selenium.webdriver.remote.remote_connection import RemoteConnection

class ProxiedRemoteConnection(RemoteConnection): # pylint:disable=too-few-public-methods
    """Extends RemoteConnection to allow for a `proxy_url` parameter which is used in an
    override implementation of _get_proxy_url"""
    def __init__(self, remote_server_addr: str, keep_alive: bool = False, ignore_proxy: bool = False, proxy_url = None):
        """Extends RemoteConnection to allow for a `proxy_url` init parameter"""
        self.__proxy_url = proxy_url
        super().__init__(remote_server_addr, keep_alive, ignore_proxy)
    def _get_proxy_url(self):
        """Overrides RemoteConnection to return the init `proxy_url` if supplied"""
        if self.__proxy_url:
            return self.__proxy_url
        return super()._get_proxy_url()
```

### Description
A non-breaking additional kwarg parameter to RemoteConnection which allows pass-in of a proxy_url to use.

### Motivation and Context
There are network topologies and configurations where a proxy for the remote connection makes sense, and you do not want to set a system-wide proxy using environment variables. This small PR allows this with the smallest possible change and effort, instead of requiring users to subclass RemoteConnection

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `proxy_url` parameter to the `RemoteConnection` class's `__init__` method, allowing users to specify a proxy URL directly.
- Updated the proxy URL assignment logic to prioritize the provided `proxy_url` over the environment variable or default behavior.
- This change enables more flexible network configurations without requiring system-wide proxy settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Add support for `proxy_url` parameter in RemoteConnection</code></dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<li>Added <code>proxy_url</code> parameter to <code>__init__</code> method.<br> <li> Modified proxy URL assignment logic to use the new <code>proxy_url</code> parameter <br>if provided.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14308/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

