### PR TITLE
[py] Fix code formatting selenium_manager_tests.py

### DIFF
--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -31,9 +31,10 @@ def test_gets_results(monkeypatch):
     expected_output = {"driver_path": "/path/to/driver"}
     lib_path = "selenium.webdriver.common.selenium_manager.SeleniumManager"
 
-    with mock.patch(lib_path + "._get_binary", return_value="/path/to/sm") as mock_get_binary, mock.patch(
-        lib_path + "._run", return_value=expected_output
-    ) as mock_run:
+    with (
+        mock.patch(lib_path + "._get_binary", return_value="/path/to/sm") as mock_get_binary,
+        mock.patch(lib_path + "._run", return_value=expected_output) as mock_run,
+    ):
         SeleniumManager().binary_paths([])
 
         mock_get_binary.assert_called_once()


### PR DESCRIPTION
### **User description**
### Motivation and Context

This PR fixes a minor code formatting violation in `py/test/selenium/webdriver/common/selenium_manager_tests.py` that the linting tools were complaining about. All Python linting runs completely clean after this fix.

Tested locally with: `tox -e linting -c ./py/tox.ini`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed code formatting in `selenium_manager_tests.py`.

- Resolved linting issues for cleaner Python code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager_tests.py</strong><dd><code>Refactor mock.patch usage for better formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/selenium_manager_tests.py

<li>Replaced nested <code>mock.patch</code> calls with a cleaner context manager.<br> <li> Improved readability and compliance with linting standards.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15413/files#diff-22c54b96b2a9efe205ece275426f943c0214c3879815146e237614365af3196d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>