### PR TITLE
[py] Add backward compatibility for AppiumConnection

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -136,6 +136,18 @@ class RemoteConnection:
     """
 
     browser_name = None
+    # Keep backward compatibility for AppiumConnection - https://github.com/SeleniumHQ/selenium/issues/14694
+    import os
+    import socket
+
+    import certifi
+
+    _timeout = (
+        float(os.getenv("GLOBAL_DEFAULT_TIMEOUT", str(socket.getdefaulttimeout())))
+        if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
+        else socket.getdefaulttimeout()
+    )
+    _ca_certs = os.getenv("REQUESTS_CA_BUNDLE") if "REQUESTS_CA_BUNDLE" in os.environ else certifi.where()
     _client_config: ClientConfig = None
 
     system = platform.system().lower()
@@ -296,6 +308,9 @@ class RemoteConnection:
             init_args_for_pool_manager=init_args_for_pool_manager,
         )
 
+        # Keep backward compatibility for AppiumConnection - https://github.com/SeleniumHQ/selenium/issues/14694
+        RemoteConnection._timeout = self._client_config.timeout
+        RemoteConnection._ca_certs = self._client_config.ca_certs
         RemoteConnection._client_config = self._client_config
 
         if remote_server_addr:

--- a/py/test/unit/selenium/webdriver/remote/remote_connection_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_connection_tests.py
@@ -307,6 +307,19 @@ def test_register_extra_headers(mock_request, remote_connection):
     assert headers["Foo"] == "bar"
 
 
+def test_backwards_compatibility_with_appium_connection():
+    # Keep backward compatibility for AppiumConnection - https://github.com/SeleniumHQ/selenium/issues/14694
+    client_config = ClientConfig(remote_server_addr="http://remote", ca_certs="/path/to/cacert.pem", timeout=300)
+    remote_connection = RemoteConnection(client_config=client_config)
+    assert remote_connection._ca_certs == "/path/to/cacert.pem"
+    assert remote_connection._timeout == 300
+    assert remote_connection._client_config == client_config
+    remote_connection.set_timeout(120)
+    assert remote_connection.get_timeout() == 120
+    remote_connection.set_certificate_bundle_path("/path/to/cacert2.pem")
+    assert remote_connection.get_certificate_bundle_path() == "/path/to/cacert2.pem"
+
+
 def test_get_connection_manager_with_timeout_from_client_config():
     remote_connection = RemoteConnection(remote_server_addr="http://remote", keep_alive=False)
     remote_connection.set_timeout(10)


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
- Fixes #14694 
- When importing both Appium and Selenium (4.26.0) where ClientConfig is introduced, 2 attributes `_ca_certs` and `_timeout` were moved to `ClientConfig`. However, looks like those are being used in AppiumConnection.
Before `AppiumConnection` is implemented on top of `4.26.0`, adding back those 2 attrs in `RemoteConnection`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Added `_timeout` and `_ca_certs` attributes to `RemoteConnection` to maintain backward compatibility with AppiumConnection.
- The `_timeout` is set using the `GLOBAL_DEFAULT_TIMEOUT` environment variable or the default socket timeout.
- The `_ca_certs` is determined by the `REQUESTS_CA_BUNDLE` environment variable or defaults to `certifi.where()`.
- Updated the `__init__` method to ensure these attributes are set from `ClientConfig`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Add backward compatibility attributes to RemoteConnection</code></dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<li>Added <code>_timeout</code> and <code>_ca_certs</code> attributes to <code>RemoteConnection</code> for <br>backward compatibility.<br> <li> Set <code>_timeout</code> and <code>_ca_certs</code> using environment variables or default <br>values.<br> <li> Updated <code>__init__</code> method to assign <code>timeout</code> and <code>ca_certs</code> from <br><code>ClientConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14696/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information