### PR TITLE
[py] Skip bidi tests on browsers that don't support bidi

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -126,6 +126,11 @@ def driver(request):
     if "WebKit" in driver_class and _platform == "Windows":
         pytest.skip("WebKit tests cannot be run on Windows")
 
+    # skip tests for drivers that don't support BiDi when --bidi is enabled
+    if request.config.option.bidi:
+        if driver_class in ("Ie", "Safari", "WebKitGTK", "WPEWebKit"):
+            pytest.skip(f"{driver_class} does not support BiDi")
+
     # conditionally mark tests as expected to fail based on driver
     marker = request.node.get_closest_marker(f"xfail_{driver_class.lower()}")
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -81,7 +81,8 @@ markers = [
     "xfail_ie: Tests expected to fail in IE",
     "xfail_remote: Tests expected to fail with Remote webdriver",
     "xfail_safari: Tests expected to fail in Safari",
-    "xfail_webkitgtk: Tests expected to fail in webkitgtk",
+    "xfail_webkitgtk: Tests expected to fail in WebKitGTK",
+    "xfail_wpewebkit: Tests expected to fail in WPEWebKit",
     "no_driver_after_test: If there are no drivers after the test it will create a new one."
 ]
 python_files = ["test_*.py", "*_test.py", "*_tests.py"]

--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -21,13 +21,19 @@ from selenium.webdriver.common.bidi.browser import ClientWindowInfo
 from selenium.webdriver.common.bidi.browser import ClientWindowState
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_browser_initialized(driver):
     """Test that the browser module is initialized properly."""
     assert driver.browser is not None
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_create_user_context(driver):
     """Test creating a user context."""
     user_context = driver.browser.create_user_context()
@@ -37,7 +43,10 @@ def test_create_user_context(driver):
     driver.browser.remove_user_context(user_context)
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_get_user_contexts(driver):
     """Test getting user contexts."""
     user_context1 = driver.browser.create_user_context()
@@ -52,7 +61,10 @@ def test_get_user_contexts(driver):
     driver.browser.remove_user_context(user_context2)
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_remove_user_context(driver):
     """Test removing a user context."""
     user_context1 = driver.browser.create_user_context()
@@ -71,7 +83,10 @@ def test_remove_user_context(driver):
     driver.browser.remove_user_context(user_context1)
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_get_client_windows(driver):
     """Test getting client windows."""
     client_windows = driver.browser.get_client_windows()
@@ -91,13 +106,19 @@ def test_get_client_windows(driver):
     assert window_info.get_y() >= 0
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_raises_exception_when_removing_default_user_context(driver):
     with pytest.raises(Exception):
         driver.browser.remove_user_context("default")
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_client_window_state_constants(driver):
     assert ClientWindowState.FULLSCREEN == "fullscreen"
     assert ClientWindowState.MAXIMIZED == "maximized"

--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -21,19 +21,11 @@ from selenium.webdriver.common.bidi.browser import ClientWindowInfo
 from selenium.webdriver.common.bidi.browser import ClientWindowState
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_browser_initialized(driver):
     """Test that the browser module is initialized properly."""
     assert driver.browser is not None
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_create_user_context(driver):
     """Test creating a user context."""
     user_context = driver.browser.create_user_context()
@@ -43,10 +35,6 @@ def test_create_user_context(driver):
     driver.browser.remove_user_context(user_context)
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_get_user_contexts(driver):
     """Test getting user contexts."""
     user_context1 = driver.browser.create_user_context()
@@ -61,10 +49,6 @@ def test_get_user_contexts(driver):
     driver.browser.remove_user_context(user_context2)
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_remove_user_context(driver):
     """Test removing a user context."""
     user_context1 = driver.browser.create_user_context()
@@ -83,10 +67,6 @@ def test_remove_user_context(driver):
     driver.browser.remove_user_context(user_context1)
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_get_client_windows(driver):
     """Test getting client windows."""
     client_windows = driver.browser.get_client_windows()
@@ -106,19 +86,11 @@ def test_get_client_windows(driver):
     assert window_info.get_y() >= 0
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_raises_exception_when_removing_default_user_context(driver):
     with pytest.raises(Exception):
         driver.browser.remove_user_context("default")
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_client_window_state_constants(driver):
     assert ClientWindowState.FULLSCREEN == "fullscreen"
     assert ClientWindowState.MAXIMIZED == "maximized"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -21,25 +21,37 @@ from selenium.webdriver.common.bidi.network import Request
 from selenium.webdriver.common.by import By
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_network_initialized(driver):
     assert driver.network is not None
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_add_intercept(driver, pages):
     result = driver.network._add_intercept()
     assert result is not None, "Intercept not added"
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_remove_intercept(driver):
     result = driver.network._add_intercept()
     driver.network._remove_intercept(result["intercept"])
     assert driver.network.intercepts == [], "Intercept not removed"
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_add_and_remove_request_handler(driver, pages):
 
     requests = []
@@ -55,7 +67,10 @@ def test_add_and_remove_request_handler(driver, pages):
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_clear_request_handlers(driver, pages):
     requests = []
 
@@ -76,7 +91,10 @@ def test_clear_request_handlers(driver, pages):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_continue_request(driver, pages):
 
     def callback(request: Request):
@@ -90,7 +108,10 @@ def test_continue_request(driver, pages):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_continue_with_auth(driver):
 
     callback_id = driver.network.add_auth_handler("user", "passwd")
