### PR TITLE
[dotnet] [bidi] Make `UrlPattern` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -122,7 +122,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.BrowsingContext.Origin), TypeInfoPropertyName = "BrowsingContext_Origin")]
 
 [JsonSerializable(typeof(Modules.Network.BytesValue.String), TypeInfoPropertyName = "Network_BytesValue_String")]
-[JsonSerializable(typeof(Modules.Network.UrlPattern.String), TypeInfoPropertyName = "Network_UrlPattern_String")]
 [JsonSerializable(typeof(Modules.Network.ContinueWithAuthParameters.Default), TypeInfoPropertyName = "Network_ContinueWithAuthParameters_Default")]
 [JsonSerializable(typeof(Modules.Network.AddInterceptCommand))]
 [JsonSerializable(typeof(Modules.Network.AddInterceptResult))]

--- a/dotnet/src/webdriver/BiDi/Modules/Network/UrlPattern.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/UrlPattern.cs
@@ -22,27 +22,24 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Pattern), "pattern")]
-[JsonDerivedType(typeof(String), "string")]
+[JsonDerivedType(typeof(PatternUrlPattern), "pattern")]
+[JsonDerivedType(typeof(StringUrlPattern), "string")]
 public abstract record UrlPattern
 {
-    public static implicit operator UrlPattern(string value) => new String(value);
-
-    public record Pattern : UrlPattern
-    {
-        public string? Protocol { get; set; }
-
-        public string? Hostname { get; set; }
-
-        public string? Port { get; set; }
-
-        public string? Pathname { get; set; }
-
-        public string? Search { get; set; }
-    }
-
-    public record String(string Pattern) : UrlPattern
-    {
-        public new string Pattern { get; } = Pattern;
-    }
+    public static implicit operator UrlPattern(string value) => new StringUrlPattern(value);
 }
+
+public record PatternUrlPattern : UrlPattern
+{
+    public string? Protocol { get; set; }
+
+    public string? Hostname { get; set; }
+
+    public string? Port { get; set; }
+
+    public string? Pathname { get; set; }
+
+    public string? Search { get; set; }
+}
+
+public record StringUrlPattern(string Pattern) : UrlPattern;

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -40,7 +40,7 @@ class NetworkTest : BiDiTestFixture
         await using var intercept = await bidi.Network.InterceptRequestAsync(e => Task.CompletedTask, new()
         {
             UrlPatterns = [
-                new UrlPattern.String("http://localhost:4444"),
+                new StringUrlPattern("http://localhost:4444"),
                 "http://localhost:4444/"
                 ]
         });
@@ -53,7 +53,7 @@ class NetworkTest : BiDiTestFixture
     {
         await using var intercept = await bidi.Network.InterceptRequestAsync(e => Task.CompletedTask, interceptOptions: new()
         {
-            UrlPatterns = [new UrlPattern.Pattern()
+            UrlPatterns = [new PatternUrlPattern()
             {
                 Hostname = "localhost",
                 Protocol = "http"


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `UrlPattern` to use non-nested types for better extensibility.

- Updated `UrlPattern` derived types to `PatternUrlPattern` and `StringUrlPattern`.

- Adjusted test cases to use the new non-nested `UrlPattern` types.

- Removed nested DTO type usage in `BiDiJsonSerializerContext`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Removed nested `UrlPattern.String` serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<li>Removed <code>JsonSerializable</code> attribute for nested <code>UrlPattern.String</code> type.<br> <li> Simplified serialization configuration by eliminating nested DTO <br>reference.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15434/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UrlPattern.cs</strong><dd><code>Refactored `UrlPattern` to non-nested derived types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Network/UrlPattern.cs

<li>Refactored <code>UrlPattern</code> to use non-nested derived types.<br> <li> Renamed <code>Pattern</code> to <code>PatternUrlPattern</code> and <code>String</code> to <code>StringUrlPattern</code>.<br> <li> Updated implicit operator to use <code>StringUrlPattern</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15434/files#diff-912a2fc11df5717e0ca2d59b85e3358f890270291a5123d56e3025bc600867c9">+13/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkTest.cs</strong><dd><code>Updated tests for non-nested `UrlPattern` types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkTest.cs

<li>Updated test cases to use <code>PatternUrlPattern</code> and <code>StringUrlPattern</code>.<br> <li> Replaced references to nested <code>UrlPattern</code> types with new non-nested <br>types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15434/files#diff-6e4fab225f6b53775948caadd4c88fda1f84c06dc51cc76412ca2a93e07dceb7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>