### PR TITLE
[dotnet] Public but non-user-related types can be invisible

### DIFF
--- a/dotnet/src/webdriver/Internal/Base64UrlEncoder.cs
+++ b/dotnet/src/webdriver/Internal/Base64UrlEncoder.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using System;
+using System.ComponentModel;
 
 #nullable enable
 
@@ -33,6 +34,7 @@ namespace OpenQA.Selenium.Internal
     /// <summary>
     /// Encodes and Decodes strings as Base64Url encoding.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Base64UrlEncoder
     {
         private const char base64PadCharacter = '=';

--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -17,14 +17,18 @@
 // under the License.
 // </copyright>
 
+using System.ComponentModel;
 using System.Net;
 using System.Net.Sockets;
+
+#nullable enable
 
 namespace OpenQA.Selenium.Internal
 {
     /// <summary>
     /// Encapsulates methods for working with ports.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class PortUtilities
     {
         /// <summary>
@@ -42,7 +46,7 @@ namespace OpenQA.Selenium.Internal
             {
                 IPEndPoint socketEndPoint = new IPEndPoint(IPAddress.Any, 0);
                 portSocket.Bind(socketEndPoint);
-                socketEndPoint = (IPEndPoint)portSocket.LocalEndPoint;
+                socketEndPoint = (IPEndPoint)portSocket.LocalEndPoint!;
                 listeningPort = socketEndPoint.Port;
             }
             finally

--- a/dotnet/src/webdriver/Internal/ReturnedCookie.cs
+++ b/dotnet/src/webdriver/Internal/ReturnedCookie.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace OpenQA.Selenium.Internal
@@ -25,6 +26,7 @@ namespace OpenQA.Selenium.Internal
     /// <summary>
     /// Represents a cookie returned to the driver by the browser.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class ReturnedCookie : Cookie
     {
 


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Certain types are used only internally, but must be public because they are used across projects for testing.

Due to technical limitations, we cannot make these types internal.

This change will make those types invisible to users, which should prevent anyone taking a dependency on them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Resolves #14813 the best we can.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Added `EditorBrowsable` attribute to internal classes to make them invisible to users.
- Set `EditorBrowsableState` to `Never` for `Base64UrlEncoder`, `PortUtilities`, and `ReturnedCookie` classes.
- Enabled nullable reference types in `PortUtilities`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Base64UrlEncoder.cs</strong><dd><code>Hide Base64UrlEncoder class from user visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Base64UrlEncoder.cs

<li>Added <code>EditorBrowsable</code> attribute to <code>Base64UrlEncoder</code> class.<br> <li> Made the class invisible to users by setting <code>EditorBrowsableState</code> to <br><code>Never</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14833/files#diff-35d9ef4edcc03326e175080418cb703fc44a741765ab59a58ed2039813178fef">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PortUtilities.cs</strong><dd><code>Hide PortUtilities class from user visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/PortUtilities.cs

<li>Added <code>EditorBrowsable</code> attribute to <code>PortUtilities</code> class.<br> <li> Made the class invisible to users by setting <code>EditorBrowsableState</code> to <br><code>Never</code>.<br> <li> Enabled nullable reference types.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14833/files#diff-c7ae823e95550e8b18f454f1f6199dc420a1d64263398ae151b13dae264a89c6">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReturnedCookie.cs</strong><dd><code>Hide ReturnedCookie class from user visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/ReturnedCookie.cs

<li>Added <code>EditorBrowsable</code> attribute to <code>ReturnedCookie</code> class.<br> <li> Made the class invisible to users by setting <code>EditorBrowsableState</code> to <br><code>Never</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14833/files#diff-59e197232c3804bd89a4b397c913285ba02a5c381995b936253ca6e17d5025ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information