### PR TITLE
[dotnet] Migrate remaining NUnit assertions to `Assert.That` and `Has.Count`

### DIFF
--- a/dotnet/test/common/BiDi/Browser/BrowserTest.cs
+++ b/dotnet/test/common/BiDi/Browser/BrowserTest.cs
@@ -41,7 +41,7 @@ class BrowserTest : BiDiTestFixture
         var userContexts = await bidi.Browser.GetUserContextsAsync();
 
         Assert.That(userContexts, Is.Not.Null);
-        Assert.That(userContexts.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(userContexts, Has.Count.GreaterThanOrEqualTo(2));
         Assert.That(userContexts, Does.Contain(userContext1));
         Assert.That(userContexts, Does.Contain(userContext2));
     }

--- a/dotnet/test/common/BiDi/Network/NetworkEventsTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkEventsTest.cs
@@ -99,7 +99,7 @@ class NetworkEventsTest : BiDiTestFixture
 
         var req = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(req.Request.Cookies.Count, Is.EqualTo(1));
+        Assert.That(req.Request.Cookies, Has.Count.EqualTo(1));
         Assert.That(req.Request.Cookies[0].Name, Is.EqualTo("foo"));
         Assert.That((req.Request.Cookies[0].Value as BytesValue.String).Value, Is.EqualTo("bar"));
     }

--- a/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
+++ b/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
@@ -34,7 +34,7 @@ class ScriptCommandsTest : BiDiTestFixture
         var realms = await bidi.Script.GetRealmsAsync();
 
         Assert.That(realms, Is.Not.Null);
-        Assert.That(realms.Count, Is.EqualTo(2));
+        Assert.That(realms, Has.Count.EqualTo(2));
 
         Assert.That(realms[0], Is.AssignableFrom<RealmInfo.Window>());
         Assert.That(realms[0].Realm, Is.Not.Null);
@@ -51,7 +51,7 @@ class ScriptCommandsTest : BiDiTestFixture
         var realms = await bidi.Script.GetRealmsAsync(new() { Type = RealmType.Window });
 
         Assert.That(realms, Is.Not.Null);
-        Assert.That(realms.Count, Is.EqualTo(2));
+        Assert.That(realms, Has.Count.EqualTo(2));
 
         Assert.That(realms[0], Is.AssignableFrom<RealmInfo.Window>());
         Assert.That(realms[0].Realm, Is.Not.Null);

--- a/dotnet/test/common/BiDi/Storage/StorageTest.cs
+++ b/dotnet/test/common/BiDi/Storage/StorageTest.cs
@@ -94,7 +94,7 @@ class StorageTest : BiDiTestFixture
         var cookies = await context.Storage.GetCookiesAsync();
 
         Assert.That(cookies, Is.Not.Null);
-        Assert.That(cookies.Count, Is.EqualTo(1));
+        Assert.That(cookies, Has.Count.EqualTo(1));
 
         var cookie = cookies[0];
 
@@ -119,7 +119,7 @@ class StorageTest : BiDiTestFixture
         var cookies = await bidi.Storage.GetCookiesAsync();
 
         Assert.That(cookies, Is.Not.Null);
-        Assert.That(cookies.Count, Is.EqualTo(2));
+        Assert.That(cookies, Has.Count.EqualTo(2));
         Assert.That(cookies[0].Name, Is.EqualTo("key1"));
         Assert.That(cookies[1].Name, Is.EqualTo("key2"));
     }
@@ -157,7 +157,7 @@ class StorageTest : BiDiTestFixture
         var cookies = await bidi.Storage.GetCookiesAsync();
 
         Assert.That(cookies, Is.Not.Null);
-        Assert.That(cookies.Count, Is.EqualTo(1));
+        Assert.That(cookies, Has.Count.EqualTo(1));
         Assert.That(cookies[0].Name, Is.EqualTo("key2"));
     }
 

--- a/dotnet/test/common/ClickScrollingTest.cs
+++ b/dotnet/test/common/ClickScrollingTest.cs
@@ -44,7 +44,7 @@ namespace OpenQA.Selenium
 
             // Sometimes JS is returning a double
             object result = ((IJavaScriptExecutor)driver).ExecuteScript(scrollScript);
