### PR TITLE
[py] Avoid waiting indefinitely on a frozen chromedriver process

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -305,7 +305,7 @@ class RemoteConnection:
         LOGGER.debug("%s %s %s", command_info[0], url, str(trimmed))
         return self._request(command_info[0], url, body=data)
 
-    def _request(self, method, url, body=None):
+    def _request(self, method, url, body=None, timeout=120):
         """Send an HTTP request to the remote server.
 
         :Args:
@@ -323,12 +323,12 @@ class RemoteConnection:
             body = None
 
         if self.keep_alive:
-            response = self._conn.request(method, url, body=body, headers=headers)
+            response = self._conn.request(method, url, body=body, headers=headers, timeout=timeout)
             statuscode = response.status
         else:
             conn = self._get_connection_manager()
             with conn as http:
-                response = http.request(method, url, body=body, headers=headers)
+                response = http.request(method, url, body=body, headers=headers, timeout=timeout)
             statuscode = response.status
         data = response.data.decode("UTF-8")
         LOGGER.debug("Remote response: status=%s | data=%s | headers=%s", response.status, data, response.headers)


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


### Description
By default requests.request waits indefinitely until it gets a response. This is unfortunate if the chromedriver process froze for some reason. 
This PR adds a default timeout of two minutes to those requests.

### Motivation and Context
Fixes waiting indefinitely because of a frozen chromedriver process.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


___

### **PR Type**
Bug fix


___

### **Description**
- Added a default timeout of 2 minutes to HTTP requests in the `remote_connection.py` to prevent indefinite waiting due to a frozen chromedriver process.
- Updated the `_request` method to accept a `timeout` parameter and applied it to HTTP requests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Add timeout parameter to HTTP requests in remote connection</code></dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<li>Added a <code>timeout</code> parameter with a default value of 120 seconds to the <br><code>_request</code> method.<br> <li> Updated HTTP request calls to include the <code>timeout</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14578/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information