### PR TITLE
[py] Deprecate CDP methods on Firefox 

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -100,8 +100,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - browser: safari
-            os: macos
           - browser: chrome
             os: ubuntu
           - browser: edge
@@ -115,4 +113,22 @@ jobs:
       cache-key: py-browser-${{ matrix.browser }}
       run: |
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:common-${{ matrix.browser }}-bidi
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-${{ matrix.browser }}
+
+  safari-tests:
+    name: Browser Tests
+    needs: build
+    uses: ./.github/workflows/bazel.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - browser: safari
+            os: macos
+    with:
+      name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
+      browser: ${{ matrix.browser }}
+      os: ${{ matrix.os }}
+      cache-key: py-browser-${{ matrix.browser }}
+      run: |
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-${{ matrix.browser }}

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -3,6 +3,7 @@ attrs==23.2.0
 certifi==2023.11.17
 cffi==1.16.0
 cryptography==42.0.8
+secretstorage==3.3.3
 debugpy==1.8.7
 filetype==1.2.0
 h11==0.14.0

--- a/py/requirements_lock.txt
+++ b/py/requirements_lock.txt
@@ -208,6 +208,7 @@ cryptography==42.0.8 \
     # via
     #   -r py/requirements.txt
     #   pyopenssl
+    #   secretstorage
 debugpy==1.8.7 \
     --hash=sha256:11ad72eb9ddb436afb8337891a986302e14944f0f755fd94e90d0d71e9100bba \
     --hash=sha256:171899588bcd412151e593bd40d9907133a7622cd6ecdbdb75f89d1551df13c2 \
@@ -288,6 +289,10 @@ jaraco-classes==3.3.0 \
     --hash=sha256:10afa92b6743f25c0cf5f37c6bb6e18e2c5bb84a16527ccfc0040ea377e7aaeb \
     --hash=sha256:c063dd08e89217cee02c8d5e5ec560f2c8ce6cdc2fcdc2e68f7b2e5547ed3621
     # via keyring
+jeepney==0.8.0 \
+    --hash=sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806 \
+    --hash=sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755
+    # via secretstorage
 keyring==24.3.0 \
     --hash=sha256:4446d35d636e6a10b8bce7caa66913dd9eca5fd222ca03a3d42c38608ac30836 \
     --hash=sha256:e730ecffd309658a08ee82535a3b5ec4b4c8669a9be11efb66249d8e0aeb9a25
@@ -512,6 +517,10 @@ rich==13.7.0 \
     --hash=sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa \
     --hash=sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235
     # via twine
+secretstorage==3.3.3 \
+    --hash=sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77 \
+    --hash=sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99
+    # via -r py/requirements.txt
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc

--- a/py/selenium/webdriver/common/bidi/cdp.py
+++ b/py/selenium/webdriver/common/bidi/cdp.py
@@ -51,6 +51,11 @@ version = None
 def import_devtools(ver):
     """Attempt to load the current latest available devtools into the module
     cache for use later."""
