### PR TITLE
[bazel] With the move to aspect_rules_js we do not need to pre-warm the npm cache

### DIFF
--- a/scripts/github-actions/ci-build.sh
+++ b/scripts/github-actions/ci-build.sh
@@ -4,12 +4,6 @@ set -eufo pipefail
 # We want to see what's going on
 set -x
 
-# The NPM repository rule wants to write to the HOME directory
-# but that's configured for the remote build machines, so run
-# that repository rule first so that the subsequent remote
-# build runs successfully. We don't care what the output is.
-bazel query @npm//:all >/dev/null
-
 # Now run the tests. The engflow build uses pinned browsers
 # so this should be fine
 # shellcheck disable=SC2046


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Simplified the CI build script by removing the pre-warming of the npm cache, which is no longer necessary due to the move to `aspect_rules_js`.
- Eliminated an unnecessary `bazel query` command to streamline the CI process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-build.sh</strong><dd><code>Simplify CI build script by removing npm cache pre-warming</code></dd></summary>
<hr>

scripts/github-actions/ci-build.sh

<li>Removed pre-warming of the npm cache.<br> <li> Simplified the CI build script by eliminating unnecessary bazel query.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14370/files#diff-bc131c15a23b4948a533cf890e6574568c0bf2bf6fe6de03b974fda90fe5bbc2">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

