### PR TITLE
Add Logging and Debugging to Investigate RBE Failures

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -61,11 +61,16 @@ on:
         required: false
         type: string
         default: ''
-      artifact-name:
+      upload-name:
         description: Name of artifact to upload
         required: false
         type: string
-        default: 'ignore-artifacts'
+        default: ''
+      upload-path:
+        description: path of artifact to upload
+        required: false
+        type: string
+        default: ''
 
 jobs:
   bazel:
@@ -171,14 +176,10 @@ jobs:
           title: "Nightly"
           prerelease: true
           files: ${{ inputs.nightly-release-files }}
-      - name: Save changes
-        if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
-        run: |
-          git diff > changes.patch
-      - name: "Upload changes"
-        if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
+      - name: "Upload artifact"
+        if: ${{ always() && inputs.upload-name != '' && inputs.upload-path != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact-name }}
-          path: changes.patch
+          name: ${{ inputs.upload-name }}
+          path: ${{ inputs.upload-path }}
           retention-days: 6

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -61,6 +61,16 @@ on:
         required: false
         type: string
         default: ''
+      download-name:
+        description: name of artifact to download
+        required: false
+        type: string
+        default: ''
+      download-path:
+        description: path of artifact to download
+        required: false
+        type: string
+        default: ''
       upload-name:
         description: Name of artifact to upload
         required: false
@@ -161,6 +171,12 @@ jobs:
       - name: Setup curl for Ubuntu
         if: inputs.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - name: "Download artifact"
+        if: ${{ inputs.download-name != '' && inputs.download-path != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.download-name }}
+          path: ${{ inputs.download-path }}
       - name: Run Bazel
         run: ${{ inputs.run }}
       - name: Start SSH session

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -83,6 +83,7 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BAZEL_LOG_FILE: bazel-logs/bzl_${{ github.run_id }}.log
       SE_AVOID_STATS: true
     steps:
       - name: Checkout source tree

--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -29,3 +29,35 @@ jobs:
       upload-name: bazel-logs
       upload-path: bazel-logs
       run: ./scripts/github-actions/ci-build.sh
+  retry-remote:
+    name: Retry Failures on RBE
+    needs: test
+    if: always() && needs.test.result == 'failure' && github.repository_owner == 'seleniumhq' && startsWith(github.head_ref, 'renovate/') != true
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: RBE Retries
+      caching: false
+      ruby-version: jruby-9.4.12.0
+      download-name: bazel-logs
+      download-path: bazel-logs
+      upload-name: retry-remote-logs
+      upload-path: bazel-logs
+      run: |
+        ./go retry_failed_tests "${BAZEL_LOG_FILE}" true
+  retry-local:
+    name: Retry Failures on GHA
+    needs: test
+    if: always() && needs.test.result == 'failure' && github.repository_owner == 'seleniumhq' && startsWith(github.head_ref, 'renovate/') != true
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: GHA Retries
+      caching: false
+      ruby-version: jruby-9.4.12.0
+      browser: needs-xvfb
+      java-version: 17
+      download-name: bazel-logs
+      download-path: bazel-logs
+      upload-name: retry-local-logs
+      upload-path: bazel-logs
+      run: |
+        ./go retry_failed_tests "${BAZEL_LOG_FILE}" false

--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -26,4 +26,6 @@ jobs:
       name: All RBE tests
       caching: false
       ruby-version: jruby-9.4.12.0
+      upload-name: bazel-logs
+      upload-path: bazel-logs
       run: ./scripts/github-actions/ci-build.sh

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -11,8 +11,11 @@ jobs:
     with:
       name: Pin Browsers
       cache-key: pin-browsers
-      run: bazel run //scripts:pinned_browsers
-      artifact-name: pinned-browsers
+      upload-name: pinned-browsers
+      upload-path: changes.patch
+      run: |
+        bazel run //scripts:pinned_browsers
+        git diff > changes.patch
 
   pull-request:
     if: github.repository_owner == 'seleniumhq'

--- a/Rakefile
+++ b/Rakefile
@@ -274,6 +274,45 @@ end
 task test_py: [:py_prep_for_install_release, 'py:marionette_test']
 task build: %i[all firefox remote selenium tests]
 
