### PR TITLE
[dotnet] Address warnings for Firefox devtool depreciations

### DIFF
--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -393,6 +393,7 @@ namespace OpenQA.Selenium.Firefox
         /// Creates a session to communicate with a browser using the Chromium Developer Tools debugging protocol.
         /// </summary>
         /// <returns>The active session to use to communicate with the Chromium Developer Tools debugging protocol.</returns>
+        [Obsolete("CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi.")]
         public DevToolsSession GetDevToolsSession()
         {
             return GetDevToolsSession(new DevToolsOptions() { ProtocolVersion = FirefoxDevToolsProtocolVersion });

--- a/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
+++ b/dotnet/src/webdriver/Remote/RemoteWebDriver.cs
@@ -428,7 +428,7 @@ namespace OpenQA.Selenium.Remote
         /// <returns>The active session to use to communicate with the Developer Tools debugging protocol.</returns>
         public DevToolsSession GetDevToolsSession()
         {
-            if (this.Capabilities.GetCapability(CapabilityType.BrowserName) == "firefox")
+            if (this.Capabilities.GetCapability(CapabilityType.BrowserName) is "firefox")
             {
                 if (_logger.IsEnabled(LogEventLevel.Warn))
                 {


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

A new warning was added with a recent obsoletion, in the `FirefoxDriver.GetDevToolsSession` method.

Additionally, `== "firefox"` comparison was buggy. `GetCapability` returns an object, and `object == string` [does not do what it seems](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK7wCYgNQB8ACATAIwCwAUBfsQJwAUAygsrAOYBKApgGafKcwAxpwAqnAM4I6ASmkBuKrUbM2ANQgAbVKIlTZCyuWAB7YxoAETFjA48+A4WMkyKAbwrnP56gAZzGngRzAF5vYh8AOgBhYyEIKQAiAAtOBLhzBI0NYwT5Cg8vfAB2czo6Y2AAK05BBGkA7jqQ0OTOLJyDAF98o1MLKzVNbSc9NwLPX39AkLDImLjElLSM9tyDce8Ssorq2vrA6XMocQyU1a6gA=). This is fixed now, and the string comparison will use value equality instead of reference equality.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


This warning can be bubbled up to users:
![image](https://github.com/user-attachments/assets/05a04e88-de0d-460e-ba58-29414ff94791)

And potentially unlogged warnings

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Marked the `GetDevToolsSession` method in `FirefoxDriver` as obsolete, providing a warning about the deprecation of CDP support for Firefox.
- Fixed a bug in `RemoteWebDriver` by correcting the string comparison for the browser name capability, ensuring proper type checking using pattern matching.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriver.cs</strong><dd><code>Mark `GetDevToolsSession` as obsolete with deprecation warning</code></dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxDriver.cs

<li>Added an <code>Obsolete</code> attribute to <code>GetDevToolsSession</code> method.<br> <li> Provided a warning message about the deprecation of CDP support for <br>Firefox.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14786/files#diff-337f94531a5e0d064a23d898667e0770f6a953ff7c264c4ba55110c5e7485fd2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.cs</strong><dd><code>Fix browser name comparison for Firefox capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/RemoteWebDriver.cs

<li>Fixed string comparison for browser name capability.<br> <li> Used pattern matching for more reliable comparison.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14786/files#diff-19a5d1746f2aacd1ae08df4a374dad3846117efdba63ef27f897a207e057e867">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information