### PR TITLE
[dotnet] [bidi] Make ContinueWithAuthCommand closer to spec (breaking change)

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -120,7 +120,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Modules.BrowsingContext.UserPromptOpenedEventArgs))]
 [JsonSerializable(typeof(Modules.BrowsingContext.UserPromptClosedEventArgs))]
 
-[JsonSerializable(typeof(Modules.Network.ContinueWithAuthParameters.Default), TypeInfoPropertyName = "Network_ContinueWithAuthParameters_Default")]
 [JsonSerializable(typeof(Modules.Network.AddInterceptCommand))]
 [JsonSerializable(typeof(Modules.Network.AddInterceptResult))]
 [JsonSerializable(typeof(Modules.Network.ContinueRequestCommand))]

--- a/dotnet/src/webdriver/BiDi/Modules/Network/ContinueWithAuthCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/ContinueWithAuthCommand.cs
@@ -48,3 +48,4 @@ public record ContinueWithAuthNoCredentialsOptions : ContinueWithAuthOptions;
 public record ContinueWithAuthDefaultCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
 
 public record ContinueWithAuthCancelCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
+

--- a/dotnet/src/webdriver/BiDi/Modules/Network/ContinueWithAuthCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/ContinueWithAuthCommand.cs
@@ -26,20 +26,25 @@ internal class ContinueWithAuthCommand(ContinueWithAuthParameters @params)
     : Command<ContinueWithAuthParameters>(@params, "network.continueWithAuth");
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "action")]
-[JsonDerivedType(typeof(Credentials), "provideCredentials")]
-[JsonDerivedType(typeof(Default), "default")]
-[JsonDerivedType(typeof(Cancel), "cancel")]
-internal abstract record ContinueWithAuthParameters(Request Request) : CommandParameters
-{
-    internal record Credentials(Request Request, [property: JsonPropertyName("credentials")] AuthCredentials AuthCredentials) : ContinueWithAuthParameters(Request);
+[JsonDerivedType(typeof(ContinueWithAuthCredentials), "provideCredentials")]
+[JsonDerivedType(typeof(ContinueWithAuthDefaultCredentials), "default")]
+[JsonDerivedType(typeof(ContinueWithAuthCancelCredentials), "cancel")]
+internal abstract record ContinueWithAuthParameters(Request Request) : CommandParameters;
 
-    internal record Default(Request Request) : ContinueWithAuthParameters(Request);
+internal record ContinueWithAuthCredentials(Request Request, AuthCredentials Credentials) : ContinueWithAuthParameters(Request);
 
-    internal record Cancel(Request Request) : ContinueWithAuthParameters(Request);
-}
+internal abstract record ContinueWithAuthNoCredentials(Request Request) : ContinueWithAuthParameters(Request);
+
+internal record ContinueWithAuthDefaultCredentials(Request Request) : ContinueWithAuthNoCredentials(Request);
+
+internal record ContinueWithAuthCancelCredentials(Request Request) : ContinueWithAuthNoCredentials(Request);
 
 public record ContinueWithAuthOptions : CommandOptions;
 
-public record ContinueWithDefaultAuthOptions : CommandOptions;
+public record ContinueWithAuthCredentialsOptions : ContinueWithAuthOptions;
 
-public record ContinueWithCancelledAuthOptions : CommandOptions;
+public record ContinueWithAuthNoCredentialsOptions : ContinueWithAuthOptions;
+
+public record ContinueWithAuthDefaultCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
+
+public record ContinueWithAuthCancelCredentialsOptions : ContinueWithAuthNoCredentialsOptions;

--- a/dotnet/src/webdriver/BiDi/Modules/Network/NetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/NetworkModule.cs
@@ -104,19 +104,19 @@ public sealed class NetworkModule(Broker broker) : Module(broker)
         await Broker.ExecuteCommandAsync(new ProvideResponseCommand(@params), options).ConfigureAwait(false);
     }
 
-    internal async Task ContinueWithAuthAsync(Request request, AuthCredentials credentials, ContinueWithAuthOptions? options = null)
+    internal async Task ContinueWithAuthAsync(Request request, AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null)
     {
-        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthParameters.Credentials(request, credentials)), options).ConfigureAwait(false);
+        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCredentials(request, credentials)), options).ConfigureAwait(false);
     }
 
-    internal async Task ContinueWithAuthAsync(Request request, ContinueWithDefaultAuthOptions? options = null)
+    internal async Task ContinueWithAuthAsync(Request request, ContinueWithAuthDefaultCredentialsOptions? options = null)
     {
-        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthParameters.Default(request)), options).ConfigureAwait(false);
+        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthDefaultCredentials(request)), options).ConfigureAwait(false);
     }
 
-    internal async Task ContinueWithAuthAsync(Request request, ContinueWithCancelledAuthOptions? options = null)
+    internal async Task ContinueWithAuthAsync(Request request, ContinueWithAuthCancelCredentialsOptions? options = null)
     {
-        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthParameters.Cancel(request)), options).ConfigureAwait(false);
+        await Broker.ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCancelCredentials(request)), options).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnBeforeRequestSentAsync(Func<BeforeRequestSentEventArgs, Task> handler, SubscriptionOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/Modules/Network/Request.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/Request.cs
@@ -53,17 +53,17 @@ public class Request
         return _bidi.Network.ContinueResponseAsync(this, options);
     }
 
