### PR TITLE
[grid] Fix tests for Grid status endpoint and UI

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/NodeStatus.java
+++ b/java/src/org/openqa/selenium/grid/data/NodeStatus.java
@@ -214,7 +214,8 @@ public class NodeStatus {
     return Objects.equals(this.nodeId, that.nodeId)
         && Objects.equals(this.externalUri, that.externalUri)
         && this.maxSessionCount == that.maxSessionCount
-        && this.sessionTimeout == that.sessionTimeout
+        && this.sessionTimeout.compareTo(that.sessionTimeout) == 0
+        && this.heartbeatPeriod.compareTo(that.heartbeatPeriod) == 0
         && Objects.equals(this.slots, that.slots)
         && Objects.equals(this.availability, that.availability)
         && Objects.equals(this.version, that.version);

--- a/java/src/org/openqa/selenium/grid/router/GridStatusHandler.java
+++ b/java/src/org/openqa/selenium/grid/router/GridStatusHandler.java
@@ -135,7 +135,19 @@ class GridStatusHandler implements HttpHandler {
 
       List<Map<String, Object>> nodeResults =
           status.getNodes().stream()
-              .map(node -> new ImmutableMap.Builder<String, Object>().putAll(node.toJson()).build())
+              .map(
+                  node ->
+                      new ImmutableMap.Builder<String, Object>()
+                          .put("id", node.getNodeId())
+                          .put("uri", node.getExternalUri())
+                          .put("maxSessions", node.getMaxSessionCount())
+                          .put("sessionTimeout", node.getSessionTimeout().toMillis())
+                          .put("osInfo", node.getOsInfo())
+                          .put("heartbeatPeriod", node.getHeartbeatPeriod().toMillis())
+                          .put("availability", node.getAvailability())
+                          .put("version", node.getVersion())
+                          .put("slots", node.getSlots())
+                          .build())
               .collect(toList());
 
       ImmutableMap.Builder<String, Object> value = ImmutableMap.builder();

--- a/java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
@@ -103,6 +103,7 @@ class LocalDistributorTest {
             .add(caps, new TestSessionFactory((id, c) -> new Handler(c)))
             .maximumConcurrentSessions(2)
             .sessionTimeout(Duration.ofSeconds(30))
+            .heartbeatPeriod(Duration.ofSeconds(5))
             .build();
 
     wait =
@@ -145,6 +146,7 @@ class LocalDistributorTest {
     assertThat(distributorNode.getNodeId()).isEqualByComparingTo(localNode.getId());
     assertThat(distributorNode.getExternalUri()).isEqualTo(uri);
     assertThat(distributorNode.getSessionTimeout()).isEqualTo(Duration.ofSeconds(30));
+    assertThat(distributorNode.getHeartbeatPeriod()).isEqualTo(Duration.ofSeconds(5));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/grid/gridui/OverallGridTest.java
+++ b/java/test/org/openqa/selenium/grid/gridui/OverallGridTest.java
@@ -68,7 +68,7 @@ class OverallGridTest extends JupiterTestBase {
 
   @Test
   void shouldReportConcurrencyZeroPercentWhenGridIsStartedWithoutLoad() {
-    driver.get(whereIs(server, "/ui#/sessions"));
+    driver.get(whereIs(server, "/ui/#/sessions"));
 
     WebElement concurrency =
         wait.until(
@@ -79,7 +79,7 @@ class OverallGridTest extends JupiterTestBase {
 
   @Test
   void shouldShowOneNodeRegistered() {
-    driver.get(whereIs(server, "/ui"));
+    driver.get(whereIs(server, "/ui/"));
 
     List<WebElement> nodeInfoIcons =
         wait.until(
@@ -93,7 +93,7 @@ class OverallGridTest extends JupiterTestBase {
     WebDriver remoteWebDriver =
         new RemoteWebDriver(server.getUrl(), Browser.detect().getCapabilities());
     try {
-      driver.get(whereIs(server, "/ui#/sessions"));
+      driver.get(whereIs(server, "/ui/#/sessions"));
 
       wait.until(textToBe(By.cssSelector("div[data-testid='session-count']"), "1"));
     } finally {


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fix test CI - RBE

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the comparison logic in `NodeStatus` for `sessionTimeout` and `heartbeatPeriod` using `compareTo`.
- Enhanced `GridStatusHandler` to map node status with detailed attributes including `heartbeatPeriod` and `sessionTimeout` in milliseconds.
- Updated `LocalDistributorTest` to include `heartbeatPeriod` in node setup and assertions.
- Corrected UI paths in `OverallGridTest` to ensure proper navigation in test cases.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NodeStatus.java</strong><dd><code>Fix NodeStatus comparison logic for time durations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/data/NodeStatus.java

<li>Fixed comparison of <code>sessionTimeout</code> and <code>heartbeatPeriod</code> using <br><code>compareTo</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14605/files#diff-04bf71dc8f94e5e1e3620bb9b03ea6162519e7adefa5dbec7a420a5c88dfc1d8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OverallGridTest.java</strong><dd><code>Fix UI path in OverallGridTest for session and node checks</code></dd></summary>
<hr>

java/test/org/openqa/selenium/grid/gridui/OverallGridTest.java

- Corrected UI path in test cases for session and node registration.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14605/files#diff-68512a69c592cb91b23da59536fb65672276b64bf474d8e021d52526d65a0716">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GridStatusHandler.java</strong><dd><code>Enhance GridStatusHandler with detailed node attributes</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/router/GridStatusHandler.java

<li>Updated node status mapping to include detailed attributes.<br> <li> Added <code>heartbeatPeriod</code> and <code>sessionTimeout</code> in milliseconds.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14605/files#diff-93e80d00adc4680d45cd2a87730f14dc6ab5f9d40dd0440a3f3741c8ae1cb453">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributorTest.java</strong><dd><code>Update LocalDistributorTest to include heartbeat period</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java

- Added `heartbeatPeriod` to node setup and test assertions.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14605/files#diff-2b9b6b96ab14f541e617736c0d98d1d2904e13ddc2117e05177d580ab2141da2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information