### PR TITLE
[bazel + ci]: Stop being selective about which parts of the tree to test

### DIFF
--- a/.skipped-tests
+++ b/.skipped-tests
@@ -19,6 +19,7 @@
 -//javascript/atoms:test-chrome
 -//javascript/atoms:test-edge
 -//javascript/atoms:test-firefox-beta
+-//javascript/chrome-driver/...
 -//javascript/node/selenium-webdriver:test-bidi-network-test.js-chrome
 -//javascript/node/selenium-webdriver:test-builder-test.js-chrome
 -//javascript/node/selenium-webdriver:test-builder-test.js-firefox

--- a/.skipped-tests
+++ b/.skipped-tests
@@ -54,3 +54,4 @@
 -//rb/spec/integration/selenium/webdriver:element-chrome
 -//rb/spec/integration/selenium/webdriver:element-chrome-bidi
 -//rb/spec/integration/selenium/webdriver:element-chrome-remote
+-//rust/tests/...

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -92,6 +92,7 @@ rust_library(
         exclude = ["main.rs"],
     ),
     edition = "2021",
+    visibility = ["//rust:__subpackages__"],
     deps = all_crate_deps(normal = True),
 )
 
@@ -116,23 +117,4 @@ rust_test(
     crate = ":selenium_manager",
     edition = "2021",
     tags = ["no-sandbox"],
-)
-
-rust_test_suite(
-    name = "integration",
-    size = "small",
-    srcs = glob(["tests/**/*_tests.rs"]),
-    data = [
-        "tests/common.rs",
-        ":selenium-manager",
-    ],
-    edition = "2021",
-    tags = [
-        "no-sandbox",
-        "requires-network",
-    ],
-    deps = [":selenium_manager"] + all_crate_deps(
-        normal = True,
-        normal_dev = True,
-    ),
 )

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rust_test_suite", "rustfmt_config")
+load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rustfmt_config")
 
 rustfmt_config(
     name = "enable-rustfmt",

--- a/rust/tests/BUILD.bazel
+++ b/rust/tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rust_test_suite", "rustfmt_config")
+load("//rust:defs.bzl", "rust_test_suite", "rustfmt_config")
 
 rustfmt_config(
     name = "enable-rustfmt",

--- a/rust/tests/BUILD.bazel
+++ b/rust/tests/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@crates//:defs.bzl", "all_crate_deps")
+load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rust_test_suite", "rustfmt_config")
+
+rustfmt_config(
+    name = "enable-rustfmt",
+)
+
+rust_test_suite(
+    name = "integration",
+    size = "small",
+    srcs = glob(["**/*_tests.rs"]),
+    data = [
+        "common.rs",
+        "//rust:selenium-manager",
+    ],
+    edition = "2021",
+    tags = [
+        "no-sandbox",
+        "requires-network",
+    ],
+    deps = ["//rust:selenium_manager"] + all_crate_deps(
+        package_name = "rust",
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/scripts/github-actions/ci-build.sh
+++ b/scripts/github-actions/ci-build.sh
@@ -10,13 +10,7 @@ set -x
 bazel test --config=remote-ci --build_tests_only \
   --test_tag_filters=-exclusive-if-local,-skip-remote \
   --keep_going --flaky_test_attempts=2 \
-  //dotnet/...  \
-  //java/... \
-  //javascript/atoms/... \
-  //javascript/node/selenium-webdriver/... \
-  //javascript/webdriver/... \
-  //py/... \
-  //rb/spec/... -- $(cat .skipped-tests | tr '\n' ' ')
+  //... -- $(cat .skipped-tests | tr '\n' ' ')
 
 # Build the packages we want to ship to users
 bazel build --config=remote-ci \


### PR DESCRIPTION
### **User description**
Now that we've got every part of the tree building with Bazel, we can stop being so selective about what we test.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed selective testing of specific directories in the CI build script.
- Enabled testing for the entire codebase by modifying the Bazel test command.
- Simplified the CI configuration to ensure all parts of the tree are tested.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-build.sh</strong><dd><code>Enable comprehensive testing across the entire codebase in CI</code></dd></summary>
<hr>

scripts/github-actions/ci-build.sh

<li>Removed selective testing of specific directories.<br> <li> Enabled testing for the entire codebase.<br> <li> Simplified the Bazel test command.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14373/files#diff-bc131c15a23b4948a533cf890e6574568c0bf2bf6fe6de03b974fda90fe5bbc2">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

