### PR TITLE
[dotnet] Don't include http headers in internal logs

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -418,7 +418,11 @@ namespace OpenQA.Selenium.Remote
                 var responseTask = base.SendAsync(request, cancellationToken);
 
                 StringBuilder requestLogMessageBuilder = new();
-                requestLogMessageBuilder.AppendFormat(">> {0} RequestUri: {1}, Content: {2}, Headers: {3}", request.Method, request.RequestUri, request.Content, request.Headers?.Count());
+                requestLogMessageBuilder.AppendFormat(">> {0} RequestUri: {1}, Content: {2}, Headers: {3}", 
+                    request.Method, 
+                    request.RequestUri?.ToString() ?? "null", 
+                    request.Content?.ToString() ?? "null", 
+                    request.Headers?.Count());
 
                 if (request.Content != null)
                 {

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -21,6 +21,7 @@ using OpenQA.Selenium.Internal.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -417,7 +418,7 @@ namespace OpenQA.Selenium.Remote
                 var responseTask = base.SendAsync(request, cancellationToken);
 
                 StringBuilder requestLogMessageBuilder = new();
-                requestLogMessageBuilder.AppendFormat(">> {0}", request);
+                requestLogMessageBuilder.AppendFormat(">> {0} RequestUri: {1}, Content: {2}, Headers: {3}", request.Method, request.RequestUri, request.Content, request.Headers?.Count());
 
                 if (request.Content != null)
                 {
@@ -430,7 +431,7 @@ namespace OpenQA.Selenium.Remote
                 var response = await responseTask.ConfigureAwait(false);
 
                 StringBuilder responseLogMessageBuilder = new();
-                responseLogMessageBuilder.AppendFormat("<< {0}", response);
+                responseLogMessageBuilder.AppendFormat("<< StatusCodde: {0}, ReasonPhrase: {1}, Content: {2}, Headers: {3}", (int)response.StatusCode, response.ReasonPhrase, response.Content, response.Headers?.Count());
 
                 if (!response.IsSuccessStatusCode && response.Content != null)
                 {

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -431,7 +431,7 @@ namespace OpenQA.Selenium.Remote
                 var response = await responseTask.ConfigureAwait(false);
 
                 StringBuilder responseLogMessageBuilder = new();
-                responseLogMessageBuilder.AppendFormat("<< StatusCodde: {0}, ReasonPhrase: {1}, Content: {2}, Headers: {3}", (int)response.StatusCode, response.ReasonPhrase, response.Content, response.Headers?.Count());
+                responseLogMessageBuilder.AppendFormat("<< StatusCode: {0}, ReasonPhrase: {1}, Content: {2}, Headers: {3}", (int)response.StatusCode, response.ReasonPhrase, response.Content, response.Headers?.Count());
 
                 if (!response.IsSuccessStatusCode && response.Content != null)
                 {


### PR DESCRIPTION
### **User description**
### Description
Before:
```
    22:28:10.657 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: get {"url":"http://localhost:63133/common/temp/page13039830558350188602.html"}
22:28:10.659 TRACE HttpCommandExecutor: >> Method: POST, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/url', Version: 1.1, Content: System.Net.Http.ByteArrayContent, Headers:
{
  Accept: application/json; charset=utf-8
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Content-Type: application/json; charset=utf-8
  Content-Length: 74
}
{"url":"http://localhost:63133/common/temp/page13039830558350188602.html"}
22:28:10.720 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 14
  Content-Type: application/json; charset=utf-8
}
22:28:10.720 DEBUG HttpCommandExecutor: Response: ( Success: )
22:28:10.731 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: findElement {"using":"css selector","value":"#alert"}
22:28:10.732 TRACE HttpCommandExecutor: >> Method: POST, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/element', Version: 1.1, Content: System.Net.Http.ByteArrayContent, Headers:
{
  Accept: application/json; charset=utf-8
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Content-Type: application/json; charset=utf-8
  Content-Length: 41
}
{"using":"css selector","value":"#alert"}
22:28:10.745 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 125
  Content-Type: application/json; charset=utf-8
}
22:28:10.745 DEBUG HttpCommandExecutor: Response: ( Success: System.Collections.Generic.Dictionary`2[System.String,System.Object])
22:28:10.747 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: clickElement {"id":"f.F6B893528C9CA515BB4C7B4302BDC6DD.d.C5E9C8115018CF29FB46019A427AFCE0.e.2"}
22:28:10.747 TRACE HttpCommandExecutor: >> Method: POST, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/element/f.F6B893528C9CA515BB4C7B4302BDC6DD.d.C5E9C8115018CF29FB46019A427AFCE0.e.2/click', Version: 1.1, Content: System.Net.Http.ByteArrayContent, Headers:
{
  Accept: application/json; charset=utf-8
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Content-Type: application/json; charset=utf-8
  Content-Length: 2
}
{}
22:28:10.792 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 14
  Content-Type: application/json; charset=utf-8
}
22:28:10.793 DEBUG HttpCommandExecutor: Response: ( Success: )
22:28:10.794 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: getAlertText {}
22:28:10.794 TRACE HttpCommandExecutor: >> Method: GET, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/alert/text', Version: 1.1, Content: <null>, Headers:
{
  Cache-Control: no-cache
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Accept: application/json
  Accept: image/png
}
22:28:10.794 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 18
  Content-Type: application/json; charset=utf-8
}
22:28:10.801 DEBUG HttpCommandExecutor: Response: ( Success: cheese)
22:28:10.801 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: dismissAlert {}
22:28:10.802 TRACE HttpCommandExecutor: >> Method: POST, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/alert/dismiss', Version: 1.1, Content: System.Net.Http.ByteArrayContent, Headers:
{
  Accept: application/json; charset=utf-8
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Content-Type: application/json; charset=utf-8
  Content-Length: 2
}
{}
22:28:10.804 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 14
  Content-Type: application/json; charset=utf-8
}
22:28:10.804 DEBUG HttpCommandExecutor: Response: ( Success: )
22:28:10.812 DEBUG HttpCommandExecutor: Executing command: [1e74cb76431bed9eb5231b6fa0e06456]: getAlertText {}
22:28:10.812 TRACE HttpCommandExecutor: >> Method: GET, RequestUri: 'http://localhost:63135/session/1e74cb76431bed9eb5231b6fa0e06456/alert/text', Version: 1.1, Content: <null>, Headers:
{
  Cache-Control: no-cache
  User-Agent: selenium/4.0.0+7d1d0e09fe91ec4b38926b12167fa5ce0007e289
  User-Agent: (.net windows)
  Accept: application/json
  Accept: image/png
}
22:28:10.813 TRACE HttpCommandExecutor: << StatusCode: 404, ReasonPhrase: 'Not Found', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Cache-Control: no-cache
  Content-Length: 961
  Content-Type: application/json; charset=utf-8
}
{"value":{"error":"no such alert","message":"no such alert\n  (Session info: chrome=129.0.6668.60)","stacktrace":"\tGetHandleVerifier [0x00007FF77662B125+29573]\n\t(No symbol) [0x00007FF77659FF50]\n\t(No symbol) [0x00007FF77645B519]\n\t(No symbol) [0x00007FF7764463A4]\n\t(No symbol) [0x00007FF77646EB81]\n\t(No symbol) [0x00007FF77647FEA7]\n\t(No symbol) [0x00007FF7764D73AD]\n\t(No symbol) [0x00007FF77647FD25]\n\t(No symbol) [0x00007FF7764D70A3]\n\t(No symbol) [0x00007FF7764A12DF]\n\t(No symbol) [0x00007FF7764A2441]\n\tGetHandleVerifier [0x00007FF77695C76D+3377613]\n\tGetHandleVerifier [0x00007FF7769A7B67+3685831]\n\tGetHandleVerifier [0x00007FF77699CF8B+3641835]\n\tGetHandleVerifier [0x00007FF7766EB2A6+816390]\n\t(No symbol) [0x00007FF7765AB25F]\n\t(No symbol) [0x00007FF7765A7084]\n\t(No symbol) [0x00007FF7765A7220]\n\t(No symbol) [0x00007FF77659607F]\n\tBaseThreadInitThunk [0x00007FF83964257D+29]\n\tRtlUserThreadStart [0x00007FF83AC8AF28+40]\n"}}
22:28:10.815 DEBUG HttpCommandExecutor: Response: ( NoAlertPresent: System.Collections.Generic.Dictionary`2[System.String,System.Object])
```

After:
``
    22:25:36.208 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: get {"url":"http://localhost:63043/common/temp/page4449485843760331092.html"}
22:25:36.210 TRACE HttpCommandExecutor: >> POST RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/url, Content: System.Net.Http.ByteArrayContent, Headers: 2
{"url":"http://localhost:63043/common/temp/page4449485843760331092.html"}
22:25:36.256 TRACE HttpCommandExecutor: << StatusCodde: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
22:25:36.256 DEBUG HttpCommandExecutor: Response: ( Success: )
22:25:36.266 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: findElement {"using":"css selector","value":"#alert"}
22:25:36.267 TRACE HttpCommandExecutor: >> POST RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/element, Content: System.Net.Http.ByteArrayContent, Headers: 2
{"using":"css selector","value":"#alert"}
22:25:36.303 TRACE HttpCommandExecutor: << StatusCodde: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
22:25:36.303 DEBUG HttpCommandExecutor: Response: ( Success: System.Collections.Generic.Dictionary`2[System.String,System.Object])
22:25:36.304 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: clickElement {"id":"f.E17E54A357AA49FBDFA2B6AEB0509871.d.F26ABC8BFDB71F13D70157ABA1E035D5.e.2"}
22:25:36.305 TRACE HttpCommandExecutor: >> POST RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/element/f.E17E54A357AA49FBDFA2B6AEB0509871.d.F26ABC8BFDB71F13D70157ABA1E035D5.e.2/click, Content: System.Net.Http.ByteArrayContent, Headers: 2
{}
22:25:36.372 TRACE HttpCommandExecutor: << StatusCodde: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
22:25:36.373 DEBUG HttpCommandExecutor: Response: ( Success: )
22:25:36.374 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: getAlertText {}
22:25:36.377 TRACE HttpCommandExecutor: >> GET RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/alert/text, Content: , Headers: 3
22:25:36.382 TRACE HttpCommandExecutor: << StatusCodde: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
22:25:36.393 DEBUG HttpCommandExecutor: Response: ( Success: cheese)
22:25:36.393 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: dismissAlert {}
22:25:36.393 TRACE HttpCommandExecutor: >> POST RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/alert/dismiss, Content: System.Net.Http.ByteArrayContent, Headers: 2
{}
22:25:36.396 TRACE HttpCommandExecutor: << StatusCodde: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
22:25:36.396 DEBUG HttpCommandExecutor: Response: ( Success: )
22:25:36.405 DEBUG HttpCommandExecutor: Executing command: [b3982ee404c0e5616649ac25dd1d79bc]: getAlertText {}
22:25:36.406 TRACE HttpCommandExecutor: >> GET RequestUri: http://localhost:63045/session/b3982ee404c0e5616649ac25dd1d79bc/alert/text, Content: , Headers: 3
22:25:36.408 TRACE HttpCommandExecutor: << StatusCodde: 404, ReasonPhrase: Not Found, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
{"value":{"error":"no such alert","message":"no such alert\n  (Session info: chrome=129.0.6668.60)","stacktrace":"\tGetHandleVerifier [0x00007FF77662B125+29573]\n\t(No symbol) [0x00007FF77659FF50]\n\t(No symbol) [0x00007FF77645B519]\n\t(No symbol) [0x00007FF7764463A4]\n\t(No symbol) [0x00007FF77646EB81]\n\t(No symbol) [0x00007FF77647FEA7]\n\t(No symbol) [0x00007FF7764D73AD]\n\t(No symbol) [0x00007FF77647FD25]\n\t(No symbol) [0x00007FF7764D70A3]\n\t(No symbol) [0x00007FF7764A12DF]\n\t(No symbol) [0x00007FF7764A2441]\n\tGetHandleVerifier [0x00007FF77695C76D+3377613]\n\tGetHandleVerifier [0x00007FF7769A7B67+3685831]\n\tGetHandleVerifier [0x00007FF77699CF8B+3641835]\n\tGetHandleVerifier [0x00007FF7766EB2A6+816390]\n\t(No symbol) [0x00007FF7765AB25F]\n\t(No symbol) [0x00007FF7765A7084]\n\t(No symbol) [0x00007FF7765A7220]\n\t(No symbol) [0x00007FF77659607F]\n\tBaseThreadInitThunk [0x00007FF83964257D+29]\n\tRtlUserThreadStart [0x00007FF83AC8AF28+40]\n"}}
22:25:36.413 DEBUG HttpCommandExecutor: Response: ( NoAlertPresent: System.Collections.Generic.Dictionary`2[System.String,System.Object])`
``

### Motivation and Context
Simplify internal logs reading. It is better when considering security aspects when auth token is sent via http header.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the logging mechanism in `HttpCommandExecutor` to exclude detailed HTTP headers from internal logs.
- Updated the log format to include the count of headers instead of their full details, reducing verbosity.
- Improved clarity of log messages by specifying key request and response attributes such as `RequestUri`, `Content`, and `StatusCode`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpCommandExecutor.cs</strong><dd><code>Simplify HTTP request and response logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/HttpCommandExecutor.cs

<li>Modified logging format for HTTP requests and responses.<br> <li> Removed detailed HTTP headers from internal logs.<br> <li> Added count of headers instead of full header details.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14546/files#diff-7e90084c9f3e8c994cbbfabdbc93ecd024159b65ca59d9f6efc53cace50e7b10">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information