### PR TITLE
[dotnet] Improve bidi exception when it is not enabled

### DIFF
--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -30,7 +30,7 @@ public static class WebDriverExtensions
     {
         var webSocketUrl = ((IHasCapabilities)webDriver).Capabilities.GetCapability("webSocketUrl");
 
-        if (webSocketUrl is null) throw new System.Exception("The driver is not compatible with bidirectional protocol or it is not enabled in driver options.");
+        if (webSocketUrl is null) throw new BiDiException("The driver is not compatible with bidirectional protocol or \"webSocketUrl\" not enabled in driver options.");
 
         var bidi = await BiDi.ConnectAsync(webSocketUrl.ToString()!).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Modules.BrowsingContext;
+using System;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -28,11 +29,18 @@ public static class WebDriverExtensions
 {
     public static async Task<BiDi> AsBiDiAsync(this IWebDriver webDriver)
     {
-        var webSocketUrl = ((IHasCapabilities)webDriver).Capabilities.GetCapability("webSocketUrl");
+        if (webDriver is null) throw new ArgumentNullException(nameof(webDriver));
+
+        string? webSocketUrl = null;
+
+        if (webDriver is IHasCapabilities hasCapabilities)
+        {
+            webSocketUrl = hasCapabilities.Capabilities.GetCapability("webSocketUrl")?.ToString();
+        }
 
         if (webSocketUrl is null) throw new BiDiException("The driver is not compatible with bidirectional protocol or \"webSocketUrl\" not enabled in driver options.");
 
-        var bidi = await BiDi.ConnectAsync(webSocketUrl.ToString()!).ConfigureAwait(false);
+        var bidi = await BiDi.ConnectAsync(webSocketUrl).ConfigureAwait(false);
 
         return bidi;
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced generic exception with a specific `BiDiException`.

- Improved error message for unsupported bidirectional protocol.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebDriver.Extensions.cs</strong><dd><code>Refined exception handling and error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs

<li>Replaced <code>System.Exception</code> with <code>BiDiException</code>.<br> <li> Updated error message for better clarity.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15163/files#diff-74a59237dd909eaf45f31d8157e01415e5ddd6cd33066dd22a753f7741175769">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>