### PR TITLE
[py] Fix failing test for Edge logging

### DIFF
--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -30,21 +30,30 @@ def test_uses_edgedriver_logging(clean_driver, driver_executable) -> None:
     log_file = "msedgedriver.log"
     service_args = ["--append-log"]
 
-    service = Service(
+    service1 = Service(
         log_output=log_file,
         service_args=service_args,
         executable_path=driver_executable,
     )
+
+    service2 = Service(
+        log_output=log_file,
+        service_args=service_args,
+        executable_path=driver_executable,
+    )
+
+    driver1 = None
     driver2 = None
     try:
-        driver1 = clean_driver(service=service)
+        driver1 = clean_driver(service=service1)
         with open(log_file) as fp:
             lines = len(fp.readlines())
-        driver2 = clean_driver(service=service)
+        driver2 = clean_driver(service=service2)
         with open(log_file) as fp:
             assert len(fp.readlines()) >= 2 * lines
     finally:
-        driver1.quit()
+        if driver1:
+            driver1.quit()
         if driver2:
             driver2.quit()
         os.remove(log_file)


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This is a fix to the internal Python test suite.

This PR fixes the test_uses_edgedriver_logging test in py/test/selenium/webdriver/edge/edge_service_tests.py.

Previously, this test was failing because it was attempting to launch 2 browsers using the same Service object. This is not possible and results in an error:
```
E       selenium.common.exceptions.SessionNotCreatedException: Message: session not created
E       from unknown error: cannot find msedge binary
```

This PR creates 2 Service objects so each driver instance can use its own.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed failing `test_uses_edgedriver_logging` in Edge service tests.

- Replaced single `Service` object with two separate instances.

- Ensured proper cleanup of driver instances and log file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge_service_tests.py</strong><dd><code>Fix Edge logging test with separate Service instances</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/edge/edge_service_tests.py

<li>Replaced single <code>Service</code> object with two separate instances.<br> <li> Updated test logic to use distinct services for each driver.<br> <li> Added conditional cleanup for <code>driver1</code> to avoid potential errors.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15605/files#diff-9ba4cbc1f50e44a2b01e9ffda260a45177281d243a43e3466cc12808d2aca955">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>