### PR TITLE
[dotnet] [bidi] Decouple EvaluateResult in Script module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -27,8 +27,8 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(MessageError))]
 [JsonSerializable(typeof(MessageEvent))]
 
-[JsonSerializable(typeof(Modules.Script.EvaluateResult.Success))]
-[JsonSerializable(typeof(Modules.Script.EvaluateResult.Exception))]
+[JsonSerializable(typeof(Modules.Script.EvaluateResultSuccess))]
+[JsonSerializable(typeof(Modules.Script.EvaluateResultException))]
 
 [JsonSerializable(typeof(Modules.Script.NumberRemoteValue))]
 [JsonSerializable(typeof(Modules.Script.BooleanRemoteValue))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/EvaluateResultConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/EvaluateResultConverter.cs
@@ -33,8 +33,8 @@ internal class EvaluateResultConverter : JsonConverter<EvaluateResult>
 
         return jsonDocument.RootElement.GetProperty("type").ToString() switch
         {
-            "success" => jsonDocument.Deserialize<EvaluateResult.Success>(options),
-            "exception" => jsonDocument.Deserialize<EvaluateResult.Exception>(options),
+            "success" => jsonDocument.Deserialize<EvaluateResultSuccess>(options),
+            "exception" => jsonDocument.Deserialize<EvaluateResultException>(options),
             _ => null,
         };
     }

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs
@@ -44,7 +44,7 @@ public class BrowsingContextScriptModule(BrowsingContext context, ScriptModule s
         return await scriptModule.GetRealmsAsync(options).ConfigureAwait(false);
     }
 
