### PR TITLE
[rust] Selenium Manager support nightly Grid (#13384)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -798,7 +798,9 @@ pub trait SeleniumManager {
         }
 
         // With the discovered browser version, discover the proper driver version using online endpoints
-        if self.get_driver_version().is_empty() {
+        if self.get_driver_version().is_empty()
+            || (self.is_grid() && self.is_nightly(self.get_driver_version()))
+        {
             match self.discover_driver_version() {
                 Ok(driver_version) => {
                     self.set_driver_version(driver_version);
@@ -1030,7 +1032,7 @@ pub trait SeleniumManager {
         }
 
         let mut release_version = driver_version.to_string();
-        if !driver_version.ends_with('0') {
+        if !driver_version.ends_with('0') && !self.is_nightly(driver_version) {
             // E.g.: version 4.8.1 is shipped within release 4.8.0
             let error_message = format!(
                 "Wrong {} version: '{}'",

--- a/rust/tests/grid_tests.rs
+++ b/rust/tests/grid_tests.rs
@@ -20,6 +20,7 @@ use crate::common::{assert_output, get_selenium_manager, get_stdout};
 use exitcode::DATAERR;
 use rstest::rstest;
 use selenium_manager::logger::JsonOutput;
+use selenium_manager::{NIGHTLY, SNAPSHOT};
 use std::path::Path;
 use std::str;
 
@@ -51,6 +52,7 @@ fn grid_latest_test() {
 #[case("4.8.0")]
 #[case("4.9.0")]
 #[case("4.10.0")]
+#[case("nightly")]
 fn grid_version_test(#[case] grid_version: &str) {
     let mut cmd = get_selenium_manager();
     cmd.args(["--grid", grid_version, "--output", "json"])
@@ -63,7 +65,12 @@ fn grid_version_test(#[case] grid_version: &str) {
     let json: JsonOutput = serde_json::from_str(&stdout).unwrap();
     let jar = Path::new(&json.result.driver_path);
     let jar_name = jar.file_name().unwrap().to_str().unwrap();
-    assert!(jar_name.contains(grid_version));
+    let version_label = if grid_version.eq_ignore_ascii_case(NIGHTLY) {
+        SNAPSHOT
+    } else {
+        grid_version
+    };
+    assert!(jar_name.contains(version_label));
 }
 
 #[rstest]


### PR DESCRIPTION
### **User description**
### Motivation and Context
This PR allows SM to support the `nightly` label to manage Grid SNAPSHOTS, as requested in #13384. For example:

```
./selenium-manager --debug --grid nightly
[2025-03-03T15:28:16.874Z DEBUG] grid not found in the system
[2025-03-03T15:28:17.036Z DEBUG] Required driver: selenium-server 4.30.0-SNAPSHOT
[2025-03-03T15:28:17.037Z DEBUG] Acquiring lock: C:\Users\boni\.cache\selenium\grid\4.30.0-SNAPSHOT\sm.lock
[2025-03-03T15:28:17.037Z DEBUG] Downloading selenium-server 4.30.0-SNAPSHOT from https://github.com/SeleniumHQ/selenium/releases/download/nightly/selenium-server-4.30.0-SNAPSHOT.jar
[2025-03-03T15:28:21.533Z INFO ] Driver path: C:\Users\boni\.cache\selenium\grid\4.30.0-SNAPSHOT\selenium-server-4.30.0-SNAPSHOT.jar
```

```
./selenium-manager --debug --grid
[2025-03-03T15:28:26.188Z DEBUG] grid not found in the system
[2025-03-03T15:28:26.230Z DEBUG] Required driver: selenium-server 4.29.0
[2025-03-03T15:28:26.232Z DEBUG] Acquiring lock: C:\Users\boni\.cache\selenium\grid\4.29.0\sm.lock
[2025-03-03T15:28:26.232Z DEBUG] Downloading selenium-server 4.29.0 from https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.29.0/selenium-server-4.29.0.jar
[2025-03-03T15:28:30.690Z INFO ] Driver path: C:\Users\boni\.cache\selenium\grid\4.29.0\selenium-server-4.29.0.jar
```

```
./selenium-manager --debug --grid 4.28.0
[2025-03-03T15:28:34.507Z DEBUG] grid not found in the system
[2025-03-03T15:28:34.508Z DEBUG] Acquiring lock: C:\Users\boni\.cache\selenium\grid\4.28.0\sm.lock
[2025-03-03T15:28:34.508Z DEBUG] Downloading selenium-server 4.28.0 from https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.28.0/selenium-server-4.28.0.jar
[2025-03-03T15:28:39.088Z INFO ] Driver path: C:\Users\boni\.cache\selenium\grid\4.28.0\selenium-server-4.28.0.jar
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added support for `nightly` label in Selenium Manager to manage Grid SNAPSHOTS.

- Updated logic to handle nightly and non-nightly driver versions.

- Enhanced metadata handling for nightly driver versions.

- Improved version parsing and validation for Grid releases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>grid.rs</strong><dd><code>Implement nightly Grid support in Selenium Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/grid.rs

<li>Added logic to detect and handle nightly driver versions.<br> <li> Updated filtering of Selenium releases based on nightly or stable <br>versions.<br> <li> Adjusted version parsing for nightly driver URLs.<br> <li> Refactored metadata handling to include nightly driver versions.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15366/files#diff-dc00b07dc056b382eda849ef5af0742baafe6b57c047ba4bc08df3cad059b3c8">+20/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update driver version discovery for nightly Grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<li>Added condition to check for nightly Grid versions.<br> <li> Updated driver version discovery logic for nightly support.<br> <li> Enhanced validation for nightly driver versions.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15366/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>