### PR TITLE
[build] allow tests tagged exclusive-if-local to run on rbe

### DIFF
--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -31,7 +31,7 @@ build:rbe --disk_cache=
 build:rbe --incompatible_enable_cc_toolchain_resolution
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 test:rbe --test_env=DISPLAY=:99.0
-test:rbe --test_tag_filters=-exclusive-if-local,-skip-rbe,-remote
+test:rbe --test_tag_filters=-skip-rbe,-remote
 
 # Env vars we can hard code
 build:rbe --action_env=HOME=/home/dev


### PR DESCRIPTION
### **User description**
Many Ruby BiDI and DevTools tests are tagged as `exclusive-if-local`, which are currently prevented from running on RBE, so there are tests that haven't been running that are failing.

As I understand that tag, it means it shouldn't run in parallel with other tests on the same machine. Since I don't think that happens on EngFlow, I *think* it should be ok to run these tests on RBE. @shs96c let me know what I'm missing with this.

We should also figure out how to make sure that all tests that are skipped on RBE in any of the bindings are being run on GitHub Actions runners.

At the very least this PR will let us make sure that the Ruby tests we have are all passing.


___

### **PR Type**
enhancement


___

### **Description**
- Modified `.bazelrc.remote` to allow tests tagged `exclusive-if-local` to run on RBE.

- Removed `exclusive-if-local` from the `test_tag_filters` for remote testing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.bazelrc.remote</strong><dd><code>Update `.bazelrc.remote` test configurations for RBE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.bazelrc.remote

<li>Removed <code>exclusive-if-local</code> from <code>test_tag_filters</code> under <code>test:remote</code>.<br> <li> Adjusted test configuration to allow specific tests to run on RBE.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15483/files#diff-81c4b7362f2e859c22b1d4cbe205f550889ee1aa9a0999552a385ab643ee1451">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>