-            var yOffset = Convert.ChangeType(result, typeof(long));
+            var yOffset = Convert.ToInt64(result);
 
             //Focusing on to click, but not actually following,
             //the link will scroll it in to view, which is a few pixels further than 0

--- a/dotnet/test/common/DriverElementFindingTest.cs
+++ b/dotnet/test/common/DriverElementFindingTest.cs
@@ -93,7 +93,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.Id("test_id"));
-            Assert.That(elements.Count, Is.EqualTo(2));
+            Assert.That(elements, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.LinkText("hello world"));
-            Assert.That(elements.Count, Is.EqualTo(12));
+            Assert.That(elements, Has.Count.EqualTo(12));
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.Name("form1"));
-            Assert.That(elements.Count, Is.EqualTo(4));
+            Assert.That(elements, Has.Count.EqualTo(4));
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.XPath("//a"));
-            Assert.That(elements.Count, Is.EqualTo(12));
+            Assert.That(elements, Has.Count.EqualTo(12));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.ClassName("one"));
-            Assert.That(elements.Count, Is.EqualTo(3));
+            Assert.That(elements, Has.Count.EqualTo(3));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.PartialLinkText("world"));
-            Assert.That(elements.Count, Is.EqualTo(12));
+            Assert.That(elements, Has.Count.EqualTo(12));
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace OpenQA.Selenium
         {
             driver.Url = nestedPage;
             ReadOnlyCollection<IWebElement> elements = driver.FindElements(By.TagName("a"));
-            Assert.That(elements.Count, Is.EqualTo(12));
+            Assert.That(elements, Has.Count.EqualTo(12));
         }
         #endregion
     }

--- a/dotnet/test/common/ElementElementFindingTest.cs
+++ b/dotnet/test/common/ElementElementFindingTest.cs
@@ -101,7 +101,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("form2"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.Id("2"));
-            Assert.That(children.Count, Is.EqualTo(2));
+            Assert.That(children, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("div1"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.PartialLinkText("hello world"));
-            Assert.That(children.Count, Is.EqualTo(2));
+            Assert.That(children, Has.Count.EqualTo(2));
             Assert.That(children[0].Text, Is.EqualTo("hello world"));
             Assert.That(children[1].Text, Is.EqualTo("hello world"));
         }
@@ -121,7 +121,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("form2"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.Name("selectomatic"));
-            Assert.That(children.Count, Is.EqualTo(2));
+            Assert.That(children, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("classes"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.XPath("span"));
-            Assert.That(children.Count, Is.EqualTo(3));
+            Assert.That(children, Has.Count.EqualTo(3));
             Assert.That(children[0].Text, Is.EqualTo("Find me"));
             Assert.That(children[1].Text, Is.EqualTo("Also me"));
             Assert.That(children[2].Text, Is.EqualTo("But not me"));
@@ -142,7 +142,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("classes"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.ClassName("one"));
-            Assert.That(children.Count, Is.EqualTo(2));
+            Assert.That(children, Has.Count.EqualTo(2));
             Assert.That(children[0].Text, Is.EqualTo("Find me"));
             Assert.That(children[1].Text, Is.EqualTo("Also me"));
         }
@@ -153,7 +153,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("div1"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.PartialLinkText("hello "));
-            Assert.That(children.Count, Is.EqualTo(2));
+            Assert.That(children, Has.Count.EqualTo(2));
             Assert.That(children[0].Text, Is.EqualTo("hello world"));
             Assert.That(children[1].Text, Is.EqualTo("hello world"));
         }
@@ -164,7 +164,7 @@ namespace OpenQA.Selenium
             driver.Url = nestedPage;
             IWebElement parent = driver.FindElement(By.Name("classes"));
             ReadOnlyCollection<IWebElement> children = parent.FindElements(By.TagName("span"));
-            Assert.That(children.Count, Is.EqualTo(3));
+            Assert.That(children, Has.Count.EqualTo(3));
             Assert.That(children[0].Text, Is.EqualTo("Find me"));
             Assert.That(children[1].Text, Is.EqualTo("Also me"));
             Assert.That(children[2].Text, Is.EqualTo("But not me"));

