### PR TITLE
[grid]: Capabilities prefix starts with se:slotMatcher for DefaultSlotMatcher decision

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
+++ b/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
@@ -50,6 +50,7 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
   */
   private static final List<String> EXTENSION_CAPABILITIES_PREFIXES =
       Arrays.asList("goog:", "moz:", "ms:", "se:");
+  private static final String SLOT_MATCHER_PREFIX = "se:slotMatcher";
 
   @Override
   public boolean matches(Capabilities stereotype, Capabilities capabilities) {
@@ -71,6 +72,10 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
     }
 
     if (!extensionCapabilitiesMatch(stereotype, capabilities)) {
+      return false;
+    }
+
+    if (!extensionCapabilitiesMatch(stereotype, capabilities, SLOT_MATCHER_PREFIX, false)) {
       return false;
     }
 
@@ -150,10 +155,21 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
      EXTENSION_CAPABILITIES_PREFIXES items. Also, we match them only when the capabilities
      of the new session request contains that specific extension capability.
     */
+    return extensionCapabilitiesMatch(stereotype, capabilities, ":", true);
+  }
+
+  private Boolean extensionCapabilitiesMatch(
+      Capabilities stereotype,
+      Capabilities capabilities,
+      String nameContains,
+      boolean excludeExtensionPrefixes) {
     return stereotype.getCapabilityNames().stream()
-        .filter(name -> name.contains(":"))
+        .filter(name -> name.contains(nameContains))
         .filter(name -> capabilities.asMap().containsKey(name))
-        .filter(name -> EXTENSION_CAPABILITIES_PREFIXES.stream().noneMatch(name::contains))
+        .filter(
+            name ->
+                !excludeExtensionPrefixes
+                    || EXTENSION_CAPABILITIES_PREFIXES.stream().noneMatch(name::contains))
         .map(
             name -> {
               if (capabilities.getCapability(name) instanceof String) {

--- a/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
+++ b/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
@@ -161,6 +161,35 @@ class DefaultSlotMatcherTest {
   }
 
   @Test
+  void prefixedSlotMatcherDoesNotMatch() {
+    Capabilities stereotype =
+        new ImmutableCapabilities(
+            CapabilityType.BROWSER_NAME,
+            "chrome",
+            CapabilityType.BROWSER_VERSION,
+            "80",
+            CapabilityType.PLATFORM_NAME,
+            Platform.WINDOWS,
+            "se:slotMatcher_version",
+            "cust4",
+            "se:slotMatcherAppName",
+            "myApp");
+    Capabilities capabilities =
+        new ImmutableCapabilities(
+            CapabilityType.BROWSER_NAME,
+            "chrome",
+            CapabilityType.BROWSER_VERSION,
+            "80",
+            CapabilityType.PLATFORM_NAME,
+            Platform.WINDOWS,
+            "se:slotMatcher_version",
+            "dev4",
+            "se:slotMatcherAppName",
+            "myApp");
+    assertThat(slotMatcher.matches(stereotype, capabilities)).isFalse();
+  }
+
+  @Test
   void matchesWhenPrefixedPlatformVersionIsNotRequested() {
     Capabilities stereotype =
         new ImmutableCapabilities(


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fixes #14576
Grid supports [Setting custom capabilities for matching specific Nodes](https://www.selenium.dev/documentation/grid/configuration/toml_options/#setting-custom-capabilities-for-matching-specific-nodes).
However, recently, this feat hasn't worked anymore. It could be due to a few capabilities (e.g: `networkname:applicationName`, `nodename:applicationName`) getting filtered (not meeting standards or something else) before coming to DefaultSlotMatcher.
Via a fix recently #14323. All caps that start with the prefix `se:` are retained in the session response.
Cap name contains `se:` is generic for many purposes, and those are also excluded in slot matcher decision as current implementation.
So, to make the feat custom caps for matching specific Nodes works, we will dedicate a prefix `se:slotMatcher`, for any cap name starts with this prefix will be used in DefaultSlotMatcher decision.
Also, it could be similar to #14323, adding an end-to-end test for this is tricky.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
