### PR TITLE
[java] use common annotations in BiDi tests

### DIFF
--- a/java/test/org/openqa/selenium/bidi/BiDiTest.java
+++ b/java/test/org/openqa/selenium/bidi/BiDiTest.java
@@ -18,15 +18,12 @@
 package org.openqa.selenium.bidi;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.bidi.browsingcontext.BrowsingContext;
@@ -35,24 +32,17 @@ import org.openqa.selenium.bidi.browsingcontext.ReadinessState;
 import org.openqa.selenium.bidi.log.JavascriptLogEntry;
 import org.openqa.selenium.bidi.log.LogLevel;
 import org.openqa.selenium.bidi.module.LogInspector;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 class BiDiTest extends JupiterTestBase {
 
   String page;
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
   @NotYetImplemented(EDGE)
+  @NeedsFreshDriver
   void canNavigateAndListenToErrors()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (org.openqa.selenium.bidi.module.LogInspector logInspector = new LogInspector(driver)) {
@@ -61,7 +51,7 @@ class BiDiTest extends JupiterTestBase {
 
       BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       NavigationResult info = browsingContext.navigate(page, ReadinessState.COMPLETE);
 
       // If navigation was successful, we expect both the url and navigation id to be set
@@ -77,13 +67,5 @@ class BiDiTest extends JupiterTestBase {
       assertThat(logEntry.getType()).isEqualTo("javascript");
       assertThat(logEntry.getLevel()).isEqualTo(LogLevel.ERROR);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java
@@ -18,31 +18,25 @@
 package org.openqa.selenium.bidi.browser;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
-import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.bidi.module.Browser;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 class BrowserCommandsTest extends JupiterTestBase {
 
-  private AppServer server;
   private Browser browser;
 
   @BeforeEach
   public void setUp() {
-    server = new NettyAppServer();
-    server.start();
     browser = new Browser(driver);
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateAUserContext() {
     String userContext = browser.createUserContext();
 
@@ -52,6 +46,7 @@ class BrowserCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetUserContexts() {
     String userContext1 = browser.createUserContext();
     String userContext2 = browser.createUserContext();
@@ -64,6 +59,7 @@ class BrowserCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canRemoveUserContext() {
     String userContext1 = browser.createUserContext();
     String userContext2 = browser.createUserContext();
@@ -78,13 +74,5 @@ class BrowserCommandsTest extends JupiterTestBase {
     assertThat(userContext2).isNotIn(updatedUserContexts);
 
     browser.removeUserContext(userContext1);
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
@@ -18,34 +18,22 @@
 package org.openqa.selenium.bidi.browsingcontext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
-import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.module.BrowsingContextInspector;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 class BrowsingContextInspectorTest extends JupiterTestBase {
 
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
-
   @Test
+  @NeedsFreshDriver
   void canListenToWindowBrowsingContextCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -66,6 +54,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToBrowsingContextDestroyedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -87,6 +76,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToTabBrowsingContextCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -106,6 +96,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToDomContentLoadedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -113,7 +104,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       inspector.onDomContentLoaded(future::complete);
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
-      context.navigate(server.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
+      context.navigate(appServer.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
 
       NavigationInfo navigationInfo = future.get(5, TimeUnit.SECONDS);
       assertThat(navigationInfo.getBrowsingContextId()).isEqualTo(context.getId());
@@ -122,6 +113,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToBrowsingContextLoadedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -129,7 +121,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       inspector.onBrowsingContextLoaded(future::complete);
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
-      context.navigate(server.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
+      context.navigate(appServer.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
 
       NavigationInfo navigationInfo = future.get(5, TimeUnit.SECONDS);
       assertThat(navigationInfo.getBrowsingContextId()).isEqualTo(context.getId());
@@ -138,6 +130,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToNavigationStartedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -145,7 +138,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       inspector.onNavigationStarted(future::complete);
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
-      context.navigate(server.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
+      context.navigate(appServer.whereIs("/bidi/logEntryAdded.html"), ReadinessState.COMPLETE);
 
       NavigationInfo navigationInfo = future.get(5, TimeUnit.SECONDS);
       assertThat(navigationInfo.getBrowsingContextId()).isEqualTo(context.getId());
@@ -154,18 +147,19 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToFragmentNavigatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
       CompletableFuture<NavigationInfo> future = new CompletableFuture<>();
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
-      context.navigate(server.whereIs("/linked_image.html"), ReadinessState.COMPLETE);
+      context.navigate(appServer.whereIs("/linked_image.html"), ReadinessState.COMPLETE);
 
       inspector.onFragmentNavigated(future::complete);
 
       context.navigate(
-          server.whereIs("/linked_image.html#linkToAnchorOnThisPage"), ReadinessState.COMPLETE);
+          appServer.whereIs("/linked_image.html#linkToAnchorOnThisPage"), ReadinessState.COMPLETE);
 
       NavigationInfo navigationInfo = future.get(5, TimeUnit.SECONDS);
       assertThat(navigationInfo.getBrowsingContextId()).isEqualTo(context.getId());
@@ -174,6 +168,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToUserPromptOpenedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (BrowsingContextInspector inspector = new BrowsingContextInspector(driver)) {
@@ -182,7 +177,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
       inspector.onUserPromptOpened(future::complete);
 
-      driver.get(server.whereIs("/alerts.html"));
+      driver.get(appServer.whereIs("/alerts.html"));
 
       driver.findElement(By.id("alert")).click();
 
@@ -193,6 +188,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   // TODO: This test is flaky for comparing the browsing context id for Chrome and Edge. Fix flaky
   // test.
   void canListenToUserPromptClosedEvent()
@@ -203,7 +199,7 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
       inspector.onUserPromptClosed(future::complete);
 
-      driver.get(server.whereIs("/alerts.html"));
+      driver.get(appServer.whereIs("/alerts.html"));
 
       driver.findElement(By.id("prompt")).click();
 
@@ -215,13 +211,5 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       assertThat(userPromptClosed.getUserText().get()).isEqualTo("selenium");
       assertThat(userPromptClosed.getAccepted()).isTrue();
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
@@ -22,11 +22,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -35,24 +32,16 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.BiDiException;
 import org.openqa.selenium.bidi.module.Browser;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.environment.webserver.Page;
 import org.openqa.selenium.print.PrintOptions;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 class BrowsingContextTest extends JupiterTestBase {
 
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
-
   @Test
+  @NeedsFreshDriver
   void canCreateABrowsingContextForGivenId() {
     String id = driver.getWindowHandle();
     BrowsingContext browsingContext = new BrowsingContext(driver, id);
@@ -60,12 +49,14 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateAWindow() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.WINDOW);
     assertThat(browsingContext.getId()).isNotEmpty();
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateAWindowWithAReferenceContext() {
     BrowsingContext browsingContext =
         new BrowsingContext(
@@ -76,12 +67,14 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateATab() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
     assertThat(browsingContext.getId()).isNotEmpty();
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateATabWithAReferenceContext() {
     BrowsingContext browsingContext =
         new BrowsingContext(
@@ -91,6 +84,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCreateAContextWithAllParameters() {
     Browser browser = new Browser(driver);
     String userContextId = browser.createUserContext();
@@ -107,10 +101,11 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canNavigateToAUrl() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
-    String url = server.whereIs("/bidi/logEntryAdded.html");
+    String url = appServer.whereIs("/bidi/logEntryAdded.html");
     NavigationResult info = browsingContext.navigate(url);
 
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -118,10 +113,11 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canNavigateToAUrlWithReadinessState() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
-    String url = server.whereIs("/bidi/logEntryAdded.html");
+    String url = appServer.whereIs("/bidi/logEntryAdded.html");
     NavigationResult info = browsingContext.navigate(url, ReadinessState.COMPLETE);
 
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -129,11 +125,12 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetTreeWithAChild() {
     String referenceContextId = driver.getWindowHandle();
     BrowsingContext parentWindow = new BrowsingContext(driver, referenceContextId);
 
-    String url = server.whereIs("iframes.html");
+    String url = appServer.whereIs("iframes.html");
 
     parentWindow.navigate(url, ReadinessState.COMPLETE);
 
@@ -147,11 +144,12 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetTreeWithDepth() {
     String referenceContextId = driver.getWindowHandle();
     BrowsingContext parentWindow = new BrowsingContext(driver, referenceContextId);
 
-    String url = server.whereIs("iframes.html");
+    String url = appServer.whereIs("iframes.html");
 
     parentWindow.navigate(url, ReadinessState.COMPLETE);
 
@@ -164,6 +162,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetAllTopLevelContexts() {
     BrowsingContext window1 = new BrowsingContext(driver, driver.getWindowHandle());
     BrowsingContext window2 = new BrowsingContext(driver, WindowType.WINDOW);
@@ -174,6 +173,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCloseAWindow() {
     BrowsingContext window1 = new BrowsingContext(driver, WindowType.WINDOW);
     BrowsingContext window2 = new BrowsingContext(driver, WindowType.WINDOW);
@@ -184,6 +184,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCloseATab() {
     BrowsingContext tab1 = new BrowsingContext(driver, WindowType.TAB);
     BrowsingContext tab2 = new BrowsingContext(driver, WindowType.TAB);
@@ -194,6 +195,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canActivateABrowsingContext() {
     BrowsingContext window1 = new BrowsingContext(driver, driver.getWindowHandle());
     // 2nd window is focused
@@ -211,10 +213,11 @@ class BrowsingContextTest extends JupiterTestBase {
   // Refer: https://github.com/w3c/webdriver-bidi/issues/187
 
   @Test
+  @NeedsFreshDriver
   void canReloadABrowsingContext() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
-    String url = server.whereIs("/bidi/logEntryAdded.html");
+    String url = appServer.whereIs("/bidi/logEntryAdded.html");
     browsingContext.navigate(url, ReadinessState.COMPLETE);
 
     NavigationResult reloadInfo = browsingContext.reload();
@@ -223,10 +226,11 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canReloadWithReadinessState() {
     BrowsingContext browsingContext = new BrowsingContext(driver, WindowType.TAB);
 
-    String url = server.whereIs("/bidi/logEntryAdded.html");
+    String url = appServer.whereIs("/bidi/logEntryAdded.html");
     browsingContext.navigate(url, ReadinessState.COMPLETE);
 
     NavigationResult reloadInfo = browsingContext.reload(ReadinessState.COMPLETE);
@@ -236,6 +240,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canHandleUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -250,6 +255,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAcceptUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -264,6 +270,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canDismissUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -278,6 +285,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canPassUserTextToUserPrompt() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -294,6 +302,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAcceptUserPromptWithUserText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -310,6 +319,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canDismissUserPromptWithUserText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -333,6 +343,7 @@ class BrowsingContextTest extends JupiterTestBase {
   // TODO: A potential solution can be replicating classic WebDriver screenshot tests.
   // Meanwhile, trusting the browsers to do the right thing.
   @Test
+  @NeedsFreshDriver
   void canCaptureScreenshot() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -344,6 +355,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCaptureScreenshotWithAllParameters() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -369,6 +381,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCaptureScreenshotOfViewport() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -385,6 +398,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCaptureElementScreenshot() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -399,6 +413,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canSetViewport() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     driver.get(appServer.whereIs("formPage.html"));
@@ -415,6 +430,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canSetViewportWithDevicePixelRatio() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     driver.get(appServer.whereIs("formPage.html"));
@@ -436,6 +452,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canPrintPage() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
@@ -453,6 +470,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canNavigateBackInTheBrowserHistory() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     browsingContext.navigate(pages.formPage, ReadinessState.COMPLETE);
@@ -465,6 +483,7 @@ class BrowsingContextTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canNavigateForwardInTheBrowserHistory() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     browsingContext.navigate(pages.formPage, ReadinessState.COMPLETE);
@@ -505,13 +524,5 @@ class BrowsingContextTest extends JupiterTestBase {
 
   private boolean getDocumentFocus() {
     return (boolean) ((JavascriptExecutor) driver).executeScript("return document.hasFocus();");
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java
@@ -17,15 +17,12 @@
 package org.openqa.selenium.bidi.browsingcontext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.bidi.module.Script;
 import org.openqa.selenium.bidi.script.EvaluateResult;
@@ -35,21 +32,14 @@ import org.openqa.selenium.bidi.script.NodeProperties;
 import org.openqa.selenium.bidi.script.RemoteReference;
 import org.openqa.selenium.bidi.script.RemoteValue;
 import org.openqa.selenium.bidi.script.ResultOwnership;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 public class LocateNodesTest extends JupiterTestBase {
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodes() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -63,6 +53,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesWithJustLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -74,6 +65,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNode() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -85,6 +77,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesWithCSSLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -107,6 +100,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesWithXPathLocator() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -129,6 +123,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(FIREFOX)
   void canLocateNodesWithInnerText() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -148,6 +143,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesWithMaxNodeCount() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
     assertThat(browsingContext.getId()).isNotEmpty();
@@ -162,6 +158,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesGivenStartNodes() {
     String handle = driver.getWindowHandle();
     BrowsingContext browsingContext = new BrowsingContext(driver, handle);
@@ -200,6 +197,7 @@ public class LocateNodesTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canLocateNodesInAGivenSandbox() {
     String sandbox = "sandbox";
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
@@ -240,13 +238,5 @@ public class LocateNodesTest extends JupiterTestBase {
 
     String sharedId = (String) ((RemoteValue) sharedIdMap.get("sharedId")).getValue().get();
     assertThat(sharedId).isEqualTo(nodeId);
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java
@@ -27,29 +27,25 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.bidi.module.Input;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 public class ReleaseCommandTest extends JupiterTestBase {
   private Input input;
 
   private String windowHandle;
 
-  private AppServer server;
-
   @BeforeEach
   public void setUp() {
     windowHandle = driver.getWindowHandle();
     input = new Input(driver);
-    server = new NettyAppServer();
-    server.start();
   }
 
   @Test
+  @NeedsFreshDriver
   public void testReleaseInBrowsingContext() {
-    driver.get(server.whereIs("/bidi/release_action.html"));
+    driver.get(appServer.whereIs("/bidi/release_action.html"));
 
     WebElement inputTextBox = driver.findElement(By.id("keys"));
 

--- a/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java
@@ -29,27 +29,23 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.bidi.module.Input;
 import org.openqa.selenium.bidi.script.RemoteReference;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 public class SetFilesCommandTest extends JupiterTestBase {
   private Input input;
 
   private String windowHandle;
 
-  private AppServer server;
-
   @BeforeEach
   public void setUp() {
     windowHandle = driver.getWindowHandle();
     input = new Input(driver);
-    server = new NettyAppServer();
-    server.start();
   }
 
   @Test
+  @NeedsFreshDriver
   void canSetFiles() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -71,6 +67,7 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   public void canSetFilesWithElementId() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -88,6 +85,7 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canSetFile() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));
@@ -106,6 +104,7 @@ public class SetFilesCommandTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canSetFileWithElementId() throws IOException {
     driver.get(pages.formPage);
     WebElement uploadElement = driver.findElement(By.id("upload"));

--- a/java/test/org/openqa/selenium/bidi/log/LogInspectorTest.java
+++ b/java/test/org/openqa/selenium/bidi/log/LogInspectorTest.java
@@ -20,7 +20,6 @@ package org.openqa.selenium.bidi.log;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -29,36 +28,27 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.module.LogInspector;
 import org.openqa.selenium.bidi.script.Source;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 class LogInspectorTest extends JupiterTestBase {
 
   String page;
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   void canListenToConsoleLog() throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<ConsoleLogEntry> future = new CompletableFuture<>();
       logInspector.onConsoleEntry(future::complete);
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("consoleLog")).click();
 
@@ -76,12 +66,13 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canFilterConsoleLogs() throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<ConsoleLogEntry> future = new CompletableFuture<>();
       logInspector.onConsoleEntry(future::complete, FilterBy.logLevel(LogLevel.INFO));
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("consoleLog")).click();
 
@@ -111,13 +102,14 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptLog()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<JavascriptLogEntry> future = new CompletableFuture<>();
       logInspector.onJavaScriptLog(future::complete);
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("jsException")).click();
 
@@ -134,12 +126,13 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canFilterJavascriptLogs() throws ExecutionException, InterruptedException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<JavascriptLogEntry> future = new CompletableFuture<>();
       logInspector.onJavaScriptLog(future::complete, FilterBy.logLevel(LogLevel.ERROR));
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("jsException")).click();
 
@@ -165,13 +158,14 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptErrorLog()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<JavascriptLogEntry> future = new CompletableFuture<>();
       logInspector.onJavaScriptException(future::complete);
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("jsException")).click();
 
@@ -184,13 +178,14 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canRetrieveStacktraceForALog()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<JavascriptLogEntry> future = new CompletableFuture<>();
       logInspector.onJavaScriptException(future::complete);
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("logWithStacktrace")).click();
 
@@ -202,12 +197,13 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canFilterLogs() throws ExecutionException, InterruptedException {
     try (LogInspector logInspector = new LogInspector(driver)) {
       CompletableFuture<LogEntry> future = new CompletableFuture<>();
       logInspector.onLog(future::complete, FilterBy.logLevel(LogLevel.INFO));
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("consoleLog")).click();
 
@@ -231,9 +227,10 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToConsoleLogForABrowsingContext()
       throws ExecutionException, InterruptedException, TimeoutException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String browsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
     try (LogInspector logInspector = new LogInspector(browsingContextId, driver)) {
@@ -255,9 +252,10 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptLogForABrowsingContext()
       throws ExecutionException, InterruptedException, TimeoutException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String browsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
     try (LogInspector logInspector = new LogInspector(browsingContextId, driver)) {
@@ -277,9 +275,10 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptErrorLogForABrowsingContext()
       throws ExecutionException, InterruptedException, TimeoutException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String browsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
     try (LogInspector logInspector = new LogInspector(browsingContextId, driver)) {
@@ -299,9 +298,10 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToConsoleLogForMultipleBrowsingContexts()
       throws ExecutionException, InterruptedException, TimeoutException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String firstBrowsingContextId = driver.getWindowHandle();
     String secondBrowsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
@@ -337,8 +337,9 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptLogForMultipleBrowsingContexts() throws InterruptedException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String firstBrowsingContextId = driver.getWindowHandle();
     String secondBrowsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
@@ -374,8 +375,9 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToJavascriptErrorLogForMultipleBrowsingContexts() throws InterruptedException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String firstBrowsingContextId = driver.getWindowHandle();
     String secondBrowsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
@@ -411,8 +413,9 @@ class LogInspectorTest extends JupiterTestBase {
 
   @Disabled("Until browsers support subscribing to multiple contexts.")
   @Test
+  @NeedsFreshDriver
   void canListenToAnyTypeOfLogForMultipleBrowsingContexts() throws InterruptedException {
-    page = server.whereIs("/bidi/logEntryAdded.html");
+    page = appServer.whereIs("/bidi/logEntryAdded.html");
     String firstBrowsingContextId = driver.getWindowHandle();
     String secondBrowsingContextId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
 
@@ -440,6 +443,7 @@ class LogInspectorTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToLogsWithMultipleConsumers()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (LogInspector logInspector = new LogInspector(driver)) {
@@ -449,7 +453,7 @@ class LogInspectorTest extends JupiterTestBase {
       CompletableFuture<JavascriptLogEntry> completableFuture2 = new CompletableFuture<>();
       logInspector.onJavaScriptLog(completableFuture2::complete);
 
-      page = server.whereIs("/bidi/logEntryAdded.html");
+      page = appServer.whereIs("/bidi/logEntryAdded.html");
       driver.get(page);
       driver.findElement(By.id("jsException")).click();
 
@@ -465,13 +469,5 @@ class LogInspectorTest extends JupiterTestBase {
       assertThat(logEntry.getType()).isEqualTo("javascript");
       assertThat(logEntry.getLevel()).isEqualTo(LogLevel.ERROR);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java
@@ -18,30 +18,19 @@
 package org.openqa.selenium.bidi.network;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.bidi.module.Network;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 class AddInterceptParametersTest extends JupiterTestBase {
 
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
-
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddInterceptPhase() {
     try (Network network = new Network(driver)) {
@@ -52,6 +41,7 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddInterceptPhases() {
     try (Network network = new Network(driver)) {
@@ -64,6 +54,7 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddStringUrlPattern() {
     try (Network network = new Network(driver)) {
@@ -76,6 +67,7 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddStringUrlPatterns() {
     try (Network network = new Network(driver)) {
@@ -91,6 +83,7 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddUrlPattern() {
     try (Network network = new Network(driver)) {
@@ -110,6 +103,7 @@ class AddInterceptParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   void canAddUrlPatterns() {
     try (Network network = new Network(driver)) {
@@ -135,13 +129,5 @@ class AddInterceptParametersTest extends JupiterTestBase {
                   .urlPatterns(List.of(pattern1, pattern2)));
       assertThat(intercept).isNotNull();
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
@@ -19,15 +19,12 @@ package org.openqa.selenium.bidi.network;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Alert;
@@ -36,23 +33,16 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UsernameAndPassword;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.bidi.module.Network;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 class NetworkCommandsTest extends JupiterTestBase {
   private String page;
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canAddIntercept() {
@@ -64,6 +54,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueRequest() throws InterruptedException {
@@ -73,7 +64,7 @@ class NetworkCommandsTest extends JupiterTestBase {
 
       CountDownLatch latch = new CountDownLatch(1);
 
-      // String alternatePage = server.whereIs("printPage.html");
+      // String alternatePage = appServer.whereIs("printPage.html");
       // TODO: Test sending request to alternate page once it is supported by browsers
       network.onBeforeRequestSent(
           beforeRequestSent -> {
@@ -89,7 +80,7 @@ class NetworkCommandsTest extends JupiterTestBase {
 
       assertThat(intercept).isNotNull();
 
-      driver.get(server.whereIs("/bidi/logEntryAdded.html"));
+      driver.get(appServer.whereIs("/bidi/logEntryAdded.html"));
 
       boolean countdown = latch.await(5, TimeUnit.SECONDS);
       assertThat(countdown).isTrue();
@@ -97,6 +88,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueResponse() throws InterruptedException {
@@ -117,7 +109,7 @@ class NetworkCommandsTest extends JupiterTestBase {
 
       assertThat(intercept).isNotNull();
 
-      driver.get(server.whereIs("/bidi/logEntryAdded.html"));
+      driver.get(appServer.whereIs("/bidi/logEntryAdded.html"));
 
       boolean countdown = latch.await(5, TimeUnit.SECONDS);
       assertThat(countdown).isTrue();
@@ -125,6 +117,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canProvideResponse() throws InterruptedException {
@@ -144,7 +137,7 @@ class NetworkCommandsTest extends JupiterTestBase {
 
       assertThat(intercept).isNotNull();
 
-      driver.get(server.whereIs("/bidi/logEntryAdded.html"));
+      driver.get(appServer.whereIs("/bidi/logEntryAdded.html"));
 
       boolean countdown = latch.await(5, TimeUnit.SECONDS);
       assertThat(countdown).isTrue();
@@ -177,7 +170,7 @@ class NetworkCommandsTest extends JupiterTestBase {
 
       assertThat(intercept).isNotNull();
 
-      driver.get(server.whereIs("/bidi/logEntryAdded.html"));
+      driver.get(appServer.whereIs("/bidi/logEntryAdded.html"));
 
       boolean countdown = latch.await(5, TimeUnit.SECONDS);
       assertThat(countdown).isTrue();
@@ -187,6 +180,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canRemoveIntercept() {
@@ -200,6 +194,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueWithAuthCredentials() {
@@ -211,13 +206,14 @@ class NetworkCommandsTest extends JupiterTestBase {
                   responseDetails.getRequest().getRequestId(),
                   new UsernameAndPassword("test", "test")));
 
-      page = server.whereIs("basicAuth");
+      page = appServer.whereIs("basicAuth");
       driver.get(page);
       assertThat(driver.findElement(By.tagName("h1")).getText()).isEqualTo("authorized");
     }
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canContinueWithoutAuthCredentials() {
@@ -227,7 +223,7 @@ class NetworkCommandsTest extends JupiterTestBase {
           responseDetails ->
               // Does not handle the alert
               network.continueWithAuthNoCredentials(responseDetails.getRequest().getRequestId()));
-      page = server.whereIs("basicAuth");
+      page = appServer.whereIs("basicAuth");
       driver.get(page);
       // This would fail if alert was handled
       Alert alert = wait.until(ExpectedConditions.alertIsPresent());
@@ -236,6 +232,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canCancelAuth() {
@@ -245,7 +242,7 @@ class NetworkCommandsTest extends JupiterTestBase {
           responseDetails ->
               // Does not handle the alert
               network.cancelAuth(responseDetails.getRequest().getRequestId()));
-      page = server.whereIs("basicAuth");
+      page = appServer.whereIs("basicAuth");
       driver.get(page);
       assertThatThrownBy(() -> wait.until(ExpectedConditions.alertIsPresent()))
           .isInstanceOf(TimeoutException.class);
@@ -253,6 +250,7 @@ class NetworkCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   void canFailRequest() {
@@ -260,18 +258,10 @@ class NetworkCommandsTest extends JupiterTestBase {
       network.addIntercept(new AddInterceptParameters(InterceptPhase.BEFORE_REQUEST_SENT));
       network.onBeforeRequestSent(
           responseDetails -> network.failRequest(responseDetails.getRequest().getRequestId()));
-      page = server.whereIs("basicAuth");
+      page = appServer.whereIs("basicAuth");
       driver.manage().timeouts().pageLoadTimeout(Duration.of(5, ChronoUnit.SECONDS));
 
       assertThatThrownBy(() -> driver.get(page)).isInstanceOf(WebDriverException.class);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.bidi.script;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
@@ -26,27 +25,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.module.Script;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 public class CallFunctionParameterTest extends JupiterTestBase {
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
-
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithDeclaration() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -65,6 +54,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithUserActivationTrue() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -93,6 +83,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithUserActivationFalse() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -121,6 +112,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithArguments() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -147,6 +139,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionToGetIFrameBrowsingContext() {
     String url = appServer.whereIs("click_too_big_in_frame.html");
     driver.get(url);
@@ -180,6 +173,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionToGetElement() {
     String url = appServer.whereIs("/bidi/logEntryAdded.html");
     driver.get(url);
@@ -207,6 +201,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithAwaitPromise() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -233,6 +228,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithAwaitPromiseFalse() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -257,6 +253,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithThisParameter() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -282,6 +279,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithOwnershipRoot() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -301,6 +299,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithOwnershipNone() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -320,6 +319,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(SAFARI)
   @NotYetImplemented(IE)
   void canCallFunctionThatThrowsException() {
@@ -346,6 +346,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionInASandBox() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -386,6 +387,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionInARealm() {
     String firstTab = driver.getWindowHandle();
     String secondTab = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -429,13 +431,5 @@ public class CallFunctionParameterTest extends JupiterTestBase {
       assertThat(successSecondContextresult.getResult().getValue().isPresent()).isTrue();
       assertThat((Long) successSecondContextresult.getResult().getValue().get()).isEqualTo(5L);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java
@@ -18,29 +18,19 @@
 package org.openqa.selenium.bidi.script;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.module.Script;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 
 public class EvaluateParametersTest extends JupiterTestBase {
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScript() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -58,6 +48,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithUserActivationTrue() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -85,6 +76,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithUserActivationFalse() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -112,6 +104,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptThatThrowsException() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -133,6 +126,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithResulWithOwnership() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -152,6 +146,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateInASandBox() {
     String id = driver.getWindowHandle();
     try (Script script = new Script(id, driver)) {
@@ -191,6 +186,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateInARealm() {
     String firstTab = driver.getWindowHandle();
     String secondTab = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -228,13 +224,5 @@ public class EvaluateParametersTest extends JupiterTestBase {
       assertThat(successSecondContextResult.getResult().getValue().isPresent()).isTrue();
       assertThat((Long) successSecondContextResult.getResult().getValue().get()).isEqualTo(5L);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java
@@ -19,7 +19,6 @@ package org.openqa.selenium.bidi.script;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,8 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriverException;
@@ -41,21 +38,14 @@ import org.openqa.selenium.bidi.log.ConsoleLogEntry;
 import org.openqa.selenium.bidi.log.LogLevel;
 import org.openqa.selenium.bidi.module.LogInspector;
 import org.openqa.selenium.bidi.module.Script;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.Pages;
 
 public class ScriptCommandsTest extends JupiterTestBase {
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithDeclaration() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -74,6 +64,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithArguments() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -103,6 +94,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionToGetIFrameBrowsingContext() {
     String url = appServer.whereIs("click_too_big_in_frame.html");
     driver.get(url);
@@ -136,6 +128,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionToGetElement() {
     String url = appServer.whereIs("/bidi/logEntryAdded.html");
     driver.get(url);
@@ -165,6 +158,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithAwaitPromise() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -192,6 +186,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithAwaitPromiseFalse() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -217,6 +212,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithThisParameter() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -244,6 +240,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithOwnershipRoot() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -266,6 +263,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionWithOwnershipNone() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -288,6 +286,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionThatThrowsException() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -313,6 +312,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionInASandBox() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -373,6 +373,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canCallFunctionInARealm() {
     String firstTab = driver.getWindowHandle();
     String secondTab = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -433,6 +434,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScript() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -450,6 +452,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptThatThrowsException() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -469,6 +472,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateScriptWithResulWithOwnership() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -487,6 +491,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateInASandBox() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -523,6 +528,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canEvaluateInARealm() {
     String firstTab = driver.getWindowHandle();
     String secondTab = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -559,6 +565,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canDisownHandles() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -615,6 +622,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canDisownHandlesInRealm() {
     String id = driver.getWindowHandle();
     Script script = new Script(id, driver);
@@ -671,6 +679,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetAllRealms() {
     String firstWindow = driver.getWindowHandle();
     String secondWindow = driver.switchTo().newWindow(WindowType.WINDOW).getWindowHandle();
@@ -695,6 +704,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetRealmByType() {
     String firstWindow = driver.getWindowHandle();
     String secondWindow = driver.switchTo().newWindow(WindowType.WINDOW).getWindowHandle();
@@ -719,6 +729,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetRealmInBrowsingContext() {
     String windowId = driver.getWindowHandle();
     String tabId = driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -735,6 +746,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canGetRealmInBrowsingContextByType() {
     String windowId = driver.getWindowHandle();
     driver.switchTo().newWindow(WindowType.TAB).getWindowHandle();
@@ -752,6 +764,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAddPreloadScript() throws ExecutionException, InterruptedException, TimeoutException {
     Script script = new Script(driver);
     String id = script.addPreloadScript("() => {{ console.log('{preload_script_console_text}') }}");
@@ -763,7 +776,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
       CompletableFuture<ConsoleLogEntry> future = new CompletableFuture<>();
       logInspector.onConsoleEntry(future::complete);
 
-      driver.get(new Pages(server).blankPage);
+      driver.get(new Pages(appServer).blankPage);
 
       ConsoleLogEntry logEntry = future.get(5, TimeUnit.SECONDS);
 
@@ -774,6 +787,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAddPreloadScriptWithArguments() {
     Script script = new Script(driver);
     String id =
@@ -785,6 +799,7 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAddPreloadScriptWithChannelOptions() {
     Script script = new Script(driver);
     SerializationOptions serializationOptions = new SerializationOptions();
@@ -798,13 +813,14 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canAddPreloadScriptInASandbox() {
     Script script = new Script(driver);
     String id = script.addPreloadScript("() => { window.bar=2; }", "sandbox");
     assertThat(id).isNotNull();
     assertThat(id).isNotEmpty();
 
-    driver.get(new Pages(server).blankPage);
+    driver.get(new Pages(appServer).blankPage);
 
     EvaluateResult result =
         script.evaluateFunctionInBrowsingContext(
@@ -814,13 +830,14 @@ public class ScriptCommandsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canRemovePreloadedScript() {
     Script script = new Script(driver.getWindowHandle(), driver);
     String id = script.addPreloadScript("() => { window.bar=2; }");
     assertThat(id).isNotNull();
     assertThat(id).isNotEmpty();
 
-    driver.get(new Pages(server).blankPage);
+    driver.get(new Pages(appServer).blankPage);
 
     EvaluateResult result =
         script.evaluateFunctionInBrowsingContext(
@@ -836,13 +853,5 @@ public class ScriptCommandsTest extends JupiterTestBase {
     assertThat(resultAfterRemoval.getResultType()).isEqualTo(EvaluateResult.Type.SUCCESS);
     assertThat(((EvaluateResultSuccess) resultAfterRemoval).getResult().getValue().isPresent())
         .isFalse();
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java
@@ -17,7 +17,6 @@
 package org.openqa.selenium.bidi.script;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.openqa.selenium.testing.Safely.safelyCall;
 import static org.openqa.selenium.testing.drivers.Browser.*;
 
 import java.util.List;
@@ -26,27 +25,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.bidi.browsingcontext.BrowsingContext;
 import org.openqa.selenium.bidi.module.Script;
-import org.openqa.selenium.environment.webserver.AppServer;
-import org.openqa.selenium.environment.webserver.NettyAppServer;
 import org.openqa.selenium.testing.JupiterTestBase;
+import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.Pages;
 
 public class ScriptEventsTest extends JupiterTestBase {
-  private AppServer server;
-
-  @BeforeEach
-  public void setUp() {
-    server = new NettyAppServer();
-    server.start();
-  }
 
   @Test
+  @NeedsFreshDriver
   void canListenToChannelMessage()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Script script = new Script(driver)) {
@@ -74,6 +64,7 @@ public class ScriptEventsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   void canListenToRealmCreatedEvent()
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Script script = new Script(driver)) {
@@ -82,7 +73,7 @@ public class ScriptEventsTest extends JupiterTestBase {
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
 
-      context.navigate(new Pages(server).blankPage);
+      context.navigate(new Pages(appServer).blankPage);
       RealmInfo realmInfo = future.get(5, TimeUnit.SECONDS);
       assertThat(realmInfo.getRealmId()).isNotNull();
       assertThat(realmInfo.getRealmType()).isEqualTo(RealmType.WINDOW);
@@ -90,6 +81,7 @@ public class ScriptEventsTest extends JupiterTestBase {
   }
 
   @Test
+  @NeedsFreshDriver
   @NotYetImplemented(EDGE)
   @NotYetImplemented(CHROME)
   @NotYetImplemented(FIREFOX)
@@ -106,13 +98,5 @@ public class ScriptEventsTest extends JupiterTestBase {
       assertThat(realmInfo.getRealmId()).isNotNull();
       assertThat(realmInfo.getRealmType()).isEqualTo(RealmType.WINDOW);
     }
-  }
-
-  @AfterEach
-  public void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-    }
-    safelyCall(server::stop);
   }
 }

--- a/java/test/org/openqa/selenium/grid/router/RemoteWebDriverBiDiTest.java
+++ b/java/test/org/openqa/selenium/grid/router/RemoteWebDriverBiDiTest.java
@@ -27,7 +27,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -54,8 +56,14 @@ import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.drivers.Browser;
 
 class RemoteWebDriverBiDiTest {
+  private static AppServer server;
   private WebDriver driver;
-  private AppServer server;
+
+  @BeforeAll
+  static void serverSetup() {
+    server = new NettyAppServer();
+    server.start();
+  }
 
   @BeforeEach
   void setup() {
@@ -73,9 +81,6 @@ class RemoteWebDriverBiDiTest {
 
     driver = new RemoteWebDriver(deployment.getServer().getUrl(), browser.getCapabilities());
     driver = new Augmenter().augment(driver);
-
-    server = new NettyAppServer();
-    server.start();
   }
 
   @Test
@@ -138,6 +143,10 @@ class RemoteWebDriverBiDiTest {
   @AfterEach
   void clean() {
     driver.quit();
+  }
+
+  @AfterAll
+  static void stopServer() {
     server.stop();
   }
 }


### PR DESCRIPTION
### **User description**
### Motivation and Context
This PR will use the common annotations in the BiDi tests to ensure the driver is restarted.
Additionally the provided NettyAppServer is used and not started before each test.

On my local system it takes ~500ms to start the NettyAppServer, this is how i stumbled into this.
I will improve the startup of the NettyAppServer as soon as this is merged.

@pujagani could you hava a look at this?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Refactored multiple test classes to remove `@BeforeEach` and `@AfterEach` annotations, replacing them with `@NeedsFreshDriver` to ensure a fresh driver for each test.
- Replaced `server` with `appServer` in test classes to standardize server usage.
- Added `@BeforeAll` and `@AfterAll` annotations in `RemoteWebDriverBiDiTest` for server lifecycle management.
- Enhanced test reliability by ensuring a fresh driver instance for each test case.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiTest.java</strong><dd><code>Refactor BiDiTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/BiDiTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-4a91048e9c253491777254c74e64c71d5740cc11b649d31b9534692b4b3f54a7">+3/-21</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowserCommandsTest.java</strong><dd><code>Refactor BrowserCommandsTest to use common annotations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/browser/BrowserCommandsTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-f2240b0d878ce01529b1809cc726a1482f55bfb895a811c759428cf883f82cec">+4/-16</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextInspectorTest.java</strong><dd><code>Refactor BrowsingContextInspectorTest to use common annotations</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-7e31cdee71aec8f625eef511eb299619a501aab66ee1bf937eedec82921ad7e9">+17/-29</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextTest.java</strong><dd><code>Refactor BrowsingContextTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-f33a246a757eda5a55a8c9939d94f577af17d34ded65badfda87cff2da956c5c">+38/-27</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LocateNodesTest.java</strong><dd><code>Refactor LocateNodesTest to use common annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/browsingcontext/LocateNodesTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-b63701b3cf1f898a95e4ef4d8b70e04724101885116b5287a447a0670a5a1ff3">+10/-20</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReleaseCommandTest.java</strong><dd><code>Refactor ReleaseCommandTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/input/ReleaseCommandTest.java

<li>Removed <code>@BeforeEach</code> annotation.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-4769925ca68216ad07a68b8d649eed68d3c6e64ff4b88e839ee0619a10d2d36a">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetFilesCommandTest.java</strong><dd><code>Refactor SetFilesCommandTest to use common annotations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/input/SetFilesCommandTest.java

<li>Removed <code>@BeforeEach</code> annotation.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-289f98a8f44edcaadef7f408831a9be69ebc845ef0873d3696d525153180437f">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LogInspectorTest.java</strong><dd><code>Refactor LogInspectorTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/log/LogInspectorTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-e9677338e15ce3385a165d7429222040655562358ced8e25ec668acf37a78b54">+31/-35</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AddInterceptParametersTest.java</strong><dd><code>Refactor AddInterceptParametersTest to use common annotations</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/network/AddInterceptParametersTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-b353be8d10c38461f2f4da0949661c40f80fcc879bc402aba63ca519449ec76f">+7/-21</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NetworkCommandsTest.java</strong><dd><code>Refactor NetworkCommandsTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-56334c02fd23ebd6590a6ae6f44b2113bdbc325175c1273c4ef17a236119e517">+19/-29</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NetworkEventsTest.java</strong><dd><code>Refactor NetworkEventsTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-d8a2f31c89a869b962bef54fdb254806ca6416d6d60323844e54b9855720cf0e">+13/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.java</strong><dd><code>Refactor CallFunctionParameterTest to use common annotations</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-07986bca9cc97288db15330752e456cc04874783fd72c14f0a4110676a53bfaa">+15/-21</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EvaluateParametersTest.java</strong><dd><code>Refactor EvaluateParametersTest to use common annotations</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-907a2642d2dcd20f3640efcabeea68e3818c85eb11af2df7febd4e15c587ea8b">+8/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ScriptCommandsTest.java</strong><dd><code>Refactor ScriptCommandsTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/ScriptCommandsTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-37b21f83d3902764db9c61f46343f33fdaa3ade7b5a6f8e125a08e35ffcf466b">+32/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ScriptEventsTest.java</strong><dd><code>Refactor ScriptEventsTest to use common annotations and appServer</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/ScriptEventsTest.java

<li>Removed <code>@BeforeEach</code> and <code>@AfterEach</code> annotations.<br> <li> Added <code>@NeedsFreshDriver</code> annotation to test methods.<br> <li> Replaced <code>server</code> with <code>appServer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-da82a5780c17157064dcb1830a9c3b66a2d78862162728ea959c96961cac7f79">+5/-21</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriverBiDiTest.java</strong><dd><code>Refactor RemoteWebDriverBiDiTest for server lifecycle management</code></dd></summary>
<hr>

java/test/org/openqa/selenium/grid/router/RemoteWebDriverBiDiTest.java

<li>Added <code>@BeforeAll</code> and <code>@AfterAll</code> annotations for server setup and <br>teardown.<br> <li> Removed <code>@BeforeEach</code> annotation for server setup.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14702/files#diff-af6b80d93a16a79dbe20903ef1973ae3e1297e73f68729367aa807039c7b7870">+13/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information