### PR TITLE
[java]Replace lambdas with method references

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -147,7 +147,7 @@ public class ChromiumDriver extends RemoteWebDriver
 
     try {
       try {
-        cdpUri = client.flatMap(httpClient -> CdpEndpointFinder.getCdpEndPoint(httpClient));
+        cdpUri = client.flatMap(CdpEndpointFinder::getCdpEndPoint);
       } catch (Exception e) {
         try {
           client.ifPresent(HttpClient::close);

--- a/java/src/org/openqa/selenium/devtools/SeleniumCdpConnection.java
+++ b/java/src/org/openqa/selenium/devtools/SeleniumCdpConnection.java
@@ -77,7 +77,7 @@ public class SeleniumCdpConnection extends Connection {
       client = reportedUri.map(uri -> CdpEndpointFinder.getHttpClient(clientFactory, uri));
 
       try {
-        cdpUri = client.flatMap(httpClient -> CdpEndpointFinder.getCdpEndPoint(httpClient));
+        cdpUri = client.flatMap(CdpEndpointFinder::getCdpEndPoint);
       } catch (Exception e) {
         try {
           client.ifPresent(HttpClient::close);
@@ -87,7 +87,7 @@ public class SeleniumCdpConnection extends Connection {
         throw e;
       }
 
-      if (!cdpUri.isPresent()) {
+      if (cdpUri.isEmpty()) {
         try {
           client.ifPresent(HttpClient::close);
         } catch (Exception e) {

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -176,7 +176,7 @@ public class FirefoxDriver extends RemoteWebDriver
     Optional<URI> cdpUri;
 
     try {
-      cdpUri = client.flatMap(httpClient -> CdpEndpointFinder.getCdpEndPoint(httpClient));
+      cdpUri = client.flatMap(CdpEndpointFinder::getCdpEndPoint);
     } catch (Exception e) {
       try {
         client.ifPresent(HttpClient::close);

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -1247,7 +1247,7 @@ public class RemoteWebDriver
           Stream.concat(
                   credential.toMap().entrySet().stream(),
                   Stream.of(Map.entry("authenticatorId", id)))
-              .collect(Collectors.toUnmodifiableMap((e) -> e.getKey(), (e) -> e.getValue())));
+              .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @Override

--- a/java/test/org/openqa/selenium/NoSuchShadowRootTest.java
+++ b/java/test/org/openqa/selenium/NoSuchShadowRootTest.java
@@ -34,6 +34,6 @@ public class NoSuchShadowRootTest extends JupiterTestBase {
     driver.get(pages.shadowRootPage);
     WebElement nonExistentShadowRootElement = driver.findElement(By.id("noShadowRoot"));
     assertThatExceptionOfType(NoSuchShadowRootException.class)
-        .isThrownBy(() -> nonExistentShadowRootElement.getShadowRoot());
+        .isThrownBy(nonExistentShadowRootElement::getShadowRoot);
   }
 }

--- a/java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java
@@ -138,9 +138,7 @@ class RelayOptionsTest {
     RelayOptions relayOptions = new RelayOptions(config);
     assertThatExceptionOfType(ConfigException.class)
         .isThrownBy(
-            () -> {
-              relayOptions.getServiceProtocolVersion();
-            })
+          relayOptions::getServiceProtocolVersion)
         .withMessageContaining("Unsupported protocol version provided: HTTP/0.9");
   }
 

--- a/java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java
@@ -137,8 +137,7 @@ class RelayOptionsTest {
     Config config = new TomlConfig(new StringReader(String.join("\n", rawConfig)));
     RelayOptions relayOptions = new RelayOptions(config);
     assertThatExceptionOfType(ConfigException.class)
-        .isThrownBy(
-          relayOptions::getServiceProtocolVersion)
+        .isThrownBy(relayOptions::getServiceProtocolVersion)
         .withMessageContaining("Unsupported protocol version provided: HTTP/0.9");
   }
 

--- a/java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java
@@ -55,9 +55,7 @@ class BaseServerOptionsTest {
     Exception exception =
         assertThrows(
             RuntimeException.class,
-            () -> {
-              options.getExternalUri();
-            });
+          options::getExternalUri);
 
     assertThat(exception.getMessage())
         .as("External URI must be parseable as URI.")

--- a/java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java
@@ -52,10 +52,7 @@ class BaseServerOptionsTest {
     BaseServerOptions options =
         new BaseServerOptions(new MapConfig(Map.of("server", Map.of("external-url", "not a URL"))));
 
-    Exception exception =
-        assertThrows(
-            RuntimeException.class,
-          options::getExternalUri);
+    Exception exception = assertThrows(RuntimeException.class, options::getExternalUri);
 
     assertThat(exception.getMessage())
         .as("External URI must be parseable as URI.")


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This pull request includes several refactorings to improve code readability and consistency across multiple files, primarily by replacing lambda expressions with method references and simplifying conditional checks.

### Code readability improvements:

* [`java/src/org/openqa/selenium/chromium/ChromiumDriver.java`](diffhunk://#diff-1af793ae2090a0cb691f1efbb3ee0d2b186c4027c5b441f6f3d55b3663e67ba1L150-R150): Replaced lambda expression with method reference in `protected ChromiumDriver` constructor.
* [`java/src/org/openqa/selenium/devtools/SeleniumCdpConnection.java`](diffhunk://#diff-d453e6dcb3f6c127b1c4df9e5b22e5aae598e079fc6aec64bdf4ad06948c49abL80-R80): Replaced lambda expressions with method references in `create` method and simplified `if` condition to use `isEmpty()` instead of `!isPresent()`. [[1]](diffhunk://#diff-d453e6dcb3f6c127b1c4df9e5b22e5aae598e079fc6aec64bdf4ad06948c49abL80-R80) [[2]](diffhunk://#diff-d453e6dcb3f6c127b1c4df9e5b22e5aae598e079fc6aec64bdf4ad06948c49abL90-R90)
* [`java/src/org/openqa/selenium/firefox/FirefoxDriver.java`](diffhunk://#diff-6661041cf9cc7bc354a777528d39914fa151c2d1709d09dc482e3cbc669cc3f2L179-R179): Replaced lambda expression with method reference in `private FirefoxDriver` constructor.
* [`java/src/org/openqa/selenium/remote/RemoteWebDriver.java`](diffhunk://#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311bL1250-R1250): Replaced lambda expression with method reference in `addCredential` method.

### Test code simplification:

* [`java/test/org/openqa/selenium/NoSuchShadowRootTest.java`](diffhunk://#diff-c85529eb9d6ea20f4ee9a402cc03b5499b1948aba329a73c74a034382689ace5L37-R37): Simplified exception assertion by replacing lambda expression with method reference in `getNoSuchShadowRoot` test method.
* [`java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java`](diffhunk://#diff-2039d658a7bf893b3bfca1b8624c2e31cc027a28d2299c56edae98e4afb4ec7eL140-R140): Simplified exception assertion by replacing lambda expression with method reference in `protocolVersionThrowsConfigException` test method.
* [`java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java`](diffhunk://#diff-0a61898c81efaf0fb17b46de713618e1d3f7a072c167c8bb74effafec3dc841cL55-R55): Simplified exception assertion by replacing lambda expression with method reference in `externalUriFailsForNonUriStrings` test method.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While often it could be a matter of taste, method references are more clear and readable compared to lambdas.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Replaced lambda expressions with method references across multiple files to improve code readability.
- Simplified conditional checks using `isEmpty()` instead of `!isPresent()`.
- Updated test assertions to use method references for consistency and clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromiumDriver.java</strong><dd><code>Use method reference in ChromiumDriver constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/chromium/ChromiumDriver.java

<li>Replaced lambda expression with method reference in <code>ChromiumDriver</code> <br>constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-1af793ae2090a0cb691f1efbb3ee0d2b186c4027c5b441f6f3d55b3663e67ba1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SeleniumCdpConnection.java</strong><dd><code>Refactor SeleniumCdpConnection with method references and simplified </code><br><code>conditions</code></dd></summary>
<hr>

java/src/org/openqa/selenium/devtools/SeleniumCdpConnection.java

<li>Replaced lambda expression with method reference in <code>create</code> method.<br> <li> Simplified conditional check using <code>isEmpty()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-d453e6dcb3f6c127b1c4df9e5b22e5aae598e079fc6aec64bdf4ad06948c49ab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriver.java</strong><dd><code>Use method reference in FirefoxDriver constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/firefox/FirefoxDriver.java

<li>Replaced lambda expression with method reference in <code>FirefoxDriver</code> <br>constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-6661041cf9cc7bc354a777528d39914fa151c2d1709d09dc482e3cbc669cc3f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Refactor addCredential method with method reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<li>Replaced lambda expression with method reference in <code>addCredential</code> <br>method.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NoSuchShadowRootTest.java</strong><dd><code>Use method reference in NoSuchShadowRootTest assertion</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/NoSuchShadowRootTest.java

<li>Replaced lambda expression with method reference in test assertion.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-c85529eb9d6ea20f4ee9a402cc03b5499b1948aba329a73c74a034382689ace5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RelayOptionsTest.java</strong><dd><code>Use method reference in RelayOptionsTest assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/node/relay/RelayOptionsTest.java

<li>Replaced lambda expression with method reference in test assertion.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-2039d658a7bf893b3bfca1b8624c2e31cc027a28d2299c56edae98e4afb4ec7e">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BaseServerOptionsTest.java</strong><dd><code>Use method reference in BaseServerOptionsTest assertion</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/server/BaseServerOptionsTest.java

<li>Replaced lambda expression with method reference in test assertion.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14857/files#diff-0a61898c81efaf0fb17b46de713618e1d3f7a072c167c8bb74effafec3dc841c">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information