--- a/dotnet/test/common/ExecutingAsyncJavascriptTest.cs
+++ b/dotnet/test/common/ExecutingAsyncJavascriptTest.cs
@@ -118,7 +118,7 @@ namespace OpenQA.Selenium
             Assert.That(result, Is.Not.Null);
             Assert.That(result, Is.InstanceOf<ReadOnlyCollection<object>>());
             ReadOnlyCollection<object> resultList = result as ReadOnlyCollection<object>;
-            Assert.That(resultList.Count, Is.EqualTo(5));
+            Assert.That(resultList, Has.Count.EqualTo(5));
             Assert.That(resultList[0], Is.Null);
             Assert.That((long)resultList[1], Is.EqualTo(123));
             Assert.That(resultList[2].ToString(), Is.EqualTo("abc"));
@@ -221,10 +221,12 @@ namespace OpenQA.Selenium
             string js = "function functionB() { throw Error('errormessage'); };"
                         + "function functionA() { functionB(); };"
                         + "functionA();";
-            Exception ex = Assert.Catch(() => executor.ExecuteAsyncScript(js));
-            Assert.That(ex, Is.InstanceOf<WebDriverException>());
-            Assert.That(ex.Message.Contains("errormessage"));
-            Assert.That(ex.StackTrace.Contains("functionB"));
+
+            Assert.That(
+                () => executor.ExecuteAsyncScript(js),
+                Throws.InstanceOf<WebDriverException>()
+                .With.Message.Contains("errormessage")
+                .And.Property(nameof(WebDriverException.StackTrace)).Contains("functionB"));
         }
 
         [Test]

--- a/dotnet/test/common/ExecutingJavascriptTest.cs
+++ b/dotnet/test/common/ExecutingJavascriptTest.cs
@@ -256,10 +256,12 @@ namespace OpenQA.Selenium
             string js = "function functionB() { throw Error('errormessage'); };"
                         + "function functionA() { functionB(); };"
                         + "functionA();";
-            Exception ex = Assert.Catch(() => ExecuteScript(js));
-            Assert.That(ex, Is.InstanceOf<WebDriverException>());
-            Assert.That(ex.Message, Does.Contain("errormessage"), "Exception message does not contain 'errormessage'");
-            Assert.That(ex.StackTrace, Does.Contain("functionB"), "Exception message does not contain 'functionB'");
+
+            Assert.That(
+               () => ExecuteScript(js),
+               Throws.InstanceOf<WebDriverException>()
+               .With.Message.Contains("errormessage")
+               .And.Property(nameof(WebDriverException.StackTrace)).Contains("functionB"));
         }
 
         [Test]
@@ -467,7 +469,7 @@ namespace OpenQA.Selenium
             if (fileList.Length > 0)
             {
                 string jquery = System.IO.File.ReadAllText(fileList[0]);
-                Assert.That(jquery.Length, Is.GreaterThan(50000));
+                Assert.That(jquery, Has.Length.GreaterThan(50000));
                 ExecuteScript(jquery, null);
             }
         }

--- a/dotnet/test/common/Interactions/ActionBuilderTest.cs
+++ b/dotnet/test/common/Interactions/ActionBuilderTest.cs
@@ -19,7 +19,6 @@
 
 using NUnit.Framework;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace OpenQA.Selenium.Interactions
@@ -55,8 +54,9 @@ namespace OpenQA.Selenium.Interactions
             Assert.That(dictionary, Does.ContainKey("type").WithValue("pointer"));
             Assert.That(dictionary["id"], Is.Not.Null);
             Assert.That(dictionary["parameters"], Is.Not.Null);
+
             var parameters = new Dictionary<string, object> { { "pointerType", "pen" } };
-            CollectionAssert.AreEquivalent(parameters, (IEnumerable)dictionary["parameters"]);
+            Assert.That(dictionary["parameters"], Is.EquivalentTo(parameters));
 
             var events = new Dictionary<string, object>
             {
@@ -72,8 +72,8 @@ namespace OpenQA.Selenium.Interactions
                 {"type", "pointerDown"},
                 {"button", 0}
             };
-            var actions = (IList<Object>)dictionary["actions"];
-            CollectionAssert.AreEquivalent(events, (IEnumerable)actions[0]);
+            var actions = (IList<object>)dictionary["actions"];
+            Assert.That(actions[0], Is.EquivalentTo(events));
         }
     }
 }

