### PR TITLE
[dotnet] Address some build warnings

### DIFF
--- a/dotnet/src/webdriver/Cookie.cs
+++ b/dotnet/src/webdriver/Cookie.cs
@@ -277,7 +277,7 @@ namespace OpenQA.Selenium
         {
             if (rawCookie == null)
             {
-                throw new ArgumentNullException(nameof(rawCookie), "Dictionary cannot be null");
+                throw new ArgumentNullException(nameof(rawCookie));
             }
 
             string name = rawCookie["name"].ToString();

--- a/dotnet/src/webdriver/CookieJar.cs
+++ b/dotnet/src/webdriver/CookieJar.cs
@@ -127,7 +127,7 @@ namespace OpenQA.Selenium
             {
                 var rawCookie = driver.InternalExecute(DriverCommand.GetCookie, new() { { "name", name } }).Value;
 
-                return Cookie.FromDictionary((Dictionary<string, object>)rawCookie);
+                return Cookie.FromDictionary((Dictionary<string, object>)rawCookie!);
             }
             catch (NoSuchCookieException)
             {

--- a/dotnet/src/webdriver/Internal/FileUtilities.cs
+++ b/dotnet/src/webdriver/Internal/FileUtilities.cs
@@ -187,20 +187,18 @@ namespace OpenQA.Selenium.Internal
             }
 
             string currentDirectory = location!;
-
-
+#if !NET8_0_OR_GREATER
             // If we're shadow copying, get the directory from the codebase instead
             if (AppDomain.CurrentDomain.ShadowCopyFiles)
             {
-#pragma warning disable SYSLIB0012 // Type or member is obsolete
                 var codeBase = executingAssembly.CodeBase;
-#pragma warning restore SYSLIB0012 // Type or member is obsolete
 
                 if (codeBase is not null)
                 {
                     currentDirectory = Path.GetDirectoryName(codeBase)!;
                 }
             }
+#endif
 
             return currentDirectory;
         }

--- a/dotnet/src/webdriver/Internal/FileUtilities.cs
+++ b/dotnet/src/webdriver/Internal/FileUtilities.cs
@@ -188,11 +188,18 @@ namespace OpenQA.Selenium.Internal
 
             string currentDirectory = location!;
 
+
             // If we're shadow copying, get the directory from the codebase instead
             if (AppDomain.CurrentDomain.ShadowCopyFiles)
             {
-                Uri uri = new Uri(executingAssembly.CodeBase);
-                currentDirectory = Path.GetDirectoryName(uri.LocalPath)!;
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
+                var codeBase = executingAssembly.CodeBase;
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
+
+                if (codeBase is not null)
+                {
+                    currentDirectory = Path.GetDirectoryName(codeBase)!;
+                }
             }
 
             return currentDirectory;

--- a/dotnet/src/webdriver/Internal/FileUtilities.cs
+++ b/dotnet/src/webdriver/Internal/FileUtilities.cs
@@ -187,6 +187,7 @@ namespace OpenQA.Selenium.Internal
             }
 
             string currentDirectory = location!;
+
 #if !NET8_0_OR_GREATER
             // If we're shadow copying, get the directory from the codebase instead
             if (AppDomain.CurrentDomain.ShadowCopyFiles)
@@ -195,7 +196,7 @@ namespace OpenQA.Selenium.Internal
 
                 if (codeBase is not null)
                 {
-                    currentDirectory = Path.GetDirectoryName(codeBase)!;
+                    currentDirectory = Path.GetDirectoryName(codeBase);
                 }
             }
 #endif


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed redundant exception message in `Cookie.FromDictionary`.

- Added null-forgiving operator to avoid nullable warnings in `CookieJar`.

- Updated obsolete `CodeBase` handling in `FileUtilities` with conditional checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cookie.cs</strong><dd><code>Simplified exception handling in `Cookie.FromDictionary`</code>&nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Cookie.cs

- Removed redundant exception message in `ArgumentNullException`.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15157/files#diff-4f2c097a95bff1720a0856e720b4aeb78f8bcf876dad4935067554e6ae34a5cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CookieJar.cs</strong><dd><code>Improved nullability handling in `CookieJar`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/CookieJar.cs

- Added null-forgiving operator to avoid nullable warnings.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15157/files#diff-1217e6dba35130a8009d53fe8e46ead689315bd510ec894f0c05caa62a9fd489">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FileUtilities.cs</strong><dd><code>Updated obsolete `CodeBase` handling in `FileUtilities`</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/FileUtilities.cs

<li>Added conditional checks for obsolete <code>CodeBase</code> property.<br> <li> Used pragma directives to suppress warnings for obsolete members.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15157/files#diff-d0ace1da1f4c95d6ffce63b8813582f0f4c60b2e6477db60334d33ad6e4d71ff">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>