### PR TITLE
[java]: fix return type and docstring for `getDownloadableFiles`

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -651,9 +651,9 @@ public class RemoteWebDriver
   }
 
   /**
-   * Retrieves the downloadable files as a map of file names and their corresponding URLs.
+   * Retrieves the names of the downloadable files.
    *
-   * @return A map containing file names as keys and URLs as values.
+   * @return A list containing the names of the downloadable files.
    * @throws WebDriverException if capability to enable downloads is not set
    */
   @Override

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
@@ -812,17 +812,15 @@ class RemoteWebDriverUnitTest {
   void getDownloadableFilesReturnsType() {
     List<String> expectedFiles = Arrays.asList("file1.txt", "file2.pdf");
 
-    WebDriverFixture fixture = new WebDriverFixture(
-        new ImmutableCapabilities("se:downloadsEnabled", true),
-        echoCapabilities,
-        valueResponder(ImmutableMap.of("names", expectedFiles))
-    );
+    WebDriverFixture fixture =
+        new WebDriverFixture(
+            new ImmutableCapabilities("se:downloadsEnabled", true),
+            echoCapabilities,
+            valueResponder(ImmutableMap.of("names", expectedFiles)));
 
     List<String> result = fixture.driver.getDownloadableFiles();
 
-    assertThat(result)
-        .isInstanceOf(List.class)
-        .isEqualTo(expectedFiles);
+    assertThat(result).isInstanceOf(List.class).isEqualTo(expectedFiles);
 
     fixture.verifyCommands(new CommandPayload(DriverCommand.GET_DOWNLOADABLE_FILES, emptyMap()));
   }

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
@@ -807,4 +807,23 @@ class RemoteWebDriverUnitTest {
     RemoteWebDriver driver = new RemoteWebDriver() {}; // anonymous subclass
     assertThat(driver.getCapabilities()).isEqualTo(new ImmutableCapabilities());
   }
+
+  @Test
+  void getDownloadableFilesReturnsType() {
+    List<String> expectedFiles = Arrays.asList("file1.txt", "file2.pdf");
+
+    WebDriverFixture fixture = new WebDriverFixture(
+        new ImmutableCapabilities("se:downloadsEnabled", true),
+        echoCapabilities,
+        valueResponder(ImmutableMap.of("names", expectedFiles))
+    );
+
+    List<String> result = fixture.driver.getDownloadableFiles();
+
+    assertThat(result)
+        .isInstanceOf(List.class)
+        .isEqualTo(expectedFiles);
+
+    fixture.verifyCommands(new CommandPayload(DriverCommand.GET_DOWNLOADABLE_FILES, emptyMap()));
+  }
 }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Fixes #15288 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the return type of `getDownloadableFiles` method to `List<String>`.

- Updated the method's JavaDoc to reflect the corrected return type.

- Added a unit test to verify the return type and behavior of `getDownloadableFiles`.

- Ensured proper formatting by running the formatting script.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Corrected JavaDoc for `getDownloadableFiles` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<li>Updated JavaDoc for <code>getDownloadableFiles</code> method to correct the <br>description.<br> <li> Changed return type in JavaDoc from <code>Map</code> to <code>List<String></code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15293/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriverUnitTest.java</strong><dd><code>Added unit test for `getDownloadableFiles` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java

<li>Added a new unit test for <code>getDownloadableFiles</code> method.<br> <li> Verified the return type and expected behavior of the method.<br> <li> Ensured the test checks for correct command payload.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15293/files#diff-0147a1bff443d7a62982143a4a8ff2a51826670b30a8bc03356a0414226ae5a8">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>