### PR TITLE
[grid] Eliminate vendor-specific handling of extension capabilities 

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
+++ b/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
@@ -39,17 +39,27 @@ import org.openqa.selenium.Capabilities;
  *       Then the {@code stereotype} must contain the same values.
  * </ul>
  *
- * <p>One thing to note is that extension capabilities are not considered when matching slots, since
- * the matching of these is implementation-specific to each driver.
+ * <p>Note that extension capabilities are considered for slot matching, with the following exceptions:
+ *
+ * <ul>
+ *   <li>Extension capabilities with prefix "se:"
+ *   <li>Extension capabilities with these suffixes:
+ *     <ul>
+ *       <li>"options"
+ *       <li>"Options"
+ *       <li>"loggingPrefs"
+ *       <li>"debuggerAddress"
+ *     </ul>
+ * </ul>
  */
 public class DefaultSlotMatcher implements SlotMatcher, Serializable {
 
   /*
-   List of prefixed extension capabilities we never should try to match, they should be
+   List of extension capability suffixes we never should try to match, they should be
    matched in the Node or in the browser driver.
   */
-  private static final List<String> EXTENSION_CAPABILITIES_PREFIXES =
-      Arrays.asList("goog:", "moz:", "ms:", "se:");
+  private static final List<String> EXTENSION_CAPABILITY_SUFFIXES =
+      Arrays.asList("Options", "options", "loggingPrefs", "debuggerAddress");
 
   @Override
   public boolean matches(Capabilities stereotype, Capabilities capabilities) {
@@ -76,14 +86,14 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
 
     // At the end, a simple browser, browserVersion and platformName match
     boolean browserNameMatch =
-        (capabilities.getBrowserName() == null || capabilities.getBrowserName().isEmpty())
+        capabilities.getBrowserName() == null
+            || capabilities.getBrowserName().isEmpty()
             || Objects.equals(stereotype.getBrowserName(), capabilities.getBrowserName());
     boolean browserVersionMatch =
-        (capabilities.getBrowserVersion() == null
-                || capabilities.getBrowserVersion().isEmpty()
-                || Objects.equals(capabilities.getBrowserVersion(), "stable"))
-            || browserVersionMatch(
-                stereotype.getBrowserVersion(), capabilities.getBrowserVersion());
+        capabilities.getBrowserVersion() == null
+            || capabilities.getBrowserVersion().isEmpty()
+            || Objects.equals(capabilities.getBrowserVersion(), "stable")
+            || browserVersionMatch(stereotype.getBrowserVersion(), capabilities.getBrowserVersion());
     boolean platformNameMatch =
         capabilities.getPlatformName() == null
             || Objects.equals(stereotype.getPlatformName(), capabilities.getPlatformName())
@@ -102,21 +112,17 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
         .filter(name -> !name.contains(":"))
         // Platform matching is special, we do it later
         .filter(name -> !"platformName".equalsIgnoreCase(name))
-        .map(
+        .filter(name -> capabilities.getCapability(name) != null)
+        .allMatch(
             name -> {
-              if (capabilities.getCapability(name) instanceof String) {
-                return stereotype
-                    .getCapability(name)
-                    .toString()
-                    .equalsIgnoreCase(capabilities.getCapability(name).toString());
-              } else {
-                return capabilities.getCapability(name) == null
-                    || Objects.equals(
-                        stereotype.getCapability(name), capabilities.getCapability(name));
+              if (stereotype.getCapability(name) instanceof String
+                  && capabilities.getCapability(name) instanceof String) {
+                return ((String) stereotype.getCapability(name))
+                    .equalsIgnoreCase((String) capabilities.getCapability(name));
               }
-            })
-        .reduce(Boolean::logicalAnd)
-        .orElse(true);
+              return Objects.equals(
+                  stereotype.getCapability(name), capabilities.getCapability(name));
+            });
   }
 
   private Boolean managedDownloadsEnabled(Capabilities stereotype, Capabilities capabilities) {
@@ -140,39 +146,39 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
     */
     return capabilities.getCapabilityNames().stream()
         .filter(name -> name.contains("platformVersion"))
-        .map(
+        .allMatch(
             platformVersionCapName ->
                 Objects.equals(
                     stereotype.getCapability(platformVersionCapName),
-                    capabilities.getCapability(platformVersionCapName)))
-        .reduce(Boolean::logicalAnd)
-        .orElse(true);
+                    capabilities.getCapability(platformVersionCapName)));
   }
 
   private Boolean extensionCapabilitiesMatch(Capabilities stereotype, Capabilities capabilities) {
     /*
-     We match extension capabilities when they are not prefixed with any of the
-     EXTENSION_CAPABILITIES_PREFIXES items. Also, we match them only when the capabilities
-     of the new session request contains that specific extension capability.
+     We match extension capabilities in new session requests whose names do not have the prefix "se:" or
+     one of the reserved suffixes ("options", "Options", "loggingPrefs", or "debuggerAddress"). These are
+     forwarded to the matched node for use in configuration, but are not considered for node matching.
     */
     return stereotype.getCapabilityNames().stream()
+        // examine only extension capabilities
         .filter(name -> name.contains(":"))
-        .filter(name -> capabilities.asMap().containsKey(name))
-        .filter(name -> EXTENSION_CAPABILITIES_PREFIXES.stream().noneMatch(name::contains))
-        .map(
+        // ignore Selenium extension capabilities
+        .filter(name -> !name.startsWith("se:"))
+        // ignore special extension capability suffixes
+        .filter(name -> EXTENSION_CAPABILITY_SUFFIXES.stream().noneMatch(name::endsWith))
+        // ignore capabilities not specified in the request
+        .filter(name -> capabilities.getCapability(name) != null)
+        .allMatch(
             name -> {
-              if (capabilities.getCapability(name) instanceof String) {
-                return stereotype
-                    .getCapability(name)
-                    .toString()
-                    .equalsIgnoreCase(capabilities.getCapability(name).toString());
-              } else {
-                return capabilities.getCapability(name) == null
-                    || Objects.equals(
-                        stereotype.getCapability(name), capabilities.getCapability(name));
+              // evaluate capabilities with String values
+              if (stereotype.getCapability(name) instanceof String
+                  && capabilities.getCapability(name) instanceof String) {
+                return ((String) stereotype.getCapability(name))
+                    .equalsIgnoreCase((String) capabilities.getCapability(name));
               }
-            })
-        .reduce(Boolean::logicalAnd)
-        .orElse(true);
+              // evaluate capabilities with Number or Boolean values
+              return Objects.equals(
+                  stereotype.getCapability(name), capabilities.getCapability(name));
+            });
   }
 }

