### PR TITLE
[dotnet][bidi] Add OnNavigationCommitted event

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContext.cs
@@ -154,6 +154,11 @@ public class BrowsingContext
         return BiDi.BrowsingContext.OnDomContentLoadedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
+    public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)
+    {
+        return BiDi.BrowsingContext.OnDomContentLoadedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
+    }
+
     public Task<Subscription> OnLoadAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)
     {
         return BiDi.BrowsingContext.OnLoadAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
@@ -194,9 +199,14 @@ public class BrowsingContext
         return BiDi.BrowsingContext.OnNavigationFailedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
-    public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)
+    public Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDomContentLoadedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
+    }
+
+    public Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, SubscriptionOptions? options = null)
+    {
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
     public override bool Equals(object? obj)

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextModule.cs
@@ -247,6 +247,16 @@ public class BrowsingContextModule(Broker broker) : Module(broker)
         return await Broker.SubscribeAsync("browsingContext.navigationFailed", handler, options).ConfigureAwait(false);
     }
 
+    public async Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("browsingContext.navigationCommitted", handler, options).ConfigureAwait(false);
+    }
+
+    public async Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, BrowsingContextsSubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("browsingContext.navigationCommitted", handler, options).ConfigureAwait(false);
+    }
+
     public async Task<Subscription> OnContextCreatedAsync(Func<BrowsingContextInfo, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("browsingContext.contextCreated", handler, options).ConfigureAwait(false);


### PR DESCRIPTION
### **User description**
### Motivation and Context
Support `NavigationCommitted` event: https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationCommitted

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added `OnNavigationCommitted` event to support navigation committed handling.

- Introduced overloads for `OnNavigationCommitted` with `Action` and `Func` handlers.

- Updated `BrowsingContext` and `BrowsingContextModule` to include new event subscriptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Add OnNavigationCommittedAsync methods in BrowsingContext</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContext.cs

<li>Added <code>OnNavigationCommittedAsync</code> method with <code>Action</code> and <code>Func</code> <br>overloads.<br> <li> Introduced event subscription logic for navigation committed events.<br> <li> Adjusted existing methods for consistency in event handling.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15253/files#diff-b8e6adfd5020e22446f46ea5e7851ab16f2d2febfe7e7bd7019b7be8bb4c66b9">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextModule.cs</strong><dd><code>Add OnNavigationCommittedAsync methods in BrowsingContextModule</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextModule.cs

<li>Added <code>OnNavigationCommittedAsync</code> method with <code>Action</code> and <code>Func</code> <br>overloads.<br> <li> Implemented subscription to <code>browsingContext.navigationCommitted</code> event.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15253/files#diff-ab3a215242fb4564f272de96ee12354fc9612a143f2be8f703f26662b499c759">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>