### PR TITLE
[java] Enable bidi support for Chrome and Firefox by default

### DIFF
--- a/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumOptions.java
@@ -67,6 +67,7 @@ public class ChromiumOptions<T extends ChromiumOptions<?>>
   public ChromiumOptions(String capabilityType, String browserType, String capability) {
     this.capabilityName = capability;
     setCapability(capabilityType, browserType);
+    enableBiDi();
   }
 
   /**

--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -66,6 +66,7 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     // will enable it.
     // https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/.
     addPreference("remote.active-protocols", 3);
+    enableBiDi();
   }
 
   public FirefoxOptions(Capabilities source) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enabled WebDriver BiDi support by default for Chrome.

- Enabled WebDriver BiDi support by default for Firefox.

- Updated constructors in `ChromiumOptions` and `FirefoxOptions` to include `enableBiDi` calls.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromiumOptions.java</strong><dd><code>Enable BiDi support by default in ChromiumOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/chromium/ChromiumOptions.java

<li>Added a call to <code>enableBiDi</code> in the constructor.<br> <li> Ensures BiDi support is enabled by default for Chromium-based <br>browsers.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15531/files#diff-4133f16d6f27fa85995d3806efc8a9a862f9a073ecbf16fb03fc3657bb2a586c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxOptions.java</strong><dd><code>Enable BiDi support by default in FirefoxOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/firefox/FirefoxOptions.java

<li>Added a call to <code>enableBiDi</code> in the default constructor.<br> <li> Ensures BiDi support is enabled by default for Firefox.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15531/files#diff-d011ae7f625544736a498af510308e81e40d69d9d85e7fee18c14aedc4ed4d9b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>