### PR TITLE
[bazel]: Prepare for bump of `rules_closure`

### DIFF
--- a/javascript/atoms/BUILD.bazel
+++ b/javascript/atoms/BUILD.bazel
@@ -40,7 +40,11 @@ closure_js_library(
         ":dom",
         ":errors",
         ":events",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/math:vec2",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 
@@ -59,7 +63,8 @@ closure_js_library(
         "JSC_USE_OF_GOOG_PROVIDE",
     ],
     deps = [
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/color:names",
     ],
 )
 
@@ -86,7 +91,15 @@ closure_js_library(
         ":events",
         ":locators",
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:selection",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/structs:map",
+        "@io_bazel_rules_closure//closure/library/structs:set",
+        "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/library/useragent:product",
     ],
 )
 
@@ -102,7 +115,10 @@ closure_js_library(
     deps = [
         ":errors",
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
     ],
 )
 
@@ -123,7 +139,16 @@ closure_js_library(
         ":domcore",
         ":json",
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
+        "@io_bazel_rules_closure//closure/library/math",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/math:rect",
+        "@io_bazel_rules_closure//closure/library/string",
+        "@io_bazel_rules_closure//closure/library/style",
+        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )
 
@@ -158,7 +183,12 @@ closure_js_library(
         ":errors",
         ":json",
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/events:browserevent",
+        "@io_bazel_rules_closure//closure/library/style",
+        "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/library/useragent:product",
     ],
 )
 
@@ -179,7 +209,8 @@ closure_js_library(
         ":dom",
         ":errors",
         ":locators",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
     ],
 )
 
@@ -219,7 +250,10 @@ closure_js_library(
         ":bot",
         ":errors",
         ":json",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/object",
+        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )
 
@@ -231,7 +265,8 @@ closure_js_library(
     ],
     deps = [
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/json",
+        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )
 
@@ -256,7 +291,13 @@ closure_js_library(
         ":json",
         ":useragent",
         "//third_party/js/wgxpath",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/math:rect",
+        "@io_bazel_rules_closure//closure/library/string",
+        "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/library/useragent:product",
     ],
 )
 
@@ -268,7 +309,12 @@ closure_js_library(
         "JSC_UNKNOWN_EXPR_TYPE",
         "JSC_USE_OF_GOOG_PROVIDE",
     ],
-    deps = ["@io_bazel_rules_closure//closure/library"],
+    deps = [
+        "@io_bazel_rules_closure//closure/library/string",
+        "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/library/useragent:product",
+        "@io_bazel_rules_closure//closure/library/useragent:product_isversion",
+    ],
 )
 
 closure_js_library(
@@ -302,7 +348,9 @@ closure_js_library(
         ":bot",
         ":errors",
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/string",
+        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )
 
@@ -315,7 +363,6 @@ closure_js_library(
     ],
     deps = [
         ":useragent",
-        "@io_bazel_rules_closure//closure/library",
     ],
 )
 

--- a/javascript/atoms/fragments/BUILD.bazel
+++ b/javascript/atoms/fragments/BUILD.bazel
@@ -108,7 +108,7 @@ closure_fragment(
         "//javascript/chrome-driver:__pkg__",
     ],
     deps = [
-        "@io_bazel_rules_closure//closure/library",
+      "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 

--- a/javascript/atoms/fragments/BUILD.bazel
+++ b/javascript/atoms/fragments/BUILD.bazel
@@ -108,7 +108,7 @@ closure_fragment(
         "//javascript/chrome-driver:__pkg__",
     ],
     deps = [
-      "@io_bazel_rules_closure//closure/library/style",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 

--- a/javascript/chrome-driver/BUILD.bazel
+++ b/javascript/chrome-driver/BUILD.bazel
@@ -15,7 +15,11 @@ closure_js_library(
     deps = [
         "//javascript/atoms:dom",
         "//javascript/atoms:locators",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/math:rect",
+        "@io_bazel_rules_closure//closure/library/math:size",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 
@@ -24,7 +28,9 @@ closure_fragment(
     browsers = ["chrome"],
     function = "goog.style.getPageOffset",
     module = "goog.style",
-    deps = ["@io_bazel_rules_closure//closure/library"],
+    deps = [
+      "@io_bazel_rules_closure//closure/library/style",
+    ],
 )
 
 closure_fragment(
@@ -135,7 +141,7 @@ closure_js_library(
     testonly = 1,
     srcs = glob(["**/*.js"]),
     visibility = ["//javascript:__pkg__"],
-    deps = ["@io_bazel_rules_closure//closure/library"],
+    deps = [],
 )
 
 filegroup(

--- a/javascript/chrome-driver/BUILD.bazel
+++ b/javascript/chrome-driver/BUILD.bazel
@@ -29,7 +29,7 @@ closure_fragment(
     function = "goog.style.getPageOffset",
     module = "goog.style",
     deps = [
-      "@io_bazel_rules_closure//closure/library/style",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 

--- a/javascript/ie-driver/BUILD.bazel
+++ b/javascript/ie-driver/BUILD.bazel
@@ -23,7 +23,8 @@ closure_js_library(
         "//javascript/atoms:errors",
         "//javascript/atoms:locators",
         "//javascript/atoms:useragent",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 

--- a/javascript/webdriver/BUILD.bazel
+++ b/javascript/webdriver/BUILD.bazel
@@ -20,7 +20,6 @@ closure_js_library(
     visibility = ["//javascript/remote:__pkg__"],
     deps = [
         "//javascript/atoms:errors",
-        "@io_bazel_rules_closure//closure/library",
     ],
 )
 
@@ -41,7 +40,7 @@ closure_js_library(
         "JSC_USE_OF_GOOG_PROVIDE",
     ],
     visibility = ["//javascript:__pkg__"],
-    deps = ["@io_bazel_rules_closure//closure/library"],
+    deps = [],
 )
 
 filegroup(

--- a/javascript/webdriver/atoms/BUILD.bazel
+++ b/javascript/webdriver/atoms/BUILD.bazel
@@ -37,7 +37,11 @@ closure_js_library(
         "//javascript/atoms:domcore",
         "//javascript/atoms:html5",
         "//javascript/webdriver:key",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
+        "@io_bazel_rules_closure//closure/library/math:coordinate",
+        "@io_bazel_rules_closure//closure/library/style",
     ],
 )
 
@@ -51,7 +55,8 @@ closure_js_library(
     visibility = ["//visibility:private"],
     deps = [
         "//javascript/atoms:domcore",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom:tagname",
     ],
 )
 
@@ -295,6 +300,5 @@ closure_js_library(
         "//javascript/webdriver:__pkg__",
     ],
     deps = [
-        "@io_bazel_rules_closure//closure/library",
     ],
 )

--- a/javascript/webdriver/atoms/inject/BUILD.bazel
+++ b/javascript/webdriver/atoms/inject/BUILD.bazel
@@ -38,7 +38,7 @@ closure_js_library(
         "//javascript/atoms:action",
         "//javascript/atoms:inject",
         "//javascript/webdriver/atoms:atoms-lib",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/json",
     ],
 )
 
@@ -68,7 +68,7 @@ closure_js_library(
         "//javascript/atoms:inject",
         "//javascript/atoms:useragent",
         "//javascript/webdriver/atoms:atoms-lib",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/json",
     ],
 )
 
@@ -97,7 +97,7 @@ closure_js_library(
         ":execute-script",
         "//javascript/atoms:inject",
         "//javascript/atoms:locators",
-        "@io_bazel_rules_closure//closure/library",
+        "@io_bazel_rules_closure//closure/library/json",
     ],
 )
 

--- a/third_party/js/wgxpath/BUILD.bazel
+++ b/third_party/js/wgxpath/BUILD.bazel
@@ -15,5 +15,11 @@ closure_js_library(
         "JSC_USE_OF_GOOG_PROVIDE",
     ],
     visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_closure//closure/library"],
+    deps = [
+      "@io_bazel_rules_closure//closure/library/array",
+      "@io_bazel_rules_closure//closure/library/dom",
+      "@io_bazel_rules_closure//closure/library/dom:nodetype",
+      "@io_bazel_rules_closure//closure/library/string",
+      "@io_bazel_rules_closure//closure/library/useragent",
+    ],
 )

--- a/third_party/js/wgxpath/BUILD.bazel
+++ b/third_party/js/wgxpath/BUILD.bazel
@@ -16,10 +16,10 @@ closure_js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-      "@io_bazel_rules_closure//closure/library/array",
-      "@io_bazel_rules_closure//closure/library/dom",
-      "@io_bazel_rules_closure//closure/library/dom:nodetype",
-      "@io_bazel_rules_closure//closure/library/string",
-      "@io_bazel_rules_closure//closure/library/useragent",
+        "@io_bazel_rules_closure//closure/library/array",
+        "@io_bazel_rules_closure//closure/library/dom",
+        "@io_bazel_rules_closure//closure/library/dom:nodetype",
+        "@io_bazel_rules_closure//closure/library/string",
+        "@io_bazel_rules_closure//closure/library/useragent",
     ],
 )


### PR DESCRIPTION
Future updates to `rules_closure` remove the handy `closure/library` target we depend on. Use exact deps instead.