-    public Task<EvaluateResult.Success> EvaluateAsync(string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public Task<EvaluateResultSuccess> EvaluateAsync(string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var contextTarget = new ContextTarget(context);
 
@@ -63,7 +63,7 @@ public class BrowsingContextScriptModule(BrowsingContext context, ScriptModule s
         return result.Result.ConvertTo<TResult>();
     }
 
-    public Task<EvaluateResult.Success> CallFunctionAsync(string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public Task<EvaluateResultSuccess> CallFunctionAsync(string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var contextTarget = new ContextTarget(context);
 

--- a/dotnet/src/webdriver/BiDi/Modules/Script/EvaluateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/EvaluateCommand.cs
@@ -37,16 +37,15 @@ public record EvaluateOptions : CommandOptions
 
 // https://github.com/dotnet/runtime/issues/72604
 //[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-//[JsonDerivedType(typeof(Success), "success")]
-//[JsonDerivedType(typeof(Exception), "exception")]
-public abstract record EvaluateResult
-{
-    public record Success(RemoteValue Result, Realm Realm) : EvaluateResult
-    {
-        public static implicit operator RemoteValue(Success success) => success.Result;
-    }
+//[JsonDerivedType(typeof(EvaluateResultSuccess), "success")]
+//[JsonDerivedType(typeof(EvaluateResultException), "exception")]
+public abstract record EvaluateResult;
 
-    public record Exception(ExceptionDetails ExceptionDetails, Realm Realm) : EvaluateResult;
+public record EvaluateResultSuccess(RemoteValue Result, Realm Realm) : EvaluateResult
+{
+    public static implicit operator RemoteValue(EvaluateResultSuccess success) => success.Result;
 }
+
+public record EvaluateResultException(ExceptionDetails ExceptionDetails, Realm Realm) : EvaluateResult;
 
 public record ExceptionDetails(long ColumnNumber, long LineNumber, StackTrace StackTrace, string Text);

--- a/dotnet/src/webdriver/BiDi/Modules/Script/ScriptEvaluateException.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/ScriptEvaluateException.cs
@@ -21,9 +21,9 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Script;
 
-public class ScriptEvaluateException(EvaluateResult.Exception evaluateResultException) : Exception
+public class ScriptEvaluateException(EvaluateResultException evaluateResultException) : Exception
 {
-    private readonly EvaluateResult.Exception _evaluateResultException = evaluateResultException;
+    private readonly EvaluateResultException _evaluateResultException = evaluateResultException;
 
     public string Text => _evaluateResultException.ExceptionDetails.Text;
 

--- a/dotnet/src/webdriver/BiDi/Modules/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/ScriptModule.cs
@@ -25,18 +25,18 @@ namespace OpenQA.Selenium.BiDi.Modules.Script;
 
 public sealed class ScriptModule(Broker broker) : Module(broker)
 {
-    public async Task<EvaluateResult.Success> EvaluateAsync(string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
+    public async Task<EvaluateResultSuccess> EvaluateAsync(string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
     {
         var @params = new EvaluateCommandParameters(expression, target, awaitPromise, options?.ResultOwnership, options?.SerializationOptions, options?.UserActivation);
 
         var result = await Broker.ExecuteCommandAsync<EvaluateCommand, EvaluateResult>(new EvaluateCommand(@params), options).ConfigureAwait(false);
 
-        if (result is EvaluateResult.Exception exp)
+        if (result is EvaluateResultException exp)
         {
             throw new ScriptEvaluateException(exp);
         }
 
-        return (EvaluateResult.Success)result;
+        return (EvaluateResultSuccess)result;
     }
 
     public async Task<TResult?> EvaluateAsync<TResult>(string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
@@ -46,18 +46,18 @@ public sealed class ScriptModule(Broker broker) : Module(broker)
         return result.Result.ConvertTo<TResult>();
     }
 
-    public async Task<EvaluateResult.Success> CallFunctionAsync(string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
+    public async Task<EvaluateResultSuccess> CallFunctionAsync(string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
     {
         var @params = new CallFunctionCommandParameters(functionDeclaration, awaitPromise, target, options?.Arguments, options?.ResultOwnership, options?.SerializationOptions, options?.This, options?.UserActivation);
 
         var result = await Broker.ExecuteCommandAsync<CallFunctionCommand, EvaluateResult>(new CallFunctionCommand(@params), options).ConfigureAwait(false);
 
-        if (result is EvaluateResult.Exception exp)
+        if (result is EvaluateResultException exp)
         {
             throw new ScriptEvaluateException(exp);
         }
 
-        return (EvaluateResult.Success)result;
+        return (EvaluateResultSuccess)result;
     }
 
     public async Task<TResult?> CallFunctionAsync<TResult>(string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)


### PR DESCRIPTION
### **User description**
Following spec https://w3c.github.io/webdriver-bidi/#type-script-EvaluateResult

I chose `EvaluateResultSuccess` instead of commonly used `SuccessEvaluateResult`, preferred the same in spec.

### Motivation and Context
Contributes to https://github.com/SeleniumHQ/selenium/issues/15407

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced nested DTO types with standalone types for better extensibility.

- Updated `EvaluateResult` structure to use `EvaluateResultSuccess` and `EvaluateResultException`.

- Adjusted serialization and deserialization logic to align with new DTO structure.

- Refactored related methods and exception handling to use updated DTO types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Updated JSON serialization for new DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<li>Replaced nested DTO types with standalone types in JSON serialization.<br> <li> Updated references to <code>EvaluateResultSuccess</code> and <br><code>EvaluateResultException</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateResultConverter.cs</strong><dd><code>Updated deserialization logic for new DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/EvaluateResultConverter.cs

<li>Adjusted deserialization logic to handle new standalone DTO types.<br> <li> Replaced nested type references with <code>EvaluateResultSuccess</code> and <br><code>EvaluateResultException</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-2b4700f9d83b3c890a0eac145398021e0ab430758d441156ab88f84ba40ff2cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextScriptModule.cs</strong><dd><code>Refactored methods to use new DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextScriptModule.cs

<li>Updated method signatures to use <code>EvaluateResultSuccess</code>.<br> <li> Refactored calls to align with new DTO structure.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-22b8fd1cae01d6e99f522989e76b88a7171b7549a995b53b1a57839d804409f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateCommand.cs</strong><dd><code>Refactored EvaluateCommand to use standalone DTOs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/EvaluateCommand.cs

<li>Replaced nested <code>EvaluateResult</code> types with standalone <br><code>EvaluateResultSuccess</code> and <code>EvaluateResultException</code>.<br> <li> Updated implicit conversion logic for <code>EvaluateResultSuccess</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-2c814f092ccb5092dff7d4668b006c35c6353d2b400075225c699e446afd285d">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptEvaluateException.cs</strong><dd><code>Updated exception handling for new DTO structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/ScriptEvaluateException.cs

<li>Updated exception handling to use <code>EvaluateResultException</code>.<br> <li> Replaced nested type references with standalone DTO type.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-5872f5333a5a564b72e342a8a776d2f7d4959f54eb2c8f959718d05ca1e43106">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptModule.cs</strong><dd><code>Refactored ScriptModule methods for new DTO types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Script/ScriptModule.cs

<li>Refactored methods to use <code>EvaluateResultSuccess</code> and <br><code>EvaluateResultException</code>.<br> <li> Updated exception handling logic to align with new DTO structure.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15493/files#diff-9f5eefb2855c2156fe6f920c1444f437415e90fe97801f55062160b6ebd1c4d9">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>