### PR TITLE
[dotnet] Make internal console writer more flexible via taking TextWriter only

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/ConsoleHandler.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ConsoleHandler.cs
@@ -1,0 +1,31 @@
+// <copyright file="ConsoleHandler.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+
+#nullable enable
+
+namespace OpenQA.Selenium.Internal.Logging
+{
+    [Obsolete("Use TextWriterHandler instead, will be removed in v4.32")]
+    /// <summary>
+    /// Represents a log handler that writes log events to the given text writer.
+    /// </summary>
+    public class ConsoleHandler() : TextWriterHandler(Console.Error);
+}

--- a/dotnet/src/webdriver/Internal/Logging/ConsoleLogHandler.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ConsoleLogHandler.cs
@@ -1,4 +1,4 @@
-// <copyright file="ConsoleHandler.cs" company="Selenium Committers">
+// <copyright file="ConsoleLogHandler.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -27,5 +27,5 @@ namespace OpenQA.Selenium.Internal.Logging
     /// <summary>
     /// Represents a log handler that writes log events to the given text writer.
     /// </summary>
-    public class ConsoleHandler() : TextWriterHandler(Console.Error);
+    public class ConsoleLogHandler() : TextWriterHandler(Console.Error);
 }

--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -17,6 +17,7 @@
 // under the License.
 // </copyright>
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
@@ -26,13 +27,13 @@ namespace OpenQA.Selenium.Internal.Logging
 {
     internal class LogContextManager
     {
-        private readonly AsyncLocal<ILogContext?> _currentAmbientLogContext = new AsyncLocal<ILogContext?>();
+        private readonly AsyncLocal<ILogContext?> _currentAmbientLogContext = new();
 
         public LogContextManager()
         {
-            var defaulConsoleLogHandler = new ConsoleLogHandler();
+            var defaulConsoleLogHandler = new TextWriterHandler(Console.Error);
 
-            GlobalContext = new LogContext(LogEventLevel.Info, null, null, new[] { defaulConsoleLogHandler });
+            GlobalContext = new LogContext(LogEventLevel.Info, null, null, [defaulConsoleLogHandler]);
         }
 
         public ILogContext GlobalContext { get; }

--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -31,9 +31,9 @@ namespace OpenQA.Selenium.Internal.Logging
 
         public LogContextManager()
         {
-            var defaulConsoleLogHandler = new TextWriterHandler(Console.Error);
+            var defaulLogHandler = new TextWriterHandler(Console.Error);
 
-            GlobalContext = new LogContext(LogEventLevel.Info, null, null, [defaulConsoleLogHandler]);
+            GlobalContext = new LogContext(LogEventLevel.Info, null, null, [defaulLogHandler]);
         }
 
         public ILogContext GlobalContext { get; }

--- a/dotnet/src/webdriver/Internal/Logging/TextWriterHandler.cs
+++ b/dotnet/src/webdriver/Internal/Logging/TextWriterHandler.cs
@@ -1,4 +1,4 @@
-// <copyright file="ConsoleLogHandler.cs" company="Selenium Committers">
+// <copyright file="TextWriterHandler.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -17,7 +17,7 @@
 // under the License.
 // </copyright>
 
-using System;
+using System.IO;
 
 #nullable enable
 
@@ -26,7 +26,7 @@ namespace OpenQA.Selenium.Internal.Logging
     /// <summary>
     /// Represents a log handler that writes log events to the console.
     /// </summary>
-    public class ConsoleLogHandler : ILogHandler
+    public class TextWriterHandler(TextWriter writer) : ILogHandler
     {
         // performance trick to avoid expensive Enum.ToString() with fixed length
         private static readonly string[] _levels = { "TRACE", "DEBUG", " INFO", " WARN", "ERROR" };
@@ -37,7 +37,7 @@ namespace OpenQA.Selenium.Internal.Logging
         /// <param name="logEvent">The log event to handle.</param>
         public void Handle(LogEvent logEvent)
         {
-            Console.Error.WriteLine($"{logEvent.Timestamp:HH:mm:ss.fff} {_levels[(int)logEvent.Level]} {logEvent.IssuedBy.Name}: {logEvent.Message}");
+            writer.WriteLine($"{logEvent.Timestamp:HH:mm:ss.fff} {_levels[(int)logEvent.Level]} {logEvent.IssuedBy.Name}: {logEvent.Message}");
         }
     }
 }

--- a/dotnet/src/webdriver/Internal/Logging/TextWriterHandler.cs
+++ b/dotnet/src/webdriver/Internal/Logging/TextWriterHandler.cs
@@ -24,7 +24,7 @@ using System.IO;
 namespace OpenQA.Selenium.Internal.Logging
 {
     /// <summary>
-    /// Represents a log handler that writes log events to the console.
+    /// Represents a log handler that writes log events to the given text writer.
     /// </summary>
     public class TextWriterHandler(TextWriter writer) : ILogHandler
     {
@@ -32,7 +32,7 @@ namespace OpenQA.Selenium.Internal.Logging
         private static readonly string[] _levels = { "TRACE", "DEBUG", " INFO", " WARN", "ERROR" };
 
         /// <summary>
-        /// Handles a log event by writing it to the console.
+        /// Handles a log event by writing it to the text writer.
         /// </summary>
         /// <param name="logEvent">The log event to handle.</param>
         public void Handle(LogEvent logEvent)

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -31,7 +31,7 @@ namespace OpenQA.Selenium.Internal.Logging
         private void ResetGlobalLog()
         {
             Log.SetLevel(LogEventLevel.Info);
-            Log.Handlers.Clear().Handlers.Add(new ConsoleLogHandler());
+            Log.Handlers.Clear().Handlers.Add(new TextWriterHandler(Console.Error));
         }
 
         [SetUp]


### PR DESCRIPTION
### **User description**
`Console` is an output. We can be more extendable/abstract/generic.

### Motivation and Context
Taking minimal required.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced `ConsoleLogHandler` with `TextWriterHandler` for flexibility.

- Updated `LogContextManager` to use `TextWriterHandler`.

- Modified logging tests to reflect the new handler.

- Improved abstraction by utilizing `TextWriter` for log output.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogContextManager.cs</strong><dd><code>Refactored LogContextManager to use TextWriterHandler</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Logging/LogContextManager.cs

<li>Replaced <code>ConsoleLogHandler</code> with <code>TextWriterHandler</code>.<br> <li> Updated <code>GlobalContext</code> initialization to use the new handler.<br> <li> Simplified <code>AsyncLocal</code> initialization syntax.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15346/files#diff-259c2c4f3567044d233aa46147d492b89964cbe4bc5e45fd976a03c88674007f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TextWriterHandler.cs</strong><dd><code>Introduced TextWriterHandler for flexible log output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Logging/TextWriterHandler.cs

<li>Renamed <code>ConsoleLogHandler</code> to <code>TextWriterHandler</code>.<br> <li> Replaced <code>Console.Error</code> with a <code>TextWriter</code> parameter.<br> <li> Updated log writing logic to use <code>TextWriter</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15346/files#diff-7bb1892987b87bd59e936203d91640d3bcc51ff8d9ff009d16b4b0e7bc6df4fc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogTest.cs</strong><dd><code>Updated logging tests for TextWriterHandler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Internal/Logging/LogTest.cs

<li>Updated tests to use <code>TextWriterHandler</code> instead of <code>ConsoleLogHandler</code>.<br> <li> Adjusted global log reset logic to reflect handler changes.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15346/files#diff-f381b4f23cf8f01f4d38e1bc82aeb949e4815570931aaa2e68dda7b358ef3799">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>