-    public Task ContinueWithAuthAsync(AuthCredentials credentials, ContinueWithAuthOptions? options = null)
+    public Task ContinueWithAuthAsync(AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null)
     {
         return _bidi.Network.ContinueWithAuthAsync(this, credentials, options);
     }
 
-    public Task ContinueWithAuthAsync(ContinueWithDefaultAuthOptions? options = null)
+    public Task ContinueWithAuthAsync(ContinueWithAuthDefaultCredentialsOptions? options = null)
     {
         return _bidi.Network.ContinueWithAuthAsync(this, options);
     }
 
-    public Task ContinueWithAuthAsync(ContinueWithCancelledAuthOptions? options = null)
+    public Task ContinueWithAuthAsync(ContinueWithAuthCancelCredentialsOptions? options = null)
     {
         return _bidi.Network.ContinueWithAuthAsync(this, options);
     }

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -162,7 +162,6 @@ class NetworkTest : BiDiTestFixture
     {
         await using var intercept = await bidi.Network.InterceptAuthAsync(async e =>
         {
-            //TODO Seems it would be better to have method which takes abstract options
             await e.Request.Request.ContinueWithAuthAsync(new AuthCredentials("test", "test"));
         });
 
@@ -177,7 +176,7 @@ class NetworkTest : BiDiTestFixture
     {
         await using var intercept = await bidi.Network.InterceptAuthAsync(async e =>
         {
-            await e.Request.Request.ContinueWithAuthAsync(new ContinueWithDefaultAuthOptions());
+            await e.Request.Request.ContinueWithAuthAsync(new ContinueWithAuthDefaultCredentialsOptions());
         });
 
         var action = async () => await context.NavigateAsync(UrlBuilder.WhereIs("basicAuth"), new() { Wait = ReadinessState.Complete });
@@ -191,7 +190,7 @@ class NetworkTest : BiDiTestFixture
     {
         await using var intercept = await bidi.Network.InterceptAuthAsync(async e =>
         {
-            await e.Request.Request.ContinueWithAuthAsync(new ContinueWithCancelledAuthOptions());
+            await e.Request.Request.ContinueWithAuthAsync(new ContinueWithAuthCancelCredentialsOptions());
         });
 
         var action = async () => await context.NavigateAsync(UrlBuilder.WhereIs("basicAuth"), new() { Wait = ReadinessState.Complete });


### PR DESCRIPTION
### **User description**
### Motivation and Context
Revisited `ContinueWithAuthCommand` to be closer with spec, fixes https://github.com/SeleniumHQ/selenium/issues/15539.
Also avoided nested types, opening the doors for static factory.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `ContinueWithAuth` method to align with BiDi spec.

- Introduced new classes for clearer type differentiation.

- Updated method overloads for better usability and clarity.

- Adjusted test cases to validate the refactored implementation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Simplified serialization context for network commands</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<li>Removed unused <code>JsonSerializable</code> type for <code>Default</code> action.<br> <li> Simplified serialization context for network commands.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15545/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContinueWithAuthCommand.cs</strong><dd><code>Refactored `ContinueWithAuthCommand` with clearer abstractions</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Network/ContinueWithAuthCommand.cs

<li>Replaced nested types with standalone records for clarity.<br> <li> Introduced <code>ContinueWithAuthNoCredentials</code> abstraction.<br> <li> Added specific records for <code>default</code> and <code>cancel</code> actions.<br> <li> Updated options classes to match new record structure.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15545/files#diff-d4716f8c44b5b3da03fd2c40b8174807013c8e2fd8f6c135e2690ec4c7f5e94c">+16/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkModule.cs</strong><dd><code>Updated `ContinueWithAuthAsync` method overloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Network/NetworkModule.cs

<li>Updated <code>ContinueWithAuthAsync</code> method overloads.<br> <li> Adjusted parameter types to match new record structure.<br> <li> Improved method naming for better alignment with spec.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15545/files#diff-b8dc6c026f6b7f6e4c904adabb414114d8cdfa731f9291c8edb8349fc1b90318">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Request.cs</strong><dd><code>Adjusted `Request` methods for refactored auth handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Network/Request.cs

<li>Updated <code>ContinueWithAuthAsync</code> calls to use new options classes.<br> <li> Improved method signatures for consistency with refactored commands.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15545/files#diff-5d8a9a93a3e6b9c9111c210822e02a1b6265d88e0a08956806b69a98678d5268">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkTest.cs</strong><dd><code>Updated tests for refactored `ContinueWithAuth` implementation</code></dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkTest.cs

<li>Updated test cases to use new options classes.<br> <li> Validated <code>ContinueWithAuth</code> behavior for all scenarios.<br> <li> Removed outdated comments for better clarity.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15545/files#diff-6e4fab225f6b53775948caadd4c88fda1f84c06dc51cc76412ca2a93e07dceb7">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>