### PR TITLE
[dotnet] Workaround using pre-processor directive

### DIFF
--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -67,6 +67,9 @@ csharp_library(
         "**/*.cs",
     ]) + devtools_version_targets(),
     out = "WebDriver",
+    defines = [
+        "NET8_0_OR_GREATER"
+    ],
     internals_visible_to = [
         "WebDriver.Common.Tests",
     ],
@@ -80,9 +83,6 @@ csharp_library(
     ],
     target_frameworks = [
         "net8.0",
-    ],
-    defines = [
-        "NET8_0_OR_GREATER"
     ],
     visibility = [
         "//dotnet:__subpackages__",
@@ -131,6 +131,9 @@ csharp_library(
         "**/*.cs",
     ]) + devtools_version_targets(),
     out = "WebDriver.StrongNamed",
+    defines = [
+        "NET8_0_OR_GREATER"
+    ],
     keyfile = "//dotnet:WebDriver.snk",
     langversion = "12.0",
     resources = [

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -68,7 +68,7 @@ csharp_library(
     ]) + devtools_version_targets(),
     out = "WebDriver",
     defines = [
-        "NET8_0_OR_GREATER"
+        "NET8_0_OR_GREATER",
     ],
     internals_visible_to = [
         "WebDriver.Common.Tests",
@@ -132,7 +132,7 @@ csharp_library(
     ]) + devtools_version_targets(),
     out = "WebDriver.StrongNamed",
     defines = [
-        "NET8_0_OR_GREATER"
+        "NET8_0_OR_GREATER",
     ],
     keyfile = "//dotnet:WebDriver.snk",
     langversion = "12.0",

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -81,6 +81,9 @@ csharp_library(
     target_frameworks = [
         "net8.0",
     ],
+    defines = [
+        "NET8_0_OR_GREATER"
+    ],
     visibility = [
         "//dotnet:__subpackages__",
     ],


### PR DESCRIPTION
### **User description**
### Description
Bazel understands `NET8_0`, but doesn't understand `NET8_0_OR_GREATER`.

### Motivation and Context
We want to use pre-processor directives.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added the `NET8_0_OR_GREATER` pre-processor directive in the Bazel build configuration to ensure compatibility with Bazel's understanding of .NET versioning.
- This change acts as a workaround for Bazel's limitation in recognizing `NET8_0_OR_GREATER`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add pre-processor directive for .NET version compatibility</code></dd></summary>
<hr>

dotnet/src/webdriver/BUILD.bazel

<li>Added <code>NET8_0_OR_GREATER</code> to the <code>defines</code> section.<br> <li> Ensures compatibility with Bazel's understanding of pre-processor <br>directives.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14499/files#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

