### PR TITLE
[dotnet] [bidi] Decouple ScreenshotOrigin in BrowsingContext module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 internal class CaptureScreenshotCommand(CaptureScreenshotCommandParameters @params)
     : Command<CaptureScreenshotCommandParameters>(@params, "browsingContext.captureScreenshot");
 
-internal record CaptureScreenshotCommandParameters(BrowsingContext Context, CaptureScreenshotOptions.ScreenshotOrigin? Origin, ImageFormat? Format, ClipRectangle? Clip) : CommandParameters;
+internal record CaptureScreenshotCommandParameters(BrowsingContext Context, ScreenshotOrigin? Origin, ImageFormat? Format, ClipRectangle? Clip) : CommandParameters;
 
 public record CaptureScreenshotOptions : CommandOptions
 {
@@ -34,12 +34,12 @@ public record CaptureScreenshotOptions : CommandOptions
     public ImageFormat? Format { get; set; }
 
     public ClipRectangle? Clip { get; set; }
+}
 
-    public enum ScreenshotOrigin
-    {
-        Viewport,
-        Document
-    }
+public enum ScreenshotOrigin
+{
+    Viewport,
+    Document
 }
 
 public record struct ImageFormat(string Type)

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
@@ -259,7 +259,7 @@ class BrowsingContextTest : BiDiTestFixture
     {
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
-            Origin = CaptureScreenshotOptions.ScreenshotOrigin.Document,
+            Origin = ScreenshotOrigin.Document,
             Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 
@@ -272,7 +272,7 @@ class BrowsingContextTest : BiDiTestFixture
     {
         var screenshot = await context.CaptureScreenshotAsync(new()
         {
-            Origin = CaptureScreenshotOptions.ScreenshotOrigin.Viewport,
+            Origin = ScreenshotOrigin.Viewport,
             Clip = new BoxClipRectangle(5, 5, 10, 10)
         });
 


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Decoupled `ScreenshotOrigin` from `CaptureScreenshotOptions` to avoid nested DTO types.

- Updated `CaptureScreenshotCommandParameters` to use the new `ScreenshotOrigin` enum.

- Refactored related test cases to align with the new structure.

- Improved code clarity and future extensibility by removing nested types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaptureScreenshotCommand.cs</strong><dd><code>Decoupled `ScreenshotOrigin` from `CaptureScreenshotOptions`</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs

<li>Replaced nested <code>CaptureScreenshotOptions.ScreenshotOrigin</code> with a <br>standalone <code>ScreenshotOrigin</code> enum.<br> <li> Updated <code>CaptureScreenshotCommandParameters</code> to use the standalone <br><code>ScreenshotOrigin</code>.<br> <li> Improved modularity by decoupling nested types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15488/files#diff-476acfd0b3ac522476d73fd60def6ca1dc5f6d4c36601eaa32ad428c5fece14c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextTest.cs</strong><dd><code>Updated tests for refactored `ScreenshotOrigin` usage</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs

<li>Updated test cases to use the standalone <code>ScreenshotOrigin</code> enum.<br> <li> Ensured compatibility with the refactored <br><code>CaptureScreenshotCommandParameters</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15488/files#diff-d58d767e97992cac4904b1756e7ee957902d213a461b4bad2884378c8379e501">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>