### PR TITLE
[dotnet] [bidi] Separate empty and base result

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -186,19 +186,19 @@ public sealed class Broker : IAsyncDisposable
 
     public async Task<TResult> ExecuteCommandAsync<TCommand, TResult>(TCommand command, CommandOptions? options)
         where TCommand : Command
-        where TResult : EmptyResult
+        where TResult : BiDiResult
     {
         var result = await ExecuteCommandCoreAsync(command, options).ConfigureAwait(false);
 
         return (TResult)result;
     }
 
-    private async Task<EmptyResult> ExecuteCommandCoreAsync<TCommand>(TCommand command, CommandOptions? options)
+    private async Task<BiDiResult> ExecuteCommandCoreAsync<TCommand>(TCommand command, CommandOptions? options)
         where TCommand : Command
     {
         command.Id = Interlocked.Increment(ref _currentCommandId);
 
-        var tcs = new TaskCompletionSource<EmptyResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<BiDiResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
 
@@ -380,7 +380,7 @@ public sealed class Broker : IAsyncDisposable
 
                 var successCommand = _pendingCommands[id.Value];
                 var messageSuccess = JsonSerializer.Deserialize(ref resultReader, successCommand.ResultType, _jsonSerializerContext)!;
-                successCommand.TaskCompletionSource.SetResult((EmptyResult)messageSuccess);
+                successCommand.TaskCompletionSource.SetResult((BiDiResult)messageSuccess);
                 _pendingCommands.TryRemove(id.Value, out _);
                 break;
 
@@ -406,12 +406,12 @@ public sealed class Broker : IAsyncDisposable
         }
     }
 
-    class CommandInfo(long id, Type resultType, TaskCompletionSource<EmptyResult> taskCompletionSource)
+    class CommandInfo(long id, Type resultType, TaskCompletionSource<BiDiResult> taskCompletionSource)
     {
         public long Id { get; } = id;
 
         public Type ResultType { get; } = resultType;
 
-        public TaskCompletionSource<EmptyResult> TaskCompletionSource { get; } = taskCompletionSource;
+        public TaskCompletionSource<BiDiResult> TaskCompletionSource { get; } = taskCompletionSource;
     };
 }

--- a/dotnet/src/webdriver/BiDi/Communication/Command.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Command.cs
@@ -42,7 +42,7 @@ public abstract class Command
 
 internal abstract class Command<TCommandParameters, TCommandResult>(TCommandParameters @params, string method) : Command(method, typeof(TCommandResult))
     where TCommandParameters : CommandParameters
-    where TCommandResult : EmptyResult
+    where TCommandResult : BiDiResult
 {
     [JsonPropertyOrder(2)]
     public TCommandParameters Params { get; } = @params;
@@ -53,4 +53,7 @@ internal record CommandParameters
     public static CommandParameters Empty { get; } = new CommandParameters();
 }
 
-public record EmptyResult;
+public sealed record EmptyResult : BiDiResult;
+
+public abstract record BiDiResult;
+

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -67,7 +67,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 #endregion
 
 [JsonSerializable(typeof(Command))]
-[JsonSerializable(typeof(EmptyResult))]
+[JsonSerializable(typeof(BiDiResult))]
 
 [JsonSerializable(typeof(Modules.Session.StatusCommand))]
 [JsonSerializable(typeof(Modules.Session.StatusResult))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/InputOriginConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/InputOriginConverter.cs
@@ -17,16 +17,15 @@
 // under the License.
 // </copyright>
 
+using OpenQA.Selenium.BiDi.Communication.Json.Internal;
 using OpenQA.Selenium.BiDi.Modules.Input;
+using OpenQA.Selenium.BiDi.Modules.Script;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Communication.Json.Converters;
 
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Json serializer options should have AOT-safe type resolution")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Json serializer options should have AOT-safe type resolution")]
 internal class InputOriginConverter : JsonConverter<Origin>
 {
     public override Origin Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -49,7 +48,7 @@ internal class InputOriginConverter : JsonConverter<Origin>
             writer.WriteStartObject();
             writer.WriteString("type", "element");
             writer.WritePropertyName("element");
-            JsonSerializer.Serialize(writer, element.Element, options);
+            JsonSerializer.Serialize(writer, element.Element, options.GetTypeInfo<ISharedReference>());
             writer.WriteEndObject();
         }
     }

--- a/dotnet/src/webdriver/BiDi/Communication/Message.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Message.cs
@@ -21,7 +21,7 @@ namespace OpenQA.Selenium.BiDi.Communication;
 
 internal abstract record Message;
 
