### PR TITLE
[dotnet] [bidi] Decouple AuthCredentials in Network module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/Network/AuthCredentials.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/AuthCredentials.cs
@@ -21,11 +21,10 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(Basic), "password")]
-public abstract record AuthCredentials
+public record AuthCredentials(string Username, string Password)
 {
-    public record Basic(string Username, string Password) : AuthCredentials;
+    [JsonInclude]
+    internal string Type { get; } = "password";
 }
 
 

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -163,7 +163,7 @@ class NetworkTest : BiDiTestFixture
         await using var intercept = await bidi.Network.InterceptAuthAsync(async e =>
         {
             //TODO Seems it would be better to have method which takes abstract options
-            await e.Request.Request.ContinueWithAuthAsync(new AuthCredentials.Basic("test", "test"));
+            await e.Request.Request.ContinueWithAuthAsync(new AuthCredentials("test", "test"));
         });
 
         await context.NavigateAsync(UrlBuilder.WhereIs("basicAuth"), new() { Wait = ReadinessState.Complete });


### PR DESCRIPTION
### **User description**
Following spec: https://w3c.github.io/webdriver-bidi/#type-network-AuthCredentials

### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `AuthCredentials` to a single record with properties.

- Removed nested `Basic` record and added `Type` property.

- Updated tests to use the new `AuthCredentials` structure.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthCredentials.cs</strong><dd><code>Refactor `AuthCredentials` to simplify structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Network/AuthCredentials.cs

<li>Refactored <code>AuthCredentials</code> to a single record with <code>Username</code> and <br><code>Password</code>.<br> <li> Removed nested <code>Basic</code> record.<br> <li> Added <code>Type</code> property with a default value of "password".


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15491/files#diff-2ad3a5b683e82ea14506dfc6d9837c50faf3a46c0669cec5b9159c65a251b48d">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkTest.cs</strong><dd><code>Update tests for refactored `AuthCredentials`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkTest.cs

<li>Updated test to use the new <code>AuthCredentials</code> structure.<br> <li> Replaced usage of <code>AuthCredentials.Basic</code> with <code>AuthCredentials</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15491/files#diff-6e4fab225f6b53775948caadd4c88fda1f84c06dc51cc76412ca2a93e07dceb7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>