### PR TITLE
[py] Fix WebKitGTK driver name check

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -150,7 +150,8 @@ def driver(request):
             options = get_options("Firefox", request.config) or webdriver.FirefoxOptions()
             options.set_capability("moz:firefoxOptions", {})
             options.enable_downloads = True
-        if driver_class == "WebKitGTK":
+        if driver_class.lower() == "webkitgtk":
+            driver_class = "WebKitGTK"
             options = get_options(driver_class, request.config)
         if driver_class == "Edge":
             options = get_options(driver_class, request.config)

--- a/py/selenium/webdriver/webkitgtk/service.py
+++ b/py/selenium/webdriver/webkitgtk/service.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import shutil
 import warnings
 from typing import List
 from typing import Mapping
@@ -21,14 +22,14 @@ from typing import Optional
 
 from selenium.webdriver.common import service
 
-DEFAULT_EXECUTABLE_PATH: str = "WebKitWebDriver"
+DEFAULT_EXECUTABLE_PATH: str = shutil.which("WebKitWebDriver")
 
 
 class Service(service.Service):
     """A Service class that is responsible for the starting and stopping of
-    `WPEWebDriver`.
+    `WebKitWebDriver`.
 
-    :param executable_path: install path of the WebKitWebDriver executable, defaults to `WebKitWebDriver`.
+    :param executable_path: install path of the WebKitWebDriver executable, defaults to the first `WebKitWebDriver` in `$PATH`.
     :param port: Port for the service to run on, defaults to 0 where the operating system will decide.
     :param service_args: (Optional) List of args to be passed to the subprocess when launching the executable.
     :param log_output: (Optional) File path for the file to be opened and passed as the subprocess stdout/stderr handler.


### PR DESCRIPTION
### **User description**
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Similar to WPEWebKit changes from 24d88d73636e33, WebKitGTK does not follow the simple capitalization scheme for the driver name.

This commit also changes the default `WebKitWebDriver` binary to the first one in `PATH` through `shutil.which`, instead of just the binary name.

(Note: The effort to move to `pathlib` instead of `shutil`[1] is more related to shutil's functions that work on files and directories, like copy and move, instead of `which`, which just searches the executable paths for the given command.)

[1] https://discuss.python.org/t/incrementally-move-high-level-path-operations-from-shutil-to-pathlib/19208

### Motivation and Context

Without this fix, using the helper WebKitGTK driver class fails unconditionally. This affects running Selenium's own tests with WebkitGTK, for example (which we import into WebKit, alongside WPT's WebDriver tests).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed WebKitGTK driver name capitalization check in `conftest.py`.

- Updated `WebKitWebDriver` binary to use `shutil.which` for path resolution.

- Ensured compatibility with WebKitGTK driver class for Selenium tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Fix WebKitGTK driver name capitalization check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Adjusted WebKitGTK driver name check to be case-insensitive.<br> <li> Ensured driver class is correctly set to <code>WebKitGTK</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15046/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Update WebKitWebDriver binary resolution using `shutil.which`</code></dd></summary>
<hr>

py/selenium/webdriver/webkitgtk/service.py

<li>Changed <code>DEFAULT_EXECUTABLE_PATH</code> to use <code>shutil.which</code>.<br> <li> Updated docstring to reflect the new binary resolution method.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15046/files#diff-2f176dbccc5f64167acc6345e2351cab42ccebdefcc77374c69cb9e23b130806">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information