### PR TITLE
[dotnet] Propagate async throughout test setup and teardown

### DIFF
--- a/dotnet/test/chrome/ChromeSpecificTests.cs
+++ b/dotnet/test/chrome/ChromeSpecificTests.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Chrome
 {
@@ -26,10 +27,10 @@ namespace OpenQA.Selenium.Chrome
     public class ChromeSpecificTests : DriverTestFixture
     {
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
     }
 }

--- a/dotnet/test/common/AssemblyFixture.cs
+++ b/dotnet/test/common/AssemblyFixture.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium
 {
@@ -31,25 +32,25 @@ namespace OpenQA.Selenium
         }
 
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
             Internal.Logging.Log.SetLevel(Internal.Logging.LogEventLevel.Trace);
 
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
             if (EnvironmentManager.Instance.Browser == Browser.Remote)
             {
-                EnvironmentManager.Instance.RemoteServer.Start();
+                await EnvironmentManager.Instance.RemoteServer.StartAsync();
             }
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
             if (EnvironmentManager.Instance.Browser == Browser.Remote)
             {
-                EnvironmentManager.Instance.RemoteServer.Stop();
+                await EnvironmentManager.Instance.RemoteServer.StopAsync();
             }
         }
     }

--- a/dotnet/test/common/Environment/EnvironmentManager.cs
+++ b/dotnet/test/common/Environment/EnvironmentManager.cs
@@ -199,11 +199,11 @@ namespace OpenQA.Selenium.Environment
         {
             if (remoteServer != null)
             {
-                remoteServer.Stop();
+                remoteServer.StopAsync().Wait();
             }
             if (webServer != null)
             {
-                webServer.Stop();
+                webServer.StopAsync().Wait();
             }
             CloseCurrentDriver();
         }

--- a/dotnet/test/common/Environment/RemoteSeleniumServer.cs
+++ b/dotnet/test/common/Environment/RemoteSeleniumServer.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Environment
 {
@@ -38,7 +39,7 @@ namespace OpenQA.Selenium.Environment
             autoStart = autoStartServer;
         }
 
