### PR TITLE
[py] Fix PyTest configuration for WPEWebKit

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -160,7 +160,7 @@ def driver(request):
             options = get_options(driver_class, request.config)
         if driver_class == "WebKitGTK":
             options = get_options(driver_class, request.config)
-        if driver_class.lower() == "WPEWebKit":
+        if driver_class == "WPEWebKit":
             options = get_options(driver_class, request.config)
         if driver_class == "Remote":
             options = get_options("Firefox", request.config) or webdriver.FirefoxOptions()


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR fixes the PyTest configuration when running tests with WPEWebKit in the internal test suite.

`conftest.py` contained the lines:
```
if driver_class.lower() == "WPEWebKit":
    options = get_options(driver_class, request.config)
```
Since this condition can never be true, options were not being set for WPEWebKit tests.

(Note, WPEWebKit still seems to be broken, as reported in #15541, but whenever that gets fixed, tests would have failed due to the issue this PR fixes)

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed PyTest configuration for WPEWebKit driver.

- Corrected condition to match `driver_class` for WPEWebKit.

- Ensures proper options are set for WPEWebKit tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Fix condition for WPEWebKit in PyTest configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Corrected the condition for <code>driver_class</code> to match "WPEWebKit".<br> <li> Ensures options are properly set for WPEWebKit tests.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15602/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>