-internal record MessageSuccess(long Id, EmptyResult Result) : Message;
+internal record MessageSuccess(long Id, BiDiResult Result) : Message;
 
 internal record MessageError(long Id) : Message
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Browser/GetClientWindowsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Browser/GetClientWindowsCommand.cs
@@ -28,7 +28,7 @@ internal class GetClientWindowsCommand()
 
 public record GetClientWindowsOptions : CommandOptions;
 
-public record GetClientWindowsResult : EmptyResult, IReadOnlyList<ClientWindowInfo>
+public record GetClientWindowsResult : BiDiResult, IReadOnlyList<ClientWindowInfo>
 {
     private readonly IReadOnlyList<ClientWindowInfo> _clientWindows;
 

--- a/dotnet/src/webdriver/BiDi/Modules/Browser/GetUserContextsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Browser/GetUserContextsCommand.cs
@@ -28,7 +28,7 @@ internal class GetUserContextsCommand()
 
 public record GetUserContextsOptions : CommandOptions;
 
-public record GetUserContextsResult : EmptyResult, IReadOnlyList<UserContextInfo>
+public record GetUserContextsResult : BiDiResult, IReadOnlyList<UserContextInfo>
 {
     private readonly IReadOnlyList<UserContextInfo> _userContexts;
 

--- a/dotnet/src/webdriver/BiDi/Modules/Browser/UserContextInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Browser/UserContextInfo.cs
@@ -21,4 +21,4 @@ using OpenQA.Selenium.BiDi.Communication;
 
 namespace OpenQA.Selenium.BiDi.Modules.Browser;
 
-public record UserContextInfo(UserContext UserContext) : EmptyResult;
+public record UserContextInfo(UserContext UserContext) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CaptureScreenshotCommand.cs
@@ -56,7 +56,7 @@ public record BoxClipRectangle(double X, double Y, double Width, double Height) 
 
 public record ElementClipRectangle([property: JsonPropertyName("element")] Script.ISharedReference SharedReference) : ClipRectangle;
 
-public record CaptureScreenshotResult(string Data) : EmptyResult
+public record CaptureScreenshotResult(string Data) : BiDiResult
 {
     public byte[] ToByteArray() => System.Convert.FromBase64String(Data);
 }

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CreateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/CreateCommand.cs
@@ -41,4 +41,4 @@ public enum ContextType
     Window
 }
 
-public record CreateResult(BrowsingContext Context) : EmptyResult;
+public record CreateResult(BrowsingContext Context) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/GetTreeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/GetTreeCommand.cs
@@ -46,4 +46,4 @@ public record BrowsingContextGetTreeOptions
     public long? MaxDepth { get; set; }
 }
 
-public record GetTreeResult(IReadOnlyList<BrowsingContextInfo> Contexts) : EmptyResult;
+public record GetTreeResult(IReadOnlyList<BrowsingContextInfo> Contexts) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/LocateNodesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/LocateNodesCommand.cs
@@ -37,7 +37,7 @@ public record LocateNodesOptions : CommandOptions
     public IEnumerable<Script.ISharedReference>? StartNodes { get; set; }
 }
 
-public record LocateNodesResult : EmptyResult, IReadOnlyList<Script.NodeRemoteValue>
+public record LocateNodesResult : BiDiResult, IReadOnlyList<Script.NodeRemoteValue>
 {
     private readonly IReadOnlyList<Script.NodeRemoteValue> _nodes;
 

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigateCommand.cs
@@ -38,4 +38,4 @@ public enum ReadinessState
     Complete
 }
 
-public record NavigateResult(Navigation Navigation, string Url) : EmptyResult;
+public record NavigateResult(Navigation Navigation, string Url) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/PrintCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/PrintCommand.cs
@@ -112,7 +112,7 @@ public readonly record struct PrintPageRange(int? Start, int? End)
 #endif
 }
 
-public record PrintResult(string Data) : EmptyResult
+public record PrintResult(string Data) : BiDiResult
 {
     public byte[] ToByteArray() => Convert.FromBase64String(Data);
 }

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/TraverseHistoryCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/TraverseHistoryCommand.cs
@@ -28,4 +28,4 @@ internal record TraverseHistoryCommandParameters(BrowsingContext Context, long D
 
 public record TraverseHistoryOptions : CommandOptions;
 
-public record TraverseHistoryResult : EmptyResult;
+public record TraverseHistoryResult : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/AddInterceptCommand.cs
@@ -46,7 +46,7 @@ public record BrowsingContextAddInterceptOptions
     public IEnumerable<UrlPattern>? UrlPatterns { get; set; }
 }
 
-public record AddInterceptResult(Intercept Intercept) : EmptyResult;
+public record AddInterceptResult(Intercept Intercept) : BiDiResult;
 
 public enum InterceptPhase
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/AddPreloadScriptCommand.cs
@@ -51,4 +51,4 @@ public record BrowsingContextAddPreloadScriptOptions
     public string? Sandbox { get; set; }
 }
 
