### PR TITLE
[dotnet] Fix name collisions for commands/responses/eventargs

### DIFF
--- a/third_party/dotnet/devtools/NuGet.Config
+++ b/third_party/dotnet/devtools/NuGet.Config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Selenium Project Packages" value="../nuget/packages" />
-  </packageSources>
-</configuration>

--- a/third_party/dotnet/devtools/src/generator/CodeGen/CommandInfo.cs
+++ b/third_party/dotnet/devtools/src/generator/CodeGen/CommandInfo.cs
@@ -9,6 +9,10 @@ namespace OpenQA.Selenium.DevToolsGenerator.CodeGen
 
         public string FullTypeName { get; } = fullTypeName;
 
+        public string FullSnakeTypeName { get; } = fullTypeName.Replace(".", "_");
+
         public string FullResponseTypeName { get; } = fullResponseTypeName;
+
+        public string FullSnakeResponseTypeName { get; } = fullResponseTypeName.Replace(".", "_");
     }
 }

--- a/third_party/dotnet/devtools/src/generator/CodeGen/EventInfo.cs
+++ b/third_party/dotnet/devtools/src/generator/CodeGen/EventInfo.cs
@@ -8,5 +8,7 @@ namespace OpenQA.Selenium.DevToolsGenerator.CodeGen
         public string EventName { get; } = eventName;
 
         public string FullTypeName { get; } = fullTypeName;
+
+        public string FullSnakeTypeName { get; } = fullTypeName.Replace(".", "_");
     }
 }

--- a/third_party/dotnet/devtools/src/generator/Templates/DevToolsSessionDomains.hbs
+++ b/third_party/dotnet/devtools/src/generator/Templates/DevToolsSessionDomains.hbs
@@ -50,11 +50,11 @@ namespace {{rootNamespace}}
     }
 
 {{#each commands}}
-    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{FullTypeName}}))]
-    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{FullResponseTypeName}}))]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{FullTypeName}}), TypeInfoPropertyName = "{{FullSnakeTypeName}}")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{FullResponseTypeName}}), TypeInfoPropertyName = "{{FullSnakeResponseTypeName}}")]
 {{/each}}
 {{#each events}}
-    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{fullTypeName}}))]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof({{FullTypeName}}), TypeInfoPropertyName = "{{FullSnakeTypeName}}")]
 {{/each}}
     [global::System.Text.Json.Serialization.JsonSourceGenerationOptions(Converters = [typeof(OpenQA.Selenium.DevTools.Json.StringConverter)])]
     internal sealed partial class {{protocolVersion}}JsonSerializerContext : global::System.Text.Json.Serialization.JsonSerializerContext;


### PR DESCRIPTION
### **User description**
Proper source generated json context

### Motivation and Context
Road for devtools json context

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added snake_case type names to avoid name collisions.

- Updated JSON serialization attributes with snake_case type names.

- Removed unused NuGet configuration file.

- Enhanced code generation for commands, responses, and events.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandInfo.cs</strong><dd><code>Add snake_case properties to CommandInfo class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/dotnet/devtools/src/generator/CodeGen/CommandInfo.cs

<li>Introduced <code>FullSnakeTypeName</code> property for snake_case type names.<br> <li> Added <code>FullSnakeResponseTypeName</code> property for snake_case response type <br>names.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15193/files#diff-fff696b5e86371adcff203158213a74ce86dbf3f1cc8b5b24cf402cf8bdae84a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EventInfo.cs</strong><dd><code>Add snake_case property to EventInfo class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/dotnet/devtools/src/generator/CodeGen/EventInfo.cs

- Introduced `FullSnakeTypeName` property for snake_case type names.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15193/files#diff-55d6df755545fd8abda039e15e90f60228b922d61f89799106a09ce537d2bf78">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DevToolsSessionDomains.hbs</strong><dd><code>Update JSON serialization attributes in templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/dotnet/devtools/src/generator/Templates/DevToolsSessionDomains.hbs

<li>Updated JSON serialization attributes to use snake_case type names.<br> <li> Enhanced template for commands and events serialization.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15193/files#diff-ed83202dd790cf01c8fd3206467d3d481ed7efdb4214d2db668ecc06430d9a42">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NuGet.Config</strong><dd><code>Remove unused NuGet configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/dotnet/devtools/NuGet.Config

- Removed unused NuGet configuration file.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15193/files#diff-093392da3ab1ef2ee66acd6887062b5a9a566c9689fc1a903957d7abb7915189">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>