### PR TITLE
[JS] Add websocket port option in Firefox ServiceBuilder when '--connect-existing' is not passed

### DIFF
--- a/javascript/selenium-webdriver/firefox.js
+++ b/javascript/selenium-webdriver/firefox.js
@@ -121,6 +121,7 @@ const zip = require('./io/zip')
 const { Browser, Capabilities, Capability } = require('./lib/capabilities')
 const { Zip } = require('./io/zip')
 const { getBinaryPaths } = require('./common/driverFinder')
+const { findFreePort } = require('./net/portprober')
 const FIREFOX_CAPABILITY_KEY = 'moz:firefoxOptions'
 
 /**
@@ -504,6 +505,31 @@ class ServiceBuilder extends remote.DriverService.Builder {
    */
   enableVerboseLogging(opt_trace) {
     return this.addArguments(opt_trace ? '-vv' : '-v')
+  }
+
+  /**
+   * Overrides the parent build() method to add the websocket port argument
+   * for Firefox when not connecting to an existing instance.
+   *
+   * @return {!DriverService} A new driver service instance.
+   */
+  build() {
+    let port = this.options_.port || findFreePort();
+    let argsPromise = Promise.resolve(port).then((port) => {
+      // Start with the default --port argument.
+      let args = this.options_.args.concat(`--port=${port}`);
+      // If the "--connect-existing" flag is not set, add the websocket port.
+      if (!this.options_.args.some(arg => arg === '--connect-existing')) {
+        return findFreePort().then(wsPort => {
+          args.push(`--websocket-port=${wsPort}`);
+          return args;
+        });
+      }
+      return args;
+    });
+
+    let options = Object.assign({}, this.options_, { args: argsPromise, port });
+    return new remote.DriverService(this.exe_, options);
   }
 }
 

--- a/javascript/selenium-webdriver/firefox.js
+++ b/javascript/selenium-webdriver/firefox.js
@@ -514,22 +514,22 @@ class ServiceBuilder extends remote.DriverService.Builder {
    * @return {!DriverService} A new driver service instance.
    */
   build() {
-    let port = this.options_.port || findFreePort();
+    let port = this.options_.port || findFreePort()
     let argsPromise = Promise.resolve(port).then((port) => {
       // Start with the default --port argument.
-      let args = this.options_.args.concat(`--port=${port}`);
+      let args = this.options_.args.concat(`--port=${port}`)
       // If the "--connect-existing" flag is not set, add the websocket port.
-      if (!this.options_.args.some(arg => arg === '--connect-existing')) {
-        return findFreePort().then(wsPort => {
-          args.push(`--websocket-port=${wsPort}`);
-          return args;
-        });
+      if (!this.options_.args.some((arg) => arg === '--connect-existing')) {
+        return findFreePort().then((wsPort) => {
+          args.push(`--websocket-port=${wsPort}`)
+          return args
+        })
       }
-      return args;
-    });
+      return args
+    })
 
-    let options = Object.assign({}, this.options_, { args: argsPromise, port });
-    return new remote.DriverService(this.exe_, options);
+    let options = Object.assign({}, this.options_, { args: argsPromise, port })
+    return new remote.DriverService(this.exe_, options)
   }
 }
 


### PR DESCRIPTION
### **User description**
Fixes https://github.com/SeleniumHQ/selenium/issues/15451

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added support for `--websocket-port` argument in Firefox ServiceBuilder.

- Ensured the websocket port is only added when `--connect-existing` is not passed.

- Integrated logic to dynamically find free ports for both service and websocket.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox.js</strong><dd><code>Added websocket port logic in Firefox ServiceBuilder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/firefox.js

<li>Imported <code>findFreePort</code> for dynamic port allocation.<br> <li> Modified <code>ServiceBuilder</code> to include <code>--websocket-port</code> argument.<br> <li> Ensured <code>--websocket-port</code> is added only when <code>--connect-existing</code> is <br>absent.<br> <li> Updated <code>build()</code> method to handle dynamic port assignment for both <br>service and websocket.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15557/files#diff-e1b61873ea487dd2e7b4eb87254b9c0f295ec4d3f79c277b7f64496bba7cad0e">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>