### PR TITLE
[grid] Introduced new variable for server start timeout

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
@@ -55,6 +55,12 @@ public class DockerFlags implements HasRoles {
   private Integer dockerPort;
 
   @Parameter(
+      names = {"--docker-server-start-timeout"},
+      description = "Max time (in seconds) to wait for the server to successfully start up, before cancelling the process.")
+  @ConfigValue(section = DockerOptions.DOCKER_SECTION, name = "server-start-timeout", example = "55")
+  private Integer serverStartTimeout;
+
+  @Parameter(
       names = {"--docker", "-D"},
       description =
           "Docker configs which map image name to stereotype capabilities (example: "

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
@@ -56,8 +56,13 @@ public class DockerFlags implements HasRoles {
 
   @Parameter(
       names = {"--docker-server-start-timeout"},
-      description = "Max time (in seconds) to wait for the server to successfully start up, before cancelling the process.")
-  @ConfigValue(section = DockerOptions.DOCKER_SECTION, name = "server-start-timeout", example = "55")
+      description =
+          "Max time (in seconds) to wait for the server to successfully start up, before cancelling"
+              + " the process.")
+  @ConfigValue(
+      section = DockerOptions.DOCKER_SECTION,
+      name = "server-start-timeout",
+      example = "55")
   private Integer serverStartTimeout;
 
   @Parameter(

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,6 +64,7 @@ public class DockerOptions {
   static final String DEFAULT_DOCKER_URL = "unix:/var/run/docker.sock";
   static final String DEFAULT_VIDEO_IMAGE = "false";
   static final int DEFAULT_MAX_SESSIONS = Runtime.getRuntime().availableProcessors();
+  static final int DEFAULT_SERVER_START_TIMEOUT = 60;
   private static final String DEFAULT_DOCKER_NETWORK = "bridge";
   private static final Logger LOG = Logger.getLogger(DockerOptions.class.getName());
   private static final Json JSON = new Json();
@@ -102,6 +104,10 @@ public class DockerOptions {
     } catch (URISyntaxException e) {
       throw new ConfigException("Unable to determine docker url", e);
     }
+  }
+
+  private Duration getServerStartTimeout() {
+    return Duration.ofSeconds(config.getInt(DOCKER_SECTION, "server-start-timeout").orElse(DEFAULT_SERVER_START_TIMEOUT));
   }
 
   private boolean isEnabled(Docker docker) {
@@ -179,6 +185,7 @@ public class DockerOptions {
                     tracer,
                     clientFactory,
                     options.getSessionTimeout(),
+                    getServerStartTimeout(),
                     docker,
                     getDockerUri(),
                     image,

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
@@ -107,7 +107,8 @@ public class DockerOptions {
   }
 
   private Duration getServerStartTimeout() {
-    return Duration.ofSeconds(config.getInt(DOCKER_SECTION, "server-start-timeout").orElse(DEFAULT_SERVER_START_TIMEOUT));
+    return Duration.ofSeconds(
+        config.getInt(DOCKER_SECTION, "server-start-timeout").orElse(DEFAULT_SERVER_START_TIMEOUT));
   }
 
   private boolean isEnabled(Docker docker) {

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -91,6 +91,7 @@ public class DockerSessionFactory implements SessionFactory {
   private final Tracer tracer;
   private final HttpClient.Factory clientFactory;
   private final Duration sessionTimeout;
+  private final Duration serverStartTimeout;
   private final Docker docker;
   private final URI dockerUri;
   private final Image browserImage;
@@ -108,6 +109,7 @@ public class DockerSessionFactory implements SessionFactory {
       Tracer tracer,
       HttpClient.Factory clientFactory,
       Duration sessionTimeout,
+      Duration serverStartTimeout,
       Docker docker,
       URI dockerUri,
       Image browserImage,
@@ -123,6 +125,7 @@ public class DockerSessionFactory implements SessionFactory {
     this.tracer = Require.nonNull("Tracer", tracer);
     this.clientFactory = Require.nonNull("HTTP client", clientFactory);
     this.sessionTimeout = Require.nonNull("Session timeout", sessionTimeout);
+    this.serverStartTimeout = Require.nonNull("Server start timeout", serverStartTimeout);
     this.docker = Require.nonNull("Docker command", docker);
     this.dockerUri = Require.nonNull("Docker URI", dockerUri);
     this.browserImage = Require.nonNull("Docker browser image", browserImage);
@@ -181,7 +184,7 @@ public class DockerSessionFactory implements SessionFactory {
               "Waiting for server to start (container id: %s, url %s)",
               container.getId(), remoteAddress));
       try {
-        waitForServerToStart(client, Duration.ofMinutes(1));
+        waitForServerToStart(client, serverStartTimeout);
       } catch (TimeoutException e) {
         span.setAttribute(AttributeKey.ERROR.getKey(), true);
         span.setStatus(Status.CANCELLED);
@@ -367,7 +370,7 @@ public class DockerSessionFactory implements SessionFactory {
         clientFactory.createClient(ClientConfig.defaultConfig().baseUri(videoContainerUrl));
     try {
       LOG.fine(String.format("Waiting for video recording... (id: %s)", videoContainer.getId()));
-      waitForServerToStart(videoClient, Duration.ofMinutes(1));
+      waitForServerToStart(videoClient, serverStartTimeout);
     } catch (Exception e) {
       videoContainer.stop(Duration.ofSeconds(10));
       String message =

--- a/scripts/dev-image/Dockerfile
+++ b/scripts/dev-image/Dockerfile
@@ -3,6 +3,7 @@ FROM shs96c/selenium-remote-build:latest
 
 USER root
 
+RUN rm -f /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -y wget curl gnupg2
 
 # So we can install browsers later

--- a/scripts/dev-image/Dockerfile
+++ b/scripts/dev-image/Dockerfile
@@ -3,7 +3,6 @@ FROM shs96c/selenium-remote-build:latest
 
 USER root
 
-RUN rm -f /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -y wget curl gnupg2
 
 # So we can install browsers later


### PR DESCRIPTION
### **User description**
Added a new variable in DockerSessionFactory that can be used as a maximum to wait for the server/node to start. Made it adjustable via a DockerFlag and set the default to 60 seconds, which was previously the hardcoded value in that field.

Also added a line to Dockerfile in dev-image, because dev container was not working as is.

~~Fixes #1~~ (I apologize, I thought the total number of issues fixed was meant here, not the exact number to identify the issue that was fixed)

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We encountered a problem that our node wasn't ready by the time it was given to start up (1 Minute in the current version of the code and not adjustable). So we wanted to make it adjustable and see if the node starts up if given more time. We already have built the jar with the changes and were able to set up the server start timeout successfully (and the node actually started up successfully to after about 90 seconds).

We also saw that the dev container is not able to start up as it is right now, we added a line in the dev-image/Dockerfile to fix it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation. (Not really sure if this is done automatically, but if not the flag probably needs to be added to https://www.selenium.dev/documentation/grid/configuration/cli_options/#docker )
- [ ] I have updated the documentation accordingly. (Again: not sure if the changes include that, from what I understand.)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced a configurable server start timeout in DockerSessionFactory.

- Added a new DockerFlag for server start timeout configuration.

- Updated dev-image Dockerfile to fix container startup issues.

- Adjusted default server start timeout to 60 seconds.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DockerFlags.java</strong><dd><code>Introduced server start timeout flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java

<li>Added a new parameter <code>--docker-server-start-timeout</code>.<br> <li> Configured the parameter to set a maximum server start time.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15345/files#diff-73c455146a4c6b8003174819c76874c0ea3f8d8e03874d447a4612145cdffb5e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerOptions.java</strong><dd><code>Added server start timeout configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java

<li>Added a default server start timeout constant.<br> <li> Implemented a method to fetch server start timeout from configuration.<br> <li> Integrated server start timeout into Docker session factory creation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15345/files#diff-5a4e578c5c5711a9b26d92a059bfe58b426177f8d2fc68aaaa79cd0fbef456bd">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerSessionFactory.java</strong><dd><code>Integrated server start timeout in session factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java

<li>Added a new <code>serverStartTimeout</code> field.<br> <li> Updated constructor to accept server start timeout.<br> <li> Replaced hardcoded timeout with configurable timeout in server start <br>logic.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15345/files#diff-a05d31304c9c75c40d9d11ef388a2c669f1f8c35e943ed8dcbc32e1da7694c5e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Fixed dev container startup issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/dev-image/Dockerfile

<li>Removed problematic Google Chrome sources list.<br> <li> Ensured dev container can start without errors.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15345/files#diff-828d9b2dcef4cc6e97effba9321132f9ea6a416fcca86f0b5a4d508f11863689">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>