### PR TITLE
[py] moved `flake8` settings to `tox.ini` from `setup.cfg`

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -335,7 +335,6 @@ py_library(
     ],
     data = [
         "pyproject.toml",
-        "setup.cfg",
         "test/selenium/webdriver/common/test_file.txt",
         "test/selenium/webdriver/common/test_file2.txt",
         ":webextensions-selenium-example-unsigned-zip",

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-exclude = .tox,docs/source/conf.py,*venv
-# Disable this once black is applied throughout & line length is better handled.
-extend-ignore = E501, E203
-# This does nothing for now as E501 is ignored.
-max-line-length = 120

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -58,3 +58,10 @@ commands =
   black selenium/ test/ conftest.py -l 120
   flake8 selenium/ test/ --min-python-version=3.8
   docformatter --in-place -r selenium/
+
+[flake8]
+exclude = .tox,docs/source/conf.py,*venv
+# Disable this once black is applied throughout & line length is better handled.
+extend-ignore = E501, E203
+# This does nothing for now as E501 is ignored.
+max-line-length = 120


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

### Description
Moved `flake8` settings from `setup.cfg` to `tox.ini` thus eliminating `setup.cfg` completely.

### Motivation and Context

- This eliminates the need to have `setup.cfg` file.
- since `flake8`  settings can be maintained in `tox.ini`, there is no need to maintain a separate config file which is `setup.cfg` just to maintain `flake8` settings.
- We can accommodate `flake8` settings in `tox.ini` and can completely get rid of `setup.cfg` file

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Moved `flake8` settings from `setup.cfg` to `tox.ini`, consolidating configuration files.
- Removed `setup.cfg` from the Bazel build data, as it is no longer needed.
- This change simplifies the configuration by maintaining `flake8` settings in `tox.ini`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Remove `setup.cfg` from Bazel build data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/BUILD.bazel

- Removed `setup.cfg` from the data section.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14749/files#diff-3e8ff3a52e8e6c0b195ea328e17c50ba6d90abca1ce1624110607da20691d7a9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setup.cfg</strong><dd><code>Remove `flake8` settings from `setup.cfg`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/setup.cfg

- Deleted the `flake8` configuration section.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14749/files#diff-b005028fca69c9f8bfb0cb65a9699c9e166346d6b4f9dea788f6e732e4f6af44">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Add `flake8` settings to `tox.ini`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/tox.ini

- Added `flake8` configuration section.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14749/files#diff-27d219400d7f64afbf3d9bceb197e20b299fdd58fb4e84c9b7c2ee7c4e828177">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information