### PR TITLE
[rb] Downgrade steep to 1.5.2 to avoid issues on windows based pipelines

### DIFF
--- a/rb/Gemfile
+++ b/rb/Gemfile
@@ -7,4 +7,4 @@ end
 
 gem 'curb', '~> 1.0.5', require: false, platforms: %i[mri mingw x64_mingw]
 gem 'debug', '~> 1.7', require: false, platforms: %i[mri mingw x64_mingw]
-gem 'steep', '~> 1.5.0', require: false, platforms: %i[mri mingw x64_mingw]
+gem 'steep', '1.5.2', require: false, platforms: %i[mri mingw x64_mingw]

--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.1)
-    minitest (5.25.1)
+    minitest (5.25.2)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -137,8 +137,8 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    securerandom (0.3.1)
-    steep (1.5.3)
+    securerandom (0.3.2)
+    steep (1.5.2)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -192,7 +192,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.16)
   selenium-devtools!
   selenium-webdriver!
-  steep (~> 1.5.0)
+  steep (= 1.5.2)
   webmock (~> 3.5)
   webrick (~> 1.7)
   yard (~> 0.9.11, >= 0.9.36)


### PR DESCRIPTION
### Description
Steep 1.5.3 depends on Active support which depends on Ruby 3.2.0 and this is causing issues on our pipelines for all of our windows based tests

The error message on our pipeline:

`steep (~> 1.5.0) mri, mingw, x64_mingw was resolved to 1.5.3, which depends on
      activesupport (>= 5.1) was resolved to 8.0.0, which depends on
        Ruby\0 (>= 3.2.0)`
        
### Motivation and Context
It is important that we have pipelines executing correctly and not being broken by dependencies

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
dependencies


___

### **Description**
- Downgraded the `steep` gem version in the `Gemfile` from `~> 1.5.0` to `1.5.2` to address compatibility or stability issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Downgrade `steep` gem version to 1.5.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/Gemfile

- Downgraded the `steep` gem version from `~> 1.5.0` to `1.5.2`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14790/files#diff-642bdae6b42094cb37012bc16f2af224644aa506d1d555386a1d81a6aae95fc6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information