### PR TITLE
[java]: Fix the message from NumberFormatException

### DIFF
--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -508,10 +508,10 @@ public class DriverService implements Closeable {
       if (Locale.getDefault(Locale.Category.FORMAT).getLanguage().equals("ar")) {
         throw new NumberFormatException(
             String.format(
-                "Couldn't format the port numbers because the System Language is arabic:"
-                    + " \"--port=%d\", please make sure to add the required arguments"
-                    + " \"-Duser.language=en -Duser.region=US\" to your JVM, for more info please"
-                    + " visit :%n"
+                "Couldn't format the port numbers because the System Language is arabic: \""
+                    + String.format("--port=%d", port)
+                    + "\", please make sure to add the required arguments \"-Duser.language=en"
+                    + " -Duser.region=US\" to your JVM, for more info please visit :\n"
                     + "  https://www.selenium.dev/documentation/webdriver/browsers/",
                 getPort()));
       }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
PR #14946 probably after running format.sh. The message with the next lines added is not consistent anymore, which causes the unit test to fail.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the `NumberFormatException` message for Arabic locale.

- Improved formatting of the exception message for clarity.

- Ensured proper handling of port formatting in error messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverService.java</strong><dd><code>Refined `NumberFormatException` message for Arabic locale</code></dd></summary>
<hr>

java/src/org/openqa/selenium/remote/service/DriverService.java

<li>Updated the <code>NumberFormatException</code> message for Arabic locale.<br> <li> Refined the message to include formatted port numbers.<br> <li> Enhanced clarity and readability of the exception message.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15116/files#diff-6a2bf51c104e6ba92d3820843d8da94e8557501e8aa10e1a4734016c0f4a0d7c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>