### PR TITLE
[grid]: platformName is empty should be considered as enum ANY instead of WINDOWS

### DIFF
--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 public enum Platform {
 
   /** Never returned, but can be used to request a browser running on any version of Windows. */
-  WINDOWS("") {
+  WINDOWS("windows") {
     @Override
     public Platform family() {
       return null;
@@ -299,6 +299,18 @@ public enum Platform {
     @Override
     public String toString() {
       return "macOS 14.0";
+    }
+  },
+
+  SEQUOIA("sequoia", "os x 15.0", "macos 15.0") {
+    @Override
+    public Platform family() {
+      return MAC;
+    }
+
+    @Override
+    public String toString() {
+      return "macOS 15.0";
     }
   },
 

--- a/java/test/org/openqa/selenium/PlatformTest.java
+++ b/java/test/org/openqa/selenium/PlatformTest.java
@@ -24,8 +24,10 @@ import static org.openqa.selenium.Platform.CATALINA;
 import static org.openqa.selenium.Platform.IOS;
 import static org.openqa.selenium.Platform.LINUX;
 import static org.openqa.selenium.Platform.MAC;
+import static org.openqa.selenium.Platform.SEQUOIA;
 import static org.openqa.selenium.Platform.UNIX;
 import static org.openqa.selenium.Platform.VISTA;
+import static org.openqa.selenium.Platform.WIN11;
 import static org.openqa.selenium.Platform.WIN8;
 import static org.openqa.selenium.Platform.WIN8_1;
 import static org.openqa.selenium.Platform.WINDOWS;
@@ -55,6 +57,11 @@ class PlatformTest {
   @Test
   void testWin81IsWindows() {
     assertThat(WIN8_1.is(WINDOWS)).isTrue();
+  }
+
+  @Test
+  void testWindows11IsWindows() {
+    assertThat(WIN11.is(WINDOWS)).isTrue();
   }
 
   @Test
@@ -166,13 +173,38 @@ class PlatformTest {
   }
 
   @Test
+  void testWindowsIsNotEmpty() {
+    assertThat(WINDOWS).isNotEqualTo(Platform.fromString(""));
+  }
+
+  @Test
   void canParseMacOsXCorrectly() {
     assertThat(Platform.fromString("Mac OS X")).isEqualTo(MAC);
   }
 
   @Test
+  void testAnyIsFromStringEmpty() {
+    assertThat(ANY).isEqualTo(Platform.fromString(""));
+  }
+
+  @Test
+  void testAnyIsFromStringAny() {
+    assertThat(ANY).isEqualTo(Platform.fromString("any"));
+  }
+
+  @Test
+  void testAnyIsNotFromStringWindows() {
+    assertThat(ANY).isNotEqualTo(Platform.fromString("windows"));
+  }
+
+  @Test
   void catalinaIsMac() {
     assertThat(CATALINA.is(MAC)).isTrue();
+  }
+
+  @Test
+  void sequoiaIsMac() {
+    assertThat(SEQUOIA.is(MAC)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
When adding a test to verify when `"platformName": ""` it should map to enum `ANY`
```java
  @Test
  void testAnyIsFromStringEmpty() {
    assertThat(ANY).isEqualTo(Platform.fromString(""));
  }
```

However, it failed with expected that is WINDOWS.

```
testAnyIsFromStringEmpty() (org.openqa.selenium.PlatformTest)
org.opentest4j.AssertionFailedError: 
expected: windows
 but was: any
```

In a end2end scenario, it also behaves the same. For example TOML given

```
[[node.driver-configuration]]
display-name = "chrome"
stereotype = '{"browserName": "chrome", "browserVersion": "", "platformName": "", "goog:chromeOptions": {"binary": "/usr/bin/google-chrome"}, "se:containerName": "selenium-node-chrome-69847c778d-8qzwg"}'
max-sessions = 1
```

When Node started up, the Node stereotypes could be seen `platformName: windows`

> INFO: Adding chrome for {"browserName": "chrome","browserVersion": "","goog:chromeOptions": {"binary": "\u002fusr\u002fbin\u002fgoogle-chrome"},"platformName": "windows","se:containerName": "selenium-node-chrome-69847c778d-8qzwg","se:downloadsEnabled": true,"se:noVncPort": 7900,"se:vncEnabled": true} 1 times

It does not make sense when checking from Grid UI, the OS logo for session requests and ongoing.

![image](https://github.com/user-attachments/assets/9c205716-ae80-4c4f-a354-f8cf7a20811d)

In case, Node stereotypes setting `"platformName": ""`. It should be loaded `"platformName":"any"` and reflect to Grid UI the unknown os icon, e.g

```toml
[[node.driver-configuration]]
display-name = "firefox"
stereotype = '{"browserName": "firefox", "browserVersion": "133.0", "platformName": "", "moz:firefoxOptions": {"binary": "/usr/bin/firefox"}, "se:containerName": ""}'
max-sessions = 1
```

> INFO: Adding firefox for {"browserName": "firefox","browserVersion": "133.0","moz:firefoxOptions": {"binary": "\u002fusr\u002fbin\u002ffirefox"},"platformName": "any","se:containerName": "","se:noVncPort": 7900,"se:vncEnabled": true} 1 times

![image](https://github.com/user-attachments/assets/92d8e5ae-7e40-4229-911a-36cbcbe37b74)

This also helps autoscaling have a consistent pattern to correctly count pending and ongoing sessions for populating the right external metrics.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
