### PR TITLE
[dotnet] Lazy-load Selenium manager binary location

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -229,12 +229,13 @@ namespace OpenQA.Selenium
     {
         public record LogEntryResponse(string Level, string Message);
 
-        public record ResultResponse(
-            [property: JsonPropertyName("driver_path")]
-            string DriverPath,
-            [property: JsonPropertyName("browser_path")]
-            string BrowserPath)
+        public record ResultResponse
         {
+            [JsonPropertyName("driver_path")]
+            public string? DriverPath { get; init; }
+
+            [JsonPropertyName("browser_path")]
+            public string? BrowserPath { get; init; }
         }
     }
 

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -229,13 +229,12 @@ namespace OpenQA.Selenium
     {
         public record LogEntryResponse(string Level, string Message);
 
-        public record ResultResponse(string DriverPath, string BrowserPath)
+        public record ResultResponse(
+            [property: JsonPropertyName("driver_path")]
+            string DriverPath,
+            [property: JsonPropertyName("browser_path")]
+            string BrowserPath)
         {
-            [JsonPropertyName("driver_path")]
-            public string DriverPath { get; } = DriverPath;
-
-            [JsonPropertyName("browser_path")]
-            public string BrowserPath { get; } = BrowserPath;
         }
     }
 

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -26,6 +26,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+#nullable enable
+
 namespace OpenQA.Selenium
 {
     /// <summary>
@@ -77,7 +79,7 @@ namespace OpenQA.Selenium
         /// <returns>
         /// An array with two entries, one for the driver path, and another one for the browser path.
         /// </returns>
-        public static Dictionary<string, string> BinaryPaths(string arguments)
+        public static Dictionary<string, string?> BinaryPaths(string arguments)
         {
             StringBuilder argsBuilder = new StringBuilder(arguments);
             argsBuilder.Append(" --language-binding csharp");
@@ -88,7 +90,7 @@ namespace OpenQA.Selenium
             }
 
             var smCommandResult = RunCommand(_lazyBinaryFullPath.Value, argsBuilder.ToString());
-            Dictionary<string, string> binaryPaths = new()
+            Dictionary<string, string?> binaryPaths = new()
             {
                 { "browser_path", smCommandResult.BrowserPath },
                 { "driver_path", smCommandResult.DriverPath }
@@ -182,7 +184,8 @@ namespace OpenQA.Selenium
 
             try
             {
-                jsonResponse = JsonSerializer.Deserialize<SeleniumManagerResponse>(output, _serializerOptions);
+                jsonResponse = JsonSerializer.Deserialize<SeleniumManagerResponse>(output, _serializerOptions)
+                    ?? throw new WebDriverException("SeleniumManagerResponse was null");
             }
             catch (Exception ex)
             {
@@ -217,36 +220,35 @@ namespace OpenQA.Selenium
                 }
             }
 
-            return jsonResponse.Result;
+            return jsonResponse.Result ?? throw new WebDriverException("Selenium manager response's Result was null");
         }
     }
 
     internal class SeleniumManagerResponse
     {
-        public IReadOnlyList<LogEntryResponse> Logs { get; set; }
+        public IReadOnlyList<LogEntryResponse>? Logs { get; set; }
 
-        public ResultResponse Result { get; set; }
+        public ResultResponse? Result { get; set; }
 
         public class LogEntryResponse
         {
-            public string Level { get; set; }
+            public string? Level { get; set; }
 
-            public string Message { get; set; }
+            public string? Message { get; set; }
         }
 
         public class ResultResponse
         {
             [JsonPropertyName("driver_path")]
-            public string DriverPath { get; set; }
+            public string? DriverPath { get; set; }
 
             [JsonPropertyName("browser_path")]
-            public string BrowserPath { get; set; }
+            public string? BrowserPath { get; set; }
         }
     }
 
     [JsonSerializable(typeof(SeleniumManagerResponse))]
     internal partial class SeleniumManagerSerializerContext : JsonSerializerContext
     {
-
     }
 }

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -232,10 +232,12 @@ namespace OpenQA.Selenium
         public record ResultResponse
         {
             [JsonPropertyName("driver_path")]
-            public string? DriverPath { get; init; }
+            [JsonRequired]
+            public string DriverPath { get; init; } = null!;
 
             [JsonPropertyName("browser_path")]
-            public string? BrowserPath { get; init; }
+            [JsonRequired]
+            public string BrowserPath { get; init; } = null!;
         }
     }
 

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -36,27 +36,28 @@ namespace OpenQA.Selenium
     {
         private static readonly ILogger _logger = Log.GetLogger(typeof(SeleniumManager));
 
-        private static readonly string BinaryFullPath = Environment.GetEnvironmentVariable("SE_MANAGER_PATH");
+        private static string? _binaryFullPath;
+        private static string BinaryFullPath => _binaryFullPath ??= GetBinaryFullPath();
 
         private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNameCaseInsensitive = true, TypeInfoResolver = SeleniumManagerSerializerContext.Default };
 
