### PR TITLE
[rust] Replace WMIC commands (deprecated) by WinAPI in Windows

### DIFF
--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d2d968dacd2ceab962c18fa28697dc189f31b3991a3554ff21e167836627a3b8",
+  "checksum": "94dc89c8790518c956fd52cd06689af1557f6c755c7bd1a1414719ef73ac468c",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -13479,6 +13479,10 @@
               "target": "which"
             },
             {
+              "id": "winapi 0.3.9",
+              "target": "winapi"
+            },
+            {
               "id": "xz2 0.1.7",
               "target": "xz2"
             },
@@ -18838,14 +18842,36 @@
         ],
         "crate_features": {
           "common": [
-            "fileapi",
-            "handleapi",
-            "processthreadsapi",
-            "std",
-            "winbase",
-            "winerror"
+            "sysinfoapi",
+            "winnt",
+            "winver"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "fileapi",
+              "handleapi",
+              "processthreadsapi",
+              "std",
+              "winbase",
+              "winerror"
+            ],
+            "i686-pc-windows-msvc": [
+              "fileapi",
+              "handleapi",
+              "processthreadsapi",
+              "std",
+              "winbase",
+              "winerror"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "fileapi",
+              "handleapi",
+              "processthreadsapi",
+              "std",
+              "winbase",
+              "winerror"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -21972,6 +21998,7 @@
     "toml 0.8.20",
     "walkdir 2.5.0",
     "which 7.0.2",
+    "winapi 0.3.9",
     "xz2 0.1.7",
     "zip 2.2.3"
   ],

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1866,6 +1866,7 @@ dependencies = [
  "toml",
  "walkdir",
  "which",
+ "winapi",
  "xz2",
  "zip",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,7 @@ apple-flat-package = "0.20.0"
 which = "7.0.2"
 fs2 = "0.4.3"
 fs_extra = "1.3.0"
+winapi = { version = "0.3.9", features = ["winver", "winnt", "sysinfoapi"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -30,7 +30,9 @@ use std::env::consts::OS;
 use std::fs::read_to_string;
 use std::path::Path;
 use toml::Table;
+#[cfg(windows)]
 use winapi::um::sysinfoapi::{GetNativeSystemInfo, SYSTEM_INFO};
+#[cfg(windows)]
 use winapi::um::winnt::{
     PROCESSOR_ARCHITECTURE_AMD64, PROCESSOR_ARCHITECTURE_ARM, PROCESSOR_ARCHITECTURE_ARM64,
     PROCESSOR_ARCHITECTURE_IA64, PROCESSOR_ARCHITECTURE_INTEL,
@@ -74,13 +76,16 @@ impl ManagerConfig {
 
         let self_os = OS;
         let self_arch = if WINDOWS.is(self_os) {
-            let mut architecture = env::var(ENV_PROCESSOR_ARCHITECTURE).unwrap_or_default();
-            if architecture.is_empty() {
-                architecture = get_win_os_architecture();
+            let mut _architecture = env::var(ENV_PROCESSOR_ARCHITECTURE).unwrap_or_default();
+            #[cfg(windows)]
+            {
+                if _architecture.is_empty() {
+                    _architecture = get_win_os_architecture();
+                }
             }
-            if architecture.contains("32") {
+            if _architecture.contains("32") {
                 ARCH_X86.to_string()
-            } else if architecture.contains("ARM") {
+            } else if _architecture.contains("ARM") {
                 ARCH_ARM64.to_string()
             } else {
                 ARCH_AMD64.to_string()
@@ -302,6 +307,7 @@ fn read_cache_path() -> String {
     cache_path
 }
 
+#[cfg(windows)]
 fn get_win_os_architecture() -> String {
     unsafe {
         let mut system_info: SYSTEM_INFO = std::mem::zeroed();

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use crate::config::OS::{LINUX, MACOS, WINDOWS};
-use crate::shell::{run_powershell_command, run_shell_command_by_os};
+use crate::shell::run_shell_command_by_os;
 use crate::{
     default_cache_folder, format_one_arg, path_to_string, Command, ENV_PROCESSOR_ARCHITECTURE,
     REQUEST_TIMEOUT_SEC, UNAME_COMMAND,
 };
-use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, PS_GET_OS_COMMAND, TTL_SEC};
+use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, TTL_SEC};
 use anyhow::anyhow;
 use anyhow::Error;
 use std::cell::RefCell;
@@ -30,6 +30,11 @@ use std::env::consts::OS;
 use std::fs::read_to_string;
 use std::path::Path;
 use toml::Table;
+use winapi::um::sysinfoapi::{GetNativeSystemInfo, SYSTEM_INFO};
+use winapi::um::winnt::{
+    PROCESSOR_ARCHITECTURE_AMD64, PROCESSOR_ARCHITECTURE_ARM, PROCESSOR_ARCHITECTURE_ARM64,
+    PROCESSOR_ARCHITECTURE_IA64, PROCESSOR_ARCHITECTURE_INTEL,
+};
 
 thread_local!(static CACHE_PATH: RefCell<String> = RefCell::new(path_to_string(&default_cache_folder())));
 
@@ -71,8 +76,7 @@ impl ManagerConfig {
         let self_arch = if WINDOWS.is(self_os) {
             let mut architecture = env::var(ENV_PROCESSOR_ARCHITECTURE).unwrap_or_default();
             if architecture.is_empty() {
-                let get_os_command = Command::new_single(PS_GET_OS_COMMAND.to_string());
-                architecture = run_powershell_command(get_os_command).unwrap_or_default();
+                architecture = get_win_os_architecture();
             }
             if architecture.contains("32") {
                 ARCH_X86.to_string()
@@ -296,4 +300,21 @@ fn read_cache_path() -> String {
         }
     });
     cache_path
+}
+
+fn get_win_os_architecture() -> String {
+    unsafe {
+        let mut system_info: SYSTEM_INFO = std::mem::zeroed();
+        GetNativeSystemInfo(&mut system_info);
+
+        match system_info.u.s() {
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 => "64-bit",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL => "32-bit",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM => "ARM",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64 => "ARM64",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64 => "Itanium-based",
+            _ => "Unknown",
+        }
+        .to_string()
+    }
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -21,7 +21,7 @@ use crate::{
     default_cache_folder, format_one_arg, path_to_string, Command, ENV_PROCESSOR_ARCHITECTURE,
     REQUEST_TIMEOUT_SEC, UNAME_COMMAND,
 };
-use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, TTL_SEC, WMIC_COMMAND_OS};
+use crate::{ARCH_AMD64, ARCH_ARM64, ARCH_X86, PS_GET_OS_COMMAND, TTL_SEC};
 use anyhow::anyhow;
 use anyhow::Error;
 use std::cell::RefCell;

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::config::OS::{LINUX, MACOS, WINDOWS};
-use crate::shell::run_shell_command_by_os;
+use crate::shell::{run_powershell_command, run_shell_command_by_os};
 use crate::{
     default_cache_folder, format_one_arg, path_to_string, Command, ENV_PROCESSOR_ARCHITECTURE,
     REQUEST_TIMEOUT_SEC, UNAME_COMMAND,
@@ -71,8 +71,8 @@ impl ManagerConfig {
         let self_arch = if WINDOWS.is(self_os) {
             let mut architecture = env::var(ENV_PROCESSOR_ARCHITECTURE).unwrap_or_default();
             if architecture.is_empty() {
-                let get_os_command = Command::new_single(WMIC_COMMAND_OS.to_string());
-                architecture = run_shell_command_by_os(self_os, get_os_command).unwrap_or_default();
+                let get_os_command = Command::new_single(PS_GET_OS_COMMAND.to_string());
+                architecture = run_powershell_command(get_os_command).unwrap_or_default();
             }
             if architecture.contains("32") {
                 ARCH_X86.to_string()

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -29,17 +29,22 @@ use directories::BaseDirs;
 use flate2::read::GzDecoder;
 use fs_extra::dir::{move_dir, CopyOptions};
 use regex::Regex;
+#[cfg(windows)]
 use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::{BufReader, Cursor, Read};
+#[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
 use std::ptr;
 use tar::Archive;
 use walkdir::{DirEntry, WalkDir};
+#[cfg(windows)]
 use winapi::shared::minwindef::LPVOID;
+#[cfg(windows)]
 use winapi::um::winver::{GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW};
 use xz2::read::XzDecoder;
 use zip::ZipArchive;
@@ -600,6 +605,12 @@ pub fn capitalize(s: &str) -> String {
     }
 }
 
+#[cfg(not(windows))]
+pub fn get_win_file_version(_file_path: &str) -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
 pub fn get_win_file_version(file_path: &str) -> Option<String> {
     unsafe {
         let wide_path: Vec<u16> = OsStr::new(file_path).encode_wide().chain(Some(0)).collect();

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -29,13 +29,18 @@ use directories::BaseDirs;
 use flate2::read::GzDecoder;
 use fs_extra::dir::{move_dir, CopyOptions};
 use regex::Regex;
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::{BufReader, Cursor, Read};
+use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::ptr;
 use tar::Archive;
 use walkdir::{DirEntry, WalkDir};
+use winapi::shared::minwindef::LPVOID;
+use winapi::um::winver::{GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW};
 use xz2::read::XzDecoder;
 use zip::ZipArchive;
 
@@ -592,5 +597,82 @@ pub fn capitalize(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+pub fn get_win_file_version(file_path: &str) -> Option<String> {
+    unsafe {
+        let wide_path: Vec<u16> = OsStr::new(file_path).encode_wide().chain(Some(0)).collect();
+
+        let mut dummy = 0;
+        let size = GetFileVersionInfoSizeW(wide_path.as_ptr(), &mut dummy);
+        if size == 0 {
+            return None;
+        }
+
+        let mut buffer: Vec<u8> = Vec::with_capacity(size as usize);
+        if GetFileVersionInfoW(wide_path.as_ptr(), 0, size, buffer.as_mut_ptr() as LPVOID) == 0 {
+            return None;
+        }
+        buffer.set_len(size as usize);
+
+        let mut lang_and_codepage_ptr: LPVOID = ptr::null_mut();
+        let mut lang_and_codepage_len: u32 = 0;
+
+        if VerQueryValueW(
+            buffer.as_ptr() as LPVOID,
+            OsStr::new("\\VarFileInfo\\Translation")
+                .encode_wide()
+                .chain(Some(0))
+                .collect::<Vec<u16>>()
+                .as_ptr(),
+            &mut lang_and_codepage_ptr,
+            &mut lang_and_codepage_len,
+        ) == 0
+        {
+            return None;
+        }
+
+        if lang_and_codepage_len == 0 {
+            return None;
+        }
+
+        let lang_and_codepage_slice = std::slice::from_raw_parts(
+            lang_and_codepage_ptr as *const u16,
+            lang_and_codepage_len as usize / 2,
+        );
+        let lang = lang_and_codepage_slice[0];
+        let codepage = lang_and_codepage_slice[1];
+
+        let query = format!(
+            "\\StringFileInfo\\{:04x}{:04x}\\ProductVersion",
+            lang, codepage
+        );
+        let query_wide: Vec<u16> = OsStr::new(&query).encode_wide().chain(Some(0)).collect();
+
+        let mut product_version_ptr: LPVOID = ptr::null_mut();
+        let mut product_version_len: u32 = 0;
+
+        if VerQueryValueW(
+            buffer.as_ptr() as LPVOID,
+            query_wide.as_ptr(),
+            &mut product_version_ptr,
+            &mut product_version_len,
+        ) == 0
+        {
+            return None;
+        }
+
+        if product_version_ptr.is_null() {
+            return None;
+        }
+
+        let product_version_slice = std::slice::from_raw_parts(
+            product_version_ptr as *const u16,
+            product_version_len as usize,
+        );
+        let product_version = String::from_utf16_lossy(product_version_slice);
+
+        Some(product_version.trim_end_matches('\0').to_string())
     }
 }

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -19,7 +19,7 @@ use crate::config::OS;
 use crate::config::OS::WINDOWS;
 use crate::{
     format_one_arg, format_three_args, run_shell_command_by_os, Command, Logger, CP_VOLUME_COMMAND,
-    HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS, MSIEXEC_INSTALL_COMMAND,
+    HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS, PS_MSIEXEC_INSTALL_COMMAND,
 };
 use anyhow::anyhow;
 use anyhow::Error;
@@ -309,7 +309,7 @@ pub fn install_msi(msi_file: &str, log: &Logger, os: &str) -> Result<(), Error> 
         msi_file_name.to_str().unwrap_or_default()
     ));
 
-    let command = Command::new_single(format_one_arg(MSIEXEC_INSTALL_COMMAND, msi_file));
+    let command = Command::new_single(format_one_arg(PS_MSIEXEC_INSTALL_COMMAND, msi_file));
     log.trace(format!("Running command: {}", command.display()));
     run_shell_command_by_os(os, command)?;
 

--- a/rust/src/files.rs
+++ b/rust/src/files.rs
@@ -19,7 +19,7 @@ use crate::config::OS;
 use crate::config::OS::WINDOWS;
 use crate::{
     format_one_arg, format_three_args, run_shell_command_by_os, Command, Logger, CP_VOLUME_COMMAND,
-    HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS, PS_MSIEXEC_INSTALL_COMMAND,
+    HDIUTIL_ATTACH_COMMAND, HDIUTIL_DETACH_COMMAND, MACOS, MSIEXEC_INSTALL_COMMAND,
 };
 use anyhow::anyhow;
 use anyhow::Error;
@@ -309,7 +309,7 @@ pub fn install_msi(msi_file: &str, log: &Logger, os: &str) -> Result<(), Error> 
         msi_file_name.to_str().unwrap_or_default()
     ));
 
-    let command = Command::new_single(format_one_arg(PS_MSIEXEC_INSTALL_COMMAND, msi_file));
+    let command = Command::new_single(format_one_arg(MSIEXEC_INSTALL_COMMAND, msi_file));
     log.trace(format!("Running command: {}", command.display()));
     run_shell_command_by_os(os, command)?;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,7 @@ use crate::config::OS::{MACOS, WINDOWS};
 use crate::config::{str_to_os, ManagerConfig};
 use crate::downloads::download_to_tmp_folder;
 use crate::edge::{EdgeManager, EDGEDRIVER_NAME, EDGE_NAMES, WEBVIEW2_NAME};
+use crate::files::get_win_file_version;
 use crate::files::{
     capitalize, collect_files_from_cache, create_path_if_not_exists, default_cache_folder,
     find_latest_from_cache, get_binary_extension, path_to_string,
@@ -37,8 +38,7 @@ use crate::metadata::{
 use crate::safari::{SafariManager, SAFARIDRIVER_NAME, SAFARI_NAME};
 use crate::safaritp::{SafariTPManager, SAFARITP_NAMES};
 use crate::shell::{
-    run_powershell_command_with_log, run_shell_command, run_shell_command_by_os,
-    run_shell_command_with_log, Command,
+    run_shell_command, run_shell_command_by_os, run_shell_command_with_log, Command,
 };
 use crate::stats::{send_stats_to_plausible, Props};
 use anyhow::anyhow;
@@ -76,8 +76,6 @@ pub const DEV: &str = "dev";
 pub const CANARY: &str = "canary";
 pub const NIGHTLY: &str = "nightly";
 pub const ESR: &str = "esr";
-pub const PS_GET_VERSION_COMMAND: &str = r#"(Get-Item "{}").VersionInfo.ProductVersion"#;
-pub const PS_GET_OS_COMMAND: &str = "(Get-WmiObject Win32_OperatingSystem).OSArchitecture";
 pub const REG_VERSION_ARG: &str = "version";
 pub const REG_CURRENT_VERSION_ARG: &str = "CurrentVersion";
 pub const REG_PV_ARG: &str = "pv";
@@ -448,12 +446,11 @@ pub trait SeleniumManager {
         ));
         let mut browser_version: Option<String> = None;
         for driver_version_command in commands.into_iter() {
-            let command_result = if driver_version_command.display().starts_with("(Get-") {
-                run_powershell_command_with_log(self.get_logger(), driver_version_command)
-            } else {
-                run_shell_command_with_log(self.get_logger(), self.get_os(), driver_version_command)
-            };
-            let output = match command_result {
+            let output = match run_shell_command_with_log(
+                self.get_logger(),
+                self.get_os(),
+                driver_version_command,
+            ) {
                 Ok(out) => out,
                 Err(_) => continue,
             };
@@ -1161,11 +1158,7 @@ pub trait SeleniumManager {
         let mut commands = Vec::new();
         if WINDOWS.is(self.get_os()) {
             if !escaped_browser_path.is_empty() {
-                let get_version_command = Command::new_single(format_one_arg(
-                    PS_GET_VERSION_COMMAND,
-                    &escaped_browser_path,
-                ));
-                commands.push(get_version_command);
+                return Ok(get_win_file_version(&escaped_browser_path));
             }
             if !self.is_browser_version_unstable() {
                 let reg_command =

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -75,8 +75,10 @@ pub const DEV: &str = "dev";
 pub const CANARY: &str = "canary";
 pub const NIGHTLY: &str = "nightly";
 pub const ESR: &str = "esr";
-pub const WMIC_COMMAND: &str = "wmic datafile where name='{}' get Version /value";
-pub const WMIC_COMMAND_OS: &str = "wmic os get osarchitecture";
+pub const PS_GET_VERSION_COMMAND: &str = r#"(Get-Item "{}").VersionInfo.ProductVersion"#;
+pub const PS_GET_OS_COMMAND: &str = "(Get-WmiObject Win32_OperatingSystem).OSArchitecture";
+pub const PS_MSIEXEC_INSTALL_COMMAND: &str =
+    r#"Start-Process -FilePath msiexec -ArgumentList "/i {} /qn ALLOWDOWNGRADE=1" -Wait"#;
 pub const REG_VERSION_ARG: &str = "version";
 pub const REG_CURRENT_VERSION_ARG: &str = "CurrentVersion";
 pub const REG_PV_ARG: &str = "pv";
@@ -85,7 +87,6 @@ pub const PLIST_COMMAND: &str =
 pub const HDIUTIL_ATTACH_COMMAND: &str = "hdiutil attach {}";
 pub const HDIUTIL_DETACH_COMMAND: &str = "hdiutil detach /Volumes/{}";
 pub const CP_VOLUME_COMMAND: &str = "cp -R /Volumes/{}/{}.app {}";
-pub const MSIEXEC_INSTALL_COMMAND: &str = "start /wait msiexec /i {} /qn ALLOWDOWNGRADE=1";
 pub const WINDOWS_CHECK_ADMIN_COMMAND: &str = "net session";
 pub const DASH_VERSION: &str = "{}{}{} -v";
 pub const DASH_DASH_VERSION: &str = "{}{}{} --version";
@@ -1158,9 +1159,11 @@ pub trait SeleniumManager {
         let mut commands = Vec::new();
         if WINDOWS.is(self.get_os()) {
             if !escaped_browser_path.is_empty() {
-                let wmic_command =
-                    Command::new_single(format_one_arg(WMIC_COMMAND, &escaped_browser_path));
-                commands.push(wmic_command);
+                let get_version_command = Command::new_single(format_one_arg(
+                    PS_GET_VERSION_COMMAND,
+                    &escaped_browser_path,
+                ));
+                commands.push(get_version_command);
             }
             if !self.is_browser_version_unstable() {
                 let reg_command =

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -448,20 +448,14 @@ pub trait SeleniumManager {
         ));
         let mut browser_version: Option<String> = None;
         for driver_version_command in commands.into_iter() {
-            let output = if driver_version_command.display().starts_with("(Get-") {
-                match run_powershell_command_with_log(self.get_logger(), driver_version_command) {
-                    Ok(out) => out,
-                    Err(_e) => continue,
-                }
+            let command_result = if driver_version_command.display().starts_with("(Get-") {
+                run_powershell_command_with_log(self.get_logger(), driver_version_command)
             } else {
-                match run_shell_command_with_log(
-                    self.get_logger(),
-                    self.get_os(),
-                    driver_version_command,
-                ) {
-                    Ok(out) => out,
-                    Err(_e) => continue,
-                }
+                run_shell_command_with_log(self.get_logger(), self.get_os(), driver_version_command)
+            };
+            let output = match command_result {
+                Ok(out) => out,
+                Err(_) => continue,
             };
 
             let full_browser_version = parse_version(output, self.get_logger()).unwrap_or_default();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -37,7 +37,8 @@ use crate::metadata::{
 use crate::safari::{SafariManager, SAFARIDRIVER_NAME, SAFARI_NAME};
 use crate::safaritp::{SafariTPManager, SAFARITP_NAMES};
 use crate::shell::{
-    run_shell_command, run_shell_command_by_os, run_shell_command_with_log, Command,
+    run_powershell_command_with_log, run_shell_command, run_shell_command_by_os,
+    run_shell_command_with_log, Command,
 };
 use crate::stats::{send_stats_to_plausible, Props};
 use anyhow::anyhow;
@@ -77,8 +78,6 @@ pub const NIGHTLY: &str = "nightly";
 pub const ESR: &str = "esr";
 pub const PS_GET_VERSION_COMMAND: &str = r#"(Get-Item "{}").VersionInfo.ProductVersion"#;
 pub const PS_GET_OS_COMMAND: &str = "(Get-WmiObject Win32_OperatingSystem).OSArchitecture";
-pub const PS_MSIEXEC_INSTALL_COMMAND: &str =
-    r#"Start-Process -FilePath msiexec -ArgumentList "/i {} /qn ALLOWDOWNGRADE=1" -Wait"#;
 pub const REG_VERSION_ARG: &str = "version";
 pub const REG_CURRENT_VERSION_ARG: &str = "CurrentVersion";
 pub const REG_PV_ARG: &str = "pv";
@@ -87,6 +86,7 @@ pub const PLIST_COMMAND: &str =
 pub const HDIUTIL_ATTACH_COMMAND: &str = "hdiutil attach {}";
 pub const HDIUTIL_DETACH_COMMAND: &str = "hdiutil detach /Volumes/{}";
 pub const CP_VOLUME_COMMAND: &str = "cp -R /Volumes/{}/{}.app {}";
+pub const MSIEXEC_INSTALL_COMMAND: &str = "start /wait msiexec /i {} /qn ALLOWDOWNGRADE=1";
 pub const WINDOWS_CHECK_ADMIN_COMMAND: &str = "net session";
 pub const DASH_VERSION: &str = "{}{}{} -v";
 pub const DASH_DASH_VERSION: &str = "{}{}{} --version";
@@ -448,14 +448,22 @@ pub trait SeleniumManager {
         ));
         let mut browser_version: Option<String> = None;
         for driver_version_command in commands.into_iter() {
-            let output = match run_shell_command_with_log(
-                self.get_logger(),
-                self.get_os(),
-                driver_version_command,
-            ) {
-                Ok(out) => out,
-                Err(_e) => continue,
+            let output = if driver_version_command.display().starts_with("(Get-") {
+                match run_powershell_command_with_log(self.get_logger(), driver_version_command) {
+                    Ok(out) => out,
+                    Err(_e) => continue,
+                }
+            } else {
+                match run_shell_command_with_log(
+                    self.get_logger(),
+                    self.get_os(),
+                    driver_version_command,
+                ) {
+                    Ok(out) => out,
+                    Err(_e) => continue,
+                }
             };
+
             let full_browser_version = parse_version(output, self.get_logger()).unwrap_or_default();
             if full_browser_version.is_empty() {
                 continue;

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -64,13 +64,6 @@ impl Command {
     }
 }
 
-pub fn run_powershell_command_with_log(log: &Logger, command: Command) -> Result<String, Error> {
-    log.debug(format!("Running ps command: {}", command.display()));
-    let output = run_powershell_command(command)?;
-    log.debug(format!("Output: {:?}", output));
-    Ok(output)
-}
-
 pub fn run_shell_command_with_log(
     log: &Logger,
     os: &str,
@@ -80,10 +73,6 @@ pub fn run_shell_command_with_log(
     let output = run_shell_command_by_os(os, command)?;
     log.debug(format!("Output: {:?}", output));
     Ok(output)
-}
-
-pub fn run_powershell_command(command: Command) -> Result<String, Error> {
-    run_shell_command("powershell", "-c", command)
 }
 
 pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Error> {

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -65,7 +65,7 @@ impl Command {
 }
 
 pub fn run_powershell_command_with_log(log: &Logger, command: Command) -> Result<String, Error> {
-    log.debug(format!("Running command: {}", command.display()));
+    log.debug(format!("Running ps command: {}", command.display()));
     let output = run_powershell_command(command)?;
     log.debug(format!("Output: {:?}", output));
     Ok(output)

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -77,7 +77,7 @@ pub fn run_shell_command_with_log(
 
 pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Error> {
     let (shell, flag) = if WINDOWS.is(os) {
-        ("cmd", "/c")
+        ("powershell", "-c")
     } else {
         ("sh", "-c")
     };

--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -64,6 +64,13 @@ impl Command {
     }
 }
 
+pub fn run_powershell_command_with_log(log: &Logger, command: Command) -> Result<String, Error> {
+    log.debug(format!("Running command: {}", command.display()));
+    let output = run_powershell_command(command)?;
+    log.debug(format!("Output: {:?}", output));
+    Ok(output)
+}
+
 pub fn run_shell_command_with_log(
     log: &Logger,
     os: &str,
@@ -75,9 +82,13 @@ pub fn run_shell_command_with_log(
     Ok(output)
 }
 
+pub fn run_powershell_command(command: Command) -> Result<String, Error> {
+    run_shell_command("powershell", "-c", command)
+}
+
 pub fn run_shell_command_by_os(os: &str, command: Command) -> Result<String, Error> {
     let (shell, flag) = if WINDOWS.is(os) {
-        ("powershell", "-c")
+        ("cmd", "/c")
     } else {
         ("sh", "-c")
     };

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -76,9 +76,7 @@ pub fn get_driver_path(cmd: &mut Command) -> String {
 pub fn exec_driver(cmd: &mut Command) -> String {
     let cmd_mut = cmd.borrow_mut();
     let driver_path = get_driver_path(cmd_mut);
-    let static_driver_path: &'static str = Box::leak(driver_path.into_boxed_str());
-    let driver_version_command =
-        shell::Command::new_multiple(vec![static_driver_path, "--version"]);
+    let driver_version_command = shell::Command::new_single(format!("{} --version", &driver_path));
     let output = run_shell_command_by_os(OS, driver_version_command).unwrap();
     println!("**** EXEC DRIVER: {}", output);
     output

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -76,7 +76,9 @@ pub fn get_driver_path(cmd: &mut Command) -> String {
 pub fn exec_driver(cmd: &mut Command) -> String {
     let cmd_mut = cmd.borrow_mut();
     let driver_path = get_driver_path(cmd_mut);
-    let driver_version_command = shell::Command::new_single(format!("{} --version", &driver_path));
+    let static_driver_path: &'static str = Box::leak(driver_path.into_boxed_str());
+    let driver_version_command =
+        shell::Command::new_multiple(vec![static_driver_path, "--version"]);
     let output = run_shell_command_by_os(OS, driver_version_command).unwrap();
     println!("**** EXEC DRIVER: {}", output);
     output

--- a/rust/tests/exec_driver_tests.rs
+++ b/rust/tests/exec_driver_tests.rs
@@ -26,7 +26,6 @@ mod common;
 #[case("chrome", "ChromeDriver")]
 #[case("edge", "Microsoft Edge WebDriver")]
 #[case("firefox", "geckodriver")]
-#[case("iexplorer", "IEDriverServer")]
 fn exec_driver_test(#[case] browser_name: String, #[case] driver_name: String) {
     let mut cmd = get_selenium_manager();
     cmd.args(["--browser", &browser_name, "--output", "json"])

--- a/rust/tests/exec_driver_tests.rs
+++ b/rust/tests/exec_driver_tests.rs
@@ -26,6 +26,7 @@ mod common;
 #[case("chrome", "ChromeDriver")]
 #[case("edge", "Microsoft Edge WebDriver")]
 #[case("firefox", "geckodriver")]
+#[case("iexplorer", "IEDriverServer")]
 fn exec_driver_test(#[case] browser_name: String, #[case] driver_name: String) {
     let mut cmd = get_selenium_manager();
     cmd.args(["--browser", &browser_name, "--output", "json"])


### PR DESCRIPTION
### **User description**
### Motivation and Context
Selenium Manager executes different commands in the shell to discover the browser version. For instance, for Chrome in Linux:

```
/usr/bin/google-chrome --version
```

This kind of command is unavailable in Windows; therefore, Selenium Manager uses [WMIC](https://ss64.com/nt/wmic.html)  (Windows Management Instrumentation Command-line) to discover browser versions in Windows (`wmic datafile where name=...`). For instance:

```
> selenium-manager.exe --browser chrome --debug
[2025-03-03T14:03:19.673Z DEBUG] chromedriver not found in PATH
[2025-03-03T14:03:19.675Z DEBUG] chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
[2025-03-03T14:03:19.676Z DEBUG] Running command: wmic datafile where name='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' get Version /value
[2025-03-03T14:03:19.807Z DEBUG] Output: "\r\r\n\r\r\nVersion=133.0.6943.142\r\r\n\r\r\n\r\r\n\r"
[2025-03-03T14:03:19.813Z DEBUG] Detected browser: chrome 133.0.6943.142
[2025-03-03T14:03:19.822Z DEBUG] Discovering versions from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
[2025-03-03T14:03:20.181Z DEBUG] Required driver: chromedriver 133.0.6943.141
[2025-03-03T14:03:20.184Z DEBUG] chromedriver 133.0.6943.141 already in the cache
[2025-03-03T14:03:20.185Z INFO ] Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\133.0.6943.141\chromedriver.exe
[2025-03-03T14:03:20.185Z INFO ] Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

WMIC has been deprecated as of Windows 10, version 21H1, and Windows Server 2022 (see [info](https://techcommunity.microsoft.com/blog/windows-itpro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/4039242)). Microsoft has announced that it will be removed in a future version of Windows, though no specific timeline has been provided for its complete removal. Microsoft recommends transitioning to alternative tools and methods, such as PowerShell, which offers more robust and modern management capabilities.

WMIC continues working in Windows 11 currently. However, we need to stop using it in Selenium Manager. This PR implements this change, as follows:

```
> selenium-manager.exe --browser chrome --debug
[2025-03-03T14:13:27.749Z DEBUG] chromedriver not found in PATH
[2025-03-03T14:13:27.750Z DEBUG] chrome detected at C:\Program Files\Google\Chrome\Application\chrome.exe
[2025-03-03T14:13:27.751Z DEBUG] Running command: (Get-Item "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe").VersionInfo.ProductVersion
[2025-03-03T14:13:28.434Z DEBUG] Output: "133.0.6943.142"
[2025-03-03T14:13:28.441Z DEBUG] Detected browser: chrome 133.0.6943.142
[2025-03-03T14:13:28.443Z DEBUG] Required driver: chromedriver 133.0.6943.141
[2025-03-03T14:13:28.444Z DEBUG] chromedriver 133.0.6943.141 already in the cache
[2025-03-03T14:13:28.444Z INFO ] Driver path: C:\Users\boni\.cache\selenium\chromedriver\win64\133.0.6943.141\chromedriver.exe
[2025-03-03T14:13:28.444Z INFO ] Browser path: C:\Program Files\Google\Chrome\Application\chrome.exe
```

I believe using PowerShell in Windows (instead of the regular `cmd.exe`) is pretty safe since PowerShell is pre-installed starting with Windows 7. However, I detected a problem with this approach: performance. Running PowerShell commands through Selenium Manager is slower than WMIC commands. For example, in the first snippet of this PR, Selenium Manager used **131ms** to run the WMIC command (19.807-19.676=0.131s). For PowerShell, the command took **683ms** (28.434-27.751=0.683s). I repeated this, and indeed, it seems that a PowerShell command took around ~700ms, while WMIC required ~100ms:

PowerShell:
28.434-27.751=0.683
15.239-14.563=0.676
38.777-38.106=0.671
13.743-13.064=0.679
11.833-11.080=0.753
20.733-20.051=0.682
53.445-52.742=0.703

WMIC:
19.807-19.676=0.131
53.781-53.652=0.129
25.457-25.345=0.112
28.647-28.536=0.111

This means that for any new Selenium session, SM would have an overhead of around 700ms. I suppose this figure can be superior in other Windows systems. In my opinion, this time is quite relevant, and we would need to improve it.

Luckily, I implemented a mechanism to cache the _resolution_ (i.e., the discovered browser version using shell commands) using the old _TTL for browsers_. After discussing it, we decided to remove that feature, and since then, commands are always executed to discover browser versions. But with this new scenario (we need to move to PowerShell in Windows at some point), I propose to recover that feature and use TTL for commands. The value we used for this value was 3600s.

@diemol @titusfortner What do you think?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced deprecated WMIC commands with PowerShell commands in Windows.

- Updated command definitions for OS architecture and MSI installation.

- Modified shell execution to use PowerShell for Windows.

- Adjusted related logic and constants to align with PowerShell usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Switch OS architecture detection to PowerShell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/config.rs

<li>Replaced WMIC commands with PowerShell commands for OS architecture <br>detection.<br> <li> Updated variable names and logic to reflect PowerShell usage.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15363/files#diff-4f8685a05fdbb7fd7ae69236497d75cdc7df84d23be9d65ac019042dfc59df4f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>files.rs</strong><dd><code>Use PowerShell for MSI installation commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/files.rs

<li>Replaced MSI installation command with PowerShell equivalent.<br> <li> Updated logging and command execution logic for MSI installation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15363/files#diff-64844fef0537ed5f6fd38575be93920c99efacb3fd4c317ed6ff1ce243c2e1f1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Replace WMIC commands with PowerShell in constants and logic</code></dd></summary>
<hr>

rust/src/lib.rs

<li>Replaced WMIC commands with PowerShell equivalents for version <br>detection.<br> <li> Added new constants for PowerShell commands.<br> <li> Removed deprecated WMIC command constants.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15363/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shell.rs</strong><dd><code>Use PowerShell as default shell for Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/shell.rs

<li>Updated shell execution logic to use PowerShell for Windows.<br> <li> Adjusted shell and flag parameters for Windows compatibility.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15363/files#diff-30b27717f4f675841032bd3834252f387d5cd629687d921db22b37bc16962a9d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>