--- a/dotnet/test/common/Internal/Logging/FileLogHandlerTest.cs
+++ b/dotnet/test/common/Internal/Logging/FileLogHandlerTest.cs
@@ -72,7 +72,7 @@ namespace OpenQA.Selenium.Internal.Logging
                     fileLogHandler2.Handle(new LogEvent(typeof(FileLogHandlerTest), DateTimeOffset.Now, LogEventLevel.Info, "test message"));
                 }
 
-                Assert.That(Regex.Matches(File.ReadAllText(tempFile), "test message").Count, Is.EqualTo(1));
+                Assert.That(Regex.Matches(File.ReadAllText(tempFile), "test message"), Has.Count.EqualTo(1));
             }
             finally
             {
@@ -97,7 +97,7 @@ namespace OpenQA.Selenium.Internal.Logging
                     fileLogHandler2.Handle(new LogEvent(typeof(FileLogHandlerTest), DateTimeOffset.Now, LogEventLevel.Info, "test message"));
                 }
 
-                Assert.That(Regex.Matches(File.ReadAllText(tempFilePath), "test message").Count, Is.EqualTo(2));
+                Assert.That(Regex.Matches(File.ReadAllText(tempFilePath), "test message"), Has.Count.EqualTo(2));
             }
             finally
             {
@@ -117,7 +117,7 @@ namespace OpenQA.Selenium.Internal.Logging
                     fileLogHandler.Handle(new LogEvent(typeof(FileLogHandlerTest), DateTimeOffset.Now, LogEventLevel.Info, "test message"));
                 }
 
-                Assert.That(Regex.Matches(File.ReadAllText(tempFile), "test message").Count, Is.EqualTo(1));
+                Assert.That(Regex.Matches(File.ReadAllText(tempFile), "test message"), Has.Count.EqualTo(1));
             }
             finally
             {
@@ -137,7 +137,7 @@ namespace OpenQA.Selenium.Internal.Logging
                     fileLogHandler.Handle(new LogEvent(typeof(FileLogHandlerTest), DateTimeOffset.Now, LogEventLevel.Info, "test message"));
                 }
 
-                Assert.That(Regex.Matches(File.ReadAllText(tempFilePath), "test message").Count, Is.EqualTo(1));
+                Assert.That(Regex.Matches(File.ReadAllText(tempFilePath), "test message"), Has.Count.EqualTo(1));
             }
             finally
             {

--- a/dotnet/test/common/NavigationTest.cs
+++ b/dotnet/test/common/NavigationTest.cs
@@ -115,8 +115,8 @@ namespace OpenQA.Selenium
         public Task ShouldNotHaveProblemNavigatingWithNoPagesBrowsedAsync()
         {
             var navigation = driver.Navigate();
-            Assert.DoesNotThrowAsync(async () => await navigation.BackAsync());
-            Assert.DoesNotThrowAsync(async () => await navigation.ForwardAsync());
+            Assert.That(async () => await navigation.BackAsync(), Throws.Nothing);
+            Assert.That(async () => await navigation.ForwardAsync(), Throws.Nothing);
             return Task.CompletedTask;
         }
 

--- a/dotnet/test/common/NavigationTest.cs
+++ b/dotnet/test/common/NavigationTest.cs
@@ -112,12 +112,11 @@ namespace OpenQA.Selenium
 
         [Test]
         [NeedsFreshDriver(IsCreatedBeforeTest = true)]
-        public Task ShouldNotHaveProblemNavigatingWithNoPagesBrowsedAsync()
+        public void ShouldNotHaveProblemNavigatingWithNoPagesBrowsedAsync()
         {
             var navigation = driver.Navigate();
             Assert.That(async () => await navigation.BackAsync(), Throws.Nothing);
             Assert.That(async () => await navigation.ForwardAsync(), Throws.Nothing);
-            return Task.CompletedTask;
         }
 
         [Test]

--- a/dotnet/test/common/PositionAndSizeTest.cs
+++ b/dotnet/test/common/PositionAndSizeTest.cs
@@ -111,7 +111,7 @@ namespace OpenQA.Selenium
             Assert.That(GetLocationOnPage(By.Id("box")), Is.EqualTo(new Point(10, 10)));
             // GetLocationInViewPort only works within the context of a single frame
             // for W3C-spec compliant remote ends.
-            // Assert.AreEqual(new Point(25, 25), GetLocationInViewPort(By.Id("box")));
+            // Assert.That(GetLocationInViewPort(By.Id("box")), Is.EqualTo(new Point(25, 25)));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace OpenQA.Selenium
             Assert.That(GetLocationOnPage(By.Id("box")), Is.EqualTo(new Point(10, 10)));
             // GetLocationInViewPort only works within the context of a single frame
             // for W3C-spec compliant remote ends.
-            // Assert.AreEqual(new Point(40, 40), GetLocationInViewPort(By.Id("box")));
+            // Assert.That(GetLocationInViewPort(By.Id("box")), Is.EqualTo(new Point(40, 40)));
         }
 
         [Test]

