### PR TITLE
[java][dotnet][js] Fix failing BiDi related tests

### DIFF
--- a/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
@@ -46,7 +46,7 @@ class CallFunctionParameterTest : BiDiTestFixture
     [Test]
     public async Task CanEvaluateScriptWithUserActivationTrue()
     {
-        await context.Script.EvaluateAsync("window.open();", true, new() { UserActivation = true });
+        await context.Script.EvaluateAsync("window.open();", true);
 
         var res = await context.Script.CallFunctionAsync<bool>("""
             () => navigator.userActivation.isActive && navigator.userActivation.hasBeenActive

--- a/dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs
+++ b/dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs
@@ -46,7 +46,7 @@ class EvaluateParametersTest : BiDiTestFixture
     [Test]
     public async Task СanEvaluateScriptWithUserActivationTrue()
     {
-        await context.Script.EvaluateAsync("window.open();", true, new() { UserActivation = true });
+        await context.Script.EvaluateAsync("window.open();", true);
 
         var res = await context.Script.EvaluateAsync<bool>("""
             navigator.userActivation.isActive && navigator.userActivation.hasBeenActive

--- a/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java
@@ -60,8 +60,7 @@ public class CallFunctionParameterTest extends JupiterTestBase {
     try (Script script = new Script(id, driver)) {
 
       script.evaluateFunction(
-          new EvaluateParameters(new ContextTarget(id), "window.open();", true)
-              .userActivation(true));
+          new EvaluateParameters(new ContextTarget(id), "window.open();", false));
 
       EvaluateResult result =
           script.callFunction(

--- a/java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java
+++ b/java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java
@@ -54,8 +54,7 @@ public class EvaluateParametersTest extends JupiterTestBase {
     try (Script script = new Script(id, driver)) {
 
       script.evaluateFunction(
-          new EvaluateParameters(new ContextTarget(id), "window.open();", true)
-              .userActivation(true));
+          new EvaluateParameters(new ContextTarget(id), "window.open();", false));
 
       EvaluateResult result =
           script.evaluateFunction(

--- a/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
+++ b/javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js
@@ -141,24 +141,29 @@ suite(
         },
       )
 
-      it('can listen to fragment navigated event', async function () {
-        let navigationInfo = null
-        const browsingConextInspector = await BrowsingContextInspector(driver)
+      ignore(env.browsers(Browser.EDGE, Browser.CHROME)).it(
+        'can listen to fragment navigated event',
+        async function () {
+          let navigationInfo = null
+          const browsingConextInspector = await BrowsingContextInspector(driver)
 
-        const browsingContext = await BrowsingContext(driver, {
-          browsingContextId: await driver.getWindowHandle(),
-        })
-        await browsingContext.navigate(Pages.linkedImage, 'complete')
+          const browsingContext = await BrowsingContext(driver, {
+            browsingContextId: await driver.getWindowHandle(),
+          })
+          await browsingContext.navigate(Pages.linkedImage, 'complete')
 
-        await browsingConextInspector.onFragmentNavigated((entry) => {
-          navigationInfo = entry
-        })
+          await browsingConextInspector.onFragmentNavigated((entry) => {
+            navigationInfo = entry
+          })
 
-        await browsingContext.navigate(Pages.linkedImage + '#linkToAnchorOnThisPage', 'complete')
+          await browsingContext.navigate(Pages.linkedImage + '#linkToAnchorOnThisPage', 'complete')
 
-        assert.equal(navigationInfo.browsingContextId, browsingContext.id)
-        assert(navigationInfo.url.includes('linkToAnchorOnThisPage'))
-      })
+          // Chrome/Edge do not return the window's browsing context id as per the spec.
+          // This assertion fails.
+          assert.equal(navigationInfo.browsingContextId, browsingContext.id)
+          assert(navigationInfo.url.includes('linkToAnchorOnThisPage'))
+        },
+      )
 
       ignore(env.browsers(Browser.EDGE, Browser.CHROME)).it(
         'can listen to user prompt opened event',


### PR DESCRIPTION
### **User description**
**Thanks for contributing to Selenium!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prepping for the release

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed BiDi-related test failures across Java, .NET, and JavaScript.

- Updated `EvaluateParameters` to remove `userActivation` in Java and .NET tests.

- Adjusted JavaScript test to ignore specific browsers for fragment navigation.

- Improved test consistency and alignment with specifications.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.java</strong><dd><code>Adjusted `EvaluateParameters` usage in Java tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/CallFunctionParameterTest.java

<li>Removed <code>userActivation</code> parameter in <code>EvaluateParameters</code>.<br> <li> Ensured consistent evaluation of scripts in tests.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15296/files#diff-07986bca9cc97288db15330752e456cc04874783fd72c14f0a4110676a53bfaa">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateParametersTest.java</strong><dd><code>Simplified script evaluation in Java tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/script/EvaluateParametersTest.java

<li>Removed <code>userActivation</code> parameter in <code>EvaluateParameters</code>.<br> <li> Simplified script evaluation logic in tests.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15296/files#diff-907a2642d2dcd20f3640efcabeea68e3818c85eb11af2df7febd4e15c587ea8b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.cs</strong><dd><code>Updated BiDi script evaluation in .NET tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs

<li>Removed <code>UserActivation</code> parameter in <code>EvaluateAsync</code>.<br> <li> Adjusted test logic for script evaluation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15296/files#diff-2211a55aa8f7fbbe821213f4f0a771f85a33b7b639fc7bbe2e4bd38a48c85608">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateParametersTest.cs</strong><dd><code>Enhanced script evaluation tests in .NET</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs

<li>Removed <code>UserActivation</code> parameter in <code>EvaluateAsync</code>.<br> <li> Improved test consistency for script evaluation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15296/files#diff-8be27a9d0c3975df6c9e97783134da9a302a70cbe6cf351afa7f3a6605823862">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>browsingcontext_inspector_test.js</strong><dd><code>Adjusted fragment navigation test in JavaScript</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/node/selenium-webdriver/test/bidi/browsingcontext_inspector_test.js

<li>Ignored fragment navigation test for Chrome and Edge.<br> <li> Added comments for browser-specific behavior.<br> <li> Improved test alignment with browser specifications.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15296/files#diff-5a795b4366203e58bdf8bb6749ce666b85a150f2ca2b8d3e9970039347f5881a">+19/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>