### PR TITLE
[py] Replace deprecated get_attribute() in tests

### DIFF
--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -259,7 +259,7 @@ def text_to_be_present_in_element_value(
 
     def _predicate(driver: WebDriverOrWebElement):
         try:
-            element_text = driver.find_element(*locator).get_attribute("value")
+            element_text = driver.find_element(*locator).get_property("value")
             return text_ in element_text
         except StaleElementReferenceException:
             return False
@@ -278,7 +278,7 @@ def text_to_be_present_in_element_attribute(
 
     def _predicate(driver: WebDriverOrWebElement):
         try:
-            element_text = driver.find_element(*locator).get_attribute(attribute_)
+            element_text = driver.find_element(*locator).get_dom_attribute(attribute_)
             if element_text is None:
                 return False
             return text_ in element_text
@@ -483,7 +483,7 @@ def element_attribute_to_include(locator: Tuple[str, str], attribute_: str) -> C
 
     def _predicate(driver: WebDriverOrWebElement):
         try:
-            element_attribute = driver.find_element(*locator).get_attribute(attribute_)
+            element_attribute = driver.find_element(*locator).get_dom_attribute(attribute_)
             return element_attribute is not None
         except StaleElementReferenceException:
             return False

--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -43,6 +43,7 @@ D = TypeVar("D")
 T = TypeVar("T")
 
 WebDriverOrWebElement = Union[WebDriver, WebElement]
+attr_get_property = ["value", "checked", "index", "selected"]
 
 
 def title_is(title: str) -> Callable[[WebDriver], bool]:
@@ -278,7 +279,11 @@ def text_to_be_present_in_element_attribute(
 
     def _predicate(driver: WebDriverOrWebElement):
         try:
-            element_text = driver.find_element(*locator).get_dom_attribute(attribute_)
+            element_text = (
+                driver.find_element(*locator).get_dom_attribute(attribute_)
+                if attribute_ not in attr_get_property
+                else driver.find_element(*locator).get_property(attribute_)
+            )
             if element_text is None:
                 return False
             return text_ in element_text
@@ -483,7 +488,11 @@ def element_attribute_to_include(locator: Tuple[str, str], attribute_: str) -> C
 
     def _predicate(driver: WebDriverOrWebElement):
         try:
-            element_attribute = driver.find_element(*locator).get_dom_attribute(attribute_)
+            element_attribute = (
+                driver.find_element(*locator).get_dom_attribute(attribute_)
+                if attribute_ not in attr_get_property
+                else driver.find_element(*locator).get_property(attribute_)
+            )
             return element_attribute is not None
         except StaleElementReferenceException:
             return False

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -94,7 +94,7 @@ class Select:
         """
         match = str(index)
         for opt in self.options:
-            if opt.get_attribute("index") == match:
+            if opt.get_dom_attribute("index") == match:
                 self._set_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")
@@ -182,7 +182,7 @@ class Select:
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
         for opt in self.options:
-            if opt.get_attribute("index") == str(index):
+            if opt.get_dom_attribute("index") == str(index):
                 self._unset_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -92,9 +92,8 @@ class Select:
 
         throws NoSuchElementException If there is no option with specified index in SELECT
         """
-        match = str(index)
         for opt in self.options:
-            if opt.get_dom_attribute("index") == match:
+            if opt.get_property("index") == index:
                 self._set_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")
@@ -182,7 +181,7 @@ class Select:
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
         for opt in self.options:
-            if opt.get_dom_attribute("index") == str(index):
+            if opt.get_property("index") == index:
                 self._unset_selected(opt)
                 return
         raise NoSuchElementException(f"Could not locate element with index {index}")

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -53,7 +53,7 @@ def test_find_elements_by_xpath(driver, pages):
     pages.load("nestedElements.html")
     elems = driver.find_elements(By.XPATH, "//option")
     assert 48 == len(elems)
-    assert "One" == elems[0].get_attribute("value")
+    assert "One" == elems[0].get_property("value")
 
 
 def test_find_elements_by_name(driver, pages):
@@ -66,28 +66,28 @@ def test_find_elements_by_name_in_element_context(driver, pages):
     pages.load("nestedElements.html")
     elem = driver.find_element(By.NAME, "form2")
     sub_elem = elem.find_element(By.NAME, "selectomatic")
-    assert "2" == sub_elem.get_attribute("id")
+    assert "2" == sub_elem.get_dom_attribute("id")
 
 
 def test_find_elements_by_link_text_in_element_context(driver, pages):
     pages.load("nestedElements.html")
     elem = driver.find_element(By.NAME, "div1")
     sub_elem = elem.find_element(By.LINK_TEXT, "hello world")
-    assert "link1" == sub_elem.get_attribute("name")
+    assert "link1" == sub_elem.get_dom_attribute("name")
 
 
 def test_find_element_by_id_in_element_context(driver, pages):
     pages.load("nestedElements.html")
     elem = driver.find_element(By.NAME, "form2")
     sub_elem = elem.find_element(By.ID, "2")
-    assert "selectomatic" == sub_elem.get_attribute("name")
+    assert "selectomatic" == sub_elem.get_dom_attribute("name")
 
 
 def test_find_element_by_xpath_in_element_context(driver, pages):
     pages.load("nestedElements.html")
     elem = driver.find_element(By.NAME, "form2")
     sub_elem = elem.find_element(By.XPATH, "select")
-    assert "2" == sub_elem.get_attribute("id")
+    assert "2" == sub_elem.get_dom_attribute("id")
 
 
 def test_find_element_by_xpath_in_element_context_not_found(driver, pages):
@@ -103,7 +103,7 @@ def test_should_be_able_to_enter_data_into_form_fields(driver, pages):
     elem.clear()
     elem.send_keys("some text")
     elem = driver.find_element(By.XPATH, "//form[@name='someForm']/input[@id='username']")
-    assert "some text" == elem.get_attribute("value")
+    assert "some text" == elem.get_property("value")
 
 
 def test_find_element_by_tag_name(driver, pages):
@@ -164,7 +164,7 @@ def test_get_attribute(driver, pages):
     url = pages.url("xhtmlTest.html")
     driver.get(url)
     elem = driver.find_element(By.ID, "id1")
-    attr = elem.get_attribute("href")
+    attr = elem.get_property("href")
     assert f"{url}#" == attr
 
 
@@ -173,7 +173,7 @@ def test_get_implicit_attribute(driver, pages):
     elems = driver.find_elements(By.XPATH, "//option")
     assert len(elems) >= 3
     for i, elem in enumerate(elems[:3]):
-        assert i == int(elem.get_attribute("index"))
+        assert i == int(elem.get_property("index"))
 
 
 def test_get_dom_attribute(driver, pages):

--- a/py/test/selenium/webdriver/common/children_finding_tests.py
+++ b/py/test/selenium/webdriver/common/children_finding_tests.py
@@ -26,7 +26,7 @@ def test_should_find_element_by_xpath(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.NAME, "form2")
     child = element.find_element(By.XPATH, "select")
-    assert child.get_attribute("id") == "2"
+    assert child.get_dom_attribute("id") == "2"
 
 
 def test_should_not_find_element_by_xpath(driver, pages):
@@ -72,7 +72,7 @@ def test_should_find_element_by_name(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.NAME, "form2")
     child = element.find_element(By.NAME, "selectomatic")
-    assert child.get_attribute("id") == "2"
+    assert child.get_dom_attribute("id") == "2"
 
 
 def test_should_find_elements_by_name(driver, pages):
@@ -86,7 +86,7 @@ def test_should_find_element_by_id(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.NAME, "form2")
     child = element.find_element(By.ID, "2")
-    assert child.get_attribute("name") == "selectomatic"
+    assert child.get_dom_attribute("name") == "selectomatic"
 
 
 def test_should_find_elements_by_id(driver, pages):
@@ -114,7 +114,7 @@ def test_should_find_element_by_link_text(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.NAME, "div1")
     child = element.find_element(By.LINK_TEXT, "hello world")
-    assert child.get_attribute("name") == "link1"
+    assert child.get_dom_attribute("name") == "link1"
 
 
 def test_should_find_elements_by_link_text(driver, pages):
@@ -122,8 +122,8 @@ def test_should_find_elements_by_link_text(driver, pages):
     element = driver.find_element(By.NAME, "div1")
     children = element.find_elements(By.LINK_TEXT, "hello world")
     assert len(children) == 2
-    assert "link1" == children[0].get_attribute("name")
-    assert "link2" == children[1].get_attribute("name")
+    assert "link1" == children[0].get_dom_attribute("name")
+    assert "link2" == children[1].get_dom_attribute("name")
 
 
 def test_should_find_element_by_class_name(driver, pages):
@@ -144,7 +144,7 @@ def test_should_find_element_by_tag_name(driver, pages):
     pages.load("nestedElements.html")
     parent = driver.find_element(By.NAME, "div1")
     element = parent.find_element(By.TAG_NAME, "a")
-    assert "link1" == element.get_attribute("name")
+    assert "link1" == element.get_dom_attribute("name")
 
 
 def test_should_find_elements_by_tag_name(driver, pages):
@@ -158,7 +158,7 @@ def test_should_be_able_to_find_an_element_by_css_selector(driver, pages):
     pages.load("nestedElements.html")
     parent = driver.find_element(By.NAME, "form2")
     element = parent.find_element(By.CSS_SELECTOR, '*[name="selectomatic"]')
-    assert "2" == element.get_attribute("id")
+    assert "2" == element.get_dom_attribute("id")
 
 
 def test_should_be_able_to_find_multiple_elements_by_css_selector(driver, pages):

--- a/py/test/selenium/webdriver/common/clear_tests.py
+++ b/py/test/selenium/webdriver/common/clear_tests.py
@@ -25,7 +25,7 @@ def test_writable_text_input_should_clear(driver, pages):
     pages.load("readOnlyPage.html")
     element = driver.find_element(By.ID, "writableTextInput")
     element.clear()
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
 
 
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
@@ -49,7 +49,7 @@ def test_writable_text_area_should_clear(driver, pages):
     pages.load("readOnlyPage.html")
     element = driver.find_element(By.ID, "writableTextArea")
     element.clear()
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
 
 
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")

--- a/py/test/selenium/webdriver/common/correct_event_firing_tests.py
+++ b/py/test/selenium/webdriver/common/correct_event_firing_tests.py
@@ -99,7 +99,7 @@ def test_should_emit_click_event_when_clicking_on_atext_input_element(driver, pa
     clicker = driver.find_element(By.ID, "clickField")
     clicker.click()
 
-    assert clicker.get_attribute("value") == "Clicked"
+    assert clicker.get_property("value") == "Clicked"
 
 
 @pytest.mark.xfail_safari

--- a/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -27,19 +27,19 @@ from selenium.webdriver.common.by import By
 def test_should_be_able_to_find_asingle_element_by_id(driver, pages):
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.ID, "linkId")
-    assert element.get_attribute("id") == "linkId"
+    assert element.get_dom_attribute("id") == "linkId"
 
 
 def test_should_be_able_to_find_asingle_element_by_numeric_id(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.ID, "2")
-    assert element.get_attribute("id") == "2"
+    assert element.get_dom_attribute("id") == "2"
 
 
 def test_should_be_able_to_find_an_element_with_css_escape(driver, pages):
     pages.load("idElements.html")
     element = driver.find_element(By.ID, "with.dots")
-    assert element.get_attribute("id") == "with.dots"
+    assert element.get_dom_attribute("id") == "with.dots"
 
 
 def test_should_be_able_to_find_multiple_elements_by_id(driver, pages):
@@ -106,7 +106,7 @@ def test_no_such_element_error(driver, pages):
 def test_should_be_able_to_find_asingle_element_by_name(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.NAME, "checky")
-    assert element.get_attribute("value") == "furrfu"
+    assert element.get_property("value") == "furrfu"
 
 
 def test_should_be_able_to_find_multiple_elements_by_name(driver, pages):
@@ -118,7 +118,7 @@ def test_should_be_able_to_find_multiple_elements_by_name(driver, pages):
 def test_should_be_able_to_find_an_element_that_does_not_support_the_name_property(driver, pages):
     pages.load("nestedElements.html")
     element = driver.find_element(By.NAME, "div1")
-    assert element.get_attribute("name") == "div1"
+    assert element.get_dom_attribute("name") == "div1"
 
 
 # By.name negative
@@ -356,7 +356,7 @@ def test_should_be_able_to_find_an_element_by_xpath_with_multiple_attributes(dri
     pages.load("formPage.html")
     element = driver.find_element(By.XPATH, "//form[@name='optional']/input[@type='submit' and @value='Click!']")
     assert element.tag_name.lower() == "input"
-    assert element.get_attribute("value") == "Click!"
+    assert element.get_property("value") == "Click!"
 
 
 def test_finding_alink_by_xpath_should_locate_an_element_with_the_given_text(driver, pages):
@@ -489,7 +489,7 @@ def test_should_be_able_to_find_asingle_element_by_css_selector(driver, pages):
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.CSS_SELECTOR, "div.content")
     assert element.tag_name.lower() == "div"
-    assert element.get_attribute("class") == "content"
+    assert element.get_dom_attribute("class") == "content"
 
 
 def test_should_be_able_to_find_multiple_elements_by_css_selector(driver, pages):
@@ -502,33 +502,33 @@ def test_should_be_able_to_find_asingle_element_by_compound_css_selector(driver,
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.CSS_SELECTOR, "div.extraDiv, div.content")
     assert element.tag_name.lower() == "div"
-    assert element.get_attribute("class") == "content"
+    assert element.get_dom_attribute("class") == "content"
 
 
 def test_should_be_able_to_find_multiple_elements_by_compound_css_selector(driver, pages):
     pages.load("xhtmlTest.html")
     elements = driver.find_elements(By.CSS_SELECTOR, "div.extraDiv, div.content")
     assert len(elements) > 1
-    assert elements[0].get_attribute("class") == "content"
-    assert elements[1].get_attribute("class") == "extraDiv"
+    assert elements[0].get_dom_attribute("class") == "content"
+    assert elements[1].get_dom_attribute("class") == "extraDiv"
 
 
 def test_should_be_able_to_find_an_element_by_boolean_attribute_using_css_selector(driver, pages):
     pages.load("locators_tests/boolean_attribute_selected.html")
     element = driver.find_element(By.CSS_SELECTOR, "option[selected='selected']")
-    assert element.get_attribute("value") == "two"
+    assert element.get_property("value") == "two"
 
 
 def test_should_be_able_to_find_an_element_by_boolean_attribute_using_short_css_selector(driver, pages):
     pages.load("locators_tests/boolean_attribute_selected.html")
     element = driver.find_element(By.CSS_SELECTOR, "option[selected]")
-    assert element.get_attribute("value") == "two"
+    assert element.get_property("value") == "two"
 
 
 def test_should_be_able_to_find_an_element_by_boolean_attribute_using_short_css_selector_on_html_4_page(driver, pages):
     pages.load("locators_tests/boolean_attribute_selected_html4.html")
     element = driver.find_element(By.CSS_SELECTOR, "option[selected]")
-    assert element.get_attribute("value") == "two"
+    assert element.get_property("value") == "two"
 
 
 # By.css_Selector negative
@@ -600,14 +600,14 @@ def test_should_be_able_to_find_multiple_links_by_text(driver, pages):
 def test_should_find_element_by_link_text_containing_equals_sign(driver, pages):
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.LINK_TEXT, "Link=equalssign")
-    assert element.get_attribute("id") == "linkWithEqualsSign"
+    assert element.get_dom_attribute("id") == "linkWithEqualsSign"
 
 
 def test_should_find_multiple_elements_by_link_text_containing_equals_sign(driver, pages):
     pages.load("xhtmlTest.html")
     elements = driver.find_elements(By.LINK_TEXT, "Link=equalssign")
     assert 1 == len(elements)
-    assert elements[0].get_attribute("id") == "linkWithEqualsSign"
+    assert elements[0].get_dom_attribute("id") == "linkWithEqualsSign"
 
 
 def test_finds_by_link_text_on_xhtml_page(driver, pages):
@@ -629,7 +629,7 @@ def test_link_with_formatting_tags(driver, pages):
 def test_driver_can_get_link_by_link_test_ignoring_trailing_whitespace(driver, pages):
     pages.load("simpleTest.html")
     link = driver.find_element(By.LINK_TEXT, "link with trailing space")
-    assert link.get_attribute("id") == "linkWithTrailingSpace"
+    assert link.get_dom_attribute("id") == "linkWithTrailingSpace"
     assert link.text == "link with trailing space"
 
 
@@ -666,14 +666,14 @@ def test_should_be_able_to_find_asingle_element_by_partial_link_text(driver, pag
 def test_should_find_element_by_partial_link_text_containing_equals_sign(driver, pages):
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.PARTIAL_LINK_TEXT, "Link=")
-    assert element.get_attribute("id") == "linkWithEqualsSign"
+    assert element.get_dom_attribute("id") == "linkWithEqualsSign"
 
 
 def test_should_find_multiple_elements_by_partial_link_text_containing_equals_sign(driver, pages):
     pages.load("xhtmlTest.html")
     elements = driver.find_elements(By.PARTIAL_LINK_TEXT, "Link=")
     assert len(elements) == 1
-    assert elements[0].get_attribute("id") == "linkWithEqualsSign"
+    assert elements[0].get_dom_attribute("id") == "linkWithEqualsSign"
 
 
 # Misc tests
@@ -693,22 +693,22 @@ def test_when_finding_by_name_should_not_return_by_id(driver, pages):
     pages.load("formPage.html")
 
     element = driver.find_element(By.NAME, "id-name1")
-    assert element.get_attribute("value") == "name"
+    assert element.get_property("value") == "name"
 
     element = driver.find_element(By.ID, "id-name1")
-    assert element.get_attribute("value") == "id"
+    assert element.get_property("value") == "id"
 
     element = driver.find_element(By.NAME, "id-name2")
-    assert element.get_attribute("value") == "name"
+    assert element.get_property("value") == "name"
 
     element = driver.find_element(By.ID, "id-name2")
-    assert element.get_attribute("value") == "id"
+    assert element.get_property("value") == "id"
 
 
 def test_should_be_able_to_find_ahidden_elements_by_name(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.NAME, "hidden")
-    assert element.get_attribute("name") == "hidden"
+    assert element.get_dom_attribute("name") == "hidden"
 
 
 def test_should_not_be_able_to_find_an_element_on_a_blank_page(driver, pages):

--- a/py/test/selenium/webdriver/common/element_attribute_tests.py
+++ b/py/test/selenium/webdriver/common/element_attribute_tests.py
@@ -24,45 +24,45 @@ from selenium.webdriver.common.by import By
 def test_should_return_null_when_getting_the_value_of_an_attribute_that_is_not_listed(driver, pages):
     pages.load("simpleTest.html")
     head = driver.find_element(By.XPATH, "/html")
-    attribute = head.get_attribute("cheese")
+    attribute = head.get_dom_attribute("cheese")
     assert attribute is None
 
 
 def test_should_return_null_when_getting_src_attribute_of_invalid_img_tag(driver, pages):
     pages.load("simpleTest.html")
     img = driver.find_element(By.ID, "invalidImgTag")
-    img_attr = img.get_attribute("src")
+    img_attr = img.get_dom_attribute("src")
     assert img_attr is None
 
 
 def test_should_return_an_absolute_url_when_getting_src_attribute_of_avalid_img_tag(driver, pages):
     pages.load("simpleTest.html")
     img = driver.find_element(By.ID, "validImgTag")
-    img_attr = img.get_attribute("src")
+    img_attr = img.get_dom_attribute("src")
     assert "icon.gif" in img_attr
 
 
 def test_should_return_an_absolute_url_when_getting_href_attribute_of_avalid_anchor_tag(driver, pages):
     pages.load("simpleTest.html")
     img = driver.find_element(By.ID, "validAnchorTag")
-    img_attr = img.get_attribute("href")
+    img_attr = img.get_dom_attribute("href")
     assert "icon.gif" in img_attr
 
 
 def test_should_return_empty_attribute_values_when_present_and_the_value_is_actually_empty(driver, pages):
     pages.load("simpleTest.html")
     body = driver.find_element(By.XPATH, "//body")
-    assert "" == body.get_attribute("style")
+    assert "" == body.get_dom_attribute("style")
 
 
 def test_should_return_the_value_of_the_disabled_attribute_as_false_if_not_set(driver, pages):
     pages.load("formPage.html")
     inputElement = driver.find_element(By.XPATH, "//input[@id='working']")
-    assert inputElement.get_attribute("disabled") is None
+    assert inputElement.get_dom_attribute("disabled") is None
     assert inputElement.is_enabled()
 
     pElement = driver.find_element(By.ID, "peas")
-    assert pElement.get_attribute("disabled") is None
+    assert pElement.get_dom_attribute("disabled") is None
     assert pElement.is_enabled()
 
 
@@ -70,7 +70,7 @@ def test_should_return_the_value_of_the_index_attribute_even_if_it_is_missing(dr
     pages.load("formPage.html")
     multiSelect = driver.find_element(By.ID, "multi")
     options = multiSelect.find_elements(By.TAG_NAME, "option")
-    assert "1" == options[1].get_attribute("index")
+    assert 1 == options[1].get_property("index")
 
 
 def test_should_indicate_the_elements_that_are_disabled_are_not_is_enabled(driver, pages):
@@ -126,9 +126,9 @@ def test_should_indicate_when_aselect_is_disabled(driver, pages):
 def test_should_return_the_value_of_checked_for_acheckbox_even_if_it_lacks_that_attribute(driver, pages):
     pages.load("formPage.html")
     checkbox = driver.find_element(By.XPATH, "//input[@id='checky']")
-    assert checkbox.get_attribute("checked") is None
+    assert checkbox.get_property("checked") is False
     checkbox.click()
-    assert "true" == checkbox.get_attribute("checked")
+    assert True is checkbox.get_property("checked")
 
 
 def test_should_return_the_value_of_selected_for_radio_buttons_even_if_they_lack_that_attribute(driver, pages):
@@ -137,14 +137,14 @@ def test_should_return_the_value_of_selected_for_radio_buttons_even_if_they_lack
     initiallyNotSelected = driver.find_element(By.ID, "peas")
     initiallySelected = driver.find_element(By.ID, "cheese_and_peas")
 
-    assert neverSelected.get_attribute("checked") is None
-    assert initiallyNotSelected.get_attribute("checked") is None
-    assert "true" == initiallySelected.get_attribute("checked")
+    assert neverSelected.get_property("checked") is False
+    assert initiallyNotSelected.get_property("checked") is False
+    assert True is initiallySelected.get_property("checked")
 
     initiallyNotSelected.click()
-    assert neverSelected.get_attribute("selected") is None
-    assert "true" == initiallyNotSelected.get_attribute("checked")
-    assert initiallySelected.get_attribute("checked") is None
+    assert neverSelected.get_property("selected") is None
+    assert True is initiallyNotSelected.get_property("checked")
+    assert initiallySelected.get_property("checked") is False
 
 
 def test_should_return_the_value_of_selected_for_options_in_selects_even_if_they_lack_that_attribute(driver, pages):
@@ -155,14 +155,14 @@ def test_should_return_the_value_of_selected_for_options_in_selects_even_if_they
     two = options[1]
     assert one.is_selected()
     assert not two.is_selected()
-    assert "true" == one.get_attribute("selected")
-    assert two.get_attribute("selected") is None
+    assert True is one.get_property("selected")
+    assert two.get_property("selected") is False
 
 
 def test_should_return_value_of_class_attribute_of_an_element(driver, pages):
     pages.load("xhtmlTest.html")
     heading = driver.find_element(By.XPATH, "//h1")
-    classname = heading.get_attribute("class")
+    classname = heading.get_dom_attribute("class")
     assert "header" == classname
 
 
@@ -172,13 +172,13 @@ def test_should_return_value_of_class_attribute_of_an_element(driver, pages):
 #    driver.switch_to.frame("iframe1")
 #
 #    wallace = driver.find_element(By.XPATH, "//div[@id='wallace']")
-#    classname = wallace.get_attribute("class")
+#    classname = wallace.get_dom_attribute("class")
 #    assert "gromit" == classname
 
 
 def test_should_return_the_contents_of_atext_area_as_its_value(driver, pages):
     pages.load("formPage.html")
-    value = driver.find_element(By.ID, "withText").get_attribute("value")
+    value = driver.find_element(By.ID, "withText").get_property("value")
     assert "Example text" == value
 
 
@@ -186,17 +186,17 @@ def test_should_return_the_contents_of_atext_area_as_its_value_when_set_to_non_n
     pages.load("formPage.html")
     e = driver.find_element(By.ID, "withText")
     driver.execute_script("arguments[0].value = 'tRuE'", e)
-    value = e.get_attribute("value")
+    value = e.get_property("value")
     assert "tRuE" == value
 
 
 def test_should_treat_readonly_as_avalue(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.NAME, "readonly")
-    readOnlyAttribute = element.get_attribute("readonly")
+    readOnlyAttribute = element.get_dom_attribute("readonly")
 
     textInput = driver.find_element(By.NAME, "x")
-    notReadOnly = textInput.get_attribute("readonly")
+    notReadOnly = textInput.get_dom_attribute("readonly")
 
     assert readOnlyAttribute != notReadOnly
 
@@ -204,12 +204,12 @@ def test_should_treat_readonly_as_avalue(driver, pages):
 def test_should_get_numeric_attribute(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "withText")
-    assert "5" == element.get_attribute("rows")
+    assert "5" == element.get_dom_attribute("rows")
 
 
 def test_can_return_atext_approximation_of_the_style_attribute(driver, pages):
     pages.load("javascriptPage.html")
-    style = driver.find_element(By.ID, "red-item").get_attribute("style")
+    style = driver.find_element(By.ID, "red-item").get_dom_attribute("style")
     assert "background-color" in style.lower()
 
 
@@ -219,54 +219,54 @@ def test_should_correctly_report_value_of_colspan(driver, pages):
     th1 = driver.find_element(By.ID, "th1")
     td2 = driver.find_element(By.ID, "td2")
 
-    assert "th1" == th1.get_attribute("id")
-    assert "3" == th1.get_attribute("colspan")
+    assert "th1" == th1.get_dom_attribute("id")
+    assert "3" == th1.get_dom_attribute("colspan")
 
-    assert "td2" == td2.get_attribute("id")
-    assert "2" == td2.get_attribute("colspan")
+    assert "td2" == td2.get_dom_attribute("id")
+    assert "2" == td2.get_dom_attribute("colspan")
 
 
 def test_can_retrieve_the_current_value_of_atext_form_field_text_input(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "working")
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
     element.send_keys("hello world")
-    assert "hello world" == element.get_attribute("value")
+    assert "hello world" == element.get_property("value")
 
 
 def test_can_retrieve_the_current_value_of_atext_form_field_email_input(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "email")
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
     element.send_keys("hello@example.com")
-    assert "hello@example.com" == element.get_attribute("value")
+    assert "hello@example.com" == element.get_property("value")
 
 
 def test_can_retrieve_the_current_value_of_atext_form_field_text_area(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "emptyTextArea")
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
     element.send_keys("hello world")
-    assert "hello world" == element.get_attribute("value")
+    assert "hello world" == element.get_property("value")
 
 
 def test_should_return_null_for_non_present_boolean_attributes(driver, pages):
     pages.load("booleanAttributes.html")
     element1 = driver.find_element(By.ID, "working")
-    assert element1.get_attribute("required") is None
+    assert element1.get_dom_attribute("required") is None
 
 
 @pytest.mark.xfail_ie
 def test_should_return_true_for_present_boolean_attributes(driver, pages):
     pages.load("booleanAttributes.html")
     element1 = driver.find_element(By.ID, "emailRequired")
-    assert "true" == element1.get_attribute("required")
+    assert "true" == element1.get_dom_attribute("required")
     element2 = driver.find_element(By.ID, "emptyTextAreaRequired")
-    assert "true" == element2.get_attribute("required")
+    assert "true" == element2.get_dom_attribute("required")
     element3 = driver.find_element(By.ID, "inputRequired")
-    assert "true" == element3.get_attribute("required")
+    assert "true" == element3.get_dom_attribute("required")
     element4 = driver.find_element(By.ID, "textAreaRequired")
-    assert "true" == element4.get_attribute("required")
+    assert "true" == element4.get_dom_attribute("required")
 
 
 @pytest.mark.xfail_chrome
@@ -276,7 +276,7 @@ def test_should_return_true_for_present_boolean_attributes(driver, pages):
 @pytest.mark.xfail_remote
 def test_should_get_unicode_chars_from_attribute(driver, pages):
     pages.load("formPage.html")
-    title = driver.find_element(By.ID, "vsearchGadget").get_attribute("title")
+    title = driver.find_element(By.ID, "vsearchGadget").get_dom_attribute("title")
     assert "Hvad s\xf8ger du?" == title
 
 
@@ -288,5 +288,5 @@ def test_should_get_unicode_chars_from_attribute(driver, pages):
 def test_should_get_values_and_not_miss_items(driver, pages):
     pages.load("attributes.html")
     expected = "4b273a33fbbd29013nN93dy4F1A~"
-    result = driver.find_element(By.CSS_SELECTOR, "li").get_attribute("value")
+    result = driver.find_element(By.CSS_SELECTOR, "li").get_property("value")
     assert expected == result

--- a/py/test/selenium/webdriver/common/executing_async_javascript_tests.py
+++ b/py/test/selenium/webdriver/common/executing_async_javascript_tests.py
@@ -157,7 +157,7 @@ def test_should_be_able_to_execute_asynchronous_scripts(driver, pages):
 
     typer = driver.find_element(by=By.NAME, value="typer")
     typer.send_keys("bob")
-    assert "bob" == typer.get_attribute("value")
+    assert "bob" == typer.get_property("value")
 
     driver.find_element(by=By.ID, value="red").click()
     driver.find_element(by=By.NAME, value="submit").click()
@@ -171,7 +171,7 @@ def test_should_be_able_to_execute_asynchronous_scripts(driver, pages):
         window.registerListener(arguments[arguments.length - 1]);"""
     )
     assert "bob" == text
-    assert "" == typer.get_attribute("value")
+    assert "" == typer.get_property("value")
 
     assert 2 == len(
         driver.find_elements(by=By.TAG_NAME, value="div")

--- a/py/test/selenium/webdriver/common/form_handling_tests.py
+++ b/py/test/selenium/webdriver/common/form_handling_tests.py
@@ -81,20 +81,20 @@ def test_should_be_able_to_enter_text_into_atext_area_by_setting_its_value(drive
     textarea = driver.find_element(By.ID, "keyUpArea")
     cheesey = "Brie and cheddar"
     textarea.send_keys(cheesey)
-    assert textarea.get_attribute("value") == cheesey
+    assert textarea.get_property("value") == cheesey
 
 
 def test_should_enter_data_into_form_fields(driver, pages):
     pages.load("xhtmlTest.html")
     element = driver.find_element(By.XPATH, "//form[@name='someForm']/input[@id='username']")
-    originalValue = element.get_attribute("value")
+    originalValue = element.get_property("value")
     assert originalValue == "change"
 
     element.clear()
     element.send_keys("some text")
 
     element = driver.find_element(By.XPATH, "//form[@name='someForm']/input[@id='username']")
-    newFormValue = element.get_attribute("value")
+    newFormValue = element.get_property("value")
     assert newFormValue == "some text"
 
 
@@ -178,11 +178,11 @@ def test_sending_keyboard_events_should_append_text_in_inputs(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "working")
     element.send_keys("Some")
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert value == "Some"
 
     element.send_keys(" text")
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert value == "Some text"
 
 
@@ -190,32 +190,32 @@ def test_should_be_able_to_clear_text_from_input_elements(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "working")
     element.send_keys("Some text")
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert len(value) > 0
 
     element.clear()
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert len(value) == 0
 
 
 def test_empty_text_boxes_should_return_an_empty_string_not_null(driver, pages):
     pages.load("formPage.html")
     emptyTextBox = driver.find_element(By.ID, "working")
-    assert emptyTextBox.get_attribute("value") == ""
+    assert emptyTextBox.get_property("value") == ""
 
     emptyTextArea = driver.find_element(By.ID, "emptyTextArea")
-    assert emptyTextArea.get_attribute("value") == ""
+    assert emptyTextArea.get_property("value") == ""
 
 
 def test_should_be_able_to_clear_text_from_text_areas(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "withText")
     element.send_keys("Some text")
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert len(value) > 0
 
     element.clear()
-    value = element.get_attribute("value")
+    value = element.get_property("value")
     assert len(value) == 0
 
 

--- a/py/test/selenium/webdriver/common/frame_switching_tests.py
+++ b/py/test/selenium/webdriver/common/frame_switching_tests.py
@@ -74,19 +74,19 @@ def test_should_be_able_to_switch_to_aframe_by_its_index(driver, pages):
 def test_should_be_able_to_switch_to_an_iframe_by_its_index(driver, pages):
     pages.load("iframes.html")
     driver.switch_to.frame(0)
-    assert driver.find_element(By.NAME, "id-name1").get_attribute("value") == "name"
+    assert driver.find_element(By.NAME, "id-name1").get_property("value") == "name"
 
 
 def test_should_be_able_to_switch_to_aframe_by_its_name(driver, pages):
     pages.load("frameset.html")
     driver.switch_to.frame("fourth")
-    assert driver.find_element(By.TAG_NAME, "frame").get_attribute("name") == "child1"
+    assert driver.find_element(By.TAG_NAME, "frame").get_dom_attribute("name") == "child1"
 
 
 def test_should_be_able_to_switch_to_an_iframe_by_its_name(driver, pages):
     pages.load("iframes.html")
     driver.switch_to.frame("iframe1-name")
-    assert driver.find_element(By.NAME, "id-name1").get_attribute("value") == "name"
+    assert driver.find_element(By.NAME, "id-name1").get_property("value") == "name"
 
 
 def test_should_be_able_to_switch_to_aframe_by_its_id(driver, pages):
@@ -98,7 +98,7 @@ def test_should_be_able_to_switch_to_aframe_by_its_id(driver, pages):
 def test_should_be_able_to_switch_to_an_iframe_by_its_id(driver, pages):
     pages.load("iframes.html")
     driver.switch_to.frame("iframe1")
-    assert driver.find_element(By.NAME, "id-name1").get_attribute("value") == "name"
+    assert driver.find_element(By.NAME, "id-name1").get_property("value") == "name"
 
 
 def test_should_be_able_to_switch_to_frame_with_name_containing_dot(driver, pages):
@@ -120,7 +120,7 @@ def test_should_be_able_to_switch_to_an_iframe_using_apreviously_located_web_ele
     driver.switch_to.frame(frame)
 
     element = driver.find_element(By.NAME, "id-name1")
-    assert element.get_attribute("value") == "name"
+    assert element.get_property("value") == "name"
 
 
 def test_should_ensure_element_is_aframe_before_switching(driver, pages):

--- a/py/test/selenium/webdriver/common/interactions_tests.py
+++ b/py/test/selenium/webdriver/common/interactions_tests.py
@@ -109,7 +109,7 @@ def test_double_click(driver, pages):
     dblClick = ActionChains(driver).double_click(toDoubleClick)
 
     dblClick.perform()
-    assert "DoubleClicked" == toDoubleClick.get_attribute("value")
+    assert "DoubleClicked" == toDoubleClick.get_property("value")
 
 
 def test_context_click(driver, pages):
@@ -120,7 +120,7 @@ def test_context_click(driver, pages):
     contextClick = ActionChains(driver).context_click(toContextClick)
 
     contextClick.perform()
-    assert "ContextClicked" == toContextClick.get_attribute("value")
+    assert "ContextClicked" == toContextClick.get_property("value")
 
 
 def test_move_and_click(driver, pages):
@@ -131,7 +131,7 @@ def test_move_and_click(driver, pages):
     click = ActionChains(driver).move_to_element(toClick).click()
 
     click.perform()
-    assert "Clicked" == toClick.get_attribute("value")
+    assert "Clicked" == toClick.get_property("value")
 
 
 def test_cannot_move_to_anull_locator(driver, pages):
@@ -195,7 +195,7 @@ def test_sending_keys_to_active_element_with_modifier(driver, pages):
 
     ActionChains(driver).key_down(Keys.SHIFT).send_keys("abc").key_up(Keys.SHIFT).perform()
 
-    assert "ABC" == e.get_attribute("value")
+    assert "ABC" == e.get_property("value")
 
 
 def test_sending_keys_to_element(driver, pages):
@@ -204,7 +204,7 @@ def test_sending_keys_to_element(driver, pages):
 
     ActionChains(driver).send_keys_to_element(e, "abc").perform()
 
-    assert "abc" == e.get_attribute("value")
+    assert "abc" == e.get_property("value")
 
 
 def test_can_send_keys_between_clicks(driver, pages):
@@ -217,7 +217,7 @@ def test_can_send_keys_between_clicks(driver, pages):
     keydown = driver.find_element(By.ID, "keyDown")
     ActionChains(driver).click(keyup).send_keys("foobar").click(keydown).perform()
 
-    assert "foobar" == keyup.get_attribute("value")
+    assert "foobar" == keyup.get_property("value")
 
 
 def test_can_reset_interactions(driver):
@@ -247,8 +247,8 @@ def test_can_pause(driver, pages):
     end = time()
 
     assert pause_time < end - start
-    assert "Clicked" == toClick.get_attribute("value")
-    assert "Clicked" == toDoubleClick.get_attribute("value")
+    assert "Clicked" == toClick.get_property("value")
+    assert "Clicked" == toDoubleClick.get_property("value")
 
 
 @pytest.mark.xfail_firefox

--- a/py/test/selenium/webdriver/common/interactions_with_device_tests.py
+++ b/py/test/selenium/webdriver/common/interactions_with_device_tests.py
@@ -79,7 +79,7 @@ def test_double_click_with_pointer(driver, pages):
 
     dblClick = ActionChains(driver, devices=[mouse]).double_click(toDoubleClick)
     dblClick.perform()
-    assert "DoubleClicked" == toDoubleClick.get_attribute("value")
+    assert "DoubleClicked" == toDoubleClick.get_property("value")
 
 
 def test_context_click_with_pointer(driver, pages):
@@ -91,7 +91,7 @@ def test_context_click_with_pointer(driver, pages):
 
     contextClick = ActionChains(driver, devices=[mouse]).context_click(toContextClick)
     contextClick.perform()
-    assert "ContextClicked" == toContextClick.get_attribute("value")
+    assert "ContextClicked" == toContextClick.get_property("value")
 
 
 def test_move_and_click_with_pointer(driver, pages):
@@ -103,7 +103,7 @@ def test_move_and_click_with_pointer(driver, pages):
 
     click = ActionChains(driver, devices=[mouse]).move_to_element(toClick).click()
     click.perform()
-    assert "Clicked" == toClick.get_attribute("value")
+    assert "Clicked" == toClick.get_property("value")
 
 
 def test_cannot_move_to_anull_locator_with_pointer(driver, pages):
@@ -179,7 +179,7 @@ def test_sending_keys_to_active_element_with_modifier_with_keyboard(driver, page
 
     ActionChains(driver, devices=[key_board]).key_down(Keys.SHIFT).send_keys("abc").key_up(Keys.SHIFT).perform()
 
-    assert "ABC" == e.get_attribute("value")
+    assert "ABC" == e.get_property("value")
 
 
 def test_sending_keys_to_element_with_keyboard(driver, pages):
@@ -190,7 +190,7 @@ def test_sending_keys_to_element_with_keyboard(driver, pages):
 
     ActionChains(driver, devices=[key_board]).send_keys_to_element(e, "abc").perform()
 
-    assert "abc" == e.get_attribute("value")
+    assert "abc" == e.get_property("value")
 
 
 def test_can_send_keys_between_clicks_with_keyboard(driver, pages):
@@ -206,7 +206,7 @@ def test_can_send_keys_between_clicks_with_keyboard(driver, pages):
 
     ActionChains(driver, devices=[key_board]).click(keyup).send_keys("foobar").click(keydown).perform()
 
-    assert "foobar" == keyup.get_attribute("value")
+    assert "foobar" == keyup.get_property("value")
 
 
 def test_can_reset_interactions_with_devices(driver):
@@ -241,8 +241,8 @@ def test_can_pause_with_pointer(driver, pages):
     end = time()
 
     assert pause_time < end - start
-    assert "Clicked" == toClick.get_attribute("value")
-    assert "Clicked" == toDoubleClick.get_attribute("value")
+    assert "Clicked" == toClick.get_property("value")
+    assert "Clicked" == toDoubleClick.get_property("value")
 
 
 @pytest.mark.xfail_firefox

--- a/py/test/selenium/webdriver/common/select_element_handling_tests.py
+++ b/py/test/selenium/webdriver/common/select_element_handling_tests.py
@@ -86,12 +86,12 @@ def test_can_select_elements_in_opt_group(driver, pages):
 def test_can_get_value_from_option_via_attribute_when_attribute_doesnt_exist(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.CSS_SELECTOR, "select[name='select-default'] option")
-    assert element.get_attribute("value") == "One"
+    assert element.get_property("value") == "One"
     element = driver.find_element(By.ID, "blankOption")
-    assert element.get_attribute("value") == ""
+    assert element.get_property("value") == ""
 
 
 def test_can_get_value_from_option_via_attribute_when_attribute_is_empty_string(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "optionEmptyValueSet")
-    assert element.get_attribute("value") == ""
+    assert element.get_property("value") == ""

--- a/py/test/selenium/webdriver/common/stale_reference_tests.py
+++ b/py/test/selenium/webdriver/common/stale_reference_tests.py
@@ -45,4 +45,4 @@ def test_should_not_crash_when_querying_the_attribute_of_astale_element(driver, 
     heading = driver.find_element(by=By.XPATH, value="//h1")
     pages.load("simpleTest.html")
     with pytest.raises(StaleElementReferenceException):
-        heading.get_attribute("class")
+        heading.get_dom_attribute("class")

--- a/py/test/selenium/webdriver/common/text_handling_tests.py
+++ b/py/test/selenium/webdriver/common/text_handling_tests.py
@@ -120,7 +120,7 @@ def test_should_be_able_to_set_more_than_one_line_of_text_in_atext_area(driver, 
 
     textarea.send_keys(expectedText)
 
-    seenText = textarea.get_attribute("value")
+    seenText = textarea.get_property("value")
     assert seenText == expectedText
 
 
@@ -129,7 +129,7 @@ def test_should_be_able_to_enter_dates_after_filling_in_other_values_first(drive
     input_ = driver.find_element(by=By.ID, value="working")
     expectedValue = "10/03/2007 to 30/07/1993"
     input_.send_keys(expectedValue)
-    seenValue = input_.get_attribute("value")
+    seenValue = input_.get_property("value")
 
     assert seenValue == expectedValue
 

--- a/py/test/selenium/webdriver/common/typing_tests.py
+++ b/py/test/selenium/webdriver/common/typing_tests.py
@@ -52,49 +52,49 @@ def test_should_type_lower_case_letters(driver, pages):
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("abc def")
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "keyReporter"), "abc def"))
-    assert keyReporter.get_attribute("value") == "abc def"
+    assert keyReporter.get_property("value") == "abc def"
 
 
 def test_should_be_able_to_type_capital_letters(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("ABC DEF")
-    assert keyReporter.get_attribute("value") == "ABC DEF"
+    assert keyReporter.get_property("value") == "ABC DEF"
 
 
 def test_should_be_able_to_type_quote_marks(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys('"')
-    assert keyReporter.get_attribute("value") == '"'
+    assert keyReporter.get_property("value") == '"'
 
 
 def test_should_be_able_to_type_the_at_character(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("@")
-    assert keyReporter.get_attribute("value") == "@"
+    assert keyReporter.get_property("value") == "@"
 
 
 def test_should_be_able_to_mix_upper_and_lower_case_letters(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("me@eXample.com")
-    assert keyReporter.get_attribute("value") == "me@eXample.com"
+    assert keyReporter.get_property("value") == "me@eXample.com"
 
 
 def test_arrow_keys_should_not_be_printable(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys(Keys.ARROW_LEFT)
-    assert keyReporter.get_attribute("value") == ""
+    assert keyReporter.get_property("value") == ""
 
 
 def test_list_of_arrow_keys_should_not_be_printable(driver, pages):
     pages.load("javascriptPage.html")
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys([Keys.ARROW_LEFT])
-    assert keyReporter.get_attribute("value") == ""
+    assert keyReporter.get_property("value") == ""
 
 
 def test_should_be_able_to_use_arrow_keys(driver, pages):
@@ -102,7 +102,7 @@ def test_should_be_able_to_use_arrow_keys(driver, pages):
     keyReporter = driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("Tet", Keys.ARROW_LEFT, "s")
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "keyReporter"), "Test"))
-    assert keyReporter.get_attribute("value") == "Test"
+    assert keyReporter.get_property("value") == "Test"
 
 
 @pytest.mark.xfail_safari
@@ -188,7 +188,7 @@ def test_should_report_key_code_of_arrow_keys_up_down_events(driver, pages):
     assert "up: 39" in result.text.strip()
 
     #  And leave no rubbish/printable keys in the "keyReporter"
-    assert element.get_attribute("value") == ""
+    assert element.get_property("value") == ""
 
 
 def test_numeric_non_shift_keys(driver, pages):
@@ -196,7 +196,7 @@ def test_numeric_non_shift_keys(driver, pages):
     element = driver.find_element(by=By.ID, value="keyReporter")
     numericLineCharsNonShifted = "`1234567890-=[]\\,.'/42"
     element.send_keys(numericLineCharsNonShifted)
-    assert element.get_attribute("value") == numericLineCharsNonShifted
+    assert element.get_property("value") == numericLineCharsNonShifted
 
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1255258")
@@ -207,7 +207,7 @@ def test_numeric_shift_keys(driver, pages):
     element = driver.find_element(by=By.ID, value="keyReporter")
     numericShiftsEtc = '~!@#$%^&*()_+{}:i"<>?|END~'
     element.send_keys(numericShiftsEtc)
-    assert element.get_attribute("value") == numericShiftsEtc
+    assert element.get_property("value") == numericShiftsEtc
     assert "up: 16" in result.text.strip()
 
 
@@ -217,7 +217,7 @@ def test_lower_case_alpha_keys(driver, pages):
     lowerAlphas = "abcdefghijklmnopqrstuvwxyz"
     element.send_keys(lowerAlphas)
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "keyReporter"), lowerAlphas))
-    assert element.get_attribute("value") == lowerAlphas
+    assert element.get_property("value") == lowerAlphas
 
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1255258")
@@ -228,7 +228,7 @@ def test_uppercase_alpha_keys(driver, pages):
     element = driver.find_element(by=By.ID, value="keyReporter")
     upperAlphas = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     element.send_keys(upperAlphas)
-    assert element.get_attribute("value") == upperAlphas
+    assert element.get_property("value") == upperAlphas
     assert "up: 16" in result.text.strip()
 
 
@@ -241,7 +241,7 @@ def test_all_printable_keys(driver, pages):
     allPrintable = "!\"#$%&'()*+,-./0123456789:<=>?@ ABCDEFGHIJKLMNOPQRSTUVWXYZ [\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
     element.send_keys(allPrintable)
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "keyReporter"), allPrintable))
-    assert element.get_attribute("value") == allPrintable
+    assert element.get_property("value") == allPrintable
     assert "up: 16" in result.text.strip()
 
 
@@ -249,7 +249,7 @@ def test_arrow_keys_and_page_up_and_down(driver, pages):
     pages.load("javascriptPage.html")
     element = driver.find_element(by=By.ID, value="keyReporter")
     element.send_keys(f"a{Keys.LEFT}b{Keys.RIGHT}{Keys.UP}{Keys.DOWN}{Keys.PAGE_UP}{Keys.PAGE_DOWN}1")
-    assert element.get_attribute("value") == "ba1"
+    assert element.get_property("value") == "ba1"
 
 
 # def test_home_and_end_and_page_up_and_page_down_keys(driver, pages):
@@ -265,20 +265,20 @@ def test_arrow_keys_and_page_up_and_down(driver, pages):
 #  element.send_keys("abc" + Keys.HOME + "0" + Keys.LEFT + Keys.RIGHT +
 #                   Keys.PAGE_UP + Keys.PAGE_DOWN + Keys.END + "1" + Keys.HOME +
 #                   "0" + Keys.PAGE_UP + Keys.END + "111" + Keys.HOME + "00")
-#  assert element.get_attribute("value") == "0000abc1111"
+#  assert element.get_property("value") == "0000abc1111"
 
 
 def test_delete_and_backspace_keys(driver, pages):
     pages.load("javascriptPage.html")
     element = driver.find_element(by=By.ID, value="keyReporter")
     element.send_keys("abcdefghi")
-    assert element.get_attribute("value") == "abcdefghi"
+    assert element.get_property("value") == "abcdefghi"
 
     element.send_keys(Keys.LEFT, Keys.LEFT, Keys.DELETE)
-    assert element.get_attribute("value") == "abcdefgi"
+    assert element.get_property("value") == "abcdefgi"
 
     element.send_keys(Keys.LEFT, Keys.LEFT, Keys.BACK_SPACE)
-    assert element.get_attribute("value") == "abcdfgi"
+    assert element.get_property("value") == "abcdfgi"
 
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1255258")
@@ -288,7 +288,7 @@ def test_special_space_keys(driver, pages):
     element = driver.find_element(by=By.ID, value="keyReporter")
     element.send_keys("abcd" + Keys.SPACE + "fgh" + Keys.SPACE + "ij")
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "keyReporter"), "abcd fgh ij"))
-    assert element.get_attribute("value") == "abcd fgh ij"
+    assert element.get_property("value") == "abcd fgh ij"
 
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1255258")
@@ -313,12 +313,12 @@ def test_numberpad_and_function_keys(driver, pages):
             Keys.NUMPAD3,
         )
     )
-    assert element.get_attribute("value") == "abcd*-+.,09+;=/3abcd"
+    assert element.get_property("value") == "abcd*-+.,09+;=/3abcd"
 
     element.clear()
     element.send_keys("FUNCTION" + Keys.F2 + "-KEYS" + Keys.F2)
     element.send_keys("" + Keys.F2 + "-TOO" + Keys.F2)
-    assert element.get_attribute("value") == "FUNCTION-KEYS-TOO"
+    assert element.get_property("value") == "FUNCTION-KEYS-TOO"
 
 
 @pytest.mark.xfail_safari
@@ -327,22 +327,22 @@ def test_shift_selection_deletes(driver, pages):
     element = driver.find_element(by=By.ID, value="keyReporter")
 
     element.send_keys("abcd efgh")
-    assert element.get_attribute("value") == "abcd efgh"
+    assert element.get_property("value") == "abcd efgh"
 
     element.send_keys(Keys.SHIFT, Keys.LEFT, Keys.LEFT, Keys.LEFT)
     element.send_keys(Keys.DELETE)
-    assert element.get_attribute("value") == "abcd e"
+    assert element.get_property("value") == "abcd e"
 
 
 def test_should_type_into_input_elements_that_have_no_type_attribute(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(by=By.ID, value="no-type")
     element.send_keys("Should Say Cheese")
-    assert element.get_attribute("value") == "Should Say Cheese"
+    assert element.get_property("value") == "Should Say Cheese"
 
 
 def test_should_type_an_integer(driver, pages):
     pages.load("javascriptPage.html")
     element = driver.find_element(by=By.ID, value="keyReporter")
     element.send_keys(1234)
-    assert element.get_attribute("value") == "1234"
+    assert element.get_property("value") == "1234"

--- a/py/test/selenium/webdriver/common/visibility_tests.py
+++ b/py/test/selenium/webdriver/common/visibility_tests.py
@@ -103,7 +103,7 @@ def test_should_not_be_able_to_type_an_element_that_is_not_displayed(driver, pag
         assert 1 == 0, "should have thrown an exception"
     except (ElementNotVisibleException, ElementNotInteractableException):
         pass
-    assert element.get_attribute("value") != "You don't see me"
+    assert element.get_property("value") != "You don't see me"
 
 
 def test_should_say_elements_with_negative_transform_are_not_displayed(driver, pages):

--- a/py/test/selenium/webdriver/common/w3c_interaction_tests.py
+++ b/py/test/selenium/webdriver/common/w3c_interaction_tests.py
@@ -48,7 +48,7 @@ def test_sending_keys_to_active_element_with_modifier(driver, pages):
 
     actions.perform()
 
-    assert "ABC" == e.get_attribute("value")
+    assert "ABC" == e.get_property("value")
 
 
 @pytest.mark.xfail_firefox
@@ -106,7 +106,7 @@ def test_move_and_click(driver, pages):
     pointer.move_to(toClick).click()
 
     actions.perform()
-    assert "Clicked" == toClick.get_attribute("value")
+    assert "Clicked" == toClick.get_property("value")
 
 
 def test_drag_and_drop(driver, pages):
@@ -141,7 +141,7 @@ def test_context_click(driver, pages):
     pointer.context_click(toContextClick)
 
     actions.perform()
-    assert "ContextClicked" == toContextClick.get_attribute("value")
+    assert "ContextClicked" == toContextClick.get_property("value")
 
 
 @pytest.mark.xfail_firefox
@@ -159,7 +159,7 @@ def test_double_click(driver, pages):
     pointer.double_click(toDoubleClick)
 
     actions.perform()
-    assert "DoubleClicked" == toDoubleClick.get_attribute("value")
+    assert "DoubleClicked" == toDoubleClick.get_property("value")
 
 
 def test_dragging_element_with_mouse_moves_it_to_another_list(driver, pages):

--- a/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -218,7 +218,7 @@ def test_expected_condition_text_to_be_present_in_element_value(driver, pages):
         "setTimeout(function(){document.getElementById('inputRequired').value = 'Example Expected text'}, 200)"
     )
     WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "inputRequired"), "Expected"))
-    assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_attribute("value")
+    assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_property("value")
 
 
 def test_expected_condition_text_to_be_present_in_element_attribute(driver, pages):
@@ -233,7 +233,7 @@ def test_expected_condition_text_to_be_present_in_element_attribute(driver, page
     WebDriverWait(driver, 2).until(
         EC.text_to_be_present_in_element_attribute((By.ID, "inputRequired"), "value", "Expected")
     )
-    assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_attribute("value")
+    assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_property("value")
 
 
 def test_expected_condition_frame_to_be_available_and_switch_to_it_by_locator(driver, pages):

--- a/py/test/selenium/webdriver/support/event_firing_webdriver_tests.py
+++ b/py/test/selenium/webdriver/support/event_firing_webdriver_tests.py
@@ -106,12 +106,12 @@ def test_should_fire_change_value_event(driver, log, pages):
     ef_driver.get(pages.url("readOnlyPage.html"))
     element = ef_driver.find_element(By.ID, "writableTextInput")
     element.clear()
-    assert "" == element.get_attribute("value")
+    assert "" == element.get_property("value")
 
     ef_driver.get(pages.url("javascriptPage.html"))
     keyReporter = ef_driver.find_element(by=By.ID, value="keyReporter")
     keyReporter.send_keys("abc def")
-    assert keyReporter.get_attribute("value") == "abc def"
+    assert keyReporter.get_property("value") == "abc def"
 
     assert (
         b"before_change_value_of" b"after_change_value_of" b"before_change_value_of" b"after_change_value_of"
@@ -138,7 +138,7 @@ def test_should_fire_find_event(driver, log, pages):
     elements = ef_driver.find_elements(By.CSS_SELECTOR, "frame#sixth")
     assert 1 == len(elements)
     assert "frame" == elements[0].tag_name.lower()
-    assert "sixth" == elements[0].get_attribute("id")
+    assert "sixth" == elements[0].get_dom_attribute("id")
 
     assert (
         b"before_find by id oneline"
@@ -178,7 +178,7 @@ def test_should_unwrap_element_args_when_switching_frames(driver, log, pages):
     ef_driver.get(pages.url("iframes.html"))
     frame = ef_driver.find_element(By.ID, "iframe1")
     ef_driver.switch_to.frame(frame)
-    assert "click me!" == ef_driver.find_element(By.ID, "imageButton").get_attribute("alt")
+    assert "click me!" == ef_driver.find_element(By.ID, "imageButton").get_dom_attribute("alt")
 
 
 def test_should_be_able_to_access_wrapped_instance_from_event_calls(driver):
@@ -196,7 +196,7 @@ def test_using_kwargs(driver, pages):
     ef_driver.get(pages.url("javascriptPage.html"))
     ef_driver.get_cookie(name="cookie_name")
     element = ef_driver.find_element(By.ID, "plainButton")
-    element.get_attribute(name="id")
+    element.get_dom_attribute(name="id")
 
 
 def test_missing_attributes_raise_error(driver, pages):
@@ -222,7 +222,7 @@ def test_can_use_pointer_input_with_event_firing_webdriver(driver, pages):
     pointer.move_to(to_click).click()
     actions.perform()
 
-    assert to_click.get_attribute("value") == "Clicked"
+    assert to_click.get_property("value") == "Clicked"
 
 
 @pytest.mark.xfail_safari

--- a/py/test/selenium/webdriver/support/relative_by_tests.py
+++ b/py/test/selenium/webdriver/support/relative_by_tests.py
@@ -28,7 +28,7 @@ def test_should_be_able_to_find_first_one(driver, pages):
 
     el = driver.find_element(with_tag_name("p").above(lowest))
 
-    assert el.get_attribute("id") == "mid"
+    assert el.get_dom_attribute("id") == "mid"
 
 
 def test_should_be_able_to_find_first_one_by_locator(driver, pages):
@@ -36,7 +36,7 @@ def test_should_be_able_to_find_first_one_by_locator(driver, pages):
 
     el = driver.find_element(with_tag_name("p").above({By.ID: "below"}))
 
-    assert el.get_attribute("id") == "mid"
+    assert el.get_dom_attribute("id") == "mid"
 
 
 def test_should_be_able_to_find_elements_above_another(driver, pages):
@@ -45,7 +45,7 @@ def test_should_be_able_to_find_elements_above_another(driver, pages):
 
     elements = driver.find_elements(with_tag_name("p").above(lowest))
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "above" in ids
     assert "mid" in ids
 
@@ -55,7 +55,7 @@ def test_should_be_able_to_find_elements_above_another_by_locator(driver, pages)
 
     elements = driver.find_elements(with_tag_name("p").above({By.ID: "below"}))
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "above" in ids
     assert "mid" in ids
 
@@ -69,7 +69,7 @@ def test_should_be_able_to_combine_filters(driver, pages):
         .to_right_of(driver.find_element(By.ID, "second"))
     )
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "third" in ids
 
 
@@ -78,7 +78,7 @@ def test_should_be_able_to_combine_filters_by_locator(driver, pages):
 
     elements = driver.find_elements(with_tag_name("td").above({By.ID: "center"}).to_right_of({By.ID: "second"}))
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "third" in ids
 
 
@@ -91,7 +91,7 @@ def test_should_be_able_to_use_css_selectors(driver, pages):
         .to_right_of(driver.find_element(By.ID, "second"))
     )
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "third" in ids
 
 
@@ -102,7 +102,7 @@ def test_should_be_able_to_use_css_selectors_by_locator(driver, pages):
         locate_with(By.CSS_SELECTOR, "td").above({By.ID: "center"}).to_right_of({By.ID: "second"})
     )
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "third" in ids
 
 
@@ -115,7 +115,7 @@ def test_should_be_able_to_use_xpath(driver, pages):
         .above(driver.find_element(By.ID, "seventh"))
     )
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "fourth" in ids
 
 
@@ -124,7 +124,7 @@ def test_should_be_able_to_use_xpath_by_locator(driver, pages):
 
     elements = driver.find_elements(locate_with(By.XPATH, "//td[1]").below({By.ID: "second"}).above({By.ID: "seventh"}))
 
-    ids = [el.get_attribute("id") for el in elements]
+    ids = [el.get_dom_attribute("id") for el in elements]
     assert "fourth" in ids
 
 
@@ -149,7 +149,7 @@ def test_near_locator_should_find_near_elements(driver, pages):
 
     el = driver.find_element(locate_with(By.ID, "rect2").near(rect1))
 
-    assert el.get_attribute("id") == "rect2"
+    assert el.get_dom_attribute("id") == "rect2"
 
 
 def test_near_locator_should_find_near_elements_by_locator(driver, pages):
@@ -157,7 +157,7 @@ def test_near_locator_should_find_near_elements_by_locator(driver, pages):
 
     el = driver.find_element(locate_with(By.ID, "rect2").near({By.ID: "rect1"}))
 
-    assert el.get_attribute("id") == "rect2"
+    assert el.get_dom_attribute("id") == "rect2"
 
 
 def test_near_locator_should_not_find_far_elements(driver, pages):
@@ -185,7 +185,7 @@ def test_near_locator_should_find_far_elements(driver, pages):
 
     el = driver.find_element(locate_with(By.ID, "rect4").near(rect3, 100))
 
-    assert el.get_attribute("id") == "rect4"
+    assert el.get_dom_attribute("id") == "rect4"
 
 
 def test_near_locator_should_find_far_elements_by_locator(driver, pages):
@@ -193,4 +193,4 @@ def test_near_locator_should_find_far_elements_by_locator(driver, pages):
 
     el = driver.find_element(locate_with(By.ID, "rect4").near({By.ID: "rect3"}, 100))
 
-    assert el.get_attribute("id") == "rect4"
+    assert el.get_dom_attribute("id") == "rect4"


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Mostly changes in
- `get_attribute("value")` -> `get_property("value")`
- `get_attribute("checked")` -> `get_property("checked")`
- `get_attribute("index")` -> `get_property("index")`
- `get_attribute("selected")` -> `get_property("selected")`
- For others, replace with `get_dom_attribute()`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Replaced deprecated `get_attribute()` method with `get_property()` and `get_dom_attribute()` across various files to align with updated WebDriver API practices.
- Updated multiple test files to ensure compatibility with the new attribute access methods.
- Enhanced the robustness of tests by using more appropriate methods for accessing element properties and attributes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_conditions.py</strong><dd><code>Update element attribute and value checks in expected conditions</code></dd></summary>
<hr>

py/selenium/webdriver/support/expected_conditions.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> for element value checks.<br> <li> Replaced <code>get_attribute()</code> with <code>get_dom_attribute()</code> for element <br>attribute checks.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-42621053a6328eeae47e9df4bcf1329a182b6241dcd1c7ee2900dfc187f9851c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>select.py</strong><dd><code>Update index attribute checks in select elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/support/select.py

<li>Replaced <code>get_attribute()</code> with <code>get_dom_attribute()</code> for index checks in <br>select elements.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-48418bfd0178cef4e4f71bf60506204d33e152281f0bb5a670b9295689b6e01e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_example_tests.py</strong><dd><code>Update attribute access methods in API example tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/api_example_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> and <code>get_dom_attribute()</code> <br>in various tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-c750a83d4b24d0fbebc7e45219d9976215b2c7ff2df066f796c29be4a9ca84b3">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>children_finding_tests.py</strong><dd><code>Update child element attribute access in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/children_finding_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_dom_attribute()</code> in child element <br>finding tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-6dd92bd5446ecd4e3a3b805316b7572ca6b8d4366a095cdccb23e02adde0cd42">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clear_tests.py</strong><dd><code>Update input value checks in clear tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/clear_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> for value checks after <br>clearing inputs.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-86d168b90e53528dd45494e3820bc3652302d8a35fbda5853bd8e72ae0912047">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>correct_event_firing_tests.py</strong><dd><code>Update event firing checks for input values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/correct_event_firing_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> for event firing checks.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-b4501b4390cc72da7b64ddf0e6e7b531c78c7947eb0b752b5bf876db3522f014">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>driver_element_finding_tests.py</strong><dd><code>Update element attribute access in driver element finding tests</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/driver_element_finding_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_dom_attribute()</code> and <code>get_property()</code> <br>in element finding tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-fbb67405b6649ea729096144d30f91182c94e53ff2ef43f42dcc3ad811c50320">+23/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executing_async_javascript_tests.py</strong><dd><code>Update async JavaScript execution tests for attribute access</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/executing_async_javascript_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in async JavaScript <br>execution tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-87dc9fc86fff047c747e4a8152c2763a7bca0743de6f2200688b1d4cf203770c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form_handling_tests.py</strong><dd><code>Update form handling tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/form_handling_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in form handling tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-2adf8f1a37446bae5049b33720f1a2de668632020701fc83efb1043e8cba33d5">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frame_switching_tests.py</strong><dd><code>Update frame switching tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/frame_switching_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> and <code>get_dom_attribute()</code> <br>in frame switching tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-19e9f5acf4ad3bd654d188af611216ba46aca6133af38523c78796d0ea282ce8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>interactions_tests.py</strong><dd><code>Update interaction tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/interactions_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in interaction tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-4977e8a03c58e04c96a319925a7be9ca721f6425d059dbfdfbb61e58aac80de2">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>interactions_with_device_tests.py</strong><dd><code>Update device interaction tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/interactions_with_device_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in device interaction <br>tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-6ea013bb347ae913ce9c9694a087eec3fef0b6e04cfda5ecea02e260564a0f21">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>select_element_handling_tests.py</strong><dd><code>Update select element handling tests for attribute access</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/select_element_handling_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in select element <br>handling tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-0232e0abf988de2bdecdc5095cfcc0d4dad3b2d36b84278973fab51f39596fe7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stale_reference_tests.py</strong><dd><code>Update stale reference tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/stale_reference_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_dom_attribute()</code> in stale reference <br>tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-b8079f7602971e690813f0815205586d5b8bed2200c33b826baa4b94f19d78b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>text_handling_tests.py</strong><dd><code>Update text handling tests for attribute access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/text_handling_tests.py

<li>Replaced <code>get_attribute()</code> with <code>get_property()</code> in text handling tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14807/files#diff-85a9c91d3538edace61a4f0a577c09b56142e6095795c516d34eb81d0461a4f4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information