### PR TITLE
[grid] UI Liveview disconnect noVNC websocket when closing dialog

### DIFF
--- a/javascript/grid-ui/src/components/LiveView/LiveView.tsx
+++ b/javascript/grid-ui/src/components/LiveView/LiveView.tsx
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useImperativeHandle, forwardRef } from 'react'
 import RFB from '@novnc/novnc/core/rfb'
 import PasswordDialog from './PasswordDialog'
 import MuiAlert, { AlertProps } from '@mui/material/Alert'
@@ -28,7 +28,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert (
   return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />
 })
 
-function LiveView (props) {
+const LiveView = forwardRef((props, ref) => {
   let canvas: any = null
 
   const [open, setOpen] = useState(false)
@@ -48,6 +48,10 @@ function LiveView (props) {
     rfb.disconnect()
     setRfb(null)
   }
+
+  useImperativeHandle(ref, () => ({
+    disconnect
+  }))
 
   const connect = () => {
     disconnect()
@@ -109,6 +113,7 @@ function LiveView (props) {
   }
 
   const handlePasswordDialogClose = () => {
+    disconnect()
     props.onClose()
   }
 
@@ -132,6 +137,7 @@ function LiveView (props) {
       return
     }
     setOpenErrorAlert(false)
+    disconnect()
     props.onClose()
   }
 
@@ -176,6 +182,6 @@ function LiveView (props) {
       </Snackbar>
     </div>
   )
-}
+})
 
 export default LiveView

--- a/javascript/grid-ui/src/components/RunningSessions/RunningSessions.tsx
+++ b/javascript/grid-ui/src/components/RunningSessions/RunningSessions.tsx
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
@@ -177,6 +177,14 @@ function RunningSessions (props) {
   const [rowsPerPage, setRowsPerPage] = useState(10)
   const [searchFilter, setSearchFilter] = useState('')
   const [searchBarHelpOpen, setSearchBarHelpOpen] = useState(false)
+  const liveViewRef = useRef(null)
+
+  const handleDialogClose = () => {
+    if (liveViewRef.current) {
+      liveViewRef.current.disconnect()
+    }
+    setRowLiveViewOpen('')
+  }
 
   const handleRequestSort = (event: React.MouseEvent<unknown>,
     property: keyof SessionData) => {
@@ -379,6 +387,7 @@ function RunningSessions (props) {
                                       sx={{ height: '600px' }}
                                     >
                                       <LiveView
+                                        ref={liveViewRef}
                                         url={row.vnc as string}
                                         scaleViewport
                                         onClose={() => setRowLiveViewOpen('')}
@@ -386,7 +395,7 @@ function RunningSessions (props) {
                                     </DialogContent>
                                     <DialogActions>
                                       <Button
-                                        onClick={() => setRowLiveViewOpen('')}
+                                        onClick={handleDialogClose}
                                         color='primary'
                                         variant='contained'
                                       >


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fixes #12358
When clicking Close button to close Liveview dialog of a session. noVNC websocket keeps transferring data in the background

Before
![vnc-close](https://github.com/user-attachments/assets/01fc7954-5a40-4674-a669-a2d83c0d2d26)

After
![vnc-close-fixed](https://github.com/user-attachments/assets/f358bfbe-81d2-47cb-a9c5-c2431a3cf1ef)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Added functionality to disconnect the noVNC WebSocket when the LiveView dialog is closed to prevent unnecessary data transfer.
- Utilized `useImperativeHandle` and `forwardRef` in `LiveView` component to expose the `disconnect` method.
- Updated `RunningSessions` component to use a reference to the `LiveView` component and ensure proper disconnection on dialog close.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LiveView.tsx</strong><dd><code>Implement WebSocket disconnection on dialog close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/grid-ui/src/components/LiveView/LiveView.tsx

<li>Added <code>useImperativeHandle</code> and <code>forwardRef</code> to manage component <br>references.<br> <li> Implemented a <code>disconnect</code> function to handle WebSocket disconnection.<br> <li> Ensured <code>disconnect</code> is called on dialog close and password dialog <br>close.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14598/files#diff-5d01e8caf6f391d6811a716c96d1910720c5d7e2bec82ffab567ce2cd5d28e4e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RunningSessions.tsx</strong><dd><code>Manage LiveView component reference for disconnection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/grid-ui/src/components/RunningSessions/RunningSessions.tsx

<li>Added <code>useRef</code> to manage <code>LiveView</code> component reference.<br> <li> Implemented <code>handleDialogClose</code> to ensure WebSocket disconnection.<br> <li> Updated dialog close button to use <code>handleDialogClose</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14598/files#diff-330405864af2744679a05343b53b57c0c57a6d50cbda3718cca8af326e726cb0">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information