### PR TITLE
[dotnet] Make Selenium Manager's AOT safety explicit

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -40,8 +40,6 @@ namespace OpenQA.Selenium
     {
         private static readonly ILogger _logger = Log.GetLogger(typeof(SeleniumManager));
 
-        private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNameCaseInsensitive = true, TypeInfoResolver = SeleniumManagerSerializerContext.Default };
-
         private static readonly Lazy<string> _lazyBinaryFullPath = new(() =>
         {
             string? binaryFullPath = Environment.GetEnvironmentVariable("SE_MANAGER_PATH");
@@ -187,7 +185,7 @@ namespace OpenQA.Selenium
 
             try
             {
-                jsonResponse = JsonSerializer.Deserialize<SeleniumManagerResponse>(output, _serializerOptions)!;
+                jsonResponse = JsonSerializer.Deserialize(output, SeleniumManagerSerializerContext.Default.SeleniumManagerResponse)!;
             }
             catch (Exception ex)
             {
@@ -210,11 +208,11 @@ namespace OpenQA.Selenium
         }
     }
 
-    internal record SeleniumManagerResponse(IReadOnlyList<LogEntryResponse> Logs, ResultResponse Result)
+    internal sealed record SeleniumManagerResponse(IReadOnlyList<LogEntryResponse> Logs, ResultResponse Result)
     {
-        public record LogEntryResponse(string Level, string Message);
+        public sealed record LogEntryResponse(string Level, string Message);
 
-        public record ResultResponse
+        public sealed record ResultResponse
         (
             [property: JsonPropertyName("driver_path")]
             string DriverPath,
@@ -224,5 +222,6 @@ namespace OpenQA.Selenium
     }
 
     [JsonSerializable(typeof(SeleniumManagerResponse))]
-    internal partial class SeleniumManagerSerializerContext : JsonSerializerContext;
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+    internal sealed partial class SeleniumManagerSerializerContext : JsonSerializerContext;
 }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

The `JsonSerializerOptions` instance passed to the `SeleniumManagerResponse` deserialization is AOT-safe, because the `TypeResolver` was set to a source-generated instance.

However, the JSON de-serialization method cannot know that. For that reason, we can use the de-serialization method that takes a `JsonTypeInfo<T>` overload.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Satisfies AOT analyzer warning
![image](https://github.com/user-attachments/assets/e336bba2-3b46-4363-aff3-f4eb5a979077)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Replaced the `JsonSerializerOptions` with `JsonSerializerContext.Default.SeleniumManagerResponse` to ensure AOT safety in the deserialization process.
- Converted `SeleniumManagerResponse`, `LogEntryResponse`, and `ResultResponse` to sealed records to enhance performance.
- Added `JsonSourceGenerationOptions` with `PropertyNameCaseInsensitive` set to true for improved JSON property handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumManager.cs</strong><dd><code>Improve AOT safety and performance in SeleniumManager</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/SeleniumManager.cs

<li>Replaced <code>JsonSerializerOptions</code> with <code>JsonSerializerContext</code> for AOT <br>safety.<br> <li> Changed records to sealed records for better performance.<br> <li> Added <code>JsonSourceGenerationOptions</code> attribute for case insensitivity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14733/files#diff-df9a0140c4ef310382b15de2b26d228971d00530d18f4c1bd3c74f735c3af665">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information