-internal record AddPreloadScriptResult(PreloadScript Script) : EmptyResult;
+internal record AddPreloadScriptResult(PreloadScript Script) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/Script/EvaluateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/EvaluateCommand.cs
@@ -39,7 +39,7 @@ public record EvaluateOptions : CommandOptions
 //[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 //[JsonDerivedType(typeof(EvaluateResultSuccess), "success")]
 //[JsonDerivedType(typeof(EvaluateResultException), "exception")]
-public abstract record EvaluateResult : EmptyResult;
+public abstract record EvaluateResult : BiDiResult;
 
 public record EvaluateResultSuccess(RemoteValue Result, Realm Realm) : EvaluateResult
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Script/GetRealmsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Script/GetRealmsCommand.cs
@@ -35,7 +35,7 @@ public record GetRealmsOptions : CommandOptions
     public RealmType? Type { get; set; }
 }
 
-public record GetRealmsResult : EmptyResult, IReadOnlyList<RealmInfo>
+public record GetRealmsResult : BiDiResult, IReadOnlyList<RealmInfo>
 {
     private readonly IReadOnlyList<RealmInfo> _realms;
 

--- a/dotnet/src/webdriver/BiDi/Modules/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Session/NewCommand.cs
@@ -28,7 +28,7 @@ internal record NewCommandParameters(CapabilitiesRequest Capabilities) : Command
 
 public record NewOptions : CommandOptions;
 
-public record NewResult(string SessionId, Capability Capability) : EmptyResult;
+public record NewResult(string SessionId, Capability Capability) : BiDiResult;
 
 public record Capability(bool AcceptInsecureCerts, string BrowserName, string BrowserVersion, string PlatformName, bool SetWindowRect, string UserAgent)
 {

--- a/dotnet/src/webdriver/BiDi/Modules/Session/StatusCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Session/StatusCommand.cs
@@ -24,6 +24,6 @@ namespace OpenQA.Selenium.BiDi.Modules.Session;
 internal class StatusCommand()
     : Command<CommandParameters, StatusResult>(CommandParameters.Empty, "session.status");
 
-public record StatusResult(bool Ready, string Message) : EmptyResult;
+public record StatusResult(bool Ready, string Message) : BiDiResult;
 
 public record StatusOptions : CommandOptions;

--- a/dotnet/src/webdriver/BiDi/Modules/Session/SubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Session/SubscribeCommand.cs
@@ -32,4 +32,4 @@ public record SubscribeOptions : CommandOptions
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
 }
 
-internal record SubscribeResult(Subscription Subscription) : EmptyResult;
+internal record SubscribeResult(Subscription Subscription) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/Storage/DeleteCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Storage/DeleteCookiesCommand.cs
@@ -28,4 +28,4 @@ internal record DeleteCookiesCommandParameters(CookieFilter? Filter, PartitionDe
 
 public record DeleteCookiesOptions : GetCookiesOptions;
 
-public record DeleteCookiesResult(PartitionKey PartitionKey) : EmptyResult;
+public record DeleteCookiesResult(PartitionKey PartitionKey) : BiDiResult;

--- a/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Storage/GetCookiesCommand.cs
@@ -37,7 +37,7 @@ public record GetCookiesOptions : CommandOptions
     public PartitionDescriptor? Partition { get; set; }
 }
 
-public record GetCookiesResult : EmptyResult, IReadOnlyList<Network.Cookie>
+public record GetCookiesResult : BiDiResult, IReadOnlyList<Network.Cookie>
 {
     private readonly IReadOnlyList<Network.Cookie> _cookies;
 

--- a/dotnet/src/webdriver/BiDi/Modules/Storage/SetCookieCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Storage/SetCookieCommand.cs
@@ -45,4 +45,4 @@ public record SetCookieOptions : CommandOptions
     public PartitionDescriptor? Partition { get; set; }
 }
 
-public record SetCookieResult(PartitionKey PartitionKey) : EmptyResult;
+public record SetCookieResult(PartitionKey PartitionKey) : BiDiResult;


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

The `EmptyResult` does two different things: act as a base type for all BiDi results, and act as a void result. We can separate these two responsibilities to two different types, leading to clearer code. Additionally, we can rest assured that any `EmptyResult` we get is not non-empty result without at runtime.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Replaced `EmptyResult` with `BiDiResult` as the base type for BiDi command results.

- Refactored multiple command result classes to inherit from `BiDiResult`.

- Updated serialization and deserialization logic to accommodate the new `BiDiResult` type.

- Improved code clarity by separating void results (`EmptyResult`) from the base result type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>25 files</summary><table>
<tr>
  <td><strong>Broker.cs</strong><dd><code>Update command execution to use `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Command.cs</strong><dd><code>Introduce `BiDiResult` and refactor command base</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-3c2d7c1c63b4af3a773d68343890cd40c7816d8bc1ba4b1ca794230a2eefcf68">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Update JSON serialization for `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>InputOriginConverter.cs</strong><dd><code>Adjust serialization logic for shared references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-70473794aeaad646b698089e2c36cf04f247d0558795dcfe72b3de26a84f0c70">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Message.cs</strong><dd><code>Update message success handling to use `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-e7202baa2b0cec5cb7818e9b9b600b7804f5cfb1bf08d70a2a8247bc3c1c0c35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetClientWindowsCommand.cs</strong><dd><code>Refactor `GetClientWindowsResult` to inherit `BiDiResult`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-01f751f67d9937f8665ab68fc913c3b87548a9bb3863c9c78ae6550923e54500">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetUserContextsCommand.cs</strong><dd><code>Refactor `GetUserContextsResult` to inherit `BiDiResult`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-e9064d1838c70b10ec00cbc839d0dbe8309a976de7a4ee7b750d9c431e6ee602">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserContextInfo.cs</strong><dd><code>Update `UserContextInfo` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-df0dca926a9b70036b9462347133f5d8b26e5a14927f7768e159c6ba3779f3ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CaptureScreenshotCommand.cs</strong><dd><code>Refactor `CaptureScreenshotResult` to inherit `BiDiResult`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-476acfd0b3ac522476d73fd60def6ca1dc5f6d4c36601eaa32ad428c5fece14c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CreateCommand.cs</strong><dd><code>Update `CreateResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-7a3ab498fee89f27ed4852bc98480a4c8c2aab9c4a247bb5965cb33b2bf29df0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetTreeCommand.cs</strong><dd><code>Refactor `GetTreeResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-6ebc70de2c1534f53980dd2a63893b634470164c71b3f127f93d92a9231a36af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocateNodesCommand.cs</strong><dd><code>Update `LocateNodesResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-189588282265ef3cca7fc6f20ff57e4a818f50babe2ab647c6d945883d140a5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavigateCommand.cs</strong><dd><code>Refactor `NavigateResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-d48dbcfaf24ffa9a0d0d3b45800f99381806de34aaaf7085b8c173f4d47c59ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrintCommand.cs</strong><dd><code>Update `PrintResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-50cef33f1ddd7186aeedce2401c299b2c0c8b83624f5a593b19b6d0b79f2a81b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TraverseHistoryCommand.cs</strong><dd><code>Refactor `TraverseHistoryResult` to inherit `BiDiResult`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-80d5935e2cceafc361a1f15b9ec5727a6479da00842dd6e6392450741d3128c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AddInterceptCommand.cs</strong><dd><code>Update `AddInterceptResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-4498bc3a3dbed2bae4e325c82ddfa9f47525e6d0ae1249005e6ebff78859d32f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AddPreloadScriptCommand.cs</strong><dd><code>Refactor `AddPreloadScriptResult` to inherit `BiDiResult`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-d3718b2df5eaea20784a7dc16e69eb3cb1dcd97e859fb9ccb72dcac4efc6cf17">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluateCommand.cs</strong><dd><code>Update `EvaluateResult` hierarchy to inherit `BiDiResult`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-2c814f092ccb5092dff7d4668b006c35c6353d2b400075225c699e446afd285d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetRealmsCommand.cs</strong><dd><code>Refactor `GetRealmsResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-b8a3db6a41d930ee02e255d64de8df2adea07eccdf915e77a172ffd7e9dba351">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NewCommand.cs</strong><dd><code>Update `NewResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-adc425ed196a7e89f9fa4c546c3bd4bfc8c6a503b6845d5239de54c6f06af8a7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StatusCommand.cs</strong><dd><code>Refactor `StatusResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-639de068b571f2324938290c67539c4f00bda982a576f8f39482884aee02e3f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SubscribeCommand.cs</strong><dd><code>Update `SubscribeResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-97ae58a30250438ea172d23213862300c04d42551ed8805e79786f6e20423f1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DeleteCookiesCommand.cs</strong><dd><code>Refactor `DeleteCookiesResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-593a32d245b74f323a67eda54d3cd39e47025ccc47454e9745d830a41f936350">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetCookiesCommand.cs</strong><dd><code>Update `GetCookiesResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-46ef808477800a7c2761187b32b93fa5f04ac0cf6e83e11f8fb0a63142a509b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SetCookieCommand.cs</strong><dd><code>Refactor `SetCookieResult` to inherit `BiDiResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15593/files#diff-f31fccf9a6ac09685f200260e4ec3250c22901fd4003c6a2f4fbe4f6b385e8ec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>