### PR TITLE
[py] Revert the Deprecation warnings of WebElement.get_attribute()

### DIFF
--- a/py/selenium/webdriver/remote/webelement.py
+++ b/py/selenium/webdriver/remote/webelement.py
@@ -173,13 +173,6 @@ class WebElement(BaseWebElement):
             # Check if the "active" CSS class is applied to an element.
             is_active = "active" in target_element.get_attribute("class")
         """
-
-        warnings.warn(
-            "using WebElement.get_attribute() has been deprecated. Please use get_dom_attribute() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         if getAttribute_js is None:
             _load_js()
         attribute_value = self.parent.execute_script(


### PR DESCRIPTION
### **User description**
Refer to https://github.com/SeleniumHQ/selenium/issues/14800
- Revert the Deprecation warnings of WebElement.get_attribute() in 4.27.1.
- It will be added back with updating the codebase to use the new methods in 4.28.0 (WIP #14807).


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted the deprecation warning for the `WebElement.get_attribute()` method in the Selenium Python bindings.
- This change addresses a bug where `get_dom_attribute()` did not return the expected results for checked checkboxes.
- The deprecation warning will be reintroduced in a future release after resolving the issue.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webelement.py</strong><dd><code>Revert deprecation of `WebElement.get_attribute()` method</code></dd></summary>
<hr>

py/selenium/webdriver/remote/webelement.py

<li>Removed deprecation warning for <code>WebElement.get_attribute()</code>.<br> <li> Reverted changes related to the deprecation of <code>get_attribute()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14808/files#diff-167af39a13c2c1c011a621b7b0f0ff5a76a6bd965a0d077e611d02de2992945c">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information