### PR TITLE
[dotnet] [bidi] Make `ClipRectangle` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -119,7 +119,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 
 [JsonSerializable(typeof(Modules.BrowsingContext.UserPromptOpenedEventArgs))]
 [JsonSerializable(typeof(Modules.BrowsingContext.UserPromptClosedEventArgs))]
-[JsonSerializable(typeof(Modules.BrowsingContext.Origin), TypeInfoPropertyName = "BrowsingContext_Origin")]
 
 [JsonSerializable(typeof(Modules.Network.BytesValue.String), TypeInfoPropertyName = "Network_BytesValue_String")]
 [JsonSerializable(typeof(Modules.Network.UrlPattern.String), TypeInfoPropertyName = "Network_UrlPattern_String")]

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
@@ -48,14 +48,13 @@ public record struct ImageFormat(string Type)
 }
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Box), "box")]
-[JsonDerivedType(typeof(Element), "element")]
-public abstract record ClipRectangle
-{
-    public record Box(double X, double Y, double Width, double Height) : ClipRectangle;
+[JsonDerivedType(typeof(BoxClipRectangle), "box")]
+[JsonDerivedType(typeof(ElementClipRectangle), "element")]
+public abstract record ClipRectangle;
 
-    public record Element([property: JsonPropertyName("element")] Script.ISharedReference SharedReference) : ClipRectangle;
-}
+public record BoxClipRectangle(double X, double Y, double Width, double Height) : ClipRectangle;
+
+public record ElementClipRectangle([property: JsonPropertyName("element")] Script.ISharedReference SharedReference) : ClipRectangle;
 
 public record CaptureScreenshotResult(string Data)
 {

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
@@ -25,21 +25,21 @@ namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 internal class CaptureScreenshotCommand(CaptureScreenshotCommandParameters @params)
     : Command<CaptureScreenshotCommandParameters>(@params, "browsingContext.captureScreenshot");
 
-internal record CaptureScreenshotCommandParameters(BrowsingContext Context, Origin? Origin, ImageFormat? Format, ClipRectangle? Clip) : CommandParameters;
+internal record CaptureScreenshotCommandParameters(BrowsingContext Context, CaptureScreenshotOptions.ScreenshotOrigin? Origin, ImageFormat? Format, ClipRectangle? Clip) : CommandParameters;
 
 public record CaptureScreenshotOptions : CommandOptions
 {
-    public Origin? Origin { get; set; }
+    public ScreenshotOrigin? Origin { get; set; }
 
     public ImageFormat? Format { get; set; }
 
     public ClipRectangle? Clip { get; set; }
-}
 
-public enum Origin
-{
-    Viewport,
-    Document
+    public enum ScreenshotOrigin
+    {
+        Viewport,
+        Document
+    }
 }
 
 public record struct ImageFormat(string Type)

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
@@ -260,7 +260,7 @@ class BrowsingContextTest : BiDiTestFixture
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
             Origin = Origin.Document,
-            Clip = new ClipRectangle.Box(5, 5, 10, 10)
+            Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 
         Assert.That(screenshot, Is.Not.Null);
@@ -273,7 +273,7 @@ class BrowsingContextTest : BiDiTestFixture
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
             Origin = Origin.Viewport,
-            Clip = new ClipRectangle.Box(5, 5, 10, 10)
+            Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 
         Assert.That(screenshot, Is.Not.Null);
@@ -289,7 +289,7 @@ class BrowsingContextTest : BiDiTestFixture
 
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
-            Clip = new ClipRectangle.Element(nodes[0])
+            Clip = new ElementClipRectangle(nodes[0])
         });
 
         Assert.That(screenshot, Is.Not.Null);

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
@@ -259,7 +259,7 @@ class BrowsingContextTest : BiDiTestFixture
     {
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
-            Origin = Origin.Document,
+            Origin = CaptureScreenshotOptions.ScreenshotOrigin.Document,
             Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 
@@ -272,7 +272,7 @@ class BrowsingContextTest : BiDiTestFixture
     {
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
-            Origin = Origin.Viewport,
+            Origin = CaptureScreenshotOptions.ScreenshotOrigin.Viewport,
             Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `ClipRectangle` to remove nested DTO types.
  - Introduced `BoxClipRectangle` and `ElementClipRectangle` as standalone types.

- Updated test cases to use new standalone DTO types.

- Improved code clarity and maintainability by avoiding nested types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaptureScreenshotCommand.cs</strong><dd><code>Refactored `ClipRectangle` to standalone DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs

<li>Replaced nested <code>ClipRectangle</code> types with standalone types.<br> <li> Introduced <code>BoxClipRectangle</code> and <code>ElementClipRectangle</code>.<br> <li> Updated JSON polymorphic type annotations for new types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15431/files#diff-476acfd0b3ac522476d73fd60def6ca1dc5f6d4c36601eaa32ad428c5fece14c">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextTest.cs</strong><dd><code>Updated tests for new standalone DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs

<li>Updated test cases to use <code>BoxClipRectangle</code> and <code>ElementClipRectangle</code>.<br> <li> Replaced references to nested <code>ClipRectangle</code> types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15431/files#diff-d58d767e97992cac4904b1756e7ee957902d213a461b4bad2884378c8379e501">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>