### PR TITLE
[rust] Selenium Manager errors when browser-path is wrong (#13352)

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d3b4f76b61f6e1c21a4bd8b7905b2b82a1dee313ae0632e04a1c1a7a2e49d414",
+  "checksum": "4ef6c22ec363acd77306d3758c75001ec6e6164f8f964457ff9af16470c5cf13",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -11951,14 +11951,7 @@
               "target": "zip"
             }
           ],
-          "selects": {
-            "cfg(target_os = \"windows\")": [
-              {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
+          "selects": {}
         },
         "deps_dev": {
           "common": [
@@ -19706,7 +19699,6 @@
     "toml 0.8.19",
     "walkdir 2.5.0",
     "which 6.0.2",
-    "windows-sys 0.59.0",
     "zip 2.1.6"
   ],
   "direct_dev_deps": [

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4ef6c22ec363acd77306d3758c75001ec6e6164f8f964457ff9af16470c5cf13",
+  "checksum": "d3b4f76b61f6e1c21a4bd8b7905b2b82a1dee313ae0632e04a1c1a7a2e49d414",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -11951,7 +11951,14 @@
               "target": "zip"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
         },
         "deps_dev": {
           "common": [
@@ -19699,6 +19706,7 @@
     "toml 0.8.19",
     "walkdir 2.5.0",
     "which 6.0.2",
+    "windows-sys 0.59.0",
     "zip 2.1.6"
   ],
   "direct_dev_deps": [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "toml",
  "walkdir",
  "which",
+ "windows-sys 0.59.0",
  "zip",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1892,7 +1892,6 @@ dependencies = [
  "toml",
  "walkdir",
  "which",
- "windows-sys 0.59.0",
  "zip",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,9 +36,6 @@ anyhow = { version = "1.0.86", default-features = false, features = ["backtrace"
 apple-flat-package = "0.18.0"
 which = "6.0.2"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = "0.59.0"
-
 [dev-dependencies]
 assert_cmd = "2.0.16"
 rstest = "0.19.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,6 +36,9 @@ anyhow = { version = "1.0.86", default-features = false, features = ["backtrace"
 apple-flat-package = "0.18.0"
 which = "6.0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = "0.59.0"
+
 [dev-dependencies]
 assert_cmd = "2.0.16"
 rstest = "0.19.0"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -42,6 +42,7 @@ pub const CACHE_PATH_KEY: &str = "cache-path";
 
 pub struct ManagerConfig {
     pub cache_path: String,
+    pub fallback_driver_from_cache: bool,
     pub browser_version: String,
     pub driver_version: String,
     pub browser_path: String,
@@ -97,6 +98,7 @@ impl ManagerConfig {
 
         ManagerConfig {
             cache_path,
+            fallback_driver_from_cache: true,
             browser_version: StringKey(vec!["browser-version", &browser_version_label], "")
                 .get_value(),
             driver_version: StringKey(vec!["driver-version", &driver_version_label], "")

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1065,6 +1065,12 @@ pub trait SeleniumManager {
             if let Some(path) = self.detect_browser_path() {
                 browser_path = path_to_string(&path);
             }
+        } else if !Path::new(&browser_path).exists() {
+            self.set_fallback_driver_from_cache(false);
+            return Err(anyhow!(format_one_arg(
+                "Browser path does not exist: {}",
+                &browser_path,
+            )));
         }
         let escaped_browser_path = self.get_escaped_path(browser_path.to_string());
 
@@ -1465,6 +1471,14 @@ pub trait SeleniumManager {
         if avoid_stats {
             self.get_config_mut().avoid_stats = true;
         }
+    }
+
+    fn is_fallback_driver_from_cache(&self) -> bool {
+        self.get_config().fallback_driver_from_cache
+    }
+
+    fn set_fallback_driver_from_cache(&mut self, fallback_driver_from_cache: bool) {
+        self.get_config_mut().fallback_driver_from_cache = fallback_driver_from_cache;
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1061,18 +1061,19 @@ pub trait SeleniumManager {
         cmd_version_arg: &str,
     ) -> Result<Option<String>, Error> {
         let mut browser_path = self.get_browser_path().to_string();
+        let mut escaped_browser_path = self.get_escaped_path(&browser_path);
         if browser_path.is_empty() {
             if let Some(path) = self.detect_browser_path() {
                 browser_path = path_to_string(&path);
+                escaped_browser_path = self.get_escaped_path(&browser_path);
             }
-        } else if !Path::new(&browser_path).exists() {
+        } else if !Path::new(&escaped_browser_path).exists() {
             self.set_fallback_driver_from_cache(false);
             return Err(anyhow!(format_one_arg(
                 "Browser path does not exist: {}",
                 &browser_path,
             )));
         }
-        let escaped_browser_path = self.get_escaped_path(browser_path.to_string());
 
         let mut commands = Vec::new();
         if WINDOWS.is(self.get_os()) {
@@ -1122,7 +1123,7 @@ pub trait SeleniumManager {
         if browser_path.is_empty() {
             match self.detect_browser_path() {
                 Some(path) => {
-                    browser_path = self.get_escaped_path(path_to_string(&path));
+                    browser_path = self.get_escaped_path(&path_to_string(&path));
                 }
                 _ => return Ok(None),
             }
@@ -1318,9 +1319,9 @@ pub trait SeleniumManager {
         canon_path
     }
 
-    fn get_escaped_path(&self, string_path: String) -> String {
-        let mut escaped_path = string_path.clone();
-        let path = Path::new(&string_path);
+    fn get_escaped_path(&self, string_path: &str) -> String {
+        let mut escaped_path = string_path.to_string();
+        let path = Path::new(string_path);
 
         if path.exists() {
             escaped_path = self.canonicalize_path(path.to_path_buf());
@@ -1331,7 +1332,7 @@ pub trait SeleniumManager {
                     Command::new_single(format_one_arg(ESCAPE_COMMAND, escaped_path.as_str()));
                 escaped_path = run_shell_command("bash", "-c", escape_command).unwrap_or_default();
                 if escaped_path.is_empty() {
-                    escaped_path = string_path.clone();
+                    escaped_path = string_path.to_string();
                 }
             }
         }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -243,25 +243,28 @@ fn main() {
         })
         .unwrap_or_else(|err| {
             let log = selenium_manager.get_logger();
-            if let Some(best_driver_from_cache) =
-                selenium_manager.find_best_driver_from_cache().unwrap()
-            {
-                log.debug_or_warn(
-                    format!(
-                        "There was an error managing {} ({}); using driver found in the cache",
-                        selenium_manager.get_driver_name(),
-                        err
-                    ),
-                    selenium_manager.is_offline(),
-                );
-                log_driver_and_browser_path(
-                    log,
-                    &best_driver_from_cache,
-                    &selenium_manager.get_browser_path_or_latest_from_cache(),
-                    selenium_manager.get_receiver(),
-                );
-                flush_and_exit(OK, log, Some(err));
-            } else if selenium_manager.is_offline() {
+            if selenium_manager.is_fallback_driver_from_cache() {
+                if let Some(best_driver_from_cache) =
+                    selenium_manager.find_best_driver_from_cache().unwrap()
+                {
+                    log.debug_or_warn(
+                        format!(
+                            "There was an error managing {} ({}); using driver found in the cache",
+                            selenium_manager.get_driver_name(),
+                            err
+                        ),
+                        selenium_manager.is_offline(),
+                    );
+                    log_driver_and_browser_path(
+                        log,
+                        &best_driver_from_cache,
+                        &selenium_manager.get_browser_path_or_latest_from_cache(),
+                        selenium_manager.get_receiver(),
+                    );
+                    flush_and_exit(OK, log, Some(err));
+                }
+            }
+            if selenium_manager.is_offline() {
                 log.warn(&err);
                 flush_and_exit(OK, log, Some(err));
             } else {

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -133,6 +133,11 @@ fn invalid_geckodriver_version_test() {
     "chrome",
     r"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
 )]
+#[case(
+    "macos",
+    "chrome",
+    r"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+)]
 fn browser_path_test(#[case] os: String, #[case] browser: String, #[case] browser_path: String) {
     if OS.eq(&os) {
         let mut cmd = get_selenium_manager();

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -151,3 +151,17 @@ fn browser_path_test(#[case] os: String, #[case] browser: String, #[case] browse
         assert!(!stdout.contains("WARN"));
     }
 }
+
+#[test]
+fn invalid_browser_path_test() {
+    let mut cmd = get_selenium_manager();
+    cmd.args([
+        "--browser",
+        "chrome",
+        "--browser-path",
+        "/bad/path/google-chrome-wrong",
+    ])
+    .assert()
+    .code(DATAERR)
+    .failure();
+}

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -133,11 +133,6 @@ fn invalid_geckodriver_version_test() {
     "chrome",
     r"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
 )]
-#[case(
-    "macos",
-    "chrome",
-    r"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-)]
 fn browser_path_test(#[case] os: String, #[case] browser: String, #[case] browser_path: String) {
     if OS.eq(&os) {
         let mut cmd = get_selenium_manager();

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -131,11 +131,6 @@ fn invalid_geckodriver_version_test() {
 #[case(
     "macos",
     "chrome",
-    r"/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
-)]
-#[case(
-    "macos",
-    "chrome",
     r"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 )]
 fn browser_path_test(#[case] os: String, #[case] browser: String, #[case] browser_path: String) {


### PR DESCRIPTION
### **User description**
### Description
This PR makes SM to error when the specified browser path does not exists. Example:

```
./selenium-manager --browser chrome --debug --browser-path /bad/path
[2024-08-12T17:17:21.501Z DEBUG] chromedriver not found in PATH
[2024-08-12T17:17:21.502Z ERROR] Browser path does not exist: /bad/path
```

### Motivation and Context
Requested in #13352.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `fallback_driver_from_cache` field to `ManagerConfig` struct and initialized it in the constructor.
- Implemented error handling for invalid browser paths, returning an error if the specified path does not exist.
- Introduced methods to get and set the `fallback_driver_from_cache` configuration.
- Modified error handling logic in `main.rs` to use the fallback driver from cache if the browser path is invalid.
- Added a test case to verify behavior when an invalid browser path is provided.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add fallback driver from cache configuration to ManagerConfig</code></dd></summary>
<hr>

rust/src/config.rs

<li>Added <code>fallback_driver_from_cache</code> field to <code>ManagerConfig</code> struct.<br> <li> Initialized <code>fallback_driver_from_cache</code> in <code>ManagerConfig</code> constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14381/files#diff-4f8685a05fdbb7fd7ae69236497d75cdc7df84d23be9d65ac019042dfc59df4f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Handle invalid browser path and manage fallback driver</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<li>Added error handling for invalid browser path.<br> <li> Introduced methods to get and set <code>fallback_driver_from_cache</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14381/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Update error handling to use fallback driver from cache</code>&nbsp; &nbsp; </dd></summary>
<hr>

rust/src/main.rs

<li>Modified error handling to check <code>fallback_driver_from_cache</code>.<br> <li> Adjusted logic for using cached driver when browser path is invalid.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14381/files#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8">+22/-19</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browser_tests.rs</strong><dd><code>Add test for invalid browser path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/tests/browser_tests.rs

- Added a test for invalid browser path scenario.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14381/files#diff-c4663bdd0f9bda0b1870b94fe25dc61d2fec5ba6431521a52a330f8002a654c3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