+desc 'Retry failed tests from a log file'
+task :retry_failed_tests, [:log_file, :rbe] do |_task, arguments|
+  log_file = arguments[:log_file]
+
+  raise 'Error: Please provide a bazel log file containing test results.' if log_file.nil?
+  raise "Error: Log file '#{log_file}' does not exist." unless File.exist?(log_file)
+
+  rbe = arguments[:rbe]
+  failing_tests = []
+
+  File.readlines(log_file).reverse_each do |line|
+    if line.match?(%r{//.+:.*FAILED})
+      failing_tests << line.strip.split[0]
+    elsif !failing_tests.empty? && line.match?(%r{//.+:.*PASSED})
+      break
+    end
+  end
+
+  puts "Found #{failing_tests.size} failing tests; Retrying"
+
+  retry_args = arguments.extras + %w[--test_output=streamed --test_env DEBUG=true]
+  retry_args << (rbe == 'true' ? '--config=remote' : '--pin_browsers')
+
+  retry_failures = false
+  failing_tests.each do |failed_target|
+    target_name = failed_target.split('/').last.tr(':', '_')
+    target_name += rbe ? '_rbe' : '_gha'
+    retry_logs = log_file.sub('.log', "_#{target_name}_retry.log")
+    begin
+      Bazel.execute('test', retry_args, failed_target, verbose: true, log_file: retry_logs)
+    rescue StandardError => e
+      retry_failures = true
+      puts "Failed retry of #{failed_target}: #{e.message}"
+    end
+  end
+
+  raise 'Some tests failed during retry' if retry_failures
+end
+
 desc 'Clean build artifacts.'
 task :clean do
   rm_rf 'build/'

--- a/rake_tasks/bazel.rb
+++ b/rake_tasks/bazel.rb
@@ -7,9 +7,7 @@ require 'io/wait'
 require_relative 'selenium_rake/checks'
 
 module Bazel
-  def self.execute(kind, args, target, &block)
-    verbose = Rake::FileUtilsExt.verbose_flag
-
+  def self.execute(kind, args, target, verbose: Rake::FileUtilsExt.verbose_flag, log_file: nil, &block)
     if target.end_with?(':run')
       kind = 'run'
       target = target[0, target.length - 4]
@@ -18,28 +16,34 @@ module Bazel
     cmd = %w[bazel] + [kind, target] + (args || [])
     cmd_out = ''
     cmd_exit_code = 0
+    puts "Executing:\n#{cmd.join(' ')}" if verbose
 
     if SeleniumRake::Checks.windows?
-      cmd += ['2>&1']
       cmd_line = cmd.join(' ')
-      cmd_out = `#{cmd_line}`.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
-      puts cmd_out if verbose
-      cmd_exit_code = $CHILD_STATUS
+      begin
+        cmd_out = `#{cmd_line} 2>&1`.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+        puts cmd_out if verbose
+        File.write(log_file, cmd_out) if log_file
+        cmd_exit_code = $CHILD_STATUS.exitstatus
+      rescue => e
+        raise "Windows command execution failed: #{e.message}"
+      end
     else
-      Open3.popen2e(*cmd) do |stdin, stdouts, wait|
-        is_running = true
-        stdin.close
-        while is_running
-          begin
-            stdouts.wait_readable
-            line = stdouts.readpartial(512)
+      begin
+        Open3.popen2e(*cmd) do |stdin, stdouts, wait|
+          stdin.close
+          log = log_file ? File.open(log_file, 'a') : nil
+          while (line = stdouts.gets)
             cmd_out += line
             $stdout.print line if verbose
-          rescue EOFError
-            is_running = false
+            log&.write(line)
+            log&.flush
           end
+          log&.close
+          cmd_exit_code = wait.value.exitstatus
         end
-        cmd_exit_code = wait.value.exitstatus
+      rescue => e
+        raise "Command execution failed: #{e.message}"
       end
     end
 

--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -44,8 +44,8 @@ module Selenium
           input = driver.find_element(css: '#working')
 
           driver.action.send_keys(input, 'abcd').perform
-          wait.until { input.attribute(:value).length == 4 }
-          expect(input.attribute(:value)).to eq('abcd')
+          wait.until { input.property(:value).length == 4 }
+          expect(input.property(:value)).to eq('abcd')
         end
 
         it 'sends keys with multiple arguments' do
@@ -55,8 +55,8 @@ module Selenium
           input.click
 
           driver.action.send_keys('abcd', 'dcba').perform
-          wait.until { input.attribute(:value).length == 8 }
-          expect(input.attribute(:value)).to eq('abcddcba')
+          wait.until { input.property(:value).length == 8 }
+          expect(input.property(:value)).to eq('abcddcba')
         end
 
         it 'sends non-ASCII keys' do
@@ -66,8 +66,8 @@ module Selenium
           input.click
 
           driver.action.send_keys('abcd', :left, 'a').perform
-          wait.until { input.attribute(:value).length == 5 }
-          expect(input.attribute(:value)).to eq('abcad')
+          wait.until { input.property(:value).length == 5 }
+          expect(input.property(:value)).to eq('abcad')
         end
       end
 
@@ -81,9 +81,9 @@ module Selenium
           event_input.click
 
           driver.action.key_down(:shift).send_keys('ab').key_up(:shift).perform
-          wait.until { event_input.attribute(:value).length == 2 }
+          wait.until { event_input.property(:value).length == 2 }
 
-          expect(event_input.attribute(:value)).to eq('AB')
+          expect(event_input.property(:value)).to eq('AB')
           expected = keylogger.text.strip
           expect(expected).to match(/^(focus )?keydown keydown keypress keyup keydown keypress keyup keyup$/)
         end
@@ -131,10 +131,10 @@ module Selenium
           event_input = driver.find_element(id: 'clickField')
 
           driver.action.click_and_hold(event_input).perform
-          expect(event_input.attribute(:value)).to eq('Hello')
+          expect(event_input.property(:value)).to eq('Hello')
 
           driver.action.release_actions
-          expect(event_input.attribute(:value)).to eq('Clicked')
+          expect(event_input.property(:value)).to eq('Clicked')
         end
       end
 
@@ -143,14 +143,14 @@ module Selenium
           driver.navigate.to url_for('javascriptPage.html')
           element = driver.find_element(id: 'clickField')
           driver.action.click(element).perform
-          expect(element.attribute(:value)).to eq('Clicked')
+          expect(element.property(:value)).to eq('Clicked')
         end
 
         it 'executes with equivalent pointer methods' do
           driver.navigate.to url_for('javascriptPage.html')
           element = driver.find_element(id: 'clickField')
           driver.action.move_to(element).pointer_down(:left).pointer_up(:left).perform
-          expect(element.attribute(:value)).to eq('Clicked')
+          expect(element.property(:value)).to eq('Clicked')
         end
       end
 
@@ -160,7 +160,7 @@ module Selenium
           element = driver.find_element(id: 'doubleClickField')
 
           driver.action.double_click(element).perform
-          expect(element.attribute(:value)).to eq('DoubleClicked')
+          expect(element.property(:value)).to eq('DoubleClicked')
         end
 
         it 'executes with equivalent pointer methods', except: {browser: %i[safari safari_preview]} do
@@ -171,7 +171,7 @@ module Selenium
                 .pointer_down(:left).pointer_up(:left)
                 .pointer_down(:left).pointer_up(:left)
                 .perform
-          expect(element.attribute(:value)).to eq('DoubleClicked')
+          expect(element.property(:value)).to eq('DoubleClicked')
         ensure
           # https://issues.chromium.org/issues/400087471
           reset_driver! if GlobalTestEnv.browser == :chrome && GlobalTestEnv.rbe?
@@ -184,7 +184,7 @@ module Selenium
           element = driver.find_element(id: 'doubleClickField')
 
           driver.action.context_click(element).perform
-          expect(element.attribute(:value)).to eq('ContextClicked')
+          expect(element.property(:value)).to eq('ContextClicked')
         end
 
         it 'executes with equivalent pointer methods' do
@@ -192,7 +192,7 @@ module Selenium
           element = driver.find_element(id: 'doubleClickField')
 
           driver.action.move_to(element).pointer_down(:right).pointer_up(:right).perform
-          expect(element.attribute(:value)).to eq('ContextClicked')
+          expect(element.property(:value)).to eq('ContextClicked')
         end
       end
 
@@ -202,7 +202,7 @@ module Selenium
           element = driver.find_element(id: 'clickField')
           driver.action.move_to(element).click.perform
 
-          expect(element.attribute(:value)).to eq('Clicked')
+          expect(element.property(:value)).to eq('Clicked')
         end
 
         it 'moves to element with offset' do
@@ -215,7 +215,7 @@ module Selenium
           y_offset = (destination_rect.y - origin_rect.y).ceil
 
           driver.action.move_to(origin, x_offset, y_offset).click.perform
-          expect(destination.attribute(:value)).to eq('Clicked')
+          expect(destination.property(:value)).to eq('Clicked')
         end
       end
 
@@ -259,7 +259,7 @@ module Selenium
           rect = element.rect
           driver.action.move_to_location(rect.x.ceil, rect.y.ceil).click.perform
 
-          expect(element.attribute(:value)).to eq('Clicked')
+          expect(element.property(:value)).to eq('Clicked')
         end
       end
 

--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -21,8 +21,14 @@ require_relative 'spec_helper'
 
 module Selenium
   module WebDriver
-    describe ActionBuilder, exclusive: {bidi: false, reason: 'Not yet implemented with BiDi'} do
-      after { driver.action.clear_all_actions }
+    describe ActionBuilder, exclusive: { bidi: false, reason: 'Not yet implemented with BiDi' } do
+      after do
+        if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome
+          reset_driver!
+        else
+          driver.action.clear_all_actions
+        end
+      end
 
       describe '#send_keys' do
         it 'sends keys to the active element', except: {browser: %i[safari safari_preview]} do
@@ -172,9 +178,6 @@ module Selenium
                 .pointer_down(:left).pointer_up(:left)
                 .perform
           expect(element.property(:value)).to eq('DoubleClicked')
-        ensure
-          # https://issues.chromium.org/issues/400087471
-          reset_driver! if GlobalTestEnv.browser == :chrome && GlobalTestEnv.rbe?
         end
       end
 

--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -172,6 +172,9 @@ module Selenium
                 .pointer_down(:left).pointer_up(:left)
                 .perform
           expect(element.attribute(:value)).to eq('DoubleClicked')
+        ensure
+          # https://issues.chromium.org/issues/400087471
+          reset_driver! if GlobalTestEnv.browser == :chrome && GlobalTestEnv.rbe?
         end
       end
 

--- a/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/action_builder_spec.rb
@@ -21,14 +21,8 @@ require_relative 'spec_helper'
 
 module Selenium
   module WebDriver
-    describe ActionBuilder, exclusive: { bidi: false, reason: 'Not yet implemented with BiDi' } do
-      after do
-        if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome
-          reset_driver!
-        else
-          driver.action.clear_all_actions
-        end
-      end
+    describe ActionBuilder, exclusive: {bidi: false, reason: 'Not yet implemented with BiDi'} do
+      after { driver.action.clear_all_actions }
 
       describe '#send_keys' do
         it 'sends keys to the active element', except: {browser: %i[safari safari_preview]} do
@@ -161,6 +155,9 @@ module Selenium
       end
 
       describe '#double_click' do
+        # https://issues.chromium.org/issues/400087471
+        before { reset_driver! if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome }
+
         it 'presses pointer twice', except: {browser: %i[safari safari_preview]} do
           driver.navigate.to url_for('javascriptPage.html')
           element = driver.find_element(id: 'doubleClickField')

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -22,15 +22,15 @@ require_relative 'spec_helper'
 module Selenium
   module WebDriver
     describe Driver, exclusive: {bidi: false, reason: 'Not yet implemented with BiDi'} do
-      it_behaves_like 'driver that can be started concurrently', exclude: [
-        {browser: %i[safari safari_preview]},
-        {browser: :firefox, rbe: true, reason: 'https://github.com/mozilla/geckodriver/issues/2219'},
-        {driver: :remote, rbe: true, reason: 'Cannot start 2+ drivers at once.' }
-      ]
-
       after { reset_driver! if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome }
 
-      it 'creates default capabilities', exclude: { browser: %i[safari safari_preview] } do
+      it_behaves_like 'driver that can be started concurrently', exclude: [
+        {browser: %i[safari safari_preview]},
+        {browser: :firefox, reason: 'https://github.com/SeleniumHQ/selenium/issues/15451'},
+        {driver: :remote, rbe: true, reason: 'Cannot start 2+ drivers at once.'}
+      ]
+
+      it 'creates default capabilities', exclude: {browser: %i[safari safari_preview]} do
         reset_driver! do |driver|
           caps = driver.capabilities
           expect(caps.proxy).to be_nil

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -25,10 +25,12 @@ module Selenium
       it_behaves_like 'driver that can be started concurrently', exclude: [
         {browser: %i[safari safari_preview]},
         {browser: :firefox, rbe: true, reason: 'https://github.com/mozilla/geckodriver/issues/2219'},
-        {driver: :remote, rbe: true, reason: 'Cannot start 2+ drivers at once.'}
+        {driver: :remote, rbe: true, reason: 'Cannot start 2+ drivers at once.' }
       ]
 
-      it 'creates default capabilities', exclude: {browser: %i[safari safari_preview]} do
+      after { reset_driver! if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome }
+
+      it 'creates default capabilities', exclude: { browser: %i[safari safari_preview] } do
         reset_driver! do |driver|
           caps = driver.capabilities
           expect(caps.proxy).to be_nil
@@ -60,8 +62,7 @@ module Selenium
 
       it 'refreshes the page' do
         driver.navigate.to url_for('javascriptPage.html')
-        sleep 1 # javascript takes too long to load
-        driver.find_element(id: 'updatediv').click
+        short_wait { driver.find_element(id: 'updatediv') }.click
         expect(driver.find_element(id: 'dynamo').text).to eq('Fish and chips!')
         driver.navigate.refresh
         wait_for_element(id: 'dynamo')

--- a/rb/spec/integration/selenium/webdriver/manager_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/manager_spec.rb
@@ -25,7 +25,14 @@ module Selenium
       describe 'cookie management' do
         before { driver.navigate.to url_for('xhtmlTest.html') }
 
-        after { driver.manage.delete_all_cookies }
+        after do
+          if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome
+            # https://issues.chromium.org/issues/400087471
+            reset_driver!
+          else
+            driver.manage.delete_all_cookies
+          end
+        end
 
         it 'sets correct defaults' do
           driver.manage.add_cookie name: 'default',

--- a/rb/spec/integration/selenium/webdriver/select_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/select_spec.rb
@@ -29,6 +29,7 @@ module Selenium
         let(:multi_disabled) { described_class.new(driver.find_element(name: 'multi_disabled')) }
 
         before { driver.navigate.to url_for('formPage.html') }
+        after { reset_driver! if GlobalTestEnv.rbe? && GlobalTestEnv.browser == :chrome }
 
         describe '#initialize' do
           it 'raises exception if not a select element' do

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -31,13 +31,32 @@ GlobalTestEnv = WebDriver::SpecSupport::TestEnvironment.new
 
 class SeleniumTestListener
   def example_finished(notification)
-    exception = notification.example.exception
+    if investigate?(notification.example) && WebDriver.logger.debug?
+      driver = GlobalTestEnv.driver_instance
+      session_id = driver.instance_variable_get(:@bridge).session_id
+
+      FileUtils.mkdir_p('bazel-logs')
+      driver.save_screenshot("bazel-logs/#{session_id}.png")
+      WebDriver.logger.info("Page Source: #{driver.page_source}")
+    end
+
+    GlobalTestEnv.reset_driver! if reset_driver?(notification.example)
+  end
+
+  private
+
+  def investigate?(example)
+    example.exception && !example.pending
+  end
+
+  def reset_driver?(example)
+    exception = example.exception
     assertion_failed = exception &&
                        (exception.is_a?(RSpec::Expectations::ExpectationNotMetError) ||
-                        exception.is_a?(RSpec::Core::Pending::PendingExampleFixedError))
-    pending_exception = exception.nil? && notification.example.pending && !notification.example.skip
+                         exception.is_a?(RSpec::Core::Pending::PendingExampleFixedError))
+    pending_exception = exception.nil? && example.pending && !example.skip
 
-    GlobalTestEnv.reset_driver! if (exception && !assertion_failed) || pending_exception
+    (exception && !assertion_failed) || pending_exception
   end
 end
 

--- a/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
@@ -31,6 +31,9 @@ module Selenium
         (handles - [driver.window_handle]).each do |handle|
           driver.switch_to.window(handle) { driver.close }
         end
+      rescue Selenium::WebDriver::Error::WebDriverError
+        # https://issues.chromium.org/issues/400087471
+        reset_driver!
       end
 
       let(:new_window) { driver.window_handles.find { |handle| handle != driver.window_handle } }
@@ -310,25 +313,25 @@ module Selenium
           wait_for_no_alert
         end
 
-        it 'raises when calling #text on a closed alert' do
-          driver.navigate.to url_for('alerts.html')
-          wait_for_element(id: 'alert')
-
-          driver.find_element(id: 'alert').click
-
-          alert = wait_for_alert
-          alert.accept
-
-          wait_for_no_alert
-          expect { alert.text }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-        end
-
-        it 'raises NoAlertOpenError if no alert is present' do
-          expect { driver.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-        end
-
-        describe 'unhandled alert error' do
+        describe 'errors' do
           after { |example| reset_driver!(example: example) }
+
+          it 'raises when calling #text on a closed alert' do
+            driver.navigate.to url_for('alerts.html')
+            wait_for_element(id: 'alert')
+
+            driver.find_element(id: 'alert').click
+
+            alert = wait_for_alert
+            alert.accept
+
+            wait_for_no_alert
+            expect { alert.text }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
+          end
+
+          it 'raises NoAlertOpenError if no alert is present' do
+            expect { driver.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
+          end
 
           it 'raises an UnexpectedAlertOpenError if an alert has not been dealt with' do
             driver.navigate.to url_for('alerts.html')

--- a/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
@@ -89,9 +89,6 @@ module Selenium
             expect {
               driver.switch_to.new_window(:unknown)
             }.to raise_error(ArgumentError)
-          ensure
-            # https://issues.chromium.org/issues/400087471
-            reset_driver! if GlobalTestEnv.browser == :chrome && GlobalTestEnv.rbe?
           end
 
           it 'switches to the new window then close it when given a block' do

--- a/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/target_locator_spec.rb
@@ -89,6 +89,9 @@ module Selenium
             expect {
               driver.switch_to.new_window(:unknown)
             }.to raise_error(ArgumentError)
+          ensure
+            # https://issues.chromium.org/issues/400087471
+            reset_driver! if GlobalTestEnv.browser == :chrome && GlobalTestEnv.rbe?
           end
 
           it 'switches to the new window then close it when given a block' do

--- a/scripts/github-actions/ci-build.sh
+++ b/scripts/github-actions/ci-build.sh
@@ -4,12 +4,25 @@ set -eufo pipefail
 # We want to see what's going on
 set -x
 
-# Now run the tests. The engflow build uses pinned browsers
-# so this should be fine
-# shellcheck disable=SC2046
-bazel test --config=remote-ci --build_tests_only \
-  --keep_going --flaky_test_attempts=2 \
-  //... -- $(cat .skipped-tests | tr '\n' ' ')
+run_bazel_tests() {
+  # shellcheck disable=SC2046
+  bazel test --config=remote-ci --build_tests_only \
+    --keep_going --flaky_test_attempts=2 \
+    //... -- $(cat .skipped-tests | tr '\n' ' ')
+}
+
+# Prepare log directory if BAZEL_LOG_FILE is set and run tests
+if [ -n "${BAZEL_LOG_FILE:-}" ]; then
+  LOG_DIR=$(dirname "$BAZEL_LOG_FILE")
+  if mkdir -p "$LOG_DIR"; then
+    run_bazel_tests 2>&1 | tee "$BAZEL_LOG_FILE"
+  else
+    echo "Error: Failed to create directory for BAZEL_LOG_FILE" >&2
+    exit 1
+  fi
+else
+  run_bazel_tests
+fi
 
 # Build the packages we want to ship to users
 bazel build --config=remote-ci --build_tag_filters=release-artifact //...

--- a/scripts/github-actions/ci-build.sh
+++ b/scripts/github-actions/ci-build.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 set -eufo pipefail
-# We want to see what's going on
-set -x
+
+# Only enable command tracing if DEBUG is set
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
 
 run_bazel_tests() {
   # shellcheck disable=SC2046


### PR DESCRIPTION
~I thought most of the failures we have in trunk are related to CDP/browser/driver version mismatches, but that doesn't appear to be true~

~This is WIP trying to make changes to get tests passing before release. Making it a PR for visibility and so it is easier to track.~

I've merged CDP and browser updates to trunk, but there are still failures.

This PR is now focused on getting more information about the RBE results so I can better figure out how to address the Ruby failures.