### PR TITLE
[dotnet] Serialize command parameters directly to UTF-8

### DIFF
--- a/dotnet/src/webdriver/Command.cs
+++ b/dotnet/src/webdriver/Command.cs
@@ -102,12 +102,28 @@ namespace OpenQA.Selenium
         }
 
         /// <summary>
+        /// Serializes the parameters of the comand to JSON as UTF-8 bytes.
+        /// </summary>
+        /// <returns></returns>
+        public byte[] GetParametersAsUtf8Bytes()
+        {
+            if (this.Parameters != null && this.Parameters.Count > 0)
+            {
+                return JsonSerializer.SerializeToUtf8Bytes(this.Parameters, s_jsonSerializerOptions);
+            }
+            else
+            {
+                return "{}"u8.ToArray();
+            }
+        }
+
+        /// <summary>
         /// Returns a string of the Command object
         /// </summary>
         /// <returns>A string representation of the Command Object</returns>
         public override string ToString()
         {
-            return string.Concat("[", this.SessionId, "]: ", this.Name, " ", this.ParametersAsJsonString);
+            return $"[{this.SessionId}]: {this.Name} Parameters: {this.ParametersAsJsonString}";
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/Command.cs
+++ b/dotnet/src/webdriver/Command.cs
@@ -123,7 +123,7 @@ namespace OpenQA.Selenium
         /// <returns>A string representation of the Command Object</returns>
         public override string ToString()
         {
-            return $"[{this.SessionId}]: {this.Name} Parameters: {this.ParametersAsJsonString}";
+            return $"[{this.SessionId}]: {this.Name} {this.ParametersAsJsonString}";
         }
 
         /// <summary>

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -280,7 +280,7 @@ namespace OpenQA.Selenium.Remote
                     acceptHeader.CharSet = Utf8CharsetType;
                     requestMessage.Headers.Accept.Add(acceptHeader);
 
-                    byte[] bytes = Encoding.UTF8.GetBytes(requestInfo.RequestBody);
+                    byte[] bytes = requestInfo.RequestBody;
                     requestMessage.Content = new ByteArrayContent(bytes, 0, bytes.Length);
 
                     MediaTypeHeaderValue contentTypeHeader = new MediaTypeHeaderValue(JsonMimeType);
@@ -370,12 +370,12 @@ namespace OpenQA.Selenium.Remote
 
                 this.FullUri = commandInfo.CreateCommandUri(serverUri, commandToExecute);
                 this.HttpMethod = commandInfo.Method;
-                this.RequestBody = commandToExecute.ParametersAsJsonString;
+                this.RequestBody = commandToExecute.GetParametersAsUtf8Bytes();
             }
 
             public Uri FullUri { get; set; }
             public string HttpMethod { get; set; }
-            public string RequestBody { get; set; }
+            public byte[] RequestBody { get; set; }
         }
 
         private class HttpResponseInfo

--- a/dotnet/src/webdriver/Remote/SendingRemoteHttpRequestEventArgs.cs
+++ b/dotnet/src/webdriver/Remote/SendingRemoteHttpRequestEventArgs.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 #nullable enable
 