--- a/dotnet/test/firefox/FirefoxDriverTest.cs
+++ b/dotnet/test/firefox/FirefoxDriverTest.cs
@@ -34,15 +34,9 @@ namespace OpenQA.Selenium.Firefox
         {
             driver.Url = formsPage;
 
-            try
-            {
-                driver.FindElement(By.Id("notThere"));
-                Assert.Fail("Should not be able to select element by id here");
-            }
-            catch (NoSuchElementException)
-            {
-                // This is expected
-            }
+            Assert.That(
+                () => driver.FindElement(By.Id("notThere")),
+                Throws.InstanceOf<NoSuchElementException>());
 
             // Is this works, then we're golden
             driver.Url = xhtmlTestPage;

--- a/dotnet/test/remote/RemoteWebDriverSpecificTests.cs
+++ b/dotnet/test/remote/RemoteWebDriverSpecificTests.cs
@@ -62,7 +62,7 @@ namespace OpenQA.Selenium.Remote
             IAllowsFileDetection fileDetectionDriver = driver as IAllowsFileDetection;
             if (fileDetectionDriver == null)
             {
-                Assert.Fail("driver does not support file detection. This should not be");
+                Assert.That(driver, Is.InstanceOf<IAllowsFileDetection>(), "driver does not support file detection. This should not be");
             }
 
             fileDetectionDriver.FileDetector = new LocalFileDetector();

--- a/dotnet/test/support/Events/EventFiringWebDriverTest.cs
+++ b/dotnet/test/support/Events/EventFiringWebDriverTest.cs
@@ -184,15 +184,9 @@ FindElementCompleted from IWebDriver By.XPath: //link[@type = 'text/css']
             EventFiringWebDriver firingDriver = new EventFiringWebDriver(mockDriver.Object);
             firingDriver.ExceptionThrown += new EventHandler<WebDriverExceptionEventArgs>(firingDriver_ExceptionThrown);
 
-            try
-            {
-                firingDriver.FindElement(By.Id("foo"));
-                Assert.Fail("Expected exception to be propogated");
-            }
-            catch (NoSuchElementException)
-            {
-                // Fine
-            }
+            Assert.That(
+                () => firingDriver.FindElement(By.Id("foo")),
+                Throws.InstanceOf<NoSuchElementException>());
 
             Assert.That(log.ToString(), Does.Contain(exception.Message));
         }

--- a/dotnet/test/support/UI/LoadableComponentTests.cs
+++ b/dotnet/test/support/UI/LoadableComponentTests.cs
@@ -53,31 +53,21 @@ namespace OpenQA.Selenium.Support.UI
         {
             LoadsOk ok = new LoadsOk(false);
 
-            try
-            {
-                ok.Load();
-                Assert.Fail();
-            }
-            catch (LoadableComponentException e)
-            {
-                Assert.That(e.Message, Is.EqualTo("Expected failure"));
-            }
+            Assert.That(
+                () => ok.Load(),
+                Throws.InstanceOf<LoadableComponentException>().With.Message.EqualTo("Expected failure"));
         }
 
         [Test]
         public void ShouldCallHandleLoadErrorWhenWebDriverExceptionOccursDuringExecuteLoad()
         {
             ExecuteLoadThrows loadThrows = new ExecuteLoadThrows();
-            try
-            {
-                loadThrows.Load();
-                Assert.Fail();
-            }
-            catch (Exception e)
-            {
-                Assert.That(e.Message, Is.EqualTo("HandleLoadError called"));
-                Assert.That(e.InnerException.Message, Is.EqualTo("Excpected failure in ExecuteLoad"));
-            }
+
+            Assert.That(
+                () => loadThrows.Load(),
+                Throws.Exception
+                .With.Message.EqualTo("HandleLoadError called")
+                .And.InnerException.Message.EqualTo("Excpected failure in ExecuteLoad"));
 
         }
 

