### PR TITLE
[dotnet] [bidi] Make `LocalValue` types not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -140,8 +140,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.Network.FetchErrorEventArgs))]
 [JsonSerializable(typeof(Modules.Network.AuthRequiredEventArgs))]
 
-[JsonSerializable(typeof(Modules.Script.Channel), TypeInfoPropertyName = "Script_Channel")]
-[JsonSerializable(typeof(Modules.Script.LocalValue.String), TypeInfoPropertyName = "Script_LocalValue_String")]
+[JsonSerializable(typeof(Modules.Script.ChannelLocalValue), TypeInfoPropertyName = "Script_ChannelLocalValue")]
 [JsonSerializable(typeof(Modules.Script.Target.Realm), TypeInfoPropertyName = "Script_Target_Realm")]
 [JsonSerializable(typeof(Modules.Script.Target.Context), TypeInfoPropertyName = "Script_Target_Context")]
 

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -140,7 +140,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.Network.FetchErrorEventArgs))]
 [JsonSerializable(typeof(Modules.Network.AuthRequiredEventArgs))]
 
-[JsonSerializable(typeof(Modules.Script.ChannelLocalValue), TypeInfoPropertyName = "Script_ChannelLocalValue")]
 [JsonSerializable(typeof(Modules.Script.Target.Realm), TypeInfoPropertyName = "Script_Target_Realm")]
 [JsonSerializable(typeof(Modules.Script.Target.Context), TypeInfoPropertyName = "Script_Target_Context")]
 

--- a/dotnet/src/webdriver/BiDi/Modules/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/AddPreloadScriptCommand.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 internal class AddPreloadScriptCommand(AddPreloadScriptCommandParameters @params)
     : Command<AddPreloadScriptCommandParameters>(@params, "script.addPreloadScript");
 
-internal record AddPreloadScriptCommandParameters(string FunctionDeclaration, IEnumerable<LocalValue.Channel>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : CommandParameters;
+internal record AddPreloadScriptCommandParameters(string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : CommandParameters;
 
 public record AddPreloadScriptOptions : CommandOptions
 {
@@ -37,7 +37,7 @@ public record AddPreloadScriptOptions : CommandOptions
         Sandbox = options?.Sandbox;
     }
 
-    public IEnumerable<LocalValue.Channel>? Arguments { get; set; }
+    public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
 
@@ -46,7 +46,7 @@ public record AddPreloadScriptOptions : CommandOptions
 
 public record BrowsingContextAddPreloadScriptOptions
 {
-    public IEnumerable<LocalValue.Channel>? Arguments { get; set; }
+    public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 
     public string? Sandbox { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
@@ -23,21 +23,21 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Modules.Script;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Number), "number")]
-[JsonDerivedType(typeof(String), "string")]
-[JsonDerivedType(typeof(Null), "null")]
-[JsonDerivedType(typeof(Undefined), "undefined")]
-[JsonDerivedType(typeof(Channel), "channel")]
-[JsonDerivedType(typeof(Array), "array")]
-[JsonDerivedType(typeof(Date), "date")]
-[JsonDerivedType(typeof(Map), "map")]
-[JsonDerivedType(typeof(Object), "object")]
-[JsonDerivedType(typeof(RegExp), "regexp")]
-[JsonDerivedType(typeof(Set), "set")]
+[JsonDerivedType(typeof(NumberLocalValue), "number")]
+[JsonDerivedType(typeof(StringLocalValue), "string")]
+[JsonDerivedType(typeof(NullLocalValue), "null")]
+[JsonDerivedType(typeof(UndefinedLocalValue), "undefined")]
+[JsonDerivedType(typeof(ChannelLocalValue), "channel")]
+[JsonDerivedType(typeof(ArrayLocalValue), "array")]
+[JsonDerivedType(typeof(DateLocalValue), "date")]
+[JsonDerivedType(typeof(MapLocalValue), "map")]
+[JsonDerivedType(typeof(ObjectLocalValue), "object")]
+[JsonDerivedType(typeof(RegExpLocalValue), "regexp")]
+[JsonDerivedType(typeof(SetLocalValue), "set")]
 public abstract record LocalValue
 {
-    public static implicit operator LocalValue(int value) { return new Number(value); }
-    public static implicit operator LocalValue(string value) { return new String(value); }
+    public static implicit operator LocalValue(int value) { return new NumberLocalValue(value); }
+    public static implicit operator LocalValue(string value) { return new StringLocalValue(value); }
 
     // TODO: Extend converting from types
     public static LocalValue ConvertFrom(object? value)
@@ -47,7 +47,7 @@ public abstract record LocalValue
             case LocalValue:
                 return (LocalValue)value;
             case null:
-                return new Null();
+                return new NullLocalValue();
             case int:
                 return (int)value;
             case string:
@@ -65,52 +65,53 @@ public abstract record LocalValue
                         values.Add([property.Name, ConvertFrom(property.GetValue(value))]);
                     }
 
-                    return new Object(values);
+                    return new ObjectLocalValue(values);
                 }
         }
     }
