### PR TITLE
[rb] Resolve `uri` gem deprecation warning

### DIFF
--- a/rb/lib/selenium/webdriver/remote/bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bridge.rb
@@ -686,7 +686,7 @@ module Selenium
         end
 
         def escaper
-          @escaper ||= defined?(URI::Parser) ? URI::DEFAULT_PARSER : URI
+          @escaper ||= defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
         end
 
         def commands(command)


### PR DESCRIPTION
### **User description**
### Description

Ruby switches the default parser from RFC2396 to RFC3986. This parser contains all methods from the old parser but delegates to RFC2396 for a few and warns. Namely `extract`, `make_regexp`, `escape`, and `unescape`.

selenium currently supports Ruby >= 3.1, so the current old compatibility code is unnecessary. `RFC2396_PARSER` is a somewhat new addition, so some kind of check is still needed. It is available in Ruby 3.1 but early patch versions are missing it.

### Motivation and Context
> /home/user/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/selenium-webdriver-4.26.0/lib/selenium/webdriver/remote/bridge.rb:679: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the `escaper` method in `bridge.rb` to resolve a deprecation warning by using `URI::RFC2396_PARSER` when available.
- Ensured compatibility with Ruby versions >= 3.1 by checking for the presence of `URI::RFC2396_PARSER`.
- This change addresses the obsolescence of `URI::RFC3986_PARSER.escape`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bridge.rb</strong><dd><code>Resolve deprecation warning by updating URI parser usage</code>&nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/remote/bridge.rb

<li>Updated the <code>escaper</code> method to use <code>URI::RFC2396_PARSER</code> if defined.<br> <li> Fallback to <code>URI::DEFAULT_PARSER</code> if <code>URI::RFC2396_PARSER</code> is not defined.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14770/files#diff-42b562229083afc6ac8cc70a735fc1b24863402aa1404f08f60322b24cdfefc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information