### PR TITLE
[py] Always set websocket-port when starting geckodriver

### DIFF
--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -58,9 +58,8 @@ class Service(service.Service):
         )
 
         # Set a port for CDP
-        if "--connect-existing" not in self.service_args:
-            self.service_args.append("--websocket-port")
-            self.service_args.append(f"{utils.free_port()}")
+        self.service_args.append("--websocket-port")
+        self.service_args.append(f"{utils.free_port()}")
 
     def command_line_args(self) -> List[str]:
         return ["--port", f"{self.port}"] + self.service_args


### PR DESCRIPTION
### **User description**
### Motivation and Context

This PR changes the Firefox `Service` class so it always passes the `--websocket-port` arg when starting geckodriver. The port is chosen automatically. Previously, it was only set when the `--connect-existing` flag was present.

This is related to #15451

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Always set `--websocket-port` when starting geckodriver.

- Remove conditional check for `--connect-existing` flag.

- Ensure consistent port assignment for CDP connections.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Ensure consistent `--websocket-port` assignment in Firefox service</code></dd></summary>
<hr>

py/selenium/webdriver/firefox/service.py

<li>Removed conditional check for <code>--connect-existing</code> flag.<br> <li> Always append <code>--websocket-port</code> and assign a free port.<br> <li> Simplified logic for setting CDP port.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15452/files#diff-1e444af73ad0e1c989ee6c2b0e03dd257071fe4a165e450a23bd86bea7d26323">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>