### PR TITLE
[dotnet] [bidi] Make script `Target` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -140,9 +140,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.Network.FetchErrorEventArgs))]
 [JsonSerializable(typeof(Modules.Network.AuthRequiredEventArgs))]
 
-[JsonSerializable(typeof(Modules.Script.Target.Realm), TypeInfoPropertyName = "Script_Target_Realm")]
-[JsonSerializable(typeof(Modules.Script.Target.Context), TypeInfoPropertyName = "Script_Target_Context")]
-
 [JsonSerializable(typeof(Modules.Script.AddPreloadScriptCommand))]
 [JsonSerializable(typeof(Modules.Script.AddPreloadScriptResult))]
 [JsonSerializable(typeof(Modules.Script.DisownCommand))]

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs
@@ -46,7 +46,7 @@ public class BrowsingContextScriptModule(BrowsingContext context, ScriptModule s
 
     public Task<EvaluateResult.Success> EvaluateAsync(string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
-        var contextTarget = new Target.Context(context);
+        var contextTarget = new ContextTarget(context);
 
         if (targetOptions is not null)
         {
@@ -65,7 +65,7 @@ public class BrowsingContextScriptModule(BrowsingContext context, ScriptModule s
 
     public Task<EvaluateResult.Success> CallFunctionAsync(string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
-        var contextTarget = new Target.Context(context);
+        var contextTarget = new ContextTarget(context);
 
         if (targetOptions is not null)
         {

--- a/dotnet/src/webdriver/BiDi/Modules/Script/Target.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/Target.cs
@@ -25,9 +25,9 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 [JsonDerivedType(typeof(ContextTarget))]
 public abstract record Target;
 
-public record RealmTarget([property: JsonPropertyName("realm")] Realm Target) : Target;
+public record RealmTarget(Realm Realm) : Target;
 
-public record ContextTarget([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Target) : Target
+public record ContextTarget(BrowsingContext.BrowsingContext Context) : Target
 {
     public string? Sandbox { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Modules/Script/Target.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/Target.cs
@@ -21,16 +21,15 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Modules.Script;
 
-[JsonDerivedType(typeof(Realm))]
-[JsonDerivedType(typeof(Context))]
-public abstract record Target
-{
-    public record Realm([property: JsonPropertyName("realm")] Script.Realm Target) : Target;
+[JsonDerivedType(typeof(RealmTarget))]
+[JsonDerivedType(typeof(ContextTarget))]
+public abstract record Target;
 
-    public record Context([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Target) : Target
-    {
-        public string? Sandbox { get; set; }
-    }
+public record RealmTarget([property: JsonPropertyName("realm")] Realm Target) : Target;
+
+public record ContextTarget([property: JsonPropertyName("context")] BrowsingContext.BrowsingContext Target) : Target
+{
+    public string? Sandbox { get; set; }
 }
 
 public class ContextTargetOptions

--- a/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
@@ -210,11 +210,11 @@ class CallFunctionParameterTest : BiDiTestFixture
 
         var realms = await bidi.Script.GetRealmsAsync();
 
-        await bidi.Script.CallFunctionAsync("() => { window.foo = 3; }", true, new Target.Realm(realms[0].Realm));
-        await bidi.Script.CallFunctionAsync("() => { window.foo = 5; }", true, new Target.Realm(realms[1].Realm));
+        await bidi.Script.CallFunctionAsync("() => { window.foo = 3; }", true, new RealmTarget(realms[0].Realm));
+        await bidi.Script.CallFunctionAsync("() => { window.foo = 5; }", true, new RealmTarget(realms[1].Realm));
 
-        var res1 = await bidi.Script.CallFunctionAsync<int>("() => window.foo", true, new Target.Realm(realms[0].Realm));
-        var res2 = await bidi.Script.CallFunctionAsync<int>("() => window.foo", true, new Target.Realm(realms[1].Realm));
+        var res1 = await bidi.Script.CallFunctionAsync<int>("() => window.foo", true, new RealmTarget(realms[0].Realm));
+        var res2 = await bidi.Script.CallFunctionAsync<int>("() => window.foo", true, new RealmTarget(realms[1].Realm));
 
         Assert.That(res1, Is.EqualTo(3));
         Assert.That(res2, Is.EqualTo(5));

--- a/dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs
+++ b/dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs
@@ -116,11 +116,11 @@ class EvaluateParametersTest : BiDiTestFixture
 
         var realms = await bidi.Script.GetRealmsAsync();
 
-        await bidi.Script.EvaluateAsync("window.foo = 3", true, new Target.Realm(realms[0].Realm));
-        await bidi.Script.EvaluateAsync("window.foo = 5", true, new Target.Realm(realms[1].Realm));
+        await bidi.Script.EvaluateAsync("window.foo = 3", true, new RealmTarget(realms[0].Realm));
+        await bidi.Script.EvaluateAsync("window.foo = 5", true, new RealmTarget(realms[1].Realm));
 
-        var res1 = await bidi.Script.EvaluateAsync<int>("window.foo", true, new Target.Realm(realms[0].Realm));
-        var res2 = await bidi.Script.EvaluateAsync<int>("window.foo", true, new Target.Realm(realms[1].Realm));
+        var res1 = await bidi.Script.EvaluateAsync<int>("window.foo", true, new RealmTarget(realms[0].Realm));
+        var res2 = await bidi.Script.EvaluateAsync<int>("window.foo", true, new RealmTarget(realms[1].Realm));
 
         Assert.That(res1, Is.EqualTo(3));
         Assert.That(res2, Is.EqualTo(5));


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored nested `Target` types into standalone types for better usability.

- Updated references to `Target.Context` and `Target.Realm` to `ContextTarget` and `RealmTarget`.

- Adjusted serialization attributes to reflect the new standalone types.

- Updated and validated test cases to use the new standalone types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Adjust serialization for standalone `Target` types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<li>Removed serialization attributes for nested <code>Target</code> types.<br> <li> Adjusted serialization to align with standalone types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15436/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextScriptModule.cs</strong><dd><code>Replace nested `Target.Context` with `ContextTarget`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs

<li>Replaced <code>Target.Context</code> with <code>ContextTarget</code> in method calls.<br> <li> Updated logic to use standalone <code>ContextTarget</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15436/files#diff-22b8fd1cae01d6e99f522989e76b88a7171b7549a995b53b1a57839d804409f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Target.cs</strong><dd><code>Refactor `Target` into standalone types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/Target.cs

<li>Refactored <code>Target</code> into standalone <code>RealmTarget</code> and <code>ContextTarget</code>.<br> <li> Updated properties and structure for new types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15436/files#diff-c445f267ee8733aa714c2ca120fc2f593d096f3b055c3abe743c3dd19b20a5ab">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.cs</strong><dd><code>Update tests to use `RealmTarget`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs

<li>Updated test cases to use <code>RealmTarget</code> instead of <code>Target.Realm</code>.<br> <li> Validated functionality with new standalone types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15436/files#diff-2211a55aa8f7fbbe821213f4f0a771f85a33b7b639fc7bbe2e4bd38a48c85608">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateParametersTest.cs</strong><dd><code>Update tests to use `RealmTarget`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/EvaluateParametersTest.cs

<li>Updated test cases to use <code>RealmTarget</code> instead of <code>Target.Realm</code>.<br> <li> Validated functionality with new standalone types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15436/files#diff-8be27a9d0c3975df6c9e97783134da9a302a70cbe6cf351afa7f3a6605823862">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>