### PR TITLE
[grid]: Capability se:vncEnabled value based on list of vnc-env-var

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeFlags.java
@@ -30,7 +30,7 @@ import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_REGISTER_
 import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_REGISTER_PERIOD;
 import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_SESSION_TIMEOUT;
 import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_USE_SELENIUM_MANAGER;
-import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_VNC_ENV_VAR;
+import static org.openqa.selenium.grid.node.config.NodeOptions.DEFAULT_VNC_ENV_VARS;
 import static org.openqa.selenium.grid.node.config.NodeOptions.NODE_SECTION;
 import static org.openqa.selenium.grid.node.config.NodeOptions.OVERRIDE_MAX_SESSIONS;
 
@@ -202,8 +202,11 @@ public class NodeFlags implements HasRoles {
       description =
           "Environment variable to check in order to determine if a vnc stream is "
               + "available or not.")
-  @ConfigValue(section = NODE_SECTION, name = "vnc-env-var", example = "SE_START_XVFB")
-  public String vncEnvVar = DEFAULT_VNC_ENV_VAR;
+  @ConfigValue(
+      section = NODE_SECTION,
+      name = "vnc-env-var",
+      example = "[\"SE_START_XVFB\", \"SE_START_VNC\", \"SE_START_NO_VNC\"]")
+  public List<String> vncEnvVar = DEFAULT_VNC_ENV_VARS;
 
   @Parameter(
       names = "--no-vnc-port",


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/2373
In docker-selenium, there are 3 env vars, and its dependency is AND logic - https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeBase/start-novnc.sh
For example noVNC can be started only when `SE_START_XVFB=true` && `SE_START_VNC=true`

In above scenario, when SE_START_XVFB=true, SE_START_VNC=false, SE_START_NO_VNC=false, in Node stereotype could be seen cap `"se:noVncPort":7900,"se:vncEnabled":true`
Due to current implementation only check env var `SE_START_XVFB` is true

Expand the checks based on the combination of list env vars - align with docker-selenium implementation.
On Grid UI, it will prevent the case that the video preview icon is visible even vnc & noVNC not really enabled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the handling of VNC environment variables by allowing a list of variables to be specified, aligning with docker-selenium implementation.
- Updated the `isVncEnabled` method to check all specified environment variables, ensuring all must be true for VNC to be enabled.
- Added comprehensive tests to verify the new behavior with both multiple and single environment variables.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NodeFlags.java</strong><dd><code>Update VNC environment variable handling to support lists</code></dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/config/NodeFlags.java

<li>Changed <code>vnc-env-var</code> to accept a list of environment variables.<br> <li> Updated the example to show multiple environment variables.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14584/files#diff-33dd4982601ad783488b7633972c9c4cb1650d3b41ea53ed8bee3159649660be">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NodeOptions.java</strong><dd><code>Modify VNC environment variable logic to use lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/config/NodeOptions.java

<li>Modified default VNC environment variable to a list.<br> <li> Updated <code>isVncEnabled</code> method to check all environment variables.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14584/files#diff-6e8d739c2d4c51a731e66ed587b852c2788e19b8fd325b3c90fb0bad5e53e594">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NodeOptionsTest.java</strong><dd><code>Add tests for VNC environment variable list handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/node/config/NodeOptionsTest.java

<li>Added tests for VNC environment variable list handling.<br> <li> Verified behavior with multiple and single environment variables.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14584/files#diff-ea9c3f272f388de0c0ac5d0c0a06d66c5b195599b3d19af1994f859cb484d737">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information