### PR TITLE
[js] Close CDP websocket connection on driver.quit

### DIFF
--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -784,6 +784,14 @@ class WebDriver {
       if (this.onQuit_) {
         return this.onQuit_.call(void 0)
       }
+
+      // Close the websocket connection on quit
+      // If the websocket connection is not closed,
+      // and we are running CDP sessions against the Selenium Grid,
+      // the node process never exits since the websocket connection is open until the Grid is shutdown.
+      if (this._wsConnection !== undefined) {
+        this._wsConnection.close()
+      }
     })
   }
 


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
When running the CDP tests against the Selenium Grid, the Node process does not stop because the CDP websocket connection is open. The Node process stops if the Selenium Grid is shut down and that causes the websocket connection to close. Ideally, we should be closing the websocket connection when we close the session. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Added logic to close the CDP websocket connection when `driver.quit` is called.
- Prevents the Node.js process from hanging by ensuring the websocket connection is closed, especially when running CDP sessions against Selenium Grid.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.js</strong><dd><code>Ensure websocket connection is closed on driver quit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/node/selenium-webdriver/lib/webdriver.js

<li>Added logic to close the websocket connection on <code>driver.quit</code>.<br> <li> Prevents node process from hanging when running CDP sessions against <br>Selenium Grid.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14501/files#diff-4530acbaed1fe859529c5e9d4020af22cace559c3a0561fb139c23c68939bb16">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

