### PR TITLE
[dotnet] [bidi] Make `PartitionDescriptor` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextStorageModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextStorageModule.cs
@@ -28,7 +28,7 @@ public class BrowsingContextStorageModule(BrowsingContext context, StorageModule
     {
         options ??= new();
 
-        options.Partition = new PartitionDescriptor.Context(context);
+        options.Partition = new ContextPartitionDescriptor(context);
 
         return storageModule.GetCookiesAsync(options);
     }
@@ -37,7 +37,7 @@ public class BrowsingContextStorageModule(BrowsingContext context, StorageModule
     {
         options ??= new();
 
-        options.Partition = new PartitionDescriptor.Context(context);
+        options.Partition = new ContextPartitionDescriptor(context);
 
         var res = await storageModule.DeleteCookiesAsync(options).ConfigureAwait(false);
 
@@ -48,7 +48,7 @@ public class BrowsingContextStorageModule(BrowsingContext context, StorageModule
     {
         options ??= new();
 
-        options.Partition = new PartitionDescriptor.Context(context);
+        options.Partition = new ContextPartitionDescriptor(context);
 
         var res = await storageModule.SetCookieAsync(cookie, options).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
@@ -80,16 +80,15 @@ public class CookieFilter
 }
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Context), "context")]
-[JsonDerivedType(typeof(StorageKey), "storageKey")]
-public abstract record PartitionDescriptor
+[JsonDerivedType(typeof(ContextPartitionDescriptor), "context")]
+[JsonDerivedType(typeof(StorageKeyPartitionDescriptor), "storageKey")]
+public abstract record PartitionDescriptor;
+
+public record ContextPartitionDescriptor([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Descriptor) : PartitionDescriptor;
+
+public record StorageKeyPartitionDescriptor : PartitionDescriptor
 {
-    public record Context([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Descriptor) : PartitionDescriptor;
+    public string? UserContext { get; set; }
 
-    public record StorageKey : PartitionDescriptor
-    {
-        public string? UserContext { get; set; }
-
-        public string? SourceOrigin { get; set; }
-    }
+    public string? SourceOrigin { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
@@ -84,7 +84,7 @@ public class CookieFilter
 [JsonDerivedType(typeof(StorageKeyPartitionDescriptor), "storageKey")]
 public abstract record PartitionDescriptor;
 
-public record ContextPartitionDescriptor([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Descriptor) : PartitionDescriptor;
+public record ContextPartitionDescriptor(BrowsingContext.BrowsingContext Context) : PartitionDescriptor;
 
 public record StorageKeyPartitionDescriptor : PartitionDescriptor
 {


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `PartitionDescriptor` to avoid nested DTO types.

- Introduced `ContextPartitionDescriptor` and `StorageKeyPartitionDescriptor`.

- Updated usages of `PartitionDescriptor.Context` to `ContextPartitionDescriptor`.

- Improved code clarity and future extensibility by removing nested types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextStorageModule.cs</strong><dd><code>Updated `PartitionDescriptor` usage in BrowsingContext module</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextStorageModule.cs

<li>Replaced <code>PartitionDescriptor.Context</code> with <code>ContextPartitionDescriptor</code>.<br> <li> Updated method implementations to use the new descriptor.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15435/files#diff-d14cda32abe31569fb1f2a56d5128f2b0a76f6c178046c2c1182e3e9c10bdbac">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GetCookiesCommand.cs</strong><dd><code>Refactored `PartitionDescriptor` and added new descriptors</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs

<li>Refactored <code>PartitionDescriptor</code> to remove nested types.<br> <li> Added <code>ContextPartitionDescriptor</code> and <code>StorageKeyPartitionDescriptor</code>.<br> <li> Updated JSON polymorphic annotations for new descriptors.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15435/files#diff-46ef808477800a7c2761187b32b93fa5f04ac0cf6e83e11f8fb0a63142a509b8">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>