### PR TITLE
[bazel + rust] Set the path to `selenium-manager` in tests based on the OS

### DIFF
--- a/rust/tests/BUILD.bazel
+++ b/rust/tests/BUILD.bazel
@@ -13,9 +13,10 @@ rust_test_suite(
         "//rust:selenium-manager",
     ],
     edition = "2021",
-    rustc_env = {
-        "CARGO_BIN_EXE_selenium-manager": "rust/selenium-manager",
-    },
+    rustc_env = select({
+      "//common:windows": {"CARGO_BIN_EXE_selenium-manager": "rust\\selenium-manager"},
+      "//conditions:default": {"CARGO_BIN_EXE_selenium-manager": "rust/selenium-manager"},
+    }),
     shared_srcs = glob(
         ["**/*.rs"],
         exclude = ["**/*_tests.rs"],


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Adjusted `CARGO_BIN_EXE_selenium-manager` path for OS compatibility.

- Used Bazel `select` to handle OS-specific paths.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Adjust `selenium-manager` path based on OS in Bazel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/tests/BUILD.bazel

<li>Replaced hardcoded <code>CARGO_BIN_EXE_selenium-manager</code> path with <br>OS-specific paths.<br> <li> Used Bazel <code>select</code> to differentiate between Windows and default <br>conditions.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15524/files#diff-233aea13fd1b2faa91856bff37261f41aa18079743a3537e9424f19eef727fe5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>