### PR TITLE
[grid] Add default sessionTimeout to NodeStatus to increase backward compatibility

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/NodeStatus.java
+++ b/java/src/org/openqa/selenium/grid/data/NodeStatus.java
@@ -76,7 +76,7 @@ public class NodeStatus {
     Set<Slot> slots = null;
     Availability availability = null;
     Duration heartbeatPeriod = null;
-    Duration sessionTimeout = null;
+    Duration sessionTimeout = Duration.ofSeconds(300);
     String version = null;
     Map<String, String> osInfo = null;
 

--- a/java/test/org/openqa/selenium/grid/data/NodeStatusTest.java
+++ b/java/test/org/openqa/selenium/grid/data/NodeStatusTest.java
@@ -72,4 +72,79 @@ class NodeStatusTest {
 
     assertThat(seen).isEqualTo(status);
   }
+
+  @Test
+  void withoutSessionTimeoutInJsonStatus() throws URISyntaxException {
+    String source =
+        "{\n"
+            + "      \"availability\": \"UP\",\n"
+            + "      \"externalUri\": \"http:\\u002f\\u002f192.168.1.101:5555\",\n"
+            + "      \"heartbeatPeriod\": 60000,\n"
+            + "      \"maxSessions\": 1,\n"
+            + "      \"nodeId\": \"d136dd9b-6497-4049-9371-42f89b14ea2b\",\n"
+            + "      \"osInfo\": {\n"
+            + "        \"arch\": \"aarch64\",\n"
+            + "        \"name\": \"Mac OS X\",\n"
+            + "        \"version\": \"15.3\"\n"
+            + "      },\n"
+            + "      \"slots\": [\n"
+            + "        {\n"
+            + "          \"id\": {\n"
+            + "            \"hostId\": \"d136dd9b-6497-4049-9371-42f89b14ea2b\",\n"
+            + "            \"id\": \"965e8cb4-7b48-4638-8bc8-6889c6319682\"\n"
+            + "          },\n"
+            + "          \"lastStarted\": \"1970-01-01T00:00:00Z\",\n"
+            + "          \"session\": null,\n"
+            + "          \"stereotype\": {\n"
+            + "            \"browserName\": \"chrome\",\n"
+            + "            \"platformName\": \"mac\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      ],\n"
+            + "      \"version\": \"4.17.0 (revision unknown*)\"\n"
+            + "    }";
+
+    Json json = new Json();
+    NodeStatus nodeStatus = json.toType(source, NodeStatus.class);
+
+    assertThat(nodeStatus.getSessionTimeout()).isEqualTo(Duration.ofSeconds(300));
+  }
+
+  @Test
+  void withSessionTimeoutInJsonStatus() throws URISyntaxException {
+    String source =
+        "{\n"
+            + "      \"availability\": \"UP\",\n"
+            + "      \"externalUri\": \"http:\\u002f\\u002f192.168.1.101:5555\",\n"
+            + "      \"heartbeatPeriod\": 60000,\n"
+            + "      \"maxSessions\": 1,\n"
+            + "      \"sessionTimeout\": 600000,\n"
+            + "      \"nodeId\": \"d136dd9b-6497-4049-9371-42f89b14ea2b\",\n"
+            + "      \"osInfo\": {\n"
+            + "        \"arch\": \"aarch64\",\n"
+            + "        \"name\": \"Mac OS X\",\n"
+            + "        \"version\": \"15.3\"\n"
+            + "      },\n"
+            + "      \"slots\": [\n"
+            + "        {\n"
+            + "          \"id\": {\n"
+            + "            \"hostId\": \"d136dd9b-6497-4049-9371-42f89b14ea2b\",\n"
+            + "            \"id\": \"965e8cb4-7b48-4638-8bc8-6889c6319682\"\n"
+            + "          },\n"
+            + "          \"lastStarted\": \"1970-01-01T00:00:00Z\",\n"
+            + "          \"session\": null,\n"
+            + "          \"stereotype\": {\n"
+            + "            \"browserName\": \"chrome\",\n"
+            + "            \"platformName\": \"mac\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      ],\n"
+            + "      \"version\": \"4.17.0 (revision unknown*)\"\n"
+            + "    }";
+
+    Json json = new Json();
+    NodeStatus nodeStatus = json.toType(source, NodeStatus.class);
+
+    assertThat(nodeStatus.getSessionTimeout()).isEqualTo(Duration.ofSeconds(600));
+  }
 }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