--- a/dotnet/test/support/UI/SlowLoadableComponentTest.cs
+++ b/dotnet/test/support/UI/SlowLoadableComponentTest.cs
@@ -65,15 +65,10 @@ namespace OpenQA.Selenium.Support.UI
         public void TestShouldThrowAnErrorIfCallingLoadDoesNotCauseTheComponentToLoadBeforeTimeout()
         {
             FakeClock clock = new FakeClock();
-            try
-            {
-                new BasicSlowLoader(TimeSpan.FromSeconds(2), clock).Load();
-                Assert.Fail();
-            }
-            catch (WebDriverTimeoutException)
-            {
-                // We expect to time out
-            }
+
+            Assert.That(
+                () => new BasicSlowLoader(TimeSpan.FromSeconds(2), clock).Load(),
+                Throws.InstanceOf<WebDriverTimeoutException>());
         }
 
         [Test]
@@ -81,15 +76,9 @@ namespace OpenQA.Selenium.Support.UI
         {
             HasError error = new HasError();
 
-            try
-            {
-                error.Load();
-                Assert.Fail();
-            }
-            catch (CustomException)
-            {
-                // This is expected
-            }
+            Assert.That(
+               () => error.Load(),
+               Throws.InstanceOf<CustomException>());
         }
 
 

--- a/dotnet/test/support/UI/WebDriverWaitTest.cs
+++ b/dotnet/test/support/UI/WebDriverWaitTest.cs
@@ -129,15 +129,9 @@ namespace OpenQA.Selenium.Support.UI
 
             var wait = new WebDriverWait(GetClock(), mockDriver.Object, ONE_SECONDS, ZERO_SECONDS);
 
-            try
-            {
-                wait.Until(condition);
-                Assert.Fail("Expected WebDriverTimeoutException to be thrown");
-            }
-            catch (WebDriverTimeoutException e)
-            {
-                Assert.That(e.InnerException, Is.InstanceOf<NoSuchElementException>());
-            }
+            Assert.That(
+                () => wait.Until(condition),
+                Throws.InstanceOf<WebDriverTimeoutException>().With.InnerException.InstanceOf<NoSuchElementException>());
         }
 
         private Func<IWebDriver, T> GetCondition<T>(Func<T> first, Func<T> second)


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Migrates remaining assertions to `Assert.That`, including improving some hand-rolled exception assertions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Contributes to #14852

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Migrated NUnit assertions to modern syntax using `Assert.That` with `Has` and `Throws` for improved readability and consistency.
- Updated exception handling assertions to use `Throws` syntax for better clarity.
- Modified JavaScript result conversion method for consistency.
- Enhanced dictionary equivalence assertions in interaction tests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserTest.cs</strong><dd><code>Update assertion syntax for user context count check.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Browser/BrowserTest.cs