-
-    public abstract record PrimitiveProtocolLocalValue : LocalValue;
-
-    public record Number(double Value) : PrimitiveProtocolLocalValue
-    {
-        public static explicit operator Number(double n) => new Number(n);
-    }
-
-    public record String(string Value) : PrimitiveProtocolLocalValue;
-
-    public record Null : PrimitiveProtocolLocalValue;
-
-    public record Undefined : PrimitiveProtocolLocalValue;
-
-    public record Channel(Channel.ChannelProperties Value) : LocalValue
-    {
-        [JsonInclude]
-        internal string type = "channel";
-
-        public record ChannelProperties(Script.Channel Channel)
-        {
-            public SerializationOptions? SerializationOptions { get; set; }
-
-            public ResultOwnership? Ownership { get; set; }
-        }
-    }
-
-    public record Array(IEnumerable<LocalValue> Value) : LocalValue;
-
-    public record Date(string Value) : LocalValue;
-
-    public record Map(IEnumerable<IEnumerable<LocalValue>> Value) : LocalValue;
-
-    public record Object(IEnumerable<IEnumerable<LocalValue>> Value) : LocalValue;
-
-    public record RegExp(RegExp.RegExpValue Value) : LocalValue
-    {
-        public record RegExpValue(string Pattern)
-        {
-            public string? Flags { get; set; }
-        }
-    }
-
-    public record Set(IEnumerable<LocalValue> Value) : LocalValue;
 }
+
+public abstract record PrimitiveProtocolLocalValue : LocalValue;
+
+public record NumberLocalValue(double Value) : PrimitiveProtocolLocalValue
+{
+    public static explicit operator NumberLocalValue(double n) => new NumberLocalValue(n);
+}
+
+public record StringLocalValue(string Value) : PrimitiveProtocolLocalValue;
+
+public record NullLocalValue : PrimitiveProtocolLocalValue;
+
+public record UndefinedLocalValue : PrimitiveProtocolLocalValue;
+
+public record ChannelLocalValue(ChannelLocalValue.ChannelProperties Value) : LocalValue
+{
+    // TODO: Revise why we need it
+    [JsonInclude]
+    internal string type = "channel";
+
+    public record ChannelProperties(Channel Channel)
+    {
+        public SerializationOptions? SerializationOptions { get; set; }
+
+        public ResultOwnership? Ownership { get; set; }
+    }
+}
+
+public record ArrayLocalValue(IEnumerable<LocalValue> Value) : LocalValue;
+
+public record DateLocalValue(string Value) : LocalValue;
+
+public record MapLocalValue(IEnumerable<IEnumerable<LocalValue>> Value) : LocalValue;
+
+public record ObjectLocalValue(IEnumerable<IEnumerable<LocalValue>> Value) : LocalValue;
+
+public record RegExpLocalValue(RegExpLocalValue.RegExpValue Value) : LocalValue
+{
+    public record RegExpValue(string Pattern)
+    {
+        public string? Flags { get; set; }
+    }
+}
+
+public record SetLocalValue(IEnumerable<LocalValue> Value) : LocalValue;

--- a/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
@@ -27,6 +27,7 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 [JsonDerivedType(typeof(StringLocalValue), "string")]
 [JsonDerivedType(typeof(NullLocalValue), "null")]
 [JsonDerivedType(typeof(UndefinedLocalValue), "undefined")]
