### PR TITLE
[bidi][java] ensure session.unsubscribe is done when the last listener is removed by id

### DIFF
--- a/java/src/org/openqa/selenium/bidi/BiDi.java
+++ b/java/src/org/openqa/selenium/bidi/BiDi.java
@@ -20,7 +20,9 @@ package org.openqa.selenium.bidi;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.openqa.selenium.internal.Require;
@@ -112,7 +114,12 @@ public class BiDi implements Closeable {
   }
 
   public void removeListener(long id) {
-    connection.removeListener(id);
+    Optional<Event<?>> event = connection.removeListener(id);
+
+    if (event.isPresent() && !connection.isEventSubscribed(event.get())) {
+      send(
+          new Command<>("session.unsubscribe", Map.of("events", List.of(event.get().getMethod()))));
+    }
   }
 
   public void clearListeners() {


### PR DESCRIPTION
### Motivation and Context / Description
When removing the last listener by `id` the `session.unsubscribe` was not done for the `event`.
When removing the last listener by `event` the `session.unsubscribe` was done.

So i guess this was a none intentional behavior. @pujagani is this assumption correct?
There might be better way to fix this so this is a PR to have an okay on this.

And there was a write lock used for read, i guess this was a copy and paste error.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
