### PR TITLE
[py] Fix driver class name in test fixtures

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -97,6 +97,17 @@ def pytest_ignore_collect(path, config):
     return len([d for d in _drivers if d.lower() in parts]) > 0
 
 
+def get_driver_class(driver_option):
+    """Generate the driver class name from the lowercase driver option"""
+    if driver_option == "webkitgtk":
+        driver_class = "WebKitGTK"
+    elif driver_option == "wpewebkit":
+        driver_class = "WPEWebKit"
+    else:
+        driver_class = driver_option.capitalize()
+    return driver_class
+
+
 driver_instance = None
 
 
@@ -105,7 +116,7 @@ def driver(request):
     kwargs = {}
 
     # browser can be changed with `--driver=firefox` as an argument or to addopts in pytest.ini
-    driver_class = getattr(request, "param", "Chrome").capitalize()
+    driver_class = get_driver_class(getattr(request, "param", "Chrome"))
 
     # skip tests if not available on the platform
     _platform = platform.system()
@@ -146,18 +157,16 @@ def driver(request):
             options = get_options(driver_class, request.config)
         if driver_class == "Chrome":
             options = get_options(driver_class, request.config)
+        if driver_class == "Edge":
+            options = get_options(driver_class, request.config)
+        if driver_class == "WebKitGTK":
+            options = get_options(driver_class, request.config)
+        if driver_class.lower() == "WPEWebKit":
+            options = get_options(driver_class, request.config)
         if driver_class == "Remote":
             options = get_options("Firefox", request.config) or webdriver.FirefoxOptions()
             options.set_capability("moz:firefoxOptions", {})
             options.enable_downloads = True
-        if driver_class.lower() == "webkitgtk":
-            driver_class = "WebKitGTK"
-            options = get_options(driver_class, request.config)
-        if driver_class == "Edge":
-            options = get_options(driver_class, request.config)
-        if driver_class.lower() == "wpewebkit":
-            driver_class = "WPEWebKit"
-            options = get_options(driver_class, request.config)
         if driver_path is not None:
             kwargs["service"] = get_service(driver_class, driver_path)
         if options is not None:
@@ -340,17 +349,6 @@ def edge_service():
 @pytest.fixture(scope="function")
 def driver_executable(request):
     return request.config.option.executable
-
-
-def get_driver_class(driver_option):
-    """Generate the driver class name from the lowercase driver option"""
-    if driver_option == "webkitgtk":
-        driver_class = "WebKitGTK"
-    elif driver_option == "wpewebkit":
-        driver_class = "WPEWebKit"
-    else:
-        driver_class = driver_option.capitalize()
-    return driver_class
 
 
 @pytest.fixture(scope="function")

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -342,11 +342,22 @@ def driver_executable(request):
     return request.config.option.executable
 
 
+def get_driver_class(driver_option):
+    """Generate the driver class name from the lowercase driver option"""
+    if driver_option == "webkitgtk":
+        driver_class = "WebKitGTK"
+    elif driver_option == "wpewebkit":
+        driver_class = "WPEWebKit"
+    else:
+        driver_class = driver_option.capitalize()
+    return driver_class
+
+
 @pytest.fixture(scope="function")
 def clean_service(request):
     try:
-        driver_class = request.config.option.drivers[0].capitalize()
-    except AttributeError:
+        driver_class = get_driver_class(request.config.option.drivers[0])
+    except (AttributeError, TypeError):
         raise Exception("This test requires a --driver to be specified.")
 
     yield get_service(driver_class, request.config.option.executable)
@@ -355,8 +366,8 @@ def clean_service(request):
 @pytest.fixture(scope="function")
 def clean_driver(request):
     try:
-        driver_class = request.config.option.drivers[0].capitalize()
-    except AttributeError:
+        driver_class = get_driver_class(request.config.option.drivers[0])
+    except (AttributeError, TypeError):
         raise Exception("This test requires a --driver to be specified.")
 
     driver_reference = getattr(webdriver, driver_class)

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -358,7 +358,7 @@ def clean_service(request):
     try:
         driver_class = get_driver_class(request.config.option.drivers[0])
     except (AttributeError, TypeError):
-        raise Exception("This test requires a --driver to be specified.")
+        raise Exception("This test requires a --driver to be specified")
 
     yield get_service(driver_class, request.config.option.executable)
 
@@ -368,7 +368,7 @@ def clean_driver(request):
     try:
         driver_class = get_driver_class(request.config.option.drivers[0])
     except (AttributeError, TypeError):
-        raise Exception("This test requires a --driver to be specified.")
+        raise Exception("This test requires a --driver to be specified")
 
     driver_reference = getattr(webdriver, driver_class)
     yield driver_reference


### PR DESCRIPTION
### **User description**
### Motivation and Context

This PR fixes some issues in the Python test configuration (PyTest fixtures).

Before this fix, running tests that use the `clean_driver` or `clean_service` fixture would fail when using certain `--driver` options.

If `--driver` option was not included, the tests would fail with:
`TypeError: 'NoneType' object is not subscriptable`
Now they correctly fail with:
`Exception: This test requires a --driver to be specified`

If `--driver=webkitgtk` or `--driver=wpewebkit` was used, tests would fail with:
`AttributeError: module 'selenium.webdriver' has no attribute 'Webkitgtk'. Did you mean: 'webkitgtk'?`
or
`AttributeError: module 'selenium.webdriver' has no attribute 'Wpewebkit'. Did you mean: 'wpewebkit'?`
Now the tests can be executed using these options.

This PR also fixes an issue where WebKitGTK and WPEWebKit tests were not skipped on non-Linux platforms.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect driver class name generation in test fixtures.

- Added `get_driver_class` function for consistent driver class handling.

- Improved error handling for missing or invalid `--driver` options.

- Enhanced compatibility with `webkitgtk` and `wpewebkit` drivers.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Refactored driver class handling and improved error messages</code></dd></summary>
<hr>

py/conftest.py

<li>Added <code>get_driver_class</code> function to generate driver class names.<br> <li> Updated <code>clean_service</code> and <code>clean_driver</code> fixtures to use <br><code>get_driver_class</code>.<br> <li> Improved error messages for missing or invalid <code>--driver</code> options.<br> <li> Enhanced support for <code>webkitgtk</code> and <code>wpewebkit</code> driver options.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15550/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+17/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>