From 4.21.0+, there was an improvement where Node will expose the `sessionTimeout` via /status endpoint (NodeStatus) for RemoteNode can get that value for setting JdkHttpClient `readtimeout`. It helps RemoteWebDriver timeout behavior correctly. In PR #13854.

Recently, there have been a few concerns that a Node with an older version (4.20.0 backward) could not register to Hub (4.21+) with the reason "Session timeout must be set". It is due to Node endpoint /status doesn't expose `sessionTimeout`, and `NodeStatus` considered it is `null` when parsing JSON response.

Adding the default sessionTimeout (300 seconds) to NodeStatus. Later, any Node versions can register to Hub version 4.29.0+ in upcoming release.

We add this to increase backward compatibility, since there are people who are setting up Grid for cross-browser with multiple versions rely on docker-selenium (where a Node image with specific Grid version and browser version at the time that image was built).

```
java -jar selenium-server-4.28.1.jar hub --log-level FINEST                           
Feb 04, 2025 12:30:00 PM org.openqa.selenium.remote.tracing.opentelemetry.OpenTelemetryTracer createTracer
INFO: Using OpenTelemetry for tracing
Feb 04, 2025 12:30:00 PM org.openqa.selenium.events.zeromq.BoundZmqEventBus <init>
INFO: XPUB binding to [binding to tcp://*:4442, advertising as tcp://[fe80:0:0:0:1005:ef25:ba6a:6e41%en0]:4442], XSUB binding to [binding to tcp://*:4443, advertising as tcp://[fe80:0:0:0:1005:ef25:ba6a:6e41%en0]:4443]
Feb 04, 2025 12:30:00 PM org.openqa.selenium.events.zeromq.UnboundZmqEventBus <init>
INFO: Connecting to tcp://[fe80:0:0:0:1005:ef25:ba6a:6e41%en0]:4442 and tcp://[fe80:0:0:0:1005:ef25:ba6a:6e41%en0]:4443
Feb 04, 2025 12:30:00 PM org.openqa.selenium.events.zeromq.UnboundZmqEventBus <init>
INFO: Sockets created
Feb 04, 2025 12:30:01 PM org.openqa.selenium.events.zeromq.UnboundZmqEventBus <init>
INFO: Event bus ready
Feb 04, 2025 12:30:02 PM org.openqa.selenium.grid.commands.Hub execute
INFO: Started Selenium Hub 4.28.1 (revision 73f5ad48a2): http://192.168.1.101:4444
Feb 04, 2025 12:30:11 PM org.openqa.selenium.events.zeromq.UnboundZmqEventBus$PollingRunnable lambda$notifyListeners$2
WARNING: Caught exception from listener: org.openqa.selenium.events.EventListener@2ee9cf0
java.lang.IllegalArgumentException: Session timeout must be set
	at org.openqa.selenium.internal.Require.positive(Require.java:102)
	at org.openqa.selenium.grid.node.Node.<init>(Node.java:141)
	at org.openqa.selenium.grid.node.remote.RemoteNode.<init>(RemoteNode.java:92)
	at org.openqa.selenium.grid.distributor.local.LocalDistributor.register(LocalDistributor.java:324)
	at org.openqa.selenium.events.EventListener.accept(EventListener.java:42)
	at org.openqa.selenium.events.EventListener.accept(EventListener.java:24)
	at org.openqa.selenium.events.zeromq.UnboundZmqEventBus$PollingRunnable.lambda$notifyListeners$2(UnboundZmqEventBus.java:325)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)



java -jar selenium-server-4.17.0.jar node --session-timeout 400
12:30:09.922 INFO [LoggingOptions.configureLogEncoding] - Using the system default encoding
12:30:09.925 INFO [OpenTelemetryTracer.createTracer] - Using OpenTelemetry for tracing
12:30:09.979 INFO [UnboundZmqEventBus.<init>] - Connecting to tcp://0.0.0.0:4442 and tcp://0.0.0.0:4443
12:30:10.000 INFO [UnboundZmqEventBus.<init>] - Sockets created
12:30:11.006 INFO [UnboundZmqEventBus.<init>] - Event bus ready
12:30:11.069 INFO [NodeServer.createHandlers] - Reporting self as: http://192.168.1.101:5555
12:30:11.085 INFO [NodeOptions.getSessionFactories] - Detected 10 available processors
12:30:11.085 INFO [NodeOptions.discoverDrivers] - Looking for existing drivers on the PATH.
12:30:11.086 INFO [NodeOptions.discoverDrivers] - Add '--selenium-manager true' to the startup command to setup drivers automatically.
12:30:11.208 WARN [SeleniumManager.lambda$runCommand$1] - There was an error managing chromedriver (Unable to discover proper chromedriver version in offline mode); using driver found in the cache
12:30:11.366 WARN [SeleniumManager.lambda$runCommand$1] - There was an error managing msedgedriver (Unable to discover proper msedgedriver version in offline mode); using driver found in the cache
12:30:11.552 WARN [SeleniumManager.lambda$runCommand$1] - There was an error managing geckodriver (Unable to discover proper geckodriver version in offline mode); using driver found in the cache
12:30:11.629 WARN [SeleniumManager.lambda$runCommand$1] - Unable to download safaridriver in offline mode
12:30:11.645 INFO [NodeOptions.report] - Adding Chrome for {"browserName": "chrome","platformName": "mac"} 10 times
12:30:11.645 INFO [NodeOptions.report] - Adding Safari for {"browserName": "safari","platformName": "mac"} 1 times
12:30:11.646 INFO [NodeOptions.report] - Adding Firefox for {"browserName": "firefox","platformName": "mac"} 10 times
12:30:11.646 INFO [NodeOptions.report] - Adding Edge for {"browserName": "MicrosoftEdge","platformName": "mac"} 10 times
12:30:11.672 INFO [Node.<init>] - Binding additional locator mechanisms: relative
12:30:11.749 INFO [NodeServer$1.start] - Starting registration process for Node http://192.168.1.101:5555
12:30:11.750 INFO [NodeServer.execute] - Started Selenium node 4.17.0 (revision e52b1be057*): http://192.168.1.101:5555
12:30:11.762 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:30:21.778 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:30:31.789 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:30:41.805 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:30:51.821 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:31:01.838 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:31:11.848 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:31:21.857 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
12:31:31.880 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
```

Relates to: https://github.com/SeleniumHQ/selenium/issues/14564, https://github.com/SeleniumHQ/docker-selenium/discussions/2615

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a default `sessionTimeout` of 300 seconds in `NodeStatus`.

- Improved backward compatibility for older Node versions registering to newer Hubs.

- Ensured seamless integration for Nodes with missing `sessionTimeout` in `/status` endpoint.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NodeStatus.java</strong><dd><code>Add default sessionTimeout in NodeStatus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/data/NodeStatus.java

<li>Set default <code>sessionTimeout</code> to 300 seconds.<br> <li> Modified <code>NodeStatus.fromJson</code> to handle missing <code>sessionTimeout</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15229/files#diff-04bf71dc8f94e5e1e3620bb9b03ea6162519e7adefa5dbec7a420a5c88dfc1d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>