### PR TITLE
[rb] Fix guard issues for Firefox in Mac

### DIFF
--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -260,8 +260,7 @@ module Selenium
         end
       end
 
-      describe 'pen stylus', except: [{browser: :firefox, reason: 'Unknown pointerType'},
-                                      {browser: :safari,  reason: 'Some issues with resolution?'}] do
+      describe 'pen stylus', only: [{browser: %i[chrome edge]}] do
         it 'sets pointer event properties' do
           driver.navigate.to url_for('pointerActionsPage.html')
           pointer_area = driver.find_element(id: 'pointerArea')
@@ -302,9 +301,8 @@ module Selenium
         end
       end
 
-      describe '#scroll_to', only: {browser: %i[chrome edge firefox]} do
-        it 'scrolls to element',
-           except: {browser: :firefox, reason: 'incorrect MoveTargetOutOfBoundsError'} do
+      describe '#scroll_to', only: {browser: %i[chrome edge]} do
+        it 'scrolls to element' do
           driver.navigate.to url_for('scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html')
           iframe = driver.find_element(tag_name: 'iframe')
 
@@ -330,8 +328,7 @@ module Selenium
       end
 
       describe '#scroll_from' do
-        it 'scrolls from element by given amount',
-           except: {browser: %i[firefox safari], reason: 'incorrect MoveTargetOutOfBoundsError'} do
+        it 'scrolls from element by given amount', only: {browser: %i[chrome edge]} do
           driver.navigate.to url_for('scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html')
           iframe = driver.find_element(tag_name: 'iframe')
           scroll_origin = WheelActions::ScrollOrigin.element(iframe)
@@ -344,8 +341,7 @@ module Selenium
           expect(in_viewport?(checkbox)).to be true
         end
 
-        it 'scrolls from element by given amount with offset',
-           except: {browser: %i[firefox safari], reason: 'incorrect MoveTargetOutOfBoundsError'} do
+        it 'scrolls from element by given amount with offset', only: {browser: %i[chrome edge]} do
           driver.navigate.to url_for('scrolling_tests/frame_with_nested_scrolling_frame_out_of_view.html')
           footer = driver.find_element(tag_name: 'footer')
           scroll_origin = WheelActions::ScrollOrigin.element(footer, 0, -50)


### PR DESCRIPTION
### Description
This PR updates the firefox guards

### Motivation and Context
The purpose of this PR is to fix and understand why the firefox guards are failing only for Mac

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Updated browser guard conditions for Firefox and Safari.

- Restricted tests to Chrome and Edge for specific scenarios.

- Removed exceptions for Firefox and Safari in scroll-related tests.

- Improved test stability by refining browser-specific conditions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action_builder_spec.rb</strong><dd><code>Adjusted browser-specific guards in WebDriver tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/action_builder_spec.rb

<li>Changed <code>pen stylus</code> test to only run on Chrome and Edge.<br> <li> Updated <code>#scroll_to</code> test to exclude Firefox and Safari.<br> <li> Modified <code>#scroll_from</code> tests to restrict to Chrome and Edge.<br> <li> Removed outdated exception reasons for Firefox and Safari.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15142/files#diff-d8e497e24cdefe7173f8fa82f71051ba7df14fb29bd17af7264f55a0da9d7e7e">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>