--- a/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
@@ -40,7 +40,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.grid.data.CreateSessionRequest;
@@ -50,7 +49,6 @@ import org.openqa.selenium.grid.node.SessionFactory;
 import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.internal.Either;
 import org.openqa.selenium.internal.Require;
-import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.remote.DriverCommand;
@@ -149,15 +147,6 @@ public class RelaySessionFactory implements SessionFactory {
               "New session request capabilities do not " + "match the stereotype."));
     }
 
-    // remove browserName capability if 'appium:app' is present as it breaks appium tests when app
-    // is provided
-    // they are mutually exclusive
-    MutableCapabilities filteredStereotype = new MutableCapabilities(stereotype);
-    if (capabilities.getCapability("appium:app") != null) {
-      filteredStereotype.setCapability(CapabilityType.BROWSER_NAME, (String) null);
-    }
-
-    capabilities = capabilities.merge(filteredStereotype);
     LOG.info("Starting session for " + capabilities);
 
     try (Span span = tracer.getCurrentContext().createSpan("relay_session_factory.apply")) {

--- a/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
+++ b/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.grid.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
@@ -536,7 +537,37 @@ class DefaultSlotMatcherTest {
   }
 
   @Test
-  void vendorExtensionPrefixedCapabilitiesAreIgnoredForMatching() {
+  void seleniumExtensionCapabilitiesAreIgnoredForMatching() {
+    Capabilities stereotype =
+      new ImmutableCapabilities(
+        CapabilityType.BROWSER_NAME,
+        "chrome",
+        CapabilityType.BROWSER_VERSION,
+        "84",
+        CapabilityType.PLATFORM_NAME,
+        Platform.WINDOWS,
+        "se:cdpVersion",
+        1,
+        "se:downloadsEnabled",
+        true);
+
+    Capabilities capabilities =
+      new ImmutableCapabilities(
+        CapabilityType.BROWSER_NAME,
+        "chrome",
+        CapabilityType.BROWSER_VERSION,
+        "84",
+        CapabilityType.PLATFORM_NAME,
+        Platform.WINDOWS,
+        "se:cdpVersion",
+        2,
+        "se:downloadsEnabled",
+        false);
+    assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
+  }
+
+  @Test
+  void vendorOptionsCapabilitiesAreIgnoredForMatching() {
     Capabilities stereotype =
         new ImmutableCapabilities(
             CapabilityType.BROWSER_NAME,
@@ -545,10 +576,10 @@ class DefaultSlotMatcherTest {
             "84",
             CapabilityType.PLATFORM_NAME,
             Platform.WINDOWS,
-            "goog:cheese",
-            "amsterdam",
-            "ms:fruit",
-            "mango");
+            "food:fruitOptions",
+            "mango",
+            "dairy:options",
+            Map.of("cheese", "amsterdam"));
 
     Capabilities capabilities =
         new ImmutableCapabilities(
@@ -558,10 +589,40 @@ class DefaultSlotMatcherTest {
             "84",
             CapabilityType.PLATFORM_NAME,
             Platform.WINDOWS,
-            "goog:cheese",
-            "gouda",
-            "ms:fruit",
-            "orange");
+            "food:fruitOptions",
+            "orange",
+            "dairy:options",
+            Map.of("cheese", "gouda"));
+    assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
+  }
+
+  @Test
+  void specialExtensionCapabilitiesAreIgnoredForMatching() {
+    Capabilities stereotype =
+      new ImmutableCapabilities(
+        CapabilityType.BROWSER_NAME,
+        "chrome",
+        CapabilityType.BROWSER_VERSION,
+        "84",
+        CapabilityType.PLATFORM_NAME,
+        Platform.WINDOWS,
+        "food:loggingPrefs",
+        "mango",
+        "food:debuggerAddress",
+        Map.of("cheese", "amsterdam"));
+
+    Capabilities capabilities =
+      new ImmutableCapabilities(
+        CapabilityType.BROWSER_NAME,
+        "chrome",
+        CapabilityType.BROWSER_VERSION,
+        "84",
+        CapabilityType.PLATFORM_NAME,
+        Platform.WINDOWS,
+        "food:loggingPrefs",
+        "orange",
+        "food:debuggerAddress",
+        Map.of("cheese", "gouda"));
     assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
   }
 

--- a/java/test/org/openqa/selenium/grid/node/config/NodeOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/NodeOptionsTest.java
@@ -63,6 +63,7 @@ import org.openqa.selenium.ie.InternetExplorerDriverInfo;
 import org.openqa.selenium.internal.Either;
 import org.openqa.selenium.json.Json;
 import org.openqa.selenium.net.NetworkUtils;
+import org.openqa.selenium.remote.Browser;
 import org.openqa.selenium.safari.SafariDriverInfo;
 
 @SuppressWarnings("DuplicatedCode")
@@ -148,7 +149,10 @@ class NodeOptionsTest {
               reported.add(caps);
               return Collections.singleton(HelperFactory.create(config, caps));
             });
-    String expected = driver.getDisplayName();
+    String expected =
+        "Edge".equals(driver.getDisplayName())
+            ? Browser.EDGE.browserName()
+            : driver.getDisplayName();
 
     Capabilities found =
         reported.stream()


### PR DESCRIPTION
### **User description**
### Description
The existing handling of extension capabilities assigns special significance to four recognized prefixes: `goog:`, `moz:`, `ms:`, and `se:`. Capabilities with these prefixes are entirely ignored by the current default slot matcher implementation, but custom prefixes are considered, as well as those for Safari and Appium. This inconsistency means that properties in extension capabilities can cause affected `newSession` requests to fail even though extension capabilities are supposed to be vendor-specific and should probably not be evaluated by the default slot matcher.

This PR retains the "special" status of the "se:" prefix and specifically filters out **all** extension capabilities with names that end with "options", "Options", "loggingPrefs", and "debuggerAddress". This maintains existing behavior while allowing node configurations and `newSession` requests to include extension capabilities that won't affect slot matching.

### Motivation and Context
Revolves #14461 

> Note that this is technically a breaking change, because it revises the default slot matcher to consider "special" extension capabilities without name suffix "options" that would previously have been ignored, and the matcher will now ignore "non-special" extension capabilities with name suffix "options" that would previously have been considered.
However, I'm unaware of any current use cases that will be adversely affected by this change.

The strategy employed by the PR is that extension capabilities which should be ignored for matching can be expressed as capabilities with name prefix "se:" or one of the "special" name suffixes. All other extension capabilities will be considered for slot matching. This is a generalization/extrapolation of existing patterns from current use cases.

### Recommended slot matcher enhancements

To reduce the need for custom slot matchers, we could extend the **WebDriverInfo** interface to add a new method that vendors could implement to evaluate their own criteria:

```
Boolean matches(Capabilities stereotype, Capabilities capabilities);
```

The default implementation would return `null` to indicate that no evaluation has been performed. If the vendor chooses to implement the `matches` method, their initial step must be to invoke their own `isSupporting` method, returning `null` if the corresponding driver doesn't support the specified capabilities. 

The implementation in **DefaultSlotMatcher** would be updated to iterate over the available **WebDriverInfo** providers, retaining only those whose `isSupporting` methods return `true`. The `matches` methods of this filtered list of providers will then be applied to the available nodes to determine which of these satisfies the criteria specified by the client request. The nodes that satisfy these evaluations (if any) would then be evaluated against the remaining common criteria.

Another potential enhancement would be to enable vendor-specific `matches` methods to return a weighted integer result instead of a simple `Boolean`. This would enable best-match behavior. Perhaps this is getting too complicated, though.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Removed the special status of certain extension capability prefixes in `DefaultSlotMatcher`, opting to ignore all extension capabilities with names ending in "options" (case-insensitive).
- Simplified the logic for matching capabilities by removing unnecessary checks and conditions.
- Updated `RelaySessionFactory` to streamline session creation by removing redundant capability filtering.
- Revised test cases in `DefaultSlotMatcherTest` to align with the new handling of extension capabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultSlotMatcher.java</strong><dd><code>Revise extension capabilities handling in DefaultSlotMatcher</code></dd></summary>
<hr>

java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java

<li>Removed special handling for specific extension capability prefixes.<br> <li> Updated logic to ignore all extension capabilities with names ending in "options" (case-insensitive). <li> Simplified capability matching logic.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14485/files#diff-08612f5a21ea03efdd38ead8885dd4b72be486ea76f0de8f0a4dce609f34af0d">+31/-51</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RelaySessionFactory.java</strong><dd><code>Simplify session creation in RelaySessionFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java

<li>Removed logic to filter out browserName when appium:app is present.<br> <li> Simplified session creation process.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14485/files#diff-8fe345d7ed627b58287d8a4c5d6813fae678894be658c5c87ffc3f9c862f62ab">+0/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultSlotMatcherTest.java</strong><dd><code>Update DefaultSlotMatcher tests for revised capability handling</code></dd></summary>
<hr>

java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java

<li>Updated test cases to reflect changes in extension capability <br>handling.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14485/files#diff-efbc947cb2db3c8fe94ef12f0e57d80901e86d3e3992611966b165c1e9543445">+10/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

