### PR TITLE
upgraded isEnabled to handle pointer-events: none; updated formPage.h…

### DIFF
--- a/common/src/web/formPage.html
+++ b/common/src/web/formPage.html
@@ -190,5 +190,8 @@ There should be a form here:
 </form>
 
 <input id="vsearchGadget" name="SearchableText" type="text" size="18" value="" title="Hvad søger du?" accesskey="4" class="inputLabel" />
+
+<button id="pointerEventsNone" style="pointer-events: none;"><span>I'm an effectively disabled button</span></button>
+
 </body>
 </html>

--- a/javascript/atoms/dom.js
+++ b/javascript/atoms/dom.js
@@ -198,6 +198,11 @@ bot.dom.isEnabled = function(el) {
     return false;
   }
 
+  // check for whether the element has pointer-events: none
+  if (bot.dom.hasPointerEventsDisabled_(el)) {
+    return false;
+  }
+
   // The element is not explicitly disabled, but if it is an OPTION or OPTGROUP,
   // we must test if it inherits its state from a parent.
   if (el.parentNode &&

--- a/py/test/selenium/webdriver/common/element_attribute_tests.py
+++ b/py/test/selenium/webdriver/common/element_attribute_tests.py
@@ -64,6 +64,11 @@ def test_should_return_the_value_of_the_disabled_attribute_as_false_if_not_set(d
     pElement = driver.find_element(By.ID, "peas")
     assert pElement.get_attribute("disabled") is None
     assert pElement.is_enabled()
+    
+def test_should_return_false_for_enabled_element_with_pointer_events_set_to_none(driver, pages):
+    pages.load("formPage.html")
+    inputElement = driver.find_element(By.ID, "pointerEventsNone")
+    assert not inputElement.is_enabled()
 
 
 def test_should_return_the_value_of_the_index_attribute_even_if_it_is_missing(driver, pages):


### PR DESCRIPTION
### **User description**
Upgraded isEnabled() to handle attribute pointer-events: none

### Description

1. updated isEnabled()
2. added example element to formPage.html
3. added Pytest test_should_return_false_for_enabled_element_with_pointer_events_set_to_none

### Motivation and Context
Bug #14427

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enhanced the `isEnabled` function to handle elements with `pointer-events: none`, ensuring they are treated as disabled.
- Added a new test in `element_attribute_tests.py` to verify that elements with `pointer-events: none` are correctly identified as not enabled.
- Updated `formPage.html` to include a button with `pointer-events: none` for testing purposes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dom.js</strong><dd><code>Enhance isEnabled function to handle pointer-events: none</code></dd></summary>
<hr>

javascript/atoms/dom.js

<li>Added check for <code>pointer-events: none</code> in <code>isEnabled</code> function.<br> <li> Returns false if element has <code>pointer-events: none</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14428/files#diff-53bbf9a76b3e18a714284bd37ffdbcb670cbf537319cdaee94aacca31bcc497d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>element_attribute_tests.py</strong><dd><code>Add test for pointer-events: none handling in isEnabled</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/element_attribute_tests.py

<li>Added test for elements with <code>pointer-events: none</code>.<br> <li> Ensures <code>is_enabled</code> returns false for such elements.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14428/files#diff-b85846ecb3eb61b5387b3d0b1cb1cdcb8a3626cd2332850d64ae8ca1847a3941">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>formPage.html</strong><dd><code>Add test element with pointer-events: none to formPage</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/web/formPage.html

- Added a button with `pointer-events: none` for testing.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14428/files#diff-e3bbb6af589f703f4bcd47a78e501fc4b60998f12925771b2b5be71ce1400784">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

