### PR TITLE
[py] fix test discovery for pytest

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -84,7 +84,7 @@ markers = [
     "xfail_webkitgtk: Tests expected to fail in webkitgtk",
     "no_driver_after_test: If there are no drivers after the test it will create a new one."
 ]
-python_files = ["test_*.py", "*_test.py"]
+python_files = ["test_*.py", "*_test.py", "*_tests.py"]
 testpaths = ["test"]
 
 # mypy global options


### PR DESCRIPTION
### **User description**
### Motivation and Context

This PR fixes test discovery for pytest, since it was not configured correctly in `pyproject.toml`.

Due to the naming convention of most of the Python tests, test discovery was not correctly finding tests to execute. You could only run tests by explicitly calling each test file, not by running the entire suite or directory.

For example... you could run `pytest py/test/selenium/webdriver/common/window_tests.py` just fine, but running `pytest py/test/selenium/webdriver/common` or `pytest py/test/selenium` would run nothing.

Without this fix, only 31 of the 1106 tests were able to be run!

(Note: this is only really evident when running `pytest` directly for local testing, since the bazel build tasks used for testing/CI call each test file explicitly and don't use test discovery)


Before this change:
```
$ pytest py/test --collect-only -q | head -n -2 | wc -l
31
```

After this change:
```
$ pytest py/test --collect-only -q | head -n -2 | wc -l
1106
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed pytest test discovery by updating `python_files` in `pyproject.toml`.

- Enabled discovery of files with `*_tests.py` naming convention.

- Improved test suite execution from 31 to 1106 tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update pytest configuration for test discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<li>Added <code>*_tests.py</code> to <code>python_files</code> for pytest discovery.<br> <li> Ensured all test files are correctly identified and executed.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15415/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>