### PR TITLE
[dotnet] [bidi] Added missing GenericLogEntry log entry type in Script module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/LogEntryConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/LogEntryConverter.cs
@@ -34,7 +34,7 @@ internal class LogEntryConverter : JsonConverter<Modules.Log.LogEntry>
         {
             "console" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<ConsoleLogEntry>()),
             "javascript" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<JavascriptLogEntry>()),
-            _ => null,
+            _ => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<GenericLogEntry>()),
         };
     }
 

--- a/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
@@ -24,6 +24,7 @@ namespace OpenQA.Selenium.BiDi.Modules.Log;
 
 // https://github.com/dotnet/runtime/issues/72604
 //[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+//[JsonDerivedType(typeof(GenericLogEntry))] // Fallback when discriminator is not recognized, we have to double check
 //[JsonDerivedType(typeof(ConsoleLogEntry), "console")]
 //[JsonDerivedType(typeof(JavascriptLogEntry), "javascript")]
 public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
@@ -31,6 +32,9 @@ public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, st
 {
     public Script.StackTrace? StackTrace { get; set; }
 }
+
+public record GenericLogEntry(BiDi BiDi, string Type, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+    : LogEntry(BiDi, Level, Source, Text, Timestamp);
 
 public record ConsoleLogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
     : LogEntry(BiDi, Level, Source, Text, Timestamp);


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#types-log-logentry

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for `GenericLogEntry` in BiDi log module.

- Updated `LogEntryConverter` to handle unrecognized log types.

- Introduced `GenericLogEntry` record as a fallback log entry type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogEntryConverter.cs</strong><dd><code>Enhance LogEntryConverter with fallback deserialization</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/LogEntryConverter.cs

<li>Updated <code>LogEntryConverter</code> to deserialize unrecognized log types.<br> <li> Added fallback to <code>GenericLogEntry</code> for unknown log entry types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15591/files#diff-573d86ca0ef4e4549d1540bcb3d744b2e56e66c49daef7758ab5232ee50aa8c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogEntry.cs</strong><dd><code>Add GenericLogEntry record for fallback handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs

<li>Introduced <code>GenericLogEntry</code> record for fallback log entries.<br> <li> Added new record to handle unrecognized log types.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15591/files#diff-4b9875950fb3e46b82d0ee93e78c35eec6750f42ba48da0202118a824e4be150">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>