@@ -29,6 +30,8 @@ namespace OpenQA.Selenium.Remote
     /// </summary>
     public class SendingRemoteHttpRequestEventArgs : EventArgs
     {
+        private string? _requestBody;
+        private readonly byte[]? _utf8RequestBody;
         private readonly Dictionary<string, string> headers = new Dictionary<string, string>();
 
         /// <summary>
@@ -42,7 +45,21 @@ namespace OpenQA.Selenium.Remote
         {
             this.Method = method ?? throw new ArgumentNullException(nameof(method));
             this.FullUrl = fullUrl ?? throw new ArgumentNullException(nameof(fullUrl));
-            this.RequestBody = requestBody;
+            _utf8RequestBody = requestBody is null ? null : Encoding.UTF8.GetBytes(requestBody);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendingRemoteHttpRequestEventArgs"/> class.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request being sent.</param>
+        /// <param name="fullUrl">The full URL of the request being sent.</param>
+        /// <param name="requestBody">The body of the request.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="method"/>, <paramref name="fullUrl"/> are null.</exception>
+        public SendingRemoteHttpRequestEventArgs(string method, string fullUrl, byte[]? requestBody)
+        {
+            this.Method = method ?? throw new ArgumentNullException(nameof(method));
+            this.FullUrl = fullUrl ?? throw new ArgumentNullException(nameof(fullUrl));
+            _utf8RequestBody = requestBody;
         }
 
         /// <summary>
@@ -58,7 +75,18 @@ namespace OpenQA.Selenium.Remote
         /// <summary>
         /// Gets the body of the HTTP request as a string.
         /// </summary>
-        public string? RequestBody { get; }
+        public string? RequestBody
+        {
+            get
+            {
+                if (_requestBody is not null)
+                {
+                    return _requestBody;
+                }
+
+                return _requestBody = _utf8RequestBody is null ? null : Encoding.UTF8.GetString(_utf8RequestBody);
+            }
+        }
 
         /// <summary>
         /// Gets a read-only dictionary of the headers of the HTTP request.

--- a/dotnet/test/common/CommandTests.cs
+++ b/dotnet/test/common/CommandTests.cs
@@ -26,6 +26,22 @@ namespace OpenQA.Selenium
     public class CommandTests
     {
         [Test]
+        public void CommandSerializesNullParameters()
+        {
+            var command = new Command(new SessionId("session"), "test command", parameters: null);
+
+            Assert.That(command.GetParametersAsUtf8Bytes(), Is.EqualTo("{}"u8.ToArray()));
+        }
+
+        [Test]
+        public void CommandSerializesEmptyParameters()
+        {
+            var command = new Command(new SessionId("session"), "test command", parameters: new Dictionary<string, object>());
+
+            Assert.That(command.GetParametersAsUtf8Bytes(), Is.EqualTo("{}"u8.ToArray()));
+        }
+
+        [Test]
         public void CommandSerializesAnonymousType()
         {
             var parameters = new Dictionary<string, object>
@@ -35,7 +51,7 @@ namespace OpenQA.Selenium
 
             var command = new Command(new SessionId("session"), "test command", parameters);
 
-            Assert.That(command.ParametersAsJsonString, Is.EqualTo("""{"arg":{"param1":true,"param2":false}}"""));
+            Assert.That(command.GetParametersAsUtf8Bytes(), Is.EqualTo("""{"arg":{"param1":true,"param2":false}}"""u8.ToArray()));
         }
     }
 }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Serialize command parameters directly into UTF-8 bytes, and pass the array around. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

`System.Text.Json` operates natively in UTF-8, and it is much more efficient to serialize to a `byte[]` rather than materializing a string.

The HTTP request contents are in the form of a `byte[]` anyway, so we are avoiding a lot of back and forth between formats here.

Old Flow: `Dictionary<string, object>` -> UTF-8 inside `STJ` -> `string` returned by `STJ` -> Encoded to `byte[]`
New Flow: `Dictionary<string, object>` -> UTF-8 returned by `STJ`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced UTF-8 byte serialization for command parameters.

- Updated HTTP request handling to use byte arrays directly.

- Enhanced event arguments to support UTF-8 request bodies.

- Added unit tests to validate new serialization logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Command.cs</strong><dd><code>Add UTF-8 serialization for command parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Command.cs

<li>Added <code>GetParametersAsUtf8Bytes</code> method for UTF-8 serialization.<br> <li> Updated <code>ToString</code> method for improved parameter representation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15151/files#diff-713ff04e841a84c186ba6acf6d405ad2b3eed93d2e850a3634cf54fb7edb3ae2">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpCommandExecutor.cs</strong><dd><code>Use byte arrays for HTTP request bodies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/HttpCommandExecutor.cs

<li>Replaced string-based request body with byte array.<br> <li> Updated HTTP request content handling to use byte arrays.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15151/files#diff-7e90084c9f3e8c994cbbfabdbc93ecd024159b65ca59d9f6efc53cace50e7b10">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SendingRemoteHttpRequestEventArgs.cs</strong><dd><code>Support UTF-8 byte arrays in event arguments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/SendingRemoteHttpRequestEventArgs.cs

<li>Added support for UTF-8 byte arrays in request body.<br> <li> Enhanced <code>RequestBody</code> property to handle string and byte arrays.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15151/files#diff-fc03208f7c3b67a7ca8ed5e92c9e54f722e0a19a6bae32425d6968a2b8e84240">+30/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandTests.cs</strong><dd><code>Add tests for UTF-8 serialization of parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/CommandTests.cs

<li>Added tests for null and empty parameter serialization.<br> <li> Updated existing tests to validate UTF-8 byte serialization.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15151/files#diff-1c58b4921076c552b8954d836fda5e231edf0264e3682b855b37cc3a912fdfdd">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>