### PR TITLE
[ci][rb] Fix remote tests

### DIFF
--- a/rb/spec/integration/selenium/webdriver/remote/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/remote/driver_spec.rb
@@ -83,10 +83,12 @@ module Selenium
 
         it 'errors when not set', {except: {browser: :firefox, reason: 'grid always sets true and firefox returns it'},
                                    exclude: {browser: :safari, reason: 'grid hangs'}} do
-          expect {
-            driver.downloadable_files
-          }.to raise_exception(Error::WebDriverError,
-                               'You must enable downloads in order to work with downloadable files.')
+          reset_driver!(enable_downloads: false) do |driver|
+            expect {
+              driver.downloadable_files
+            }.to raise_exception(Error::WebDriverError,
+                                 'You must enable downloads in order to work with downloadable files.')
+          end
         end
 
         private


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description

It looks like an update for test fixture or something which enable downloads from the beginning, so the expectation in test not happen anymore.
Adding a step to reset the driver state with `enable_downloads: false` to get expect exception in test

```
  1) Selenium::WebDriver::Remote::Driver errors when not set
     Failure/Error:
       expect {
         driver.downloadable_files
       }.to raise_exception(Error::WebDriverError,
                            'You must enable downloads in order to work with downloadable files.')

       expected Selenium::WebDriver::Error::WebDriverError with "You must enable downloads in order to work with downloadable files.", got #<Selenium::WebDriver::Error::UnknownError: Cannot find downloads file system for session id: f94b5a8... os.arch: 'amd64', os.version: '10.0', java.version: '17.0.11'
       Driver info: driver.version: unknown> with backtrace:
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a test in `driver_spec.rb` by adding a step to reset the driver state with `enable_downloads: false`.
- Wrapped the expectation in a block to ensure the driver state is reset before checking for exceptions.
- Ensured the test correctly raises a `WebDriverError` when downloads are not enabled.



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver_spec.rb</strong><dd><code>Fix test by resetting driver state for download settings</code>&nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/remote/driver_spec.rb

<li>Added a step to reset the driver state with <code>enable_downloads: false</code>.<br> <li> Wrapped the expectation in a block to ensure the driver state is <br>reset.<br> <li> Ensured the test raises the correct exception when downloads are not <br>enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14679/files#diff-db47db156d4dc461f0c562cb6a62e35da297668eb11294f28c1484ae51e86453">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information