### PR TITLE
[dotnet] [bidi] Make `LogEntry` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -66,8 +66,8 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.Script.RealmInfo.AudioWorklet))]
 [JsonSerializable(typeof(Modules.Script.RealmInfo.Worklet))]
 
-[JsonSerializable(typeof(Modules.Log.Entry.Console))]
-[JsonSerializable(typeof(Modules.Log.Entry.Javascript))]
+[JsonSerializable(typeof(Modules.Log.ConsoleLogEntry))]
+[JsonSerializable(typeof(Modules.Log.JavascriptLogEntry))]
 #endregion
 
 [JsonSerializable(typeof(Command))]
@@ -157,7 +157,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.Script.RealmDestroyedEventArgs))]
 [JsonSerializable(typeof(IReadOnlyList<Modules.Script.RealmInfo>))]
 
-[JsonSerializable(typeof(Modules.Log.Entry))]
+[JsonSerializable(typeof(Modules.Log.LogEntry))]
 
 [JsonSerializable(typeof(Modules.Storage.GetCookiesCommand))]
 [JsonSerializable(typeof(Modules.Storage.GetCookiesResult))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/LogEntryConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/LogEntryConverter.cs
@@ -25,21 +25,21 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Communication.Json.Converters.Polymorphic;
 
 // https://github.com/dotnet/runtime/issues/72604
-internal class LogEntryConverter : JsonConverter<Modules.Log.Entry>
+internal class LogEntryConverter : JsonConverter<Modules.Log.LogEntry>
 {
-    public override Modules.Log.Entry? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override Modules.Log.LogEntry? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var jsonDocument = JsonDocument.ParseValue(ref reader);
 
         return jsonDocument.RootElement.GetProperty("type").ToString() switch
         {
-            "console" => jsonDocument.Deserialize<Modules.Log.Entry.Console>(options),
-            "javascript" => jsonDocument.Deserialize<Modules.Log.Entry.Javascript>(options),
+            "console" => jsonDocument.Deserialize<ConsoleLogEntry>(options),
+            "javascript" => jsonDocument.Deserialize<JavascriptLogEntry>(options),
             _ => null,
         };
     }
 
-    public override void Write(Utf8JsonWriter writer, Modules.Log.Entry value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, Modules.Log.LogEntry value, JsonSerializerOptions options)
     {
         throw new NotImplementedException();
     }

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextLogModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextLogModule.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 
 public class BrowsingContextLogModule(BrowsingContext context, LogModule logModule)
 {
-    public Task<Subscription> OnEntryAddedAsync(Func<Entry, Task> handler, SubscriptionOptions? options = null)
+    public Task<Subscription> OnEntryAddedAsync(Func<Log.LogEntry, Task> handler, SubscriptionOptions? options = null)
     {
         return logModule.OnEntryAddedAsync(async args =>
         {
@@ -36,7 +36,7 @@ public class BrowsingContextLogModule(BrowsingContext context, LogModule logModu
         }, options);
     }
 
-    public Task<Subscription> OnEntryAddedAsync(Action<Entry> handler, SubscriptionOptions? options = null)
+    public Task<Subscription> OnEntryAddedAsync(Action<Log.LogEntry> handler, SubscriptionOptions? options = null)
     {
         return logModule.OnEntryAddedAsync(args =>
         {

--- a/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
@@ -24,8 +24,8 @@ namespace OpenQA.Selenium.BiDi.Modules.Log;
 
 // https://github.com/dotnet/runtime/issues/72604
 //[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-//[JsonDerivedType(typeof(Console), "console")]
-//[JsonDerivedType(typeof(Javascript), "javascript")]
+//[JsonDerivedType(typeof(ConsoleLogEntry), "console")]
+//[JsonDerivedType(typeof(JavascriptLogEntry), "javascript")]
 public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
     : EventArgs(BiDi)
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
@@ -1,4 +1,4 @@
-// <copyright file="Entry.cs" company="Selenium Committers">
+// <copyright file="LogEntry.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -26,17 +26,17 @@ namespace OpenQA.Selenium.BiDi.Modules.Log;
 //[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 //[JsonDerivedType(typeof(Console), "console")]
 //[JsonDerivedType(typeof(Javascript), "javascript")]
-public abstract record Entry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
     : EventArgs(BiDi)
 {
     public Script.StackTrace? StackTrace { get; set; }
-
-    public record Console(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
-    : Entry(BiDi, Level, Source, Text, Timestamp);
-
-    public record Javascript(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
-        : Entry(BiDi, Level, Source, Text, Timestamp);
 }
+
+public record ConsoleLogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
+    : LogEntry(BiDi, Level, Source, Text, Timestamp);
+
+public record JavascriptLogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+    : LogEntry(BiDi, Level, Source, Text, Timestamp);
 
 public enum Level
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Log/LogModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Log/LogModule.cs
@@ -25,12 +25,12 @@ namespace OpenQA.Selenium.BiDi.Modules.Log;
 
 public sealed class LogModule(Broker broker) : Module(broker)
 {
-    public async Task<Subscription> OnEntryAddedAsync(Func<Entry, Task> handler, SubscriptionOptions? options = null)
+    public async Task<Subscription> OnEntryAddedAsync(Func<LogEntry, Task> handler, SubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("log.entryAdded", handler, options).ConfigureAwait(false);
     }
 
-    public async Task<Subscription> OnEntryAddedAsync(Action<Entry> handler, SubscriptionOptions? options = null)
+    public async Task<Subscription> OnEntryAddedAsync(Action<LogEntry> handler, SubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("log.entryAdded", handler, options).ConfigureAwait(false);
     }

--- a/dotnet/test/common/BiDi/Log/LogTest.cs
+++ b/dotnet/test/common/BiDi/Log/LogTest.cs
@@ -29,7 +29,7 @@ class LogTest : BiDiTestFixture
     [Test]
     public async Task CanListenToConsoleLog()
     {
-        TaskCompletionSource<Entry> tcs = new();
+        TaskCompletionSource<Modules.Log.LogEntry> tcs = new();
 
         await using var subscription = await context.Log.OnEntryAddedAsync(tcs.SetResult);
 
@@ -44,9 +44,9 @@ class LogTest : BiDiTestFixture
         Assert.That(logEntry.Source.Realm, Is.Not.Null);
         Assert.That(logEntry.Text, Is.EqualTo("Hello, world!"));
         Assert.That(logEntry.Level, Is.EqualTo(Level.Info));
-        Assert.That(logEntry, Is.AssignableFrom<Entry.Console>());
+        Assert.That(logEntry, Is.AssignableFrom<ConsoleLogEntry>());
 
-        var consoleLogEntry = logEntry as Entry.Console;
+        var consoleLogEntry = logEntry as ConsoleLogEntry;
 
         Assert.That(consoleLogEntry.Method, Is.EqualTo("log"));
 
@@ -58,7 +58,7 @@ class LogTest : BiDiTestFixture
     [Test]
     public async Task CanListenToJavascriptLog()
     {
-        TaskCompletionSource<Entry> tcs = new();
+        TaskCompletionSource<Modules.Log.LogEntry> tcs = new();
 
         await using var subscription = await context.Log.OnEntryAddedAsync(tcs.SetResult);
 
@@ -73,13 +73,13 @@ class LogTest : BiDiTestFixture
         Assert.That(logEntry.Source.Realm, Is.Not.Null);
         Assert.That(logEntry.Text, Is.EqualTo("Error: Not working"));
         Assert.That(logEntry.Level, Is.EqualTo(Level.Error));
-        Assert.That(logEntry, Is.AssignableFrom<Entry.Javascript>());
+        Assert.That(logEntry, Is.AssignableFrom<JavascriptLogEntry>());
     }
 
     [Test]
     public async Task CanRetrieveStacktrace()
     {
-        TaskCompletionSource<Entry> tcs = new();
+        TaskCompletionSource<Modules.Log.LogEntry> tcs = new();
 
         await using var subscription = await bidi.Log.OnEntryAddedAsync(tcs.SetResult);
 

--- a/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
+++ b/dotnet/test/common/BiDi/Script/ScriptCommandsTest.cs
@@ -93,7 +93,7 @@ class ScriptCommandsTest : BiDiTestFixture
 
         Assert.That(preloadScript, Is.Not.Null);
 
-        TaskCompletionSource<Modules.Log.Entry> tcs = new();
+        TaskCompletionSource<Modules.Log.LogEntry> tcs = new();
 
         await context.Log.OnEntryAddedAsync(tcs.SetResult);
 


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored nested DTO types to standalone classes for better extensibility.

- Updated `LogEntry` and related types to standalone classes.

- Adjusted JSON serialization and deserialization logic for new class structure.

- Updated tests to align with refactored `LogEntry` structure.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Updated JSON serialization for refactored `LogEntry` types</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogEntryConverter.cs</strong><dd><code>Adjusted polymorphic converter for `LogEntry` refactor</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-573d86ca0ef4e4549d1540bcb3d744b2e56e66c49daef7758ab5232ee50aa8c8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BrowsingContextLogModule.cs</strong><dd><code>Updated method signatures to use new `LogEntry` types</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-fb5f1c3153431260ba2776a4e583f3fe3517561d328c1b5b2e1dcafdded7c35a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogEntry.cs</strong><dd><code>Refactored `Entry` and nested types to standalone `LogEntry` classes</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-4b9875950fb3e46b82d0ee93e78c35eec6750f42ba48da0202118a824e4be150">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogModule.cs</strong><dd><code>Updated `LogModule` to use refactored `LogEntry` types</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-8032237204046f006c93e0aff8a1efacf3e658d237a96346c53a3accbe22f3ba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>LogTest.cs</strong><dd><code>Updated tests to align with `LogEntry` refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-00ee3978523c9ccdf5eb11bd2171161adbdc2b681349ade936d258cb394ec492">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScriptCommandsTest.cs</strong><dd><code>Adjusted script command tests for `LogEntry` changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15432/files#diff-f556a10a263ca5a37c0ac56fc1c010d1defc3b1dc2d99ec62af45d8b31ae81a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>