@@ -101,7 +122,10 @@ def test_continue_with_auth(driver):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_remove_auth_handler(driver):
     callback_id = driver.network.add_auth_handler("user", "passwd")
     assert callback_id is not None, "Request handler not added"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -21,37 +21,21 @@ from selenium.webdriver.common.bidi.network import Request
 from selenium.webdriver.common.by import By
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_network_initialized(driver):
     assert driver.network is not None
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_add_intercept(driver, pages):
     result = driver.network._add_intercept()
     assert result is not None, "Intercept not added"
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_remove_intercept(driver):
     result = driver.network._add_intercept()
     driver.network._remove_intercept(result["intercept"])
     assert driver.network.intercepts == [], "Intercept not removed"
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_add_and_remove_request_handler(driver, pages):
 
     requests = []
@@ -67,10 +51,6 @@ def test_add_and_remove_request_handler(driver, pages):
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_clear_request_handlers(driver, pages):
     requests = []
 
@@ -91,10 +71,6 @@ def test_clear_request_handlers(driver, pages):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_continue_request(driver, pages):
 
     def callback(request: Request):
@@ -108,10 +84,6 @@ def test_continue_request(driver, pages):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_continue_with_auth(driver):
 
     callback_id = driver.network.add_auth_handler("user", "passwd")
@@ -122,10 +94,6 @@ def test_continue_with_auth(driver):
 
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_remove_auth_handler(driver):
     callback_id = driver.network.add_auth_handler("user", "passwd")
     assert callback_id is not None, "Request handler not added"

--- a/py/test/selenium/webdriver/common/bidi_script_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_script_tests.py
@@ -14,16 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_logs_console_messages(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 
@@ -42,10 +37,6 @@ def test_logs_console_messages(driver, pages):
     assert log_entry.type_ == "console"
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_logs_console_errors(driver, pages):
     pages.load("bidi/logEntryAdded.html")
     log_entries = []
@@ -70,10 +61,6 @@ def test_logs_console_errors(driver, pages):
     assert log_entry.type_ == "console"
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_logs_multiple_console_messages(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 
@@ -88,10 +75,6 @@ def test_logs_multiple_console_messages(driver, pages):
     assert len(log_entries) == 2
 
 
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 def test_removes_console_message_handler(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 

--- a/py/test/selenium/webdriver/common/bidi_script_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_script_tests.py
@@ -20,7 +20,10 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_logs_console_messages(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 
@@ -39,7 +42,10 @@ def test_logs_console_messages(driver, pages):
     assert log_entry.type_ == "console"
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_logs_console_errors(driver, pages):
     pages.load("bidi/logEntryAdded.html")
     log_entries = []
@@ -64,7 +70,10 @@ def test_logs_console_errors(driver, pages):
     assert log_entry.type_ == "console"
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_logs_multiple_console_messages(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 
@@ -79,7 +88,10 @@ def test_logs_multiple_console_messages(driver, pages):
     assert len(log_entries) == 2
 
 
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 def test_removes_console_message_handler(driver, pages):
     pages.load("bidi/logEntryAdded.html")
 

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -23,7 +23,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
 @pytest.mark.xfail_remote(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 async def test_check_console_messages(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -37,7 +40,10 @@ async def test_check_console_messages(driver, pages):
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
 @pytest.mark.xfail_remote(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 async def test_check_error_console_messages(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -51,8 +57,11 @@ async def test_check_error_console_messages(driver, pages):
 
 
 @pytest.mark.xfail_firefox
-@pytest.mark.xfail_safari
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_remote
+@pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 async def test_collect_js_exceptions(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -64,8 +73,11 @@ async def test_collect_js_exceptions(driver, pages):
 
 
 @pytest.mark.xfail_firefox
-@pytest.mark.xfail_safari
+@pytest.mark.xfail_ie
 @pytest.mark.xfail_remote
+@pytest.mark.xfail_safari
+@pytest.mark.xfail_webkitgtk
+@pytest.mark.xfail_wpewebkit
 async def test_collect_log_mutations(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import pytest
 
 from selenium.webdriver.common.by import By
@@ -23,10 +24,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
 @pytest.mark.xfail_remote(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 async def test_check_console_messages(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -40,10 +37,6 @@ async def test_check_console_messages(driver, pages):
 
 @pytest.mark.xfail_firefox(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
 @pytest.mark.xfail_remote(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1819965")
-@pytest.mark.xfail_ie
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 async def test_check_error_console_messages(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -57,11 +50,7 @@ async def test_check_error_console_messages(driver, pages):
 
 
 @pytest.mark.xfail_firefox
-@pytest.mark.xfail_ie
 @pytest.mark.xfail_remote
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 async def test_collect_js_exceptions(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)
@@ -73,11 +62,7 @@ async def test_collect_js_exceptions(driver, pages):
 
 
 @pytest.mark.xfail_firefox
-@pytest.mark.xfail_ie
 @pytest.mark.xfail_remote
-@pytest.mark.xfail_safari
-@pytest.mark.xfail_webkitgtk
-@pytest.mark.xfail_wpewebkit
 async def test_collect_log_mutations(driver, pages):
     async with driver.bidi_connection() as session:
         log = Log(driver, session)


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adjusts the internal Python PyTest configuration so tests are skipped when `--bidi` is enabled on browsers that don't support BiDi (`ie`, `safari`, `webkitgtk`, `wpewebkit`).

This removes the need to mark BiDi tests with `xfail` markers on browsers where they are expected to fail.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

