### PR TITLE
Bug 14229 fixed

### DIFF
--- a/common/src/web/javascriptPage.html
+++ b/common/src/web/javascriptPage.html
@@ -279,6 +279,10 @@
   </div>
 </div>
 
+<form id="aParentFormId">
+  <input type="text" name="tagName">
+</form>
+
 </body>
 </html>
 

--- a/javascript/atoms/domcore.js
+++ b/javascript/atoms/domcore.js
@@ -169,6 +169,11 @@ bot.dom.core.isElement = function (node, opt_tagName) {
   if (opt_tagName && (typeof opt_tagName !== 'string')) {
     opt_tagName = opt_tagName.toString();
   }
+  // because node.tagName.toUpperCase() fails when tagName is "tagName"
+  if (node instanceof HTMLFormElement) {
+    return !!node && node.nodeType == goog.dom.NodeType.ELEMENT &&
+    (!opt_tagName || "FORM" == opt_tagName);
+  }
   return !!node && node.nodeType == goog.dom.NodeType.ELEMENT &&
     (!opt_tagName || node.tagName.toUpperCase() == opt_tagName);
 };

--- a/py/test/selenium/webdriver/common/visibility_tests.py
+++ b/py/test/selenium/webdriver/common/visibility_tests.py
@@ -29,6 +29,7 @@ def test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not(driver,
     assert driver.find_element(by=By.ID, value="none").is_displayed() is False
     assert driver.find_element(by=By.ID, value="suppressedParagraph").is_displayed() is False
     assert driver.find_element(by=By.ID, value="hidden").is_displayed() is False
+    assert driver.find_element(by=By.ID, value="aParentFormId").is_displayed() is True
 
 
 def test_visibility_should_take_into_account_parent_visibility(driver, pages):


### PR DESCRIPTION
### **User description**
Updatedis_displayed functionality to ensure that form elements with child id's of "tagName" are handled safely. Added a test

### Description

1. Updated Domcore.js to handle FormHTMLElements safely
2. Added form element with child input id of "tagName" to JavascriptPage.html for testing
3. Added line in test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not() in Visibility_Tests.py to ensure this functionality is tested moving forward

### Motivation and Context
Bug #14229

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated `isElement` function in `domcore.js` to handle `HTMLFormElement` safely and prevent failures when `tagName` is "tagName".
- Added a form element with a child input id of "tagName" to `javascriptPage.html` for testing.
- Enhanced `test_should_allow_the_user_to_tell_if_an_element_is_displayed_or_not` in `visibility_tests.py` to include the new form element.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domcore.js</strong><dd><code>Handle HTMLFormElement safely in isElement function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/domcore.js

<li>Added a condition to handle <code>HTMLFormElement</code> safely in <code>isElement</code> <br>function.<br> <li> Ensured <code>node.tagName.toUpperCase()</code> does not fail when <code>tagName</code> is <br>"tagName".<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14389/files#diff-93ad5279a4d732ddbf30ed3968d78033759c1cbb7bd36147e6c5ed761d6ce32a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visibility_tests.py</strong><dd><code>Add test for form element visibility with specific child input id</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/visibility_tests.py

<li>Added a test case to check visibility of form element with child input <br>id of "tagName".<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14389/files#diff-599817b9d089a804ae8cded7c0dc57493b7d0df13886773a5ea5218c0be719c0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>javascriptPage.html</strong><dd><code>Add form element with specific child input id for testing</code></dd></summary>
<hr>

common/src/web/javascriptPage.html

<li>Added a form element with child input id of "tagName" for testing <br>purposes.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14389/files#diff-ae4246f838b956b3a7f202c40e51048b8458bdef5e711ca02afc1d35cfeb26d8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