-        static SeleniumManager()
+        private static string GetBinaryFullPath()
         {
-
-            if (BinaryFullPath == null)
+            string? binaryFullPath = Environment.GetEnvironmentVariable("SE_MANAGER_PATH");
+            if (binaryFullPath == null)
             {
                 var currentDirectory = AppContext.BaseDirectory;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "windows", "selenium-manager.exe");
+                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "windows", "selenium-manager.exe");
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "linux", "selenium-manager");
+                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "linux", "selenium-manager");
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    BinaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "macos", "selenium-manager");
+                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "macos", "selenium-manager");
                 }
                 else
                 {
@@ -65,10 +66,11 @@ namespace OpenQA.Selenium
                 }
             }
 
-            if (!File.Exists(BinaryFullPath))
+            if (!File.Exists(binaryFullPath))
             {
-                throw new WebDriverException($"Unable to locate or obtain Selenium Manager binary at {BinaryFullPath}");
+                throw new WebDriverException($"Unable to locate or obtain Selenium Manager binary at {binaryFullPath}");
             }
+            return binaryFullPath;
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -196,7 +196,7 @@ namespace OpenQA.Selenium
             {
                 foreach (var entry in jsonResponse.Logs)
                 {
-                    switch (entry.Level)
+                    switch (entry?.Level)
                     {
                         case "WARN":
                             if (_logger.IsEnabled(LogEventLevel.Warn))
@@ -226,7 +226,7 @@ namespace OpenQA.Selenium
 
     internal class SeleniumManagerResponse
     {
-        public IReadOnlyList<LogEntryResponse>? Logs { get; set; }
+        public IReadOnlyList<LogEntryResponse?>? Logs { get; set; }
 
         public ResultResponse? Result { get; set; }
 


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The location of the selenium manager binary is calculated when it is first accessed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I ran into this while working on https://github.com/SeleniumHQ/selenium/issues/14480

It is considered bad practice for static constructors to throw exceptions. If an exception is throws, the type is rendered unusable for the rest of the application lifecycle. The stack-trace of the exception is also much harder to follow, and the debugging experience is worsened. The fact that it throws `TypeInitializationException` threw me off initially, because I was testing AOT at the time.

Exceptions are expected on this flow, in exceptional cases, they are even thrown directly. With this change, the Stack trace changes:

Before:
![image](https://github.com/user-attachments/assets/38219090-4afc-41bf-98bf-f3c97f0de9d8)

After:
![image](https://github.com/user-attachments/assets/295bd5e2-22a0-49c3-ba04-e449713d2933)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented lazy-loading for the Selenium Manager binary path to improve performance and avoid exceptions during static initialization.
- Replaced the static constructor with a method `GetBinaryFullPath` to determine the binary path dynamically.
- Enhanced error handling by providing more informative exception messages when the binary is not found or the platform is unsupported.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumManager.cs</strong><dd><code>Implement lazy-loading for Selenium Manager binary path</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/SeleniumManager.cs

<li>Introduced lazy-loading for the Selenium Manager binary path.<br> <li> Replaced static constructor with a method to determine binary path.<br> <li> Improved error handling for unsupported platforms.<br> <li> Enhanced exception messages for missing binaries.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14639/files#diff-df9a0140c4ef310382b15de2b26d228971d00530d18f4c1bd3c74f735c3af665">+11/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information