### PR TITLE
[dotnet] [bidi] Make input `Origin` as not nested

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/InputOriginConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/InputOriginConverter.cs
@@ -33,20 +33,20 @@ internal class InputOriginConverter : JsonConverter<Origin>
 
     public override void Write(Utf8JsonWriter writer, Origin value, JsonSerializerOptions options)
     {
-        if (value is Origin.Viewport)
+        if (value is ViewportOrigin)
         {
             writer.WriteStringValue("viewport");
         }
-        else if (value is Origin.Pointer)
+        else if (value is PointerOrigin)
         {
             writer.WriteStringValue("pointer");
         }
-        else if (value is Origin.Element element)
+        else if (value is ElementOrigin element)
         {
             writer.WriteStartObject();
             writer.WriteString("type", "element");
             writer.WritePropertyName("element");
-            JsonSerializer.Serialize(writer, element.SharedReference, options);
+            JsonSerializer.Serialize(writer, element.Element, options);
             writer.WriteEndObject();
         }
     }

--- a/dotnet/src/webdriver/BiDi/Modules/Input/Origin.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Input/Origin.cs
@@ -21,14 +21,14 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Modules.Input;
 
-public abstract record Origin
+public abstract record Origin;
+
+public record ViewportOrigin() : Origin;
+
+public record PointerOrigin() : Origin;
+
+public record ElementOrigin(Script.ISharedReference Element) : Origin
 {
-    public record Viewport() : Origin;
-
-    public record Pointer() : Origin;
-
-    public record Element([property: JsonPropertyName("element")] Script.ISharedReference SharedReference) : Origin
-    {
-        public string Type { get; } = "element";
-    }
+    [JsonInclude]
+    internal string Type { get; } = "element";
 }

--- a/dotnet/src/webdriver/BiDi/Modules/Input/Origin.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Input/Origin.cs
@@ -17,8 +17,6 @@
 // under the License.
 // </copyright>
 
-using System.Text.Json.Serialization;
-
 namespace OpenQA.Selenium.BiDi.Modules.Input;
 
 public abstract record Origin;
@@ -27,8 +25,4 @@ public record ViewportOrigin() : Origin;
 
 public record PointerOrigin() : Origin;
 
-public record ElementOrigin(Script.ISharedReference Element) : Origin
-{
-    [JsonInclude]
-    internal string Type { get; } = "element";
-}
+public record ElementOrigin(Script.ISharedReference Element) : Origin;


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored nested `Origin` types to standalone types.

- Updated JSON serialization logic for new `Origin` types.

- Improved code clarity by renaming and restructuring classes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InputOriginConverter.cs</strong><dd><code>Update JSON serialization for refactored `Origin` types</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/Converters/InputOriginConverter.cs

<li>Replaced checks for nested <code>Origin</code> types with standalone types.<br> <li> Updated JSON serialization logic to align with new type structure.<br> <li> Adjusted property serialization for <code>ElementOrigin</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15445/files#diff-70473794aeaad646b698089e2c36cf04f247d0558795dcfe72b3de26a84f0c70">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Origin.cs</strong><dd><code>Refactor `Origin` nested types into standalone records</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Input/Origin.cs

<li>Refactored <code>Origin</code> nested types into standalone records.<br> <li> Renamed <code>Viewport</code>, <code>Pointer</code>, and <code>Element</code> to <code>ViewportOrigin</code>, <br><code>PointerOrigin</code>, and <code>ElementOrigin</code>.<br> <li> Adjusted <code>ElementOrigin</code> to include <code>Type</code> property with internal <br>visibility.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15445/files#diff-0a8861b74af8ad42ee91e3486cc157757485f36664edd6780704e4c6e772ba26">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>