### PR TITLE
[py]Fix: Timeout env variable GLOBAL_DEFAULT_TIMEOUT has no effect

### DIFF
--- a/py/selenium/webdriver/remote/client_config.py
+++ b/py/selenium/webdriver/remote/client_config.py
@@ -105,13 +105,9 @@ class ClientConfig:
         self.extra_headers = extra_headers
 
         self.timeout = (
-            (
-                float(os.getenv("GLOBAL_DEFAULT_TIMEOUT", str(socket.getdefaulttimeout())))
-                if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
-                else socket.getdefaulttimeout()
-            )
-            if timeout is None
-            else timeout
+            float(os.getenv("GLOBAL_DEFAULT_TIMEOUT"))
+            if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
+            else (timeout if timeout is not None else socket.getdefaulttimeout())
         )
 
         self.ca_certs = (
@@ -122,7 +118,11 @@ class ClientConfig:
 
     def reset_timeout(self) -> None:
         """Resets the timeout to the default value of socket."""
-        self._timeout = socket.getdefaulttimeout()
+        self._timeout = (
+            float(os.getenv("GLOBAL_DEFAULT_TIMEOUT"))
+            if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
+            else socket.getdefaulttimeout()
+        )
 
     def get_proxy_url(self) -> Optional[str]:
         """Returns the proxy URL to use for the connection."""

--- a/py/test/unit/selenium/webdriver/remote/client_config_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/client_config_tests.py
@@ -1,0 +1,109 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import socket
+
+from selenium.webdriver.remote.client_config import ClientConfig
+
+
+def test_timeout_from_env_variable():
+    """Test that timeout is set from GLOBAL_DEFAULT_TIMEOUT environment variable."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    try:
+        os.environ["GLOBAL_DEFAULT_TIMEOUT"] = "45"
+        config = ClientConfig(remote_server_addr="http://localhost:4444")
+        assert config.timeout == 45
+    finally:
+        if original_env is None:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        else:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+
+
+def test_timeout_from_parameter():
+    """Test that timeout is set from constructor parameter when no env variable."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    try:
+        if "GLOBAL_DEFAULT_TIMEOUT" in os.environ:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        config = ClientConfig(remote_server_addr="http://localhost:4444", timeout=30)
+        assert config.timeout == 30
+    finally:
+        if original_env is not None:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+
+
+def test_timeout_fallback_to_socket_default():
+    """Test that timeout falls back to socket default when no env variable or parameter."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    original_timeout = socket.getdefaulttimeout()
+    try:
+        if "GLOBAL_DEFAULT_TIMEOUT" in os.environ:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        socket.setdefaulttimeout(60)
+        config = ClientConfig(remote_server_addr="http://localhost:4444")
+        assert config.timeout == 60
+    finally:
+        if original_env is not None:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+        socket.setdefaulttimeout(original_timeout)
+
+
+def test_env_variable_priority():
+    """Test that GLOBAL_DEFAULT_TIMEOUT takes priority over parameter."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    try:
+        os.environ["GLOBAL_DEFAULT_TIMEOUT"] = "45"
+        config = ClientConfig(remote_server_addr="http://localhost:4444", timeout=30)
+        assert config.timeout == 45
+    finally:
+        if original_env is None:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        else:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+
+
+def test_reset_timeout_with_env_variable():
+    """Test that reset_timeout() uses GLOBAL_DEFAULT_TIMEOUT when set."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    try:
+        os.environ["GLOBAL_DEFAULT_TIMEOUT"] = "45"
+        config = ClientConfig(remote_server_addr="http://localhost:4444", timeout=30)
+        config.reset_timeout()
+        assert config.timeout == 45
+    finally:
+        if original_env is None:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        else:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+
+
+def test_reset_timeout_without_env_variable():
+    """Test that reset_timeout() uses socket default when no env variable."""
+    original_env = os.environ.get("GLOBAL_DEFAULT_TIMEOUT")
+    original_timeout = socket.getdefaulttimeout()
+    try:
+        if "GLOBAL_DEFAULT_TIMEOUT" in os.environ:
+            del os.environ["GLOBAL_DEFAULT_TIMEOUT"]
+        socket.setdefaulttimeout(60)
+        config = ClientConfig(remote_server_addr="http://localhost:4444", timeout=30)
+        config.reset_timeout()
+        assert config.timeout == 60
+    finally:
+        if original_env is not None:
+            os.environ["GLOBAL_DEFAULT_TIMEOUT"] = original_env
+        socket.setdefaulttimeout(original_timeout)


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #15604

### 💥 What does this PR do?
This PR fixes an issue where the `GLOBAL_DEFAULT_TIMEOUT` environment variable was being ignored when setting timeout values in Selenium's Python bindings. The current implementation always uses a hardcoded timeout value (120 seconds) in the remote connection classes, making the environment variable ineffective.

### 🔧 Implementation Notes
The implementation has been simplified to properly prioritize timeout sources:
1. Use `GLOBAL_DEFAULT_TIMEOUT` if it's set in the environment
2. Otherwise, use the explicitly provided timeout parameter
3. Fall back to `socket.getdefaulttimeout()` if neither is available

This same logic was also applied to the `reset_timeout()` method to ensure consistent behavior throughout the client lifecycle.

### 💡 Additional Considerations
This fix restores expected behavior without changing the API. Users who set the `GLOBAL_DEFAULT_TIMEOUT` environment variable will now see it properly respected.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes the `GLOBAL_DEFAULT_TIMEOUT` environment variable being ignored.

- Adjusts timeout logic to prioritize environment variable correctly.

- Ensures consistent behavior in `reset_timeout` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_config.py</strong><dd><code>Fix timeout logic to respect environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/client_config.py

<li>Updated timeout logic to prioritize <code>GLOBAL_DEFAULT_TIMEOUT</code>.<br> <li> Modified <code>reset_timeout</code> to respect <code>GLOBAL_DEFAULT_TIMEOUT</code>.<br> <li> Simplified conditional checks for timeout assignment.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15628/files#diff-421b55d14e80d4473c60003a3f53c9fa819375d52cb45b6c40403f481a9b8925">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>