+[JsonDerivedType(typeof(BooleanLocalValue), "boolean")]
 [JsonDerivedType(typeof(ChannelLocalValue), "channel")]
 [JsonDerivedType(typeof(ArrayLocalValue), "array")]
 [JsonDerivedType(typeof(DateLocalValue), "date")]
@@ -83,6 +84,8 @@ public record StringLocalValue(string Value) : PrimitiveProtocolLocalValue;
 public record NullLocalValue : PrimitiveProtocolLocalValue;
 
 public record UndefinedLocalValue : PrimitiveProtocolLocalValue;
+
+public record BooleanLocalValue(bool Value) : PrimitiveProtocolLocalValue;
 
 public record ChannelLocalValue(ChannelLocalValue.ChannelProperties Value) : LocalValue
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
@@ -37,7 +37,7 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 public abstract record LocalValue
 {
     public static implicit operator LocalValue(int value) { return new NumberLocalValue(value); }
-    public static implicit operator LocalValue(string value) { return new StringLocalValue(value); }
+    public static implicit operator LocalValue(string? value) { return value is null ? new NullLocalValue() : new StringLocalValue(value); }
 
     // TODO: Extend converting from types
     public static LocalValue ConvertFrom(object? value)

--- a/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/LocalValue.cs
@@ -28,6 +28,7 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 [JsonDerivedType(typeof(NullLocalValue), "null")]
 [JsonDerivedType(typeof(UndefinedLocalValue), "undefined")]
 [JsonDerivedType(typeof(BooleanLocalValue), "boolean")]
+[JsonDerivedType(typeof(BigIntLocalValue), "bigint")]
 [JsonDerivedType(typeof(ChannelLocalValue), "channel")]
 [JsonDerivedType(typeof(ArrayLocalValue), "array")]
 [JsonDerivedType(typeof(DateLocalValue), "date")]
@@ -86,6 +87,8 @@ public record NullLocalValue : PrimitiveProtocolLocalValue;
 public record UndefinedLocalValue : PrimitiveProtocolLocalValue;
 
 public record BooleanLocalValue(bool Value) : PrimitiveProtocolLocalValue;
+
+public record BigIntLocalValue(string Value) : PrimitiveProtocolLocalValue;
 
 public record ChannelLocalValue(ChannelLocalValue.ChannelProperties Value) : LocalValue
 {

--- a/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
@@ -27,7 +27,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentUndefined()
     {
-        var arg = new LocalValue.Undefined();
+        var arg = new UndefinedLocalValue();
         Assert.That(async () =>
         {
             await context.Script.CallFunctionAsync($$"""
@@ -43,7 +43,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNull()
     {
-        var arg = new LocalValue.Null();
+        var arg = new NullLocalValue();
         Assert.That(async () =>
         {
             await context.Script.CallFunctionAsync($$"""
@@ -59,7 +59,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentEmptyString()
     {
-        var arg = new LocalValue.String(string.Empty);
+        var arg = new StringLocalValue(string.Empty);
         Assert.That(async () =>
         {
             await context.Script.CallFunctionAsync($$"""
@@ -75,7 +75,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNonEmptyString()
     {
-        var arg = new LocalValue.String("whoa");
+        var arg = new StringLocalValue("whoa");
         Assert.That(async () =>
         {
             await context.Script.CallFunctionAsync($$"""
@@ -93,7 +93,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     {
         const string PinnedDateTimeString = "2025-03-09T00:30:33.083Z";
 
-        var arg = new LocalValue.Date(PinnedDateTimeString);
+        var arg = new DateLocalValue(PinnedDateTimeString);
 
         Assert.That(async () =>
         {
@@ -112,7 +112,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     {
         const string EpochString = "1970-01-01T00:00:00.000Z";
 
-        var arg = new LocalValue.Date(EpochString);
+        var arg = new DateLocalValue(EpochString);
 
         Assert.That(async () =>
         {
@@ -129,7 +129,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberFive()
     {
-        var arg = new LocalValue.Number(5);
+        var arg = new NumberLocalValue(5);
 
         Assert.That(async () =>
         {
@@ -146,7 +146,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberNegativeFive()
     {
-        var arg = new LocalValue.Number(-5);
+        var arg = new NumberLocalValue(-5);
 
         Assert.That(async () =>
         {
@@ -163,7 +163,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberZero()
     {
-        var arg = new LocalValue.Number(0);
+        var arg = new NumberLocalValue(0);
 
         Assert.That(async () =>
         {
@@ -182,7 +182,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [IgnoreBrowser(Selenium.Browser.Chrome, "Chromium can't handle -0 argument as a number: https://github.com/w3c/webdriver-bidi/issues/887")]
     public void CanCallFunctionWithArgumentNumberNegativeZero()
     {
-        var arg = new LocalValue.Number(double.NegativeZero);
+        var arg = new NumberLocalValue(double.NegativeZero);
 
         Assert.That(async () =>
         {
@@ -199,7 +199,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberPositiveInfinity()
     {
-        var arg = new LocalValue.Number(double.PositiveInfinity);
+        var arg = new NumberLocalValue(double.PositiveInfinity);
 
         Assert.That(async () =>
         {
@@ -216,7 +216,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberNegativeInfinity()
     {
-        var arg = new LocalValue.Number(double.NegativeInfinity);
+        var arg = new NumberLocalValue(double.NegativeInfinity);
 
         Assert.That(async () =>
         {
@@ -233,7 +233,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentNumberNaN()
     {
-        var arg = new LocalValue.Number(double.NaN);
+        var arg = new NumberLocalValue(double.NaN);
         Assert.That(async () =>
         {
             await context.Script.CallFunctionAsync($$"""
@@ -249,7 +249,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentRegExp()
     {
-        var arg = new LocalValue.RegExp(new LocalValue.RegExp.RegExpValue("foo*") { Flags = "g" });
+        var arg = new RegExpLocalValue(new RegExpLocalValue.RegExpValue("foo*") { Flags = "g" });
 
         Assert.That(async () =>
         {
@@ -266,7 +266,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentArray()
     {
-        var arg = new LocalValue.Array([new LocalValue.String("hi")]);
+        var arg = new ArrayLocalValue([new StringLocalValue("hi")]);
 
         Assert.That(async () =>
         {
@@ -283,7 +283,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentObject()
     {
-        var arg = new LocalValue.Object([[new LocalValue.String("objKey"), new LocalValue.String("objValue")]]);
+        var arg = new ObjectLocalValue([[new StringLocalValue("objKey"), new StringLocalValue("objValue")]]);
 
         Assert.That(async () =>
         {
@@ -300,7 +300,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentMap()
     {
-        var arg = new LocalValue.Map([[new LocalValue.String("mapKey"), new LocalValue.String("mapValue")]]);
+        var arg = new MapLocalValue([[new StringLocalValue("mapKey"), new StringLocalValue("mapValue")]]);
 
         Assert.That(async () =>
         {
@@ -317,7 +317,7 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     [Test]
     public void CanCallFunctionWithArgumentSet()
     {
-        var arg = new LocalValue.Set([new LocalValue.String("setKey")]);
+        var arg = new SetLocalValue([new StringLocalValue("setKey")]);
 
         Assert.That(async () =>
         {

--- a/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
@@ -57,6 +57,22 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     }
 
     [Test]
+    public void CanCallFunctionWithArgumentBoolean()
+    {
+        var arg = new BooleanLocalValue(true);
+        Assert.That(async () =>
+        {
+            await context.Script.CallFunctionAsync($$"""
+            (arg) => {
+              if (arg !== true) {
+              throw new Error("Assert failed: " + arg);
+              }
+            }
+            """, false, new() { Arguments = [arg] });
+        }, Throws.Nothing);
+    }
+
+    [Test]
     public void CanCallFunctionWithArgumentEmptyString()
     {
         var arg = new StringLocalValue(string.Empty);

--- a/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionLocalValueTest.cs
@@ -73,6 +73,22 @@ class CallFunctionLocalValueTest : BiDiTestFixture
     }
 
     [Test]
+    public void CanCallFunctionWithArgumentBigInt()
+    {
+        var arg = new BigIntLocalValue("12345");
+        Assert.That(async () =>
+        {
+            await context.Script.CallFunctionAsync($$"""
+            (arg) => {
+              if (arg !== 12345n) {
+              throw new Error("Assert failed: " + arg);
+              }
+            }
+            """, false, new() { Arguments = [arg] });
+        }, Throws.Nothing);
+    }
+
+    [Test]
     public void CanCallFunctionWithArgumentEmptyString()
     {
         var arg = new StringLocalValue(string.Empty);

--- a/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
@@ -138,7 +138,7 @@ class CallFunctionParameterTest : BiDiTestFixture
     [Test]
     public async Task CanCallFunctionWithThisParameter()
     {
-        var thisParameter = new LocalValue.Object([["some_property", 42]]);
+        var thisParameter = new ObjectLocalValue([["some_property", 42]]);
 
         var res = await context.Script.CallFunctionAsync<int>("""
             function(){return this.some_property}

--- a/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
+++ b/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
@@ -110,7 +110,7 @@ class ScriptCommandsTest : BiDiTestFixture
     {
         var preloadScript = await bidi.Script.AddPreloadScriptAsync("(channel) => channel('will_be_send', 'will_be_ignored')", new()
         {
-            Arguments = [new LocalValue.Channel(new(new("channel_name")))]
+            Arguments = [new ChannelLocalValue(new(new("channel_name")))]
         });
 
         Assert.That(preloadScript, Is.Not.Null);
@@ -122,7 +122,7 @@ class ScriptCommandsTest : BiDiTestFixture
     {
         var preloadScript = await bidi.Script.AddPreloadScriptAsync("(channel) => channel('will_be_send', 'will_be_ignored')", new()
         {
-            Arguments = [new LocalValue.Channel(new(new("channel_name"))
+            Arguments = [new ChannelLocalValue(new(new("channel_name"))
             {
                 SerializationOptions = new()
                 {

--- a/dotnet/test/common/BiDi/Script/ScriptEventsTest.cs
+++ b/dotnet/test/common/BiDi/Script/ScriptEventsTest.cs
@@ -35,7 +35,7 @@ class ScriptEventsTest : BiDiTestFixture
 
         await context.Script.CallFunctionAsync("(channel) => channel('foo')", false, new()
         {
-            Arguments = [new LocalValue.Channel(new(new("channel_name")))]
+            Arguments = [new ChannelLocalValue(new(new("channel_name")))]
         });
 
         var message = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `LocalValue` nested types to standalone types for better extensibility.

- Updated all references to `LocalValue` nested types in codebase and tests.

- Improved type naming consistency by appending `LocalValue` to standalone types.

- Enhanced test coverage to validate changes in `LocalValue` type structure.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Updated JSON serialization to use standalone `LocalValue` types.</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AddPreloadScriptCommand.cs</strong><dd><code>Refactored <code>AddPreloadScriptCommand</code> to use standalone <code>LocalValue</code> types.</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-d3718b2df5eaea20784a7dc16e69eb3cb1dcd97e859fb9ccb72dcac4efc6cf17">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalValue.cs</strong><dd><code>Converted `LocalValue` nested types to standalone types.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-b2d3bd83230255db2e435ac34700a0af0595469211636058e6eb477107171b22">+44/-43</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>CallFunctionLocalValueTest.cs</strong><dd><code>Updated tests to validate standalone `LocalValue` types.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-30e71e855b2436173edf5ce35368b843613bc33c9601155c03f0a249d79ea27d">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CallFunctionParameterTest.cs</strong><dd><code>Adjusted tests for `LocalValue` type refactoring.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-2211a55aa8f7fbbe821213f4f0a771f85a33b7b639fc7bbe2e4bd38a48c85608">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScriptCommandsTest.cs</strong><dd><code>Modified tests to use refactored `LocalValue` types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-f556a10a263ca5a37c0ac56fc1c010d1defc3b1dc2d99ec62af45d8b31ae81a3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScriptEventsTest.cs</strong><dd><code>Updated event tests to reflect `LocalValue` type changes.</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15428/files#diff-80887b705f4f70b738b8ad11ff24e4ce6f04e3c95692ef05ad359b151d150607">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>