### PR TITLE
[java] Refine logger initialization with correct class literal

### DIFF
--- a/java/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
+++ b/java/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
@@ -36,7 +36,7 @@ import org.zeromq.ZMQ;
 
 class BoundZmqEventBus implements EventBus {
 
-  private static final Logger LOG = Logger.getLogger(EventBus.class.getName());
+  private static final Logger LOG = Logger.getLogger(BoundZmqEventBus.class.getName());
   private final UnboundZmqEventBus delegate;
   private final ZMQ.Socket xpub;
   private final ZMQ.Socket xsub;

--- a/java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
+++ b/java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
@@ -59,7 +59,7 @@ import org.zeromq.ZMQ;
 class UnboundZmqEventBus implements EventBus {
 
   static final EventName REJECTED_EVENT = new EventName("selenium-rejected-event");
-  private static final Logger LOG = Logger.getLogger(EventBus.class.getName());
+  private static final Logger LOG = Logger.getLogger(UnboundZmqEventBus.class.getName());
   private static final Json JSON = new Json();
   private final AtomicBoolean pollingStarted = new AtomicBoolean(false);
   private final PollingRunnable socketPolling;

--- a/java/test/org/openqa/selenium/grid/router/JmxTest.java
+++ b/java/test/org/openqa/selenium/grid/router/JmxTest.java
@@ -64,7 +64,7 @@ import org.openqa.selenium.remote.tracing.Tracer;
 
 class JmxTest {
 
-  private static final Logger LOG = Logger.getLogger(LocalNode.class.getName());
+  private static final Logger LOG = Logger.getLogger(JmxTest.class.getName());
 
   private final Capabilities CAPS = new ImmutableCapabilities("browserName", "cheese");
   private final MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

<!--- Provide a general summary of your changes in the Title above -->
This pull request includes several changes to improve the logging in the `selenium` project. The changes primarily involve updating the logger initialization to use the correct class names.

Logging improvements:

* [`java/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java`](diffhunk://#diff-c4752bf62f33d45156f8a72fff06a2b170808c46a2cca05c16c3ea59d42c5ba2L39-R39): Updated the logger initialization to use `BoundZmqEventBus.class.getName()` instead of `EventBus.class.getName()`.
* [`java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java`](diffhunk://#diff-ea93b2ee631a178a45fc86aeaff0ed640a0b721b261a910abc0a513c97074068L62-R62): Updated the logger initialization to use `UnboundZmqEventBus.class.getName()` instead of `EventBus.class.getName()`.
* [`java/test/org/openqa/selenium/grid/router/JmxTest.java`](diffhunk://#diff-89598c0635d3d9b749c357e36e67a49f5f6d979e90d8231b058659bcd453d3dfL67-R67): Updated the logger initialization to use `JmxTest.class.getName()` instead of `LocalNode.class.getName()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected logger initialization to use appropriate class names.

- Updated `BoundZmqEventBus` to use `BoundZmqEventBus.class.getName()`.

- Updated `UnboundZmqEventBus` to use `UnboundZmqEventBus.class.getName()`.

- Updated `JmxTest` to use `JmxTest.class.getName()` for logger.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BoundZmqEventBus.java</strong><dd><code>Fix logger class reference in BoundZmqEventBus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java

<li>Updated logger initialization to use <code>BoundZmqEventBus.class.getName()</code>.<br> <li> Ensures the logger references the correct class.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15289/files#diff-c4752bf62f33d45156f8a72fff06a2b170808c46a2cca05c16c3ea59d42c5ba2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UnboundZmqEventBus.java</strong><dd><code>Fix logger class reference in UnboundZmqEventBus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java

<li>Updated logger initialization to use <br><code>UnboundZmqEventBus.class.getName()</code>.<br> <li> Ensures the logger references the correct class.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15289/files#diff-ea93b2ee631a178a45fc86aeaff0ed640a0b721b261a910abc0a513c97074068">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JmxTest.java</strong><dd><code>Fix logger class reference in JmxTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/router/JmxTest.java

<li>Updated logger initialization to use <code>JmxTest.class.getName()</code>.<br> <li> Ensures the logger references the correct class.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15289/files#diff-89598c0635d3d9b749c357e36e67a49f5f6d979e90d8231b058659bcd453d3df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>