### PR TITLE
[dotnet][bidi] Remove json serialization from transport layer

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Transport/ITransport.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Transport/ITransport.cs
@@ -20,7 +20,6 @@
 using System.Threading.Tasks;
 using System.Threading;
 using System;
-using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -30,8 +29,7 @@ interface ITransport : IDisposable
 {
     Task ConnectAsync(CancellationToken cancellationToken);
 
-    Task<T> ReceiveAsJsonAsync<T>(JsonSerializerContext jsonSerializerContext, CancellationToken cancellationToken);
+    Task<byte[]> ReceiveAsync(CancellationToken cancellationToken);
 
-    Task SendAsJsonAsync<TCommand>(TCommand command, JsonSerializerContext jsonSerializerContext, CancellationToken cancellationToken)
-        where TCommand : Command;
+    Task SendAsync(byte[] data, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
### **User description**
### Motivation and Context
Simplify transport layer to know nothing about json serialization context
.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Removed JSON serialization from the transport layer.

- Introduced raw byte data handling for sending/receiving.

- Simplified `ITransport` interface by removing JSON-specific methods.

- Updated `Broker` and `WebSocketTransport` to use new transport methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Refactored Broker to remove JSON serialization dependency</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Broker.cs

<li>Replaced JSON-specific transport methods with raw byte handling.<br> <li> Updated message deserialization to use <code>JsonSerializer.Deserialize</code>.<br> <li> Adjusted command execution to serialize/deserialize manually.<br> <li> Fixed formatting in generic constraints.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15250/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+11/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ITransport.cs</strong><dd><code>Simplified ITransport interface for raw byte handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Transport/ITransport.cs

<li>Removed JSON-specific methods from <code>ITransport</code> interface.<br> <li> Added methods for raw byte data handling.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15250/files#diff-7b5b2738d5adba54c51eb48fe2c90e79a454bafa2d0c328be783f226d887bbc1">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebSocketTransport.cs</strong><dd><code>Updated WebSocketTransport to handle raw byte data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Transport/WebSocketTransport.cs

<li>Replaced JSON serialization with raw byte handling.<br> <li> Updated logging to reflect raw byte data.<br> <li> Adjusted WebSocket send/receive methods for new interface.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15250/files#diff-70000b6ab9285fcef12da09f72bab4a93ce60cabd8daa57a4b6468d5ba85f7c7">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>