### PR TITLE
[rb] Remove java date dependency

### DIFF
--- a/rb/Gemfile.lock
+++ b/rb/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.1)
+    activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -25,7 +25,6 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -41,7 +40,6 @@ GEM
     csv (3.3.2)
     curb (1.0.6)
     date (3.4.1)
-    date (3.4.1-java)
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -169,7 +167,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)


### PR DESCRIPTION
### **User description**
### Description
The java date dependency gives us issues with Bazel due to `strip_prefix`, this PR just remove the dependency from the gemfile.lock so it's possible to install

### Motivation and Context
We want to be able to build the ruby docs for the latest release, a more permanent fix is under investigation

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the java date dependency from `gemfile.lock` to resolve issues with Bazel caused by `strip_prefix`.

- Enables building Ruby docs for the latest release.

- A more permanent fix is under investigation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>