-        public void Start()
+        public async Task StartAsync()
         {
             if (autoStart && (webserverProcess == null || webserverProcess.HasExited))
             {
@@ -67,7 +68,7 @@ namespace OpenQA.Selenium.Environment
                 {
                     try
                     {
-                        using var response = httpClient.GetAsync("http://localhost:6000/wd/hub/status").GetAwaiter().GetResult();
+                        using var response = await httpClient.GetAsync("http://localhost:6000/wd/hub/status");
 
                         if (response.StatusCode == HttpStatusCode.OK)
                         {
@@ -86,7 +87,7 @@ namespace OpenQA.Selenium.Environment
             }
         }
 
-        public void Stop()
+        public async Task StopAsync()
         {
             if (autoStart && webserverProcess != null && !webserverProcess.HasExited)
             {
@@ -94,7 +95,7 @@ namespace OpenQA.Selenium.Environment
 
                 try
                 {
-                    using var response = httpClient.GetAsync("http://localhost:6000/selenium-server/driver?cmd=shutDownSeleniumServer").GetAwaiter().GetResult();
+                    using var response = await httpClient.GetAsync("http://localhost:6000/selenium-server/driver?cmd=shutDownSeleniumServer");
                 }
                 catch (Exception ex) when (ex is HttpRequestException || ex is TimeoutException)
                 {

--- a/dotnet/test/common/Environment/TestWebServer.cs
+++ b/dotnet/test/common/Environment/TestWebServer.cs
@@ -25,6 +25,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Environment
 {
@@ -50,7 +51,7 @@ namespace OpenQA.Selenium.Environment
             this.port = config.Port;
         }
 
-        public void Start()
+        public async Task StartAsync()
         {
             if (webserverProcess == null || webserverProcess.HasExited)
             {
@@ -146,7 +147,7 @@ namespace OpenQA.Selenium.Environment
                 {
                     try
                     {
-                        using var response = httpClient.GetAsync(EnvironmentManager.Instance.UrlBuilder.LocalWhereIs("simpleTest.html")).GetAwaiter().GetResult();
+                        using var response = await httpClient.GetAsync(EnvironmentManager.Instance.UrlBuilder.LocalWhereIs("simpleTest.html"));
 
                         if (response.StatusCode == HttpStatusCode.OK)
                         {
@@ -174,7 +175,7 @@ namespace OpenQA.Selenium.Environment
             }
         }
 
-        public void Stop()
+        public async Task StopAsync()
         {
             if (webserverProcess != null)
             {
@@ -182,7 +183,7 @@ namespace OpenQA.Selenium.Environment
                 {
                     try
                     {
-                        using (httpClient.GetAsync(EnvironmentManager.Instance.UrlBuilder.LocalWhereIs("quitquitquit")).GetAwaiter().GetResult())
+                        using (await httpClient.GetAsync(EnvironmentManager.Instance.UrlBuilder.LocalWhereIs("quitquitquit")))
                         {
 
                         }

--- a/dotnet/test/edge/AssemblyTeardown.cs
+++ b/dotnet/test/edge/AssemblyTeardown.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Edge
 {
@@ -27,16 +28,16 @@ namespace OpenQA.Selenium.Edge
     public class MySetUpClass
     {
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
     }
 }

--- a/dotnet/test/firefox/AssemblyTeardown.cs
+++ b/dotnet/test/firefox/AssemblyTeardown.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Firefox
 {
@@ -27,16 +28,16 @@ namespace OpenQA.Selenium.Firefox
     public class MySetUpClass
     {
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
     }
 }

--- a/dotnet/test/ie/AssemblyTeardown.cs
+++ b/dotnet/test/ie/AssemblyTeardown.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.IE
 {
@@ -27,16 +28,16 @@ namespace OpenQA.Selenium.IE
     public class MySetUpClass
     {
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
     }
 }

--- a/dotnet/test/remote/AssemblyTeardown.cs
+++ b/dotnet/test/remote/AssemblyTeardown.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Remote
 {
@@ -27,23 +28,23 @@ namespace OpenQA.Selenium.Remote
     public class MySetUpClass
     {
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
             if (EnvironmentManager.Instance.Browser == Browser.Remote)
             {
-                EnvironmentManager.Instance.RemoteServer.Start();
+                await EnvironmentManager.Instance.RemoteServer.StartAsync();
             }
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
             if (EnvironmentManager.Instance.Browser == Browser.Remote)
             {
-                EnvironmentManager.Instance.RemoteServer.Stop();
+                await EnvironmentManager.Instance.RemoteServer.StopAsync();
             }
         }
     }

--- a/dotnet/test/support/UI/PopupWindowFinderTest.cs
+++ b/dotnet/test/support/UI/PopupWindowFinderTest.cs
@@ -19,6 +19,7 @@
 
 using NUnit.Framework;
 using OpenQA.Selenium.Environment;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Support.UI
 {
@@ -27,16 +28,16 @@ namespace OpenQA.Selenium.Support.UI
     {
         //TODO: Move these to a standalone class when more tests rely on the server being up
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
 
         [Test]

--- a/dotnet/test/support/UI/SelectBrowserTests.cs
+++ b/dotnet/test/support/UI/SelectBrowserTests.cs
@@ -21,6 +21,7 @@ using NUnit.Framework;
 using OpenQA.Selenium.Environment;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Support.UI
 {
@@ -28,16 +29,16 @@ namespace OpenQA.Selenium.Support.UI
     public class SelectBrowserTests : DriverTestFixture
     {
         [OneTimeSetUp]
-        public void RunBeforeAnyTest()
+        public async Task RunBeforeAnyTestAsync()
         {
-            EnvironmentManager.Instance.WebServer.Start();
+            await EnvironmentManager.Instance.WebServer.StartAsync();
         }
 
         [OneTimeTearDown]
-        public void RunAfterAnyTests()
+        public async Task RunAfterAnyTestsAsync()
         {
             EnvironmentManager.Instance.CloseCurrentDriver();
-            EnvironmentManager.Instance.WebServer.Stop();
+            await EnvironmentManager.Instance.WebServer.StopAsync();
         }
 
         [SetUp]


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Propagates `async` all the way to the top (where NUnit handles it) instead of `GetAwaiter().GetResult()`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Sync-over-async makes for bulkier code. It also prevents future `SuppressThrowing` optimizations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Converted test setup and teardown methods to use async/await pattern across multiple test files.
- Replaced synchronous start and stop methods with async versions in `EnvironmentManager`, `RemoteSeleniumServer`, and `TestWebServer`.
- Improved code readability and potential performance by avoiding sync-over-async patterns.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeSpecificTests.cs</strong><dd><code>Convert Chrome test teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/chrome/ChromeSpecificTests.cs

<li>Added <code>async</code> keyword to <code>RunAfterAnyTests</code> method.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-9c32a39a991584681ed755c12b2376458d3d041d771606d66672fe29f373c657">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AssemblyFixture.cs</strong><dd><code>Update AssemblyFixture setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/AssemblyFixture.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous start and stop methods with async versions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-23705eeb748248cde8912e0843565f1158683ca08f2188049f7f4fc1fc84d93c">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnvironmentManager.cs</strong><dd><code>Use async stop methods in EnvironmentManager destructor</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Environment/EnvironmentManager.cs

<li>Replaced synchronous stop methods with async versions in destructor.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-75436dc8c8dced10f6b96f66e3e3a5d6b31ec7e64ae11a0187b48877d82c3972">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteSeleniumServer.cs</strong><dd><code>Convert RemoteSeleniumServer start and stop to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Environment/RemoteSeleniumServer.cs

<li>Converted <code>Start</code> and <code>Stop</code> methods to async.<br> <li> Replaced synchronous HTTP requests with async versions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-1e04e449a46d2564bba6d0063c6170cc726f81c2ccb8d79054d3152a3cc33bf2">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestWebServer.cs</strong><dd><code>Convert TestWebServer start and stop to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Environment/TestWebServer.cs

<li>Converted <code>Start</code> and <code>Stop</code> methods to async.<br> <li> Replaced synchronous HTTP requests with async versions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-9b1522ed8b7052b3c0e172fa95173cec4340245fe34caf1ca94cf17376a10dca">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AssemblyTeardown.cs</strong><dd><code>Update Edge assembly setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/edge/AssemblyTeardown.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-71771085afb623379045d6bf1d6a292e5c855e76bd1177b7aa445483e0280df9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AssemblyTeardown.cs</strong><dd><code>Update Firefox assembly setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/firefox/AssemblyTeardown.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-939ed1ed65e2615347459908f6e4e76ee6067ce955d83a07ef8349ed612eff40">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AssemblyTeardown.cs</strong><dd><code>Update IE assembly setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/ie/AssemblyTeardown.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-9a93752d5be390d0e32ee128151b48247ab2b60de6f630c2eae2c7206b06a7ad">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AssemblyTeardown.cs</strong><dd><code>Update Remote assembly setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/remote/AssemblyTeardown.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous start and stop methods with async versions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-374ee903c7d3b153f7c470183351209fbb7609abf21135de0d38b1c25f426b6f">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PopupWindowFinderTest.cs</strong><dd><code>Update PopupWindowFinderTest setup and teardown to async</code>&nbsp; </dd></summary>
<hr>

dotnet/test/support/UI/PopupWindowFinderTest.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-ad1db3b86cffbd53b5a6675035896c75d9f0e8a7efcaa470d87003edbc253f52">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SelectBrowserTests.cs</strong><dd><code>Update SelectBrowserTests setup and teardown to async</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/support/UI/SelectBrowserTests.cs

<li>Added <code>async</code> keyword to setup and teardown methods.<br> <li> Replaced synchronous stop method with <code>StopAsync</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14775/files#diff-37d1e35ccc4394cb760e3c5dfb7dc0308ca35b5ca2beceabc0f0616c24338b9c">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information