### PR TITLE
[ci] Fix pinned browsers fetch different msedgedriver version per OS

### DIFF
--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -165,8 +165,8 @@ js_library(
 
     http_archive(
         name = "linux_edgedriver",
-        url = "https://msedgedriver.azureedge.net/130.0.2849.56/edgedriver_linux64.zip",
-        sha256 = "c5aa82d87750a6f49b741790a432194ff91d0a232c54eb5507a526f45146f440",
+        url = "https://msedgedriver.azureedge.net/130.0.2849.46/edgedriver_linux64.zip",
+        sha256 = "6a62b28e9373776ae7d3f6611f5dd126c454d73264c2bb826659d3283da57f27",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -182,8 +182,8 @@ js_library(
 
     http_archive(
         name = "mac_edgedriver",
-        url = "https://msedgedriver.azureedge.net/130.0.2849.56/edgedriver_mac64.zip",
-        sha256 = "97141db0a53b22356094ff4d7a806a19ab816499366539e633a32fc4af8da2a3",
+        url = "https://msedgedriver.azureedge.net/130.0.2849.61/edgedriver_mac64.zip",
+        sha256 = "82e761138b112bd57950f6b873d601cd4b1e9c8403663c0ffaad8e5b167efc17",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -261,12 +261,15 @@ js_library(
 
 
 def edgedriver():
-    r = http.request("GET", "https://msedgedriver.azureedge.net/LATEST_STABLE")
-    v = r.data.decode("utf-16").strip()
+    r_stable = http.request("GET", "https://msedgedriver.azureedge.net/LATEST_STABLE")
+    stable_version = r_stable.data.decode("utf-16").strip()
+    major_version = stable_version.split('.')[0]
+    r = http.request("GET", f"https://msedgedriver.azureedge.net/LATEST_RELEASE_{major_version}_LINUX")
+    linux_version = r.data.decode("utf-16").strip()
 
     content = ""
 
-    linux = "https://msedgedriver.azureedge.net/%s/edgedriver_linux64.zip" % v
+    linux = "https://msedgedriver.azureedge.net/%s/edgedriver_linux64.zip" % linux_version
     sha = calculate_hash(linux)
     content = (
         content
@@ -291,7 +294,9 @@ js_library(
         % (linux, sha)
     )
 
-    mac = "https://msedgedriver.azureedge.net/%s/edgedriver_mac64.zip" % v
+    r = http.request("GET", f"https://msedgedriver.azureedge.net/LATEST_RELEASE_{major_version}_MACOS")
+    macos_version = r.data.decode("utf-16").strip()
+    mac = "https://msedgedriver.azureedge.net/%s/edgedriver_mac64.zip" % macos_version
     sha = calculate_hash(mac)
     content = (
         content


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Get stable version, then get major version number, and using API to fetch different versions might have per OS - following https://github.com/MicrosoftEdge/EdgeWebDriver/issues/39#issuecomment-1182478500

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Updated the EdgeDriver URLs and SHA256 checksums in `common/repositories.bzl` to reflect the latest versions for Linux and MacOS.
- Enhanced the `scripts/pinned_browsers.py` to fetch the major version of the stable EdgeDriver and use it to determine the specific version URLs for Linux and MacOS.
- Calculated and updated the SHA256 checksums for the new EdgeDriver URLs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.bzl</strong><dd><code>Update EdgeDriver URLs and SHA256 checksums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/repositories.bzl

<li>Updated the URL and SHA256 for the Linux EdgeDriver.<br> <li> Updated the URL and SHA256 for the Mac EdgeDriver.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14683/files#diff-25d82cd18102fed27d3202000e1f1b3a56a85ad2848236d91989cd30a3952401">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pinned_browsers.py</strong><dd><code>Fetch and use specific EdgeDriver versions per OS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/pinned_browsers.py

<li>Added logic to fetch the major version of the stable EdgeDriver.<br> <li> Updated URLs to fetch specific EdgeDriver versions for Linux and <br>MacOS.<br> <li> Calculated SHA256 for the new URLs.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14683/files#diff-9bc520a03e2388594f328bfa1305be5eebb75ae0ce2966be57e29b6ea6e0df78">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information