### PR TITLE
[dotnet] Don't write trace log message when waiting until driver service is initialized

### DIFF
--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -16,7 +16,6 @@
 // limitations under the License.
 // </copyright>
 
-using OpenQA.Selenium.Internal.Logging;
 using OpenQA.Selenium.Remote;
 using System;
 using System.Diagnostics;
@@ -42,7 +41,6 @@ namespace OpenQA.Selenium
         private bool isDisposed;
         private Process driverServiceProcess;
         private TimeSpan initializationTimeout = TimeSpan.FromSeconds(20);
-        private readonly static ILogger logger = Log.GetLogger<DriverService>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DriverService"/> class.
@@ -238,10 +236,7 @@ namespace OpenQA.Selenium
                 }
                 catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
                 {
-                    if (logger.IsEnabled(LogEventLevel.Trace))
-                    {
-                        logger.Trace(ex.ToString());
-                    }
+                    // do noothing: the exception is expected, meaning driver service is not initialized
                 }
 
                 return isInitialized;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -236,7 +236,7 @@ namespace OpenQA.Selenium
                 }
                 catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
                 {
-                    // do noothing: the exception is expected, meaning driver service is not initialized
+                    // do nothing: the exception is expected, meaning driver service is not initialized
                 }
 
                 return isInitialized;


### PR DESCRIPTION
### **User description**
On CI execution we see a lot of exceptions logged to output. Given that timeout is 5 seconds only, it is good just to suppress these exceptions even in internal logs.

### Motivation and Context
In internal logs output we see:

```
Starting ChromeDriver 129.0.6668.89 (951c0b97221f8d4ba37cf97d324505c832251cf9-refs/branch-heads/6668@{#1503}) on port 33711
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully on port 33711.
=> OpenQA.Selenium.DevTools.DevToolsNetworkTest
14:07:49.693 TRACE DriverService: System.Net.Http.HttpRequestException: Connection refused (localhost:33711)
 ---> System.Net.Sockets.SocketException (111): Connection refused
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
   at System.Net.Sockets.Socket.<ConnectAsync>g__WaitForConnectWithCancellation|285_0(AwaitableSocketAsyncEventArgs saea, ValueTask connectTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at OpenQA.Selenium.DriverService.<>c__DisplayClass51_1.<<get_IsInitialized>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at OpenQA.Selenium.DriverService.get_IsInitialized()
14:07:49.759 DEBUG HttpCommandExecutor: Executing command: []: newSession {"capabilities":{"firstMatch":[{"browserName":"chrome","browserVersion":"129","goog:chromeOptions":{"args":["--no-sandbox","--disable-dev-shm-usage"],"binary":"external/_main~pin_browsers_extension~linux_chrome/chrome-linux64/chrome"}}]}}
14:07:49.770 TRACE HttpCommandExecutor: >> POST RequestUri: http://localhost:33711/session, Content: System.Net.Http.ByteArrayContent, Headers: 2
{"capabilities":{"firstMatch":[{"browserName":"chrome","browserVersion":"129","goog:chromeOptions":{"args":["--no-sandbox","--disable-dev-shm-usage"],"binary":"external/_main~pin_browsers_extension~linux_chrome/chrome-linux64/chrome"}}]}}
14:07:50.644 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
14:07:50.654 DEBUG HttpCommandExecutor: Response: (8595a7fcc69f3c9a13e891be7132dbe1 Success: System.Collections.Generic.Dictionary`2[System.String,System.Object])
=> OpenQA.Selenium.DevTools.DevToolsNetworkTest.ByPassServiceWorker
14:07:51.017 DEBUG HttpCommandExecutor: Executing command: [8595a7fcc69f3c9a13e891be7132dbe1]: quit {}
14:07:51.018 TRACE HttpCommandExecutor: >> DELETE RequestUri: http://localhost:33711/session/8595a7fcc69f3c9a13e891be7132dbe1, Content: null, Headers: 2
14:07:51.071 TRACE HttpCommandExecutor: << StatusCode: 200, ReasonPhrase: OK, Content: System.Net.Http.HttpConnectionResponseContent, Headers: 1
14:07:51.071 DEBUG HttpCommandExecutor: Response: ( Success: )
=> OpenQA.Selenium.DevTools.DevToolsNetworkTest.EmulateNetworkConditionOffline
14:07:51.105 TRACE DriverService: System.Net.Http.HttpRequestException: Connection refused (localhost:44883)
 ---> System.Net.Sockets.SocketException (111): Connection refused
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
   at System.Net.Sockets.Socket.<ConnectAsync>g__WaitForConnectWithCancellation|285_0(AwaitableSocketAsyncEventArgs saea, ValueTask connectTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at OpenQA.Selenium.DriverService.<>c__DisplayClass51_1.<<get_IsInitialized>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at OpenQA.Selenium.DriverService.get_IsInitialized()
14:07:51.108 TRACE DriverService: System.Net.Http.HttpRequestException: Connection refused (localhost:44883)
 ---> System.Net.Sockets.SocketException (111): Connection refused
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
   at System.Net.Sockets.Socket.<ConnectAsync>g__WaitForConnectWithCancellation|285_0(AwaitableSocketAsyncEventArgs saea, ValueTask connectTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at OpenQA.Selenium.DriverService.<>c__DisplayClass51_1.<<get_IsInitialized>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at OpenQA.Selenium.DriverService.get_IsInitialized()
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Removed trace logging of exceptions when waiting for the driver service to initialize, reducing unnecessary log output.
- Deleted the logger initialization and the condition checking if trace logging is enabled.
- Added a comment to clarify that exceptions during initialization are expected and should not be logged.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverService.cs</strong><dd><code>Suppress trace logging for driver service initialization exceptions</code></dd></summary>
<hr>

dotnet/src/webdriver/DriverService.cs

<li>Removed trace logging for exceptions during driver service <br>initialization.<br> <li> Deleted the logger initialization and trace log condition.<br> <li> Improved code clarity by commenting on the expected nature of <br>exceptions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14557/files#diff-c38089621d41671b4719164b262303e275d4a4a442125fd9d4ea61eeca855c2b">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information