### PR TITLE
[bazel] Bump deps to avoid warnings when starting the bazel daemon

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,16 +15,16 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.2", dev_dependency = True, repo_name = "com_google_protobuf")
 
 # Required for rules_rust to import the crates properly
-bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.1.0", dev_dependency = True)
 
 bazel_dep(name = "rules_dotnet", version = "0.17.5")
-bazel_dep(name = "rules_java", version = "7.12.4")
+bazel_dep(name = "rules_java", version = "8.7.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 bazel_dep(name = "rules_nodejs", version = "6.3.2")
 bazel_dep(name = "rules_oci", version = "1.8.0")
-bazel_dep(name = "rules_pkg", version = "0.10.1")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_python", version = "0.33.0")
-bazel_dep(name = "rules_proto", version = "6.0.2")
+bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "rules_ruby", version = "0.13.0")
 
 linter = use_extension("@apple_rules_lint//lint:extensions.bzl", "linter")


### PR DESCRIPTION
### **PR Type**
enhancement, dependencies


___

### **Description**
- Updated Bazel dependencies to newer versions.

- Addressed warnings when starting the Bazel daemon.

- Improved compatibility and functionality with updated dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Updated Bazel dependency versions for multiple rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<li>Updated <code>rules_cc</code> version from 0.0.9 to 0.1.0.<br> <li> Updated <code>rules_java</code> version from 7.12.4 to 8.7.1.<br> <li> Updated <code>rules_pkg</code> version from 0.10.1 to 1.0.1.<br> <li> Updated <code>rules_proto</code> version from 6.0.2 to 7.0.2.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15137/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>