### PR TITLE
[dotnet] [bidi] Decouple WindowProxyProperties in Script module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/Script/RemoteValue.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/RemoteValue.cs
@@ -260,13 +260,11 @@ public record NodeRemoteValue : RemoteValue, ISharedReference
     public NodeProperties? Value { get; internal set; }
 }
 
-public record WindowProxyRemoteValue(WindowProxyRemoteValue.Properties Value) : RemoteValue
+public record WindowProxyRemoteValue(WindowProxyProperties Value) : RemoteValue
 {
     public Handle? Handle { get; set; }
 
     public InternalId? InternalId { get; set; }
-
-    public record Properties(BrowsingContext.BrowsingContext Context);
 }
 
 public abstract record PrimitiveProtocolRemoteValue : RemoteValue;

--- a/dotnet/src/webdriver/BiDi/Modules/Script/WindowProxyProperties.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/WindowProxyProperties.cs
@@ -1,0 +1,22 @@
+// <copyright file="WindowProxyProperties.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+namespace OpenQA.Selenium.BiDi.Modules.Script;
+
+public record WindowProxyProperties(BrowsingContext.BrowsingContext Context);


### PR DESCRIPTION
### **User description**
### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Decoupled `WindowProxyProperties` into a standalone class for better modularity.

- Replaced nested `Properties` record with `WindowProxyProperties` in `WindowProxyRemoteValue`.

- Improved code maintainability and future extensibility by avoiding nested DTO types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteValue.cs</strong><dd><code>Refactored `WindowProxyRemoteValue` to use standalone properties</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/RemoteValue.cs

<li>Replaced nested <code>Properties</code> record with <code>WindowProxyProperties</code>.<br> <li> Updated <code>WindowProxyRemoteValue</code> to use the new <code>WindowProxyProperties</code>.<br> <li> Removed the nested <code>Properties</code> record definition.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15490/files#diff-0aa418714ecf5cc03a9f8342f491b0fb0fabcf2af051815e9bf56136834e31e5">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WindowProxyProperties.cs</strong><dd><code>Introduced standalone `WindowProxyProperties` record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/WindowProxyProperties.cs

<li>Added a new standalone <code>WindowProxyProperties</code> record.<br> <li> Defined <code>Context</code> property within <code>WindowProxyProperties</code>.<br> <li> Included licensing and namespace details for the new file.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15490/files#diff-701f63cd91cf39cca623c49ca50caf7628502cc5352cb7dd0e9fc33325c427d9">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>