### PR TITLE
[rust] xz uncompressor for Firefox Linux nightlies

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "94895b25f9b1d0a76ec78d588887353422bc623faf9ef986467b199d2a966765",
+  "checksum": "0e8299f5a76cfec7030579fd20069b2debeacc1752e14c4a3b169492b2f18ed4",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -14224,6 +14224,10 @@
               "target": "which"
             },
             {
+              "id": "xz2 0.1.7",
+              "target": "xz2"
+            },
+            {
               "id": "zip 2.2.0",
               "target": "zip"
             }
@@ -22758,6 +22762,7 @@
     "toml 0.8.19",
     "walkdir 2.5.0",
     "which 6.0.3",
+    "xz2 0.1.7",
     "zip 2.2.0"
   ],
   "direct_dev_deps": [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "toml",
  "walkdir",
  "which",
+ "xz2",
  "zip",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ exitcode = "1.1.2"
 toml = "0.8.19"
 bzip2 = "0.4.4"
 sevenz-rust = "0.6.1"
+xz2 = "0.1.7"
 walkdir = "2.5.0"
 debpkg = "0.6.0"
 anyhow = { version = "1.0.89", default-features = false, features = ["backtrace", "std"] }


### PR DESCRIPTION
### **User description**
### Description
Add a xz uncompressor.

### Motivation and Context
Mozilla provides Linux nightlies in tar.xz archived now. Closes: #14831

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for decompressing XZ files using the `xz2` crate.
- Implemented a new function `uncompress_xz` to handle the extraction of XZ compressed files.
- Updated the `uncompress` function to include logic for handling XZ file extensions.
- Added the `xz2` crate to the project's dependencies in `Cargo.toml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>files.rs</strong><dd><code>Add XZ file decompression support in Rust</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/files.rs

<li>Added <code>xz2</code> dependency for XZ file decompression.<br> <li> Introduced <code>uncompress_xz</code> function to handle XZ file extraction.<br> <li> Updated <code>uncompress</code> function to support XZ file format.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14832/files#diff-64844fef0537ed5f6fd38575be93920c99efacb3fd4c317ed6ff1ce243c2e1f1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add xz2 crate dependency for XZ support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/Cargo.toml

- Added `xz2` crate to dependencies for XZ decompression.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14832/files#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information