### PR TITLE
[py] Add missing modules to Python API docs

### DIFF
--- a/py/docs/source/api.rst
+++ b/py/docs/source/api.rst
@@ -21,10 +21,29 @@ Webdriver.common
    :toctree: webdriver
 
    selenium.webdriver.common.action_chains
+   selenium.webdriver.common.actions.action_builder
+   selenium.webdriver.common.actions.input_device
+   selenium.webdriver.common.actions.interaction
+   selenium.webdriver.common.actions.key_actions
+   selenium.webdriver.common.actions.key_input
+   selenium.webdriver.common.actions.mouse_button
+   selenium.webdriver.common.actions.pointer_actions
+   selenium.webdriver.common.actions.pointer_input
+   selenium.webdriver.common.actions.wheel_actions
+   selenium.webdriver.common.actions.wheel_input
    selenium.webdriver.common.alert
+   selenium.webdriver.common.bidi.browser
+   selenium.webdriver.common.bidi.cdp
+   selenium.webdriver.common.bidi.common
+   selenium.webdriver.common.bidi.console
+   selenium.webdriver.common.bidi.network
+   selenium.webdriver.common.bidi.script
+   selenium.webdriver.common.bidi.session
    selenium.webdriver.common.by
    selenium.webdriver.common.desired_capabilities
    selenium.webdriver.common.driver_finder
+   selenium.webdriver.common.fedcm.account
+   selenium.webdriver.common.fedcm.dialog
    selenium.webdriver.common.keys
    selenium.webdriver.common.log
    selenium.webdriver.common.options
@@ -36,20 +55,6 @@ Webdriver.common
    selenium.webdriver.common.utils
    selenium.webdriver.common.virtual_authenticator
    selenium.webdriver.common.window
-   selenium.webdriver.common.actions.action_builder
-   selenium.webdriver.common.actions.input_device
-   selenium.webdriver.common.actions.interaction
-   selenium.webdriver.common.actions.key_actions
-   selenium.webdriver.common.actions.key_input
-   selenium.webdriver.common.actions.mouse_button
-   selenium.webdriver.common.actions.pointer_actions
-   selenium.webdriver.common.actions.pointer_input
-   selenium.webdriver.common.actions.wheel_actions
-   selenium.webdriver.common.actions.wheel_input
-   selenium.webdriver.common.bidi.cdp
-   selenium.webdriver.common.bidi.console
-   selenium.webdriver.common.bidi.script
-   selenium.webdriver.common.bidi.session
 
 Webdriver.support
 -----------------
@@ -125,8 +130,8 @@ Webdriver.ie
 .. autosummary::
    :toctree: webdriver_ie
 
-   selenium.webdriver.ie.service
    selenium.webdriver.ie.options
+   selenium.webdriver.ie.service
    selenium.webdriver.ie.webdriver
 
 Webdriver.remote
@@ -137,9 +142,12 @@ Webdriver.remote
    :toctree: webdriver_remote
 
    selenium.webdriver.remote.bidi_connection
+   selenium.webdriver.remote.client_config
    selenium.webdriver.remote.command
    selenium.webdriver.remote.errorhandler
+   selenium.webdriver.remote.fedcm
    selenium.webdriver.remote.file_detector
+   selenium.webdriver.remote.locator_converter
    selenium.webdriver.remote.mobile
    selenium.webdriver.remote.remote_connection
    selenium.webdriver.remote.script_key
@@ -163,17 +171,6 @@ Webdriver.safari
   selenium.webdriver.safari.service
   selenium.webdriver.safari.webdriver
 
-Webdriver.wpewebkit
--------------------
-
-.. currentmodule:: selenium.webdriver.wpewebkit
-.. autosummary::
-  :toctree: webdriver_wpewebkit
-
-  selenium.webdriver.wpewebkit.options
-  selenium.webdriver.wpewebkit.service
-  selenium.webdriver.wpewebkit.webdriver
-
 Webdriver.webkitgtk
 -------------------
 
@@ -184,6 +181,17 @@ Webdriver.webkitgtk
   selenium.webdriver.webkitgtk.options
   selenium.webdriver.webkitgtk.service
   selenium.webdriver.webkitgtk.webdriver
+
+Webdriver.wpewebkit
+-------------------
+
+.. currentmodule:: selenium.webdriver.wpewebkit
+.. autosummary::
+  :toctree: webdriver_wpewebkit
+
+  selenium.webdriver.wpewebkit.options
+  selenium.webdriver.wpewebkit.service
+  selenium.webdriver.wpewebkit.webdriver
 
 Indices and tables
 


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes: #15623 

### 💥 What does this PR do?

This PR updates the Python API documentation to include modules that were missing.

In `py/docs/source/api.rst`, all the Python modules in the selenium package are listed. Sphinx uses this file to generate the docs from source code docstrings. This file needs to be updated anytime a new module is added or removed from the Python package.

It hasn't been updated in a while, and the following modules were missing:

```
selenium.webdriver.common.bidi.browser
selenium.webdriver.common.bidi.common
selenium.webdriver.common.bidi.network
selenium.webdriver.common.fedcm.account
selenium.webdriver.common.fedcm.dialog

selenium.webdriver.remote.client_config
selenium.webdriver.remote.fedcm
selenium.webdriver.remote.locator_converter
```

I also rearranged some of the modules so they are in correct alphabetical order.

----

For future reference, here is the code I used to find all the modules in the package (run this from the `./py` directory:

```
#!/usr/bin/env python3
#
# Find all modules in a package without importing the package.
# Returns a list of module names.
# This will work for a package installed in `site-packages` or read from source.
#
# Requires Python 3.9+

import importlib.util
import os
import site


def get_modules(package_name):
    try:
        mod_paths = importlib.util.find_spec(package_name).submodule_search_locations
    except AttributeError:
        raise Exception("package not found")
    modules = [package_name]
    for mod_path in mod_paths:
        path = mod_path if "site-packages" in mod_path else package_name
        for dirpath, _, filenames in os.walk(path):
            for filename in filenames:
                if filename.endswith(".py") and not filename.startswith("__"):
                    module_name = (
                        os.path.join(dirpath, filename)
                        .removeprefix(site.getsitepackages()[0])
                        .removeprefix(os.sep)
                        .removesuffix(".py")
                        .replace(os.sep, ".")
                    )
                    modules.append(module_name)
    return sorted(set(modules))


if __name__ == "__main__":
    modules = get_modules("selenium")
    for module in modules:
        if "devtools" not in module:
            print(f"   {module}")
```



### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Documentation, Bug fix


___

### **Description**
- Added missing Python modules to API documentation.

- Rearranged modules in alphabetical order for consistency.

- Corrected placement of `Webdriver.wpewebkit` section in documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.rst</strong><dd><code>Update and organize Python API documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/docs/source/api.rst

<li>Added missing modules to the Python API documentation.<br> <li> Rearranged modules alphabetically for better organization.<br> <li> Corrected the placement of <code>Webdriver.wpewebkit</code> section.<br> <li> Updated Sphinx directives for accurate documentation generation.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15624/files#diff-7e8f0a6376548281d6c1a5b57121f0a701a76c5f88129fe7def3d89f39b63c43">+34/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>