+
+    warnings.warn(
+        "import_devtools() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     global devtools
     global version
     version = ver
@@ -80,6 +85,11 @@ def get_connection_context(fn_name):
     If there is no current connection, raise a ``RuntimeError`` with a
     helpful message.
     """
+
+    warnings.warn(
+        "get_connection_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     try:
         return _connection_context.get()
     except LookupError:
@@ -92,6 +102,11 @@ def get_session_context(fn_name):
     If there is no current session, raise a ``RuntimeError`` with a
     helpful message.
     """
+
+    warnings.warn(
+        "get_session_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     try:
         return _session_context.get()
     except LookupError:
@@ -102,6 +117,11 @@ def get_session_context(fn_name):
 def connection_context(connection):
     """This context manager installs ``connection`` as the session context for
     the current Trio task."""
+
+    warnings.warn(
+        "connection_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     token = _connection_context.set(connection)
     try:
         yield
@@ -113,6 +133,11 @@ def connection_context(connection):
 def session_context(session):
     """This context manager installs ``session`` as the session context for the
     current Trio task."""
+
+    warnings.warn(
+        "session_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     token = _session_context.set(session)
     try:
         yield
@@ -127,6 +152,11 @@ def set_global_connection(connection):
     This is generally not recommended, except it may be necessary in
     certain use cases such as running inside Jupyter notebook.
     """
+
+    warnings.warn(
+        "set_global_connection() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     global _connection_context
     _connection_context = contextvars.ContextVar("_connection_context", default=connection)
 
@@ -138,6 +168,11 @@ def set_global_session(session):
     This is generally not recommended, except it may be necessary in
     certain use cases such as running inside Jupyter notebook.
     """
+
+    warnings.warn(
+        "set_global_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+        DeprecationWarning, 
+        stacklevel=2)
     global _session_context
     _session_context = contextvars.ContextVar("_session_context", default=session)
 
@@ -203,6 +238,10 @@ class CdpBase:
         :param cmd: any CDP command
         :returns: a CDP result
         """
+        warnings.warn(
+            "execute() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         cmd_id = next(self.id_iter)
         cmd_event = trio.Event()
         self.inflight_cmd[cmd_id] = cmd, cmd_event
@@ -230,6 +269,10 @@ class CdpBase:
     def listen(self, *event_types, buffer_size=10):
         """Return an async iterator that iterates over events matching the
         indicated types."""
+        warnings.warn(
+            "listen() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         sender, receiver = trio.open_memory_channel(buffer_size)
         for event_type in event_types:
             self.channels[event_type].add(sender)
@@ -243,6 +286,10 @@ class CdpBase:
         an async with block. The block will not exit until the indicated
         event is received.
         """
+        warnings.warn(
+            "wait_for() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         sender: trio.MemorySendChannel
         receiver: trio.MemoryReceiveChannel
         sender, receiver = trio.open_memory_channel(buffer_size)
@@ -258,6 +305,10 @@ class CdpBase:
 
         :param dict data: a JSON dictionary
         """
+        warnings.warn(
+            "handle_date() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         if "id" in data:
             self._handle_cmd_response(data)
         else:
@@ -269,6 +320,10 @@ class CdpBase:
 
         :param dict data: response as a JSON dictionary
         """
+        warnings.warn(
+            "handle_cmd_response() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         cmd_id = data["id"]
         try:
             cmd, event = self.inflight_cmd.pop(cmd_id)
@@ -295,6 +350,10 @@ class CdpBase:
 
         :param dict data: event as a JSON dictionary
         """
+        warnings.warn(
+            "_handle_event() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         global devtools
         event = devtools.util.parse_json_event(data)
         logger.debug("Received event: %s", event)
@@ -339,6 +398,10 @@ class CdpSession(CdpBase):
         This keeps track of concurrent callers and only disables DOM
         events when all callers have exited.
         """
+        warnings.warn(
+            "dom_enable() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         global devtools
         async with self._dom_enable_lock:
             self._dom_enable_count += 1
@@ -360,6 +423,10 @@ class CdpSession(CdpBase):
         This keeps track of concurrent callers and only disables page
         events when all callers have exited.
         """
+        warnings.warn(
+            "page_enable() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         global devtools
         async with self._page_enable_lock:
             self._page_enable_count += 1
@@ -403,6 +470,10 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
         ``CdpConnectionClosed`` after the CDP connection is closed. It
         is safe to call this multiple times.
         """
+        warnings.warn(
+            "aclose() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         await self.ws.aclose()
 
     @asynccontextmanager
@@ -414,6 +485,10 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
         dom.get_document()`` and it will execute on the current session
         automatically.
         """
+        warnings.warn(
+            "open_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         session = await self.connect_session(target_id)
         with session_context(session):
             yield session
@@ -421,6 +496,10 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
     async def connect_session(self, target_id) -> "CdpSession":
         """Returns a new :class:`CdpSession` connected to the specified
         target."""
+        warnings.warn(
+            "connect_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         global devtools
         session_id = await self.execute(devtools.target.attach_to_target(target_id, True))
         session = CdpSession(self.ws, session_id, target_id)
@@ -430,6 +509,10 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
     async def _reader_task(self):
         """Runs in the background and handles incoming messages: dispatching
         responses to commands and events to listeners."""
+        warnings.warn(
+            "render_task() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
         global devtools
         while True:
             try:
@@ -479,7 +562,11 @@ async def open_cdp(url) -> typing.AsyncIterator[CdpConnection]:
     you want to use multiple connections concurrently, it is recommended
     to open each on in a separate task.
     """
-
+    
+    warnings.warn(
+            "open_cdp() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
     async with trio.open_nursery() as nursery:
         conn = await connect_cdp(nursery, url)
         try:
@@ -503,6 +590,10 @@ async def connect_cdp(nursery, url) -> CdpConnection:
     current task. This argument is for unusual use cases, such as
     running inside of a notebook.
     """
+    warnings.warn(
+            "connect_cdp() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
+            DeprecationWarning, 
+            stacklevel=2)
     ws = await connect_websocket_url(nursery, url, max_message_size=MAX_WS_MESSAGE_SIZE)
     cdp_conn = CdpConnection(ws)
     nursery.start_soon(cdp_conn._reader_task)

--- a/py/selenium/webdriver/common/bidi/cdp.py
+++ b/py/selenium/webdriver/common/bidi/cdp.py
@@ -51,11 +51,6 @@ version = None
 def import_devtools(ver):
     """Attempt to load the current latest available devtools into the module
     cache for use later."""
-
-    warnings.warn(
-        "import_devtools() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     global devtools
     global version
     version = ver
@@ -85,11 +80,6 @@ def get_connection_context(fn_name):
     If there is no current connection, raise a ``RuntimeError`` with a
     helpful message.
     """
-
-    warnings.warn(
-        "get_connection_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     try:
         return _connection_context.get()
     except LookupError:
@@ -102,11 +92,6 @@ def get_session_context(fn_name):
     If there is no current session, raise a ``RuntimeError`` with a
     helpful message.
     """
-
-    warnings.warn(
-        "get_session_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     try:
         return _session_context.get()
     except LookupError:
@@ -117,11 +102,6 @@ def get_session_context(fn_name):
 def connection_context(connection):
     """This context manager installs ``connection`` as the session context for
     the current Trio task."""
-
-    warnings.warn(
-        "connection_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     token = _connection_context.set(connection)
     try:
         yield
@@ -133,11 +113,6 @@ def connection_context(connection):
 def session_context(session):
     """This context manager installs ``session`` as the session context for the
     current Trio task."""
-
-    warnings.warn(
-        "session_context() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     token = _session_context.set(session)
     try:
         yield
@@ -152,11 +127,6 @@ def set_global_connection(connection):
     This is generally not recommended, except it may be necessary in
     certain use cases such as running inside Jupyter notebook.
     """
-
-    warnings.warn(
-        "set_global_connection() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     global _connection_context
     _connection_context = contextvars.ContextVar("_connection_context", default=connection)
 
@@ -168,11 +138,6 @@ def set_global_session(session):
     This is generally not recommended, except it may be necessary in
     certain use cases such as running inside Jupyter notebook.
     """
-
-    warnings.warn(
-        "set_global_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-        DeprecationWarning, 
-        stacklevel=2)
     global _session_context
     _session_context = contextvars.ContextVar("_session_context", default=session)
 
@@ -238,10 +203,6 @@ class CdpBase:
         :param cmd: any CDP command
         :returns: a CDP result
         """
-        warnings.warn(
-            "execute() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         cmd_id = next(self.id_iter)
         cmd_event = trio.Event()
         self.inflight_cmd[cmd_id] = cmd, cmd_event
@@ -269,10 +230,6 @@ class CdpBase:
     def listen(self, *event_types, buffer_size=10):
         """Return an async iterator that iterates over events matching the
         indicated types."""
-        warnings.warn(
-            "listen() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         sender, receiver = trio.open_memory_channel(buffer_size)
         for event_type in event_types:
             self.channels[event_type].add(sender)
@@ -286,10 +243,6 @@ class CdpBase:
         an async with block. The block will not exit until the indicated
         event is received.
         """
-        warnings.warn(
-            "wait_for() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         sender: trio.MemorySendChannel
         receiver: trio.MemoryReceiveChannel
         sender, receiver = trio.open_memory_channel(buffer_size)
@@ -305,10 +258,6 @@ class CdpBase:
 
         :param dict data: a JSON dictionary
         """
-        warnings.warn(
-            "handle_date() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         if "id" in data:
             self._handle_cmd_response(data)
         else:
@@ -320,10 +269,6 @@ class CdpBase:
 
         :param dict data: response as a JSON dictionary
         """
-        warnings.warn(
-            "handle_cmd_response() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         cmd_id = data["id"]
         try:
             cmd, event = self.inflight_cmd.pop(cmd_id)
@@ -350,10 +295,6 @@ class CdpBase:
 
         :param dict data: event as a JSON dictionary
         """
-        warnings.warn(
-            "_handle_event() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         global devtools
         event = devtools.util.parse_json_event(data)
         logger.debug("Received event: %s", event)
@@ -398,10 +339,6 @@ class CdpSession(CdpBase):
         This keeps track of concurrent callers and only disables DOM
         events when all callers have exited.
         """
-        warnings.warn(
-            "dom_enable() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         global devtools
         async with self._dom_enable_lock:
             self._dom_enable_count += 1
@@ -423,10 +360,6 @@ class CdpSession(CdpBase):
         This keeps track of concurrent callers and only disables page
         events when all callers have exited.
         """
-        warnings.warn(
-            "page_enable() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         global devtools
         async with self._page_enable_lock:
             self._page_enable_count += 1
@@ -470,10 +403,6 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
         ``CdpConnectionClosed`` after the CDP connection is closed. It
         is safe to call this multiple times.
         """
-        warnings.warn(
-            "aclose() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         await self.ws.aclose()
 
     @asynccontextmanager
@@ -485,10 +414,6 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
         dom.get_document()`` and it will execute on the current session
         automatically.
         """
-        warnings.warn(
-            "open_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         session = await self.connect_session(target_id)
         with session_context(session):
             yield session
@@ -496,10 +421,6 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
     async def connect_session(self, target_id) -> "CdpSession":
         """Returns a new :class:`CdpSession` connected to the specified
         target."""
-        warnings.warn(
-            "connect_session() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         global devtools
         session_id = await self.execute(devtools.target.attach_to_target(target_id, True))
         session = CdpSession(self.ws, session_id, target_id)
@@ -509,10 +430,6 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
     async def _reader_task(self):
         """Runs in the background and handles incoming messages: dispatching
         responses to commands and events to listeners."""
-        warnings.warn(
-            "render_task() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
         global devtools
         while True:
             try:
@@ -562,11 +479,7 @@ async def open_cdp(url) -> typing.AsyncIterator[CdpConnection]:
     you want to use multiple connections concurrently, it is recommended
     to open each on in a separate task.
     """
-    
-    warnings.warn(
-            "open_cdp() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
+
     async with trio.open_nursery() as nursery:
         conn = await connect_cdp(nursery, url)
         try:
@@ -590,10 +503,6 @@ async def connect_cdp(nursery, url) -> CdpConnection:
     current task. This argument is for unusual use cases, such as
     running inside of a notebook.
     """
-    warnings.warn(
-            "connect_cdp() is now deprecated for Firefox. Please migrate to the new BiDi implementations", 
-            DeprecationWarning, 
-            stacklevel=2)
     ws = await connect_websocket_url(nursery, url, max_message_size=MAX_WS_MESSAGE_SIZE)
     cdp_conn = CdpConnection(ws)
     nursery.start_soon(cdp_conn._reader_task)

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1057,6 +1057,12 @@ class WebDriver(BaseWebDriver):
                     raise WebDriverException("Unable to find url to connect to from capabilities")
 
                 devtools = cdp.import_devtools(version)
+                if self.caps["browserName"].lower() == "firefox":
+                    warnings.warn(
+                        "CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
             self._websocket_connection = WebSocketConnection(ws_url)
             targets = self._websocket_connection.execute(devtools.target.get_targets())
             target_id = targets[0].target_id
@@ -1127,11 +1133,6 @@ class WebDriver(BaseWebDriver):
         if _firefox:
             # Mozilla Automation Team asked to only support 85
             # until WebDriver Bidi is available.
-            warnings.warn(
-                "CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             version = 85
         else:
             version = re.search(r".*/(\d+)\.", browser_version).group(1)

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1127,6 +1127,11 @@ class WebDriver(BaseWebDriver):
         if _firefox:
             # Mozilla Automation Team asked to only support 85
             # until WebDriver Bidi is available.
+            warnings.warn(
+                "CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             version = 85
         else:
             version = re.search(r".*/(\d+)\.", browser_version).group(1)

--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -25,7 +25,7 @@ def test_check_console_messages(driver, pages):
         devtools, connection = driver.start_devtools()
     console_api_calls = []
 
-    if driver.capabilities["browserName"] == "firefox":
+    if driver.caps["browserName"].lower() == "firefox":
         assert (
             record[0].message.args[0]
             == "CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi."

--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -21,8 +21,17 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 @pytest.mark.xfail_safari
 def test_check_console_messages(driver, pages):
-    devtools, connection = driver.start_devtools()
+    with pytest.warns(None) as record:
+        devtools, connection = driver.start_devtools()
     console_api_calls = []
+
+    if driver.capabilities["browserName"] == "firefox":
+        assert (
+            record[0].message.args[0]
+            == "CDP support for Firefox is deprecated and will be removed in future versions. Please switch to WebDriver BiDi."
+        )
+    else:
+        assert len(record) == 0
 
     connection.execute(devtools.runtime.enable())
     connection.on(devtools.runtime.ConsoleAPICalled, console_api_calls.append)

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -27,7 +27,9 @@ def test_log_output_as_filename() -> None:
     log_file = "geckodriver.log"
     service = Service(log_output=log_file)
     try:
-        driver = Firefox(service=service)
+        with pytest.warns(None) as record:
+            driver = Firefox(service=service)
+        assert len(record) == 0
         with open(log_file) as fp:
             assert "geckodriver\tINFO\tListening" in fp.readline()
     finally:

--- a/py/test/selenium/webdriver/remote/remote_firefox_profile_tests.py
+++ b/py/test/selenium/webdriver/remote/remote_firefox_profile_tests.py
@@ -22,7 +22,9 @@ from selenium import webdriver
 
 @pytest.fixture
 def driver(options):
-    driver = webdriver.Remote(options=options)
+    with pytest.warns(None) as record:
+        driver = webdriver.Remote(options=options)
+    assert len(record) == 0
     yield driver
     driver.quit()
 


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
This pull request introduces deprecation warnings for CDP (Chrome DevTools Protocol) support in Firefox and updates the corresponding tests. The most important changes include adding a deprecation warning in the `webdriver` module and ensuring that the tests handle these warnings appropriately.

Deprecation warning for CDP support in Firefox:

* [`py/selenium/webdriver/remote/webdriver.py`](diffhunk://#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985R1130-R1134): Added a deprecation warning for CDP support in Firefox, advising users to switch to WebDriver BiDi.

Updates to tests to handle deprecation warnings:

* [`py/test/selenium/webdriver/common/devtools_tests.py`](diffhunk://#diff-800b0102b563606add570f812f89944831fc639473425183366834ab7a754c0fR24-R35): Modified the `test_check_console_messages` test to check for the deprecation warning when using Firefox.
* [`py/test/selenium/webdriver/firefox/firefox_service_tests.py`](diffhunk://#diff-0927a021a9a819b97290f07bfb19947826b5d90f3515efff87e5f59ffb388f63R30-R32): Updated the `test_log_output_as_filename` test to ensure no warnings are recorded.
* [`py/test/selenium/webdriver/remote/remote_firefox_profile_tests.py`](diffhunk://#diff-1939f53bc8bdebf02dbefc8c76c4ad18fb92f8e6d41720058151e9bd3757bde9R25-R27): Added a check to ensure no warnings are recorded when initializing the `Remote` driver with Firefox options.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added a deprecation warning for CDP support in Firefox, advising users to switch to WebDriver BiDi.
- Updated tests to check for deprecation warnings when using Firefox.
- Ensured that no warnings are recorded in tests for other browsers.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add deprecation warning for CDP in Firefox</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/webdriver.py

<li>Added a deprecation warning for CDP support in Firefox.<br> <li> Instructed users to switch to WebDriver BiDi.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14787/files#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devtools_tests.py</strong><dd><code>Update tests to handle Firefox CDP deprecation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/devtools_tests.py

<li>Modified test to check for deprecation warning in Firefox.<br> <li> Ensured no warnings are recorded for other browsers.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14787/files#diff-800b0102b563606add570f812f89944831fc639473425183366834ab7a754c0f">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_service_tests.py</strong><dd><code>Ensure no warnings in Firefox service tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/firefox/firefox_service_tests.py

- Added check to ensure no warnings are recorded.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14787/files#diff-0927a021a9a819b97290f07bfb19947826b5d90f3515efff87e5f59ffb388f63">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remote_firefox_profile_tests.py</strong><dd><code>Ensure no warnings in remote Firefox profile tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/remote/remote_firefox_profile_tests.py

- Added check to ensure no warnings are recorded.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14787/files#diff-1939f53bc8bdebf02dbefc8c76c4ad18fb92f8e6d41720058151e9bd3757bde9">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information