### PR TITLE
[py]: allow tests to run for `sameSite` cookies in firefox and safari

### DIFF
--- a/py/test/selenium/webdriver/common/cookie_tests.py
+++ b/py/test/selenium/webdriver/common/cookie_tests.py
@@ -80,35 +80,24 @@ def test_add_cookie(cookie, driver):
     assert cookie["name"] in returned
 
 
-@pytest.mark.xfail_firefox(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_remote(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_safari
 def test_add_cookie_same_site_strict(same_site_cookie_strict, driver):
     driver.add_cookie(same_site_cookie_strict)
     returned = driver.get_cookie("foo")
     assert "sameSite" in returned and returned["sameSite"] == "Strict"
 
 
-@pytest.mark.xfail_firefox(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_remote(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_safari
 def test_add_cookie_same_site_lax(same_site_cookie_lax, driver):
     driver.add_cookie(same_site_cookie_lax)
     returned = driver.get_cookie("foo")
     assert "sameSite" in returned and returned["sameSite"] == "Lax"
 
 
-@pytest.mark.xfail_firefox(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_remote(reason="sameSite cookie attribute not implemented")
-@pytest.mark.xfail_safari
 def test_add_cookie_same_site_none(same_site_cookie_none, driver):
     driver.add_cookie(same_site_cookie_none)
     # Note that insecure sites (http:) can't set cookies with the Secure directive.
     # driver.get_cookie would return None
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
 def test_adding_acookie_that_expired_in_the_past(cookie, driver):
     expired = cookie.copy()
     expired["expiry"] = calendar.timegm(time.gmtime()) - 1


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

`sameSite` cookies have been implemented in firefox  as per - https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/ and the tests pass locally.

Removed the `xfail` for firefox, safari, ie and remote.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
tests


___

### **Description**
- Removed `xfail` markers for `sameSite` cookie tests in Firefox, Safari, IE, and remote, allowing these tests to run.
- Enabled testing for `sameSite` cookie attributes: Strict, Lax, and None, ensuring compatibility with recent browser updates.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cookie_tests.py</strong><dd><code>Enable `sameSite` cookie tests for Firefox and Safari</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/cookie_tests.py

<li>Removed <code>xfail</code> markers for Firefox, Safari, IE, and remote for <code>sameSite</code> <br>cookie tests.<br> <li> Enabled tests for <code>sameSite</code> cookie attributes: Strict, Lax, and None.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14893/files#diff-478d123ad61d455ee5c2b8195bc8e6f110b6690b75ed4ef5530be6e63b2862fa">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information