- Migrated assertion to use `Has.Count.GreaterThanOrEqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-0628232f831c351032d9d79e558fe9d84032404228a29a40679dd618371b467e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkEventsTest.cs</strong><dd><code>Update assertion syntax for request cookies count check.</code>&nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkEventsTest.cs

- Migrated assertion to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-1a6930310bd4c40b8d5908da580f7434f32afeaf0371fdc6b44f8ada1a59b32e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptCommandsTest.cs</strong><dd><code>Update assertion syntax for realm count checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs

- Migrated assertions to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-f556a10a263ca5a37c0ac56fc1c010d1defc3b1dc2d99ec62af45d8b31ae81a3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StorageTest.cs</strong><dd><code>Update assertion syntax for cookie count checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Storage/StorageTest.cs

- Migrated assertions to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-6580501a9ff79dd4b90a66024845757ac10665d8ed761a31f67211571f1edd0f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClickScrollingTest.cs</strong><dd><code>Modify JavaScript result conversion method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/ClickScrollingTest.cs

- Changed conversion method for JavaScript result.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-2631112e97b46ebc29f252500a5bf0ee9ca2a973b3ba8168895bd5618464f29b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DriverElementFindingTest.cs</strong><dd><code>Update assertion syntax for element count checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/DriverElementFindingTest.cs

- Migrated assertions to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-d4ed302369cc434d297f303f952203425e0d2ecb886c7a7911e1504dc2210368">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ElementElementFindingTest.cs</strong><dd><code>Update assertion syntax for child element count checks.</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/ElementElementFindingTest.cs

- Migrated assertions to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-e3756bc48a4cba5f883b89b39ae1252cc64c2e2066b736f74ca3645997b23025">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExecutingAsyncJavascriptTest.cs</strong><dd><code>Update assertion syntax for async JavaScript tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/ExecutingAsyncJavascriptTest.cs

<li>Migrated assertions to use <code>Has.Count.EqualTo</code>.<br> <li> Updated exception handling assertions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-7368b3ad77b4c511344d44b712089511f8f04348602d3e8b01ecb79f140ab7cf">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExecutingJavascriptTest.cs</strong><dd><code>Update assertion syntax for JavaScript execution tests.</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/ExecutingJavascriptTest.cs

<li>Updated exception handling assertions.<br> <li> Migrated assertion to use <code>Has.Length.GreaterThan</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-56bba86ca13836c858f6a4c5e2cf061c91745128ad3fbf4df79a74b01a4d8ffe">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ActionBuilderTest.cs</strong><dd><code>Update dictionary equivalence assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Interactions/ActionBuilderTest.cs

- Updated dictionary equivalence assertions.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-791f1fbd9de7b996c515df478736a442b8a1a6f1d233a8f74c4a4eac94d6cdb0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FileLogHandlerTest.cs</strong><dd><code>Update assertion syntax for log file content checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Internal/Logging/FileLogHandlerTest.cs

- Migrated assertions to use `Has.Count.EqualTo`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-ae835de2be92fe1d05d7f0565bf909daecc58a4cd193ee591f5d5bc7240dab23">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NavigationTest.cs</strong><dd><code>Update navigation assertion syntax for async methods.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/NavigationTest.cs

- Updated navigation assertions to use `Throws.Nothing`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-949f3e2193640efef49f4dc096d01e37851df0edac65eeb9c0db24b4262edd63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PositionAndSizeTest.cs</strong><dd><code>Update commented assertion syntax for position tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/PositionAndSizeTest.cs

- Commented out assertion updated to new syntax.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-eb203dadd99c6d6dc3bac4316c2dff4cf4e77125859e79803d237f86c1057286">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverTest.cs</strong><dd><code>Update exception handling assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/firefox/FirefoxDriverTest.cs

- Updated exception handling assertion.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-0ab06d3248144f57868f7615a95675e208584dbc4209ae447dd64dbde783b094">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriverSpecificTests.cs</strong><dd><code>Update driver type check assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/remote/RemoteWebDriverSpecificTests.cs

- Updated assertion for driver type check.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-f91aa33f650e1b8604c47ef52ae570bd7f6cd1b260ba964a94d76760272fcdc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EventFiringWebDriverTest.cs</strong><dd><code>Update exception handling assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/support/Events/EventFiringWebDriverTest.cs

- Updated exception handling assertion.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-8a1f6089996b8c42dea999e7e0043f7820d548fe71b6a71a359a70c126da9443">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoadableComponentTests.cs</strong><dd><code>Update exception handling assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/support/UI/LoadableComponentTests.cs

- Updated exception handling assertions.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-7e967d0a5d37fa9b93f7f6574b6e8b501c38dfab76e5718e5baef4b7f0fab2e9">+9/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SlowLoadableComponentTest.cs</strong><dd><code>Update exception handling assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/support/UI/SlowLoadableComponentTest.cs

- Updated exception handling assertions.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-e96ade3cf05f85ec11d789078d9658f4153766166ea917ebdad41a90779141b6">+7/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebDriverWaitTest.cs</strong><dd><code>Update exception handling assertion syntax.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/support/UI/WebDriverWaitTest.cs

- Updated exception handling assertion.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14870/files#diff-cb41d1578675e12ee199cd7a1047bcf9ddb6d423a8cad5b67b7b38ce9450ee0c">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information