### PR TITLE
[bazel] Bump `rules_jvm_external` to 6.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 
 bazel_dep(name = "rules_dotnet", version = "0.15.1")
 bazel_dep(name = "rules_java", version = "7.6.3")
-bazel_dep(name = "rules_jvm_external", version = "6.1")
+bazel_dep(name = "rules_jvm_external", version = "6.3")
 bazel_dep(name = "rules_nodejs", version = "6.2.0")
 bazel_dep(name = "rules_oci", version = "1.7.6")
 bazel_dep(name = "rules_pkg", version = "0.10.1")


### PR DESCRIPTION
### **PR Type**
enhancement, dependencies


___

### **Description**
- Updated the Bazel dependency `rules_jvm_external` from version 6.1 to 6.3 to ensure compatibility and leverage improvements in the newer version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Update `rules_jvm_external` dependency to version 6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

- Updated the version of `rules_jvm_external` from 6.1 to 6.3.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14492/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

