### PR TITLE
[dotnet] [bidi] Reveal browsing context module in bidi instance

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -39,7 +39,7 @@ public class BiDi : IAsyncDisposable
     }
 
     internal Modules.Session.SessionModule SessionModule => _sessionModule.Value;
-    internal Modules.BrowsingContext.BrowsingContextModule BrowsingContext => _browsingContextModule.Value;
+    public Modules.BrowsingContext.BrowsingContextModule BrowsingContext => _browsingContextModule.Value;
     public Modules.Browser.BrowserModule Browser => _browserModule.Value;
     public Modules.Network.NetworkModule Network => _networkModule.Value;
     internal Modules.Input.InputModule InputModule => _inputModule.Value;


### PR DESCRIPTION
### **User description**
### Description

This addresses the 2nd point from https://github.com/SeleniumHQ/selenium/issues/14530, I missed it eventually.

> Don't mimic `BiDi` instance as `BrowsingContext`

### Motivation and Context

Open door to API from `BrowsingContext` module, users will be able to:
```csharp
await bidi.BrowsingContext.CreateAsync(...);
```

Currently this API is hidden by mistake.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Exposed the `BrowsingContext` module in the `BiDi` class by changing its access modifier from `internal` to `public`.
- This change allows users to directly access the `BrowsingContext` module, aligning with the intended API design.
- Addresses the second point from the related ticket, improving the usability of the `BiDi` instance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDi.cs</strong><dd><code>Expose BrowsingContext Module in BiDi Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BiDi.cs

<li>Changed access modifier of <code>BrowsingContext</code> from <code>internal</code> to <code>public</code>.<br> <li> Exposed the <code>BrowsingContext</code> module to be publicly accessible.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14684/files#diff-3f77d71f94e2a47ea90b74f6d37b5a5b94dc83b2f558b30ab070588b9028c2f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information