### PR TITLE
[dotnet] Obsolete setters and constructors on `Response` that are not conducive to immutability

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -340,9 +340,8 @@ namespace OpenQA.Selenium.Remote
 
             if (response.Value is string valueString)
             {
-#pragma warning disable CS0618 // Response.Value setter can be used internally
-                response.Value = valueString.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
-#pragma warning restore CS0618
+                valueString = valueString.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+                response = new Response(response.SessionId, valueString, response.Status);
             }
 
             return response;

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -340,7 +340,9 @@ namespace OpenQA.Selenium.Remote
 
             if (response.Value is string valueString)
             {
+#pragma warning disable CS0618 // Response.Value setter can be used internally
                 response.Value = valueString.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+#pragma warning restore CS0618
             }
 
             return response;

--- a/dotnet/src/webdriver/Response.cs
+++ b/dotnet/src/webdriver/Response.cs
@@ -42,6 +42,7 @@ namespace OpenQA.Selenium
         /// <summary>
         /// Initializes a new instance of the <see cref="Response"/> class
         /// </summary>
+        [Obsolete("Set all values using the Response(string, object, WebDriverResult) constructor instead. This constructor will be removed in Selenium 4.30")]
         public Response()
         {
         }
@@ -50,6 +51,7 @@ namespace OpenQA.Selenium
         /// Initializes a new instance of the <see cref="Response"/> class
         /// </summary>
         /// <param name="sessionId">Session ID in use</param>
+        [Obsolete("Set all values using the Response(string, object, WebDriverResult) constructor instead. This constructor will be removed in Selenium 4.30")]
         public Response(SessionId? sessionId)
         {
             this.SessionId = sessionId?.ToString();

--- a/dotnet/src/webdriver/Response.cs
+++ b/dotnet/src/webdriver/Response.cs
@@ -136,18 +136,35 @@ namespace OpenQA.Selenium
         /// <summary>
         /// Gets or sets the value from JSON.
         /// </summary>
-        public object? Value { get; set; }
+        public object? Value
+        {
+            get;
+
+            [Obsolete("The Response type will be immutable and this setter will be removed in Selenium 4.30")]
+            set;
+        }
 
         /// <summary>
         /// Gets or sets the session ID.
         /// </summary>
-        public string? SessionId { get; set; }
+        public string? SessionId
+        {
+            get;
+
+            [Obsolete("The Response type will be immutable and this setter will be removed in Selenium 4.30")]
+            set;
+        }
 
         /// <summary>
         /// Gets or sets the status value of the response.
         /// </summary>
-        public WebDriverResult Status { get; set; }
+        public WebDriverResult Status
+        {
+            get;
 
+            [Obsolete("The Response type will be immutable and this setter will be removed in Selenium 4.30")]
+            set;
+        }
 
         /// <summary>
         /// Returns a new <see cref="Response"/> from a JSON-encoded string.


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Obsolete every constructor on `Response` besides the one which sets all values. Obsolete public setters on `Response` properties.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

A programmatic guarantee of immutability would be a conceptual simplification, because it allows us to make assumptions and guarantees we could not otherwise make.

For example, in the future we could expose `JsonNode? ValueAsNode` property which would allow us to manage the response as a strongly-typed node instead of knowing ahead of time what the types could be.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Marked constructors and setters in `Response` as obsolete.

- Introduced warnings for deprecated `Response` members.

- Updated `HttpCommandExecutor` to handle obsolete `Response.Value` setter.

- Prepared `Response` class for immutability in future releases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpCommandExecutor.cs</strong><dd><code>Suppress warnings for obsolete `Response.Value` setter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/HttpCommandExecutor.cs

<li>Added pragma directives to suppress warnings for obsolete <br><code>Response.Value</code> setter.<br> <li> Adjusted <code>CreateResponse</code> method to handle deprecated <code>Response.Value</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15107/files#diff-7e90084c9f3e8c994cbbfabdbc93ecd024159b65ca59d9f6efc53cace50e7b10">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Response.cs</strong><dd><code>Mark `Response` constructors and setters as obsolete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Response.cs

<li>Marked default and single-parameter constructors as obsolete.<br> <li> Marked setters for <code>Value</code>, <code>SessionId</code>, and <code>Status</code> as obsolete.<br> <li> Added warnings for deprecated members to prepare for immutability.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15107/files#diff-c118ca207b54c33c677d0ea6b7d9379cb63ecfb92a537e512741f0b96013e77c">+22/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>