### PR TITLE
chore(ci): correct github-script API calls

### DIFF
--- a/.github/workflows/delete-comments.yml
+++ b/.github/workflows/delete-comments.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             const comment = context.payload.comment.body;
-            const triggerStrings = ['www.mediafire.com', 'Download'];
+            const triggerStrings = ['www.mediafire.com'];
             return triggerStrings.some(triggerString => comment.includes(triggerString));
 
       - name: Delete comment if it contains any of the specific strings

--- a/.github/workflows/delete-comments.yml
+++ b/.github/workflows/delete-comments.yml
@@ -32,14 +32,13 @@ jobs:
               comment_id: commentId
             });
 
-      - name: Block user if comment contains any of the specific strings
+      - name: Block user from the org if their comment contained any of the banned strings
         if: steps.check_comment.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           script: |
-            const userId = context.payload.comment.user.id;
-            await github.rest.users.block({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              user_id: userId
+            const username = context.payload.comment.user.login
+            await github.rest.orgs.blockUser({
+              org: context.repo.owner,
+              username: username
             });

--- a/.github/workflows/delete-comments.yml
+++ b/.github/workflows/delete-comments.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           script: |
             const commentId = context.payload.comment.id;
-            await github.issues.deleteComment({
+            await github.rest.issues.deleteComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: commentId
@@ -38,7 +38,7 @@ jobs:
         with:
           script: |
             const userId = context.payload.comment.user.id;
-            await github.users.block({
+            await github.rest.users.block({
               owner: context.repo.owner,
               repo: context.repo.repo,
               user_id: userId


### PR DESCRIPTION
### **User description**
### Description

Since V5 of github-script the Octokit context available via `github` no longer has REST methods directly on it, they were moved to `github.rest.*` instead. Update the references in delete-comments.yml job to match.

### Motivation and Context

The GitHub Actions workflow will fail when it attempts to delete a comment without this change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated the GitHub Actions workflow to use the new `github.rest.*` syntax for API calls, ensuring compatibility with version 5 of `github-script`.
- Modified the `deleteComment` and `block` methods to align with the updated Octokit context, preventing workflow failures.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>delete-comments.yml</strong><dd><code>Update GitHub API calls to new Octokit syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/delete-comments.yml

<li>Updated GitHub API calls to use <code>github.rest.*</code> syntax.<br> <li> Changed <code>deleteComment</code> and <code>block</code> methods to use the new Octokit <br>context.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14442/files#diff-c3f71ecf99cc2c1fcfc1bc50e192d0e24d916aa72c4ab59ed4a2abd44d43e575">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

