### PR TITLE
[dotnet] [bidi] Make `Locator` types as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
@@ -43,15 +43,15 @@ public record InnerTextLocator(string Value) : Locator
 {
     public bool? IgnoreCase { get; set; }
 
-    public MatchType? MatchType { get; set; }
+    public Match? MatchType { get; set; }
 
     public long? MaxDepth { get; set; }
+
+    public enum Match
+    {
+        Full,
+        Partial
+    }
 }
 
 public record XPathLocator(string Value) : Locator;
-
-public enum MatchType
-{
-    Full,
-    Partial
-}

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
@@ -22,34 +22,33 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Accessibility), "accessibility")]
-[JsonDerivedType(typeof(Css), "css")]
-[JsonDerivedType(typeof(InnerText), "innerText")]
-[JsonDerivedType(typeof(XPath), "xpath")]
-public abstract record Locator
+[JsonDerivedType(typeof(AccessibilityLocator), "accessibility")]
+[JsonDerivedType(typeof(CssLocator), "css")]
+[JsonDerivedType(typeof(InnerTextLocator), "innerText")]
+[JsonDerivedType(typeof(XPathLocator), "xpath")]
+public abstract record Locator;
+
+public record AccessibilityLocator(AccessibilityLocator.AccessibilityLocatorValue Value) : Locator
 {
-    public record Accessibility(Accessibility.AccessibilityValue Value) : Locator
+    public record AccessibilityLocatorValue
     {
-        public record AccessibilityValue
-        {
-            public string? Name { get; set; }
-            public string? Role { get; set; }
-        }
+        public string? Name { get; set; }
+        public string? Role { get; set; }
     }
-
-    public record Css(string Value) : Locator;
-
-    public record InnerText(string Value) : Locator
-    {
-        public bool? IgnoreCase { get; set; }
-
-        public MatchType? MatchType { get; set; }
-
-        public long? MaxDepth { get; set; }
-    }
-
-    public record XPath(string Value) : Locator;
 }
+
+public record CssLocator(string Value) : Locator;
+
+public record InnerTextLocator(string Value) : Locator
+{
+    public bool? IgnoreCase { get; set; }
+
+    public MatchType? MatchType { get; set; }
+
+    public long? MaxDepth { get; set; }
+}
+
+public record XPathLocator(string Value) : Locator;
 
 public enum MatchType
 {

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs
@@ -24,6 +24,7 @@ namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(AccessibilityLocator), "accessibility")]
 [JsonDerivedType(typeof(CssLocator), "css")]
+[JsonDerivedType(typeof(ContextLocator), "context")]
 [JsonDerivedType(typeof(InnerTextLocator), "innerText")]
 [JsonDerivedType(typeof(XPathLocator), "xpath")]
 public abstract record Locator;
@@ -38,6 +39,11 @@ public record AccessibilityLocator(AccessibilityLocator.AccessibilityLocatorValu
 }
 
 public record CssLocator(string Value) : Locator;
+
+public record ContextLocator(ContextLocator.ContextLocatorValue Value) : Locator
+{
+    public record ContextLocatorValue(BrowsingContext Context);
+}
 
 public record InnerTextLocator(string Value) : Locator
 {

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
@@ -285,7 +285,7 @@ class BrowsingContextTest : BiDiTestFixture
     {
         await context.NavigateAsync(UrlBuilder.WhereIs("formPage.html"), new() { Wait = ReadinessState.Complete });
 
-        var nodes = await context.LocateNodesAsync(new Locator.Css("#checky"));
+        var nodes = await context.LocateNodesAsync(new CssLocator("#checky"));
 
         var screenshot = await context.CaptureScreenshotAsync(new()
         {

--- a/dotnet/test/common/BiDi/Input/CombinedInputActionsTest.cs
+++ b/dotnet/test/common/BiDi/Input/CombinedInputActionsTest.cs
@@ -61,7 +61,7 @@ class CombinedInputActionsTest : BiDiTestFixture
     {
         driver.Url = UrlBuilder.WhereIs("formSelectionPage.html");
 
-        var options = await context.LocateNodesAsync(new Locator.Css("option"));
+        var options = await context.LocateNodesAsync(new CssLocator("option"));
 
         await context.Input.PerformActionsAsync([
             new PointerActions

--- a/dotnet/test/common/BiDi/Input/SetFilesTest.cs
+++ b/dotnet/test/common/BiDi/Input/SetFilesTest.cs
@@ -45,7 +45,7 @@ class SetFilesTest : BiDiTestFixture
     {
         driver.Url = UrlBuilder.WhereIs("formPage.html");
 
-        var nodes = await context.LocateNodesAsync(new Locator.Css("[id='upload']"));
+        var nodes = await context.LocateNodesAsync(new CssLocator("[id='upload']"));
 
         await context.Input.SetFilesAsync(nodes[0], [_tempFile]);
 


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `Locator` types to non-nested classes for better extensibility.

- Updated `Locator` type references in test cases to new non-nested types.

- Simplified and clarified type definitions for `AccessibilityLocator`, `CssLocator`, `InnerTextLocator`, and `XPathLocator`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Locator.cs</strong><dd><code>Refactored `Locator` types to non-nested classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/Locator.cs

<li>Refactored <code>Locator</code> types to non-nested classes.<br> <li> Renamed nested types like <code>Locator.Css</code> to <code>CssLocator</code>.<br> <li> Simplified <code>AccessibilityLocator</code> and other related type definitions.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15429/files#diff-b8706f7b862f82312bfc44bdfaa18e28fc85364ca7ac838ea2d195ca542e2c7f">+19/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextTest.cs</strong><dd><code>Updated test to use new `CssLocator` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs

- Updated test to use `CssLocator` instead of `Locator.Css`.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15429/files#diff-d58d767e97992cac4904b1756e7ee957902d213a461b4bad2884378c8379e501">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CombinedInputActionsTest.cs</strong><dd><code>Updated test to use new `CssLocator` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Input/CombinedInputActionsTest.cs

- Updated test to use `CssLocator` instead of `Locator.Css`.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15429/files#diff-ba73199d528fb1226e0b4c3e86931764a59707505001c3623e781f3589f9ace0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SetFilesTest.cs</strong><dd><code>Updated test to use new `CssLocator` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Input/SetFilesTest.cs

- Updated test to use `CssLocator` instead of `Locator.Css`.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15429/files#diff-f8179c187e33db2d8248a03ed85a4a60ca9f762f51626ee0074f313f7b3cc637">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>