### PR TITLE
[grid] stop the health check of a restarted node

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/GridModel.java
+++ b/java/src/org/openqa/selenium/grid/distributor/GridModel.java
@@ -114,7 +114,9 @@ public class GridModel {
                   "Re-adding node with id %s and URI %s.",
                   node.getNodeId(), node.getExternalUri()));
 
-          events.fire(new NodeRestartedEvent(node));
+          // Send the previous state to allow cleaning up the old node related resources.
+          // Nodes are initially added in the "down" state, so the new state must be ignored.
+          events.fire(new NodeRestartedEvent(next));
           iterator.remove();
           break;
         }
@@ -226,7 +228,8 @@ public class GridModel {
         if (nodeHealthCount.getOrDefault(id, 0) > UNHEALTHY_THRESHOLD) {
           LOG.info(
               String.format(
-                  "Removing Node %s, unhealthy threshold has been reached", node.getExternalUri()));
+                  "Removing Node %s (uri: %s), unhealthy threshold has been reached",
+                  node.getNodeId(), node.getExternalUri()));
           toRemove.add(node);
           break;
         }
@@ -239,11 +242,17 @@ public class GridModel {
             lastTouched.plus(node.getHeartbeatPeriod().multipliedBy(PURGE_TIMEOUT_MULTIPLIER));
 
         if (node.getAvailability() == UP && lostTime.isBefore(now)) {
-          LOG.info(String.format("Switching Node %s from UP to DOWN", node.getExternalUri()));
+          LOG.info(
+              String.format(
+                  "Switching Node %s (uri: %s) from UP to DOWN",
+                  node.getNodeId(), node.getExternalUri()));
           replacements.put(node, rewrite(node, DOWN));
           nodePurgeTimes.put(id, Instant.now());
         } else if (node.getAvailability() == DOWN && deadTime.isBefore(now)) {
-          LOG.info(String.format("Removing Node %s, DOWN for too long", node.getExternalUri()));
+          LOG.info(
+              String.format(
+                  "Removing Node %s (uri: %s), DOWN for too long",
+                  node.getNodeId(), node.getExternalUri()));
           toRemove.add(node);
         }
       }

--- a/java/src/org/openqa/selenium/grid/sessionmap/jdbc/JdbcBackedSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/jdbc/JdbcBackedSessionMap.java
@@ -92,7 +92,8 @@ public class JdbcBackedSessionMap extends SessionMap implements Closeable {
                     .forEach(this::remove)));
 
     bus.addListener(
-        NodeRestartedEvent.listener(nodeStatus -> this.removeByUri(nodeStatus.getExternalUri())));
+        NodeRestartedEvent.listener(
+            previousNodeStatus -> this.removeByUri(previousNodeStatus.getExternalUri())));
   }
 
   public static SessionMap create(Config config) {

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
@@ -67,10 +67,11 @@ public class LocalSessionMap extends SessionMap {
 
     bus.addListener(
         NodeRestartedEvent.listener(
-            nodeStatus -> {
+            previousNodeStatus -> {
               List<SessionId> toRemove =
                   knownSessions.entrySet().stream()
-                      .filter((e) -> e.getValue().getUri().equals(nodeStatus.getExternalUri()))
+                      .filter(
+                          (e) -> e.getValue().getUri().equals(previousNodeStatus.getExternalUri()))
                       .map(Map.Entry::getKey)
                       .collect(Collectors.toList());
 

--- a/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
@@ -87,7 +87,8 @@ public class RedisBackedSessionMap extends SessionMap {
                     .forEach(this::remove)));
 
     bus.addListener(
-        NodeRestartedEvent.listener(nodeStatus -> this.removeByUri(nodeStatus.getExternalUri())));
+        NodeRestartedEvent.listener(
+            previousNodeStatus -> this.removeByUri(previousNodeStatus.getExternalUri())));
   }
 
   public static SessionMap create(Config config) {


### PR DESCRIPTION
### **User description**
### Description
This PR will stop the old health check of a restarted node and remove the old node from the model.
The `NodeRestartedEvent` will now contain the node status of the old node, this will allow to cleanup related resources.
The status of a newly added node is DOWN in any case, so sending the node status of the new node with the event was kind of useless anyway. This is also the reason for removing the old `LocalDistributer.handleNodeRestarted` code.

### Motivation and Context
This will speed up the cleanup and should fix a leak, as the node is removed from the model before raising the event.
But removing it from the model will stop the dead node detection, so the old health check should never be stopped.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `NodeRestartedEvent` to use previous node status for cleanup.

- Improved logging with detailed node information (ID and URI).

- Removed redundant `handleNodeRestarted` method in `LocalDistributor`.

- Simplified node removal logic across multiple session map implementations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GridModel.java</strong><dd><code>Refactor node restart and removal logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/GridModel.java

<li>Updated <code>NodeRestartedEvent</code> to use previous node status.<br> <li> Enhanced logging to include node ID and URI.<br> <li> Adjusted logic for removing unhealthy or inactive nodes.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15011/files#diff-72eb65833e6f3833e365d678e81969b2ecc3210df5c9b1ef0e044086ae1e6b53">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalDistributor.java</strong><dd><code>Simplify node restart handling in LocalDistributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java

<li>Removed <code>handleNodeRestarted</code> method.<br> <li> Simplified node removal logic.<br> <li> Updated event listener for <code>NodeRestartedEvent</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15011/files#diff-024d7dccb0a4ff87c444dc3549032e7c6b2595f582f4f267cdf48c7f8c2f87c1">+5/-25</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JdbcBackedSessionMap.java</strong><dd><code>Update session cleanup for restarted nodes in JDBC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/sessionmap/jdbc/JdbcBackedSessionMap.java

- Updated `NodeRestartedEvent` listener to use previous node status.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15011/files#diff-33e0803b77eb7aefdc10160034da3e301593045d1aae04c638974c8038c2ed49">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalSessionMap.java</strong><dd><code>Enhance session cleanup for restarted nodes locally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java

<li>Updated <code>NodeRestartedEvent</code> listener to use previous node status.<br> <li> Improved session cleanup logic for restarted nodes.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15011/files#diff-a695248e570684a11df57eeb89b45904fd436368f81ad223fceb74c8cdebef71">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisBackedSessionMap.java</strong><dd><code>Improve session cleanup for restarted nodes in Redis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java

- Updated `NodeRestartedEvent` listener to use previous node status.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15011/files#diff-7fff9f5ca983b8caed39b4ef6324318e669dbbad9e36d77520006357e06ae22e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information