### PR TITLE
[py] Call service.stop() when session can't be started

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -42,7 +42,6 @@ from selenium.common.exceptions import InvalidArgumentException
 from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchCookieException
 from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import SessionNotCreatedException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.bidi.browser import Browser
 from selenium.webdriver.common.bidi.network import Network
@@ -350,7 +349,7 @@ class WebDriver(BaseWebDriver):
             response = self.execute(Command.NEW_SESSION, caps)["value"]
             self.session_id = response.get("sessionId")
             self.caps = response.get("capabilities")
-        except (SessionNotCreatedException, WebDriverException):
+        except Exception:
             if self.service is not None:
                 self.service.stop()
             raise

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 """The WebDriver implementation."""
+
 import base64
 import contextlib
 import copy
@@ -348,8 +350,9 @@ class WebDriver(BaseWebDriver):
             response = self.execute(Command.NEW_SESSION, caps)["value"]
             self.session_id = response.get("sessionId")
             self.caps = response.get("capabilities")
-        except SessionNotCreatedException:
-            self.service.stop()
+        except (SessionNotCreatedException, WebDriverException):
+            if self.service is not None:
+                self.service.stop()
             raise
 
     def _wrap_value(self, value):

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -40,6 +40,7 @@ from selenium.common.exceptions import InvalidArgumentException
 from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchCookieException
 from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import SessionNotCreatedException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.bidi.browser import Browser
 from selenium.webdriver.common.bidi.network import Network
@@ -343,9 +344,13 @@ class WebDriver(BaseWebDriver):
         """
 
         caps = _create_caps(capabilities)
-        response = self.execute(Command.NEW_SESSION, caps)["value"]
-        self.session_id = response.get("sessionId")
-        self.caps = response.get("capabilities")
+        try:
+            response = self.execute(Command.NEW_SESSION, caps)["value"]
+            self.session_id = response.get("sessionId")
+            self.caps = response.get("capabilities")
+        except SessionNotCreatedException:
+            self.service.stop()
+            raise
 
     def _wrap_value(self, value):
         if isinstance(value, dict):

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -117,10 +117,6 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
-    try:
-        driver.quit()
-    except Exception:
-        pass
 
 
 @pytest.fixture

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -117,7 +117,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable
     with pytest.raises(SessionNotCreatedException):
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
-    assert service.process.poll() < 0
+    assert service.process.poll() is not None
     try:
         driver.quit()
     except Exception:

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -109,7 +109,7 @@ def test_log_output_null_default(driver, capfd) -> None:
 
 
 @pytest.mark.no_driver_after_test
-def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options = Options()
     options.add_argument("--user-data-dir=/no/such/location")
     service = Service()

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import os
 import subprocess
 import time
@@ -21,6 +22,8 @@ from unittest.mock import patch
 
 import pytest
 
+from selenium.common.exceptions import SessionNotCreatedException
+from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 
 
@@ -103,6 +106,21 @@ def test_log_output_null_default(driver, capfd) -> None:
     out, err = capfd.readouterr()
     assert "Starting ChromeDriver" not in out
     driver.quit()
+
+
+@pytest.mark.no_driver_after_test
+def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+    options = Options()
+    options.add_argument("--user-data-dir=/no/such/location")
+    service = Service()
+    with pytest.raises(SessionNotCreatedException):
+        driver = clean_driver(options=options, service=service)
+    assert not service.is_connectable()
+    assert service.process.poll() < 0
+    try:
+        driver.quit()
+    except Exception:
+        pass
 
 
 @pytest.fixture

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -18,7 +18,6 @@
 import os
 import subprocess
 import time
-
 from unittest.mock import patch
 
 import pytest

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -114,7 +114,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options.add_argument("--user-data-dir=/no/such/location")
     service = Service()
     with pytest.raises(SessionNotCreatedException):
-        driver = clean_driver(options=options, service=service)
+        clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
 

--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -18,6 +18,7 @@
 import os
 import subprocess
 import time
+
 from unittest.mock import patch
 
 import pytest

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -117,10 +117,6 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
-    try:
-        driver.quit()
-    except Exception:
-        pass
 
 
 @pytest.fixture

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -117,7 +117,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable
     with pytest.raises(SessionNotCreatedException):
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
-    assert service.process.poll() < 0
+    assert service.process.poll() is not None
     try:
         driver.quit()
     except Exception:

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -109,7 +109,7 @@ def test_log_output_null_default(driver, capfd) -> None:
 
 
 @pytest.mark.no_driver_after_test
-def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options = Options()
     options.add_argument("--user-data-dir=/no/such/location")
     service = Service()

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -18,7 +18,6 @@
 import os
 import subprocess
 import time
-
 from unittest.mock import patch
 
 import pytest

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import os
 import subprocess
 import time
@@ -21,6 +22,8 @@ from unittest.mock import patch
 
 import pytest
 
+from selenium.common.exceptions import SessionNotCreatedException
+from selenium.webdriver.edge.options import Options
 from selenium.webdriver.edge.service import Service
 
 
@@ -103,6 +106,21 @@ def test_log_output_null_default(driver, capfd) -> None:
     out, err = capfd.readouterr()
     assert "Starting Microsoft Edge WebDriver" not in out
     driver.quit()
+
+
+@pytest.mark.no_driver_after_test
+def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+    options = Options()
+    options.add_argument("--user-data-dir=/no/such/location")
+    service = Service()
+    with pytest.raises(SessionNotCreatedException):
+        driver = clean_driver(options=options, service=service)
+    assert not service.is_connectable()
+    assert service.process.poll() < 0
+    try:
+        driver.quit()
+    except Exception:
+        pass
 
 
 @pytest.fixture

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -114,7 +114,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options.add_argument("--user-data-dir=/no/such/location")
     service = Service()
     with pytest.raises(SessionNotCreatedException):
-        driver = clean_driver(options=options, service=service)
+        clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
 

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -18,6 +18,7 @@
 import os
 import subprocess
 import time
+
 from unittest.mock import patch
 
 import pytest

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -72,10 +72,6 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
-    try:
-        driver.quit()
-    except Exception:
-        pass
 
 
 @pytest.fixture

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -66,7 +66,7 @@ def test_log_output_as_stdout(capfd) -> None:
 
 def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options = Options()
-    options.add_argument("-profile==/no/such/location")
+    options.add_argument("-profile=/no/such/location")
     service = Service()
     with pytest.raises(SessionNotCreatedException):
         driver = clean_driver(options=options, service=service)

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -74,7 +74,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable
     with pytest.raises(SessionNotCreatedException):
         driver = clean_driver(options=options, service=service)
     assert not service.is_connectable()
-    assert service.process.poll() < 0
+    assert service.process.poll() is not None
     try:
         driver.quit()
     except Exception:

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -64,7 +64,7 @@ def test_log_output_as_stdout(capfd) -> None:
     driver.quit()
 
 
-def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options = Options()
     options.add_argument("-profile==/no/such/location")
     service = Service()

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -17,14 +17,12 @@
 
 import os
 import subprocess
-
 from unittest.mock import patch
 
 import pytest
 
-from selenium.webdriver import Firefox
 from selenium.common.exceptions import SessionNotCreatedException
-from selenium.common.exceptions import WebDriverException
+from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.service import Service
 
@@ -68,7 +66,6 @@ def test_log_output_as_stdout(capfd) -> None:
 
 def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
     options = Options()
-    #options.set_preference('profile', "/no/such/location")
     options.add_argument("-profile==/no/such/location")
     service = Service()
     with pytest.raises(SessionNotCreatedException):

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -69,7 +69,7 @@ def test_driver_is_stopped_if_browser_cant_start(clean_driver) -> None:
     options.add_argument("-profile=/no/such/location")
     service = Service()
     with pytest.raises(SessionNotCreatedException):
-        driver = clean_driver(options=options, service=service)
+        clean_driver(options=options, service=service)
     assert not service.is_connectable()
     assert service.process.poll() is not None
 

--- a/py/test/selenium/webdriver/firefox/firefox_service_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_service_tests.py
@@ -14,13 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import os
 import subprocess
+
 from unittest.mock import patch
 
 import pytest
 
 from selenium.webdriver import Firefox
+from selenium.common.exceptions import SessionNotCreatedException
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.service import Service
 
 
@@ -59,6 +64,21 @@ def test_log_output_as_stdout(capfd) -> None:
     out, err = capfd.readouterr()
     assert "geckodriver\tINFO\tListening" in out
     driver.quit()
+
+
+def test_driver_is_stopped_if_browser_cant_start(clean_driver, driver_executable) -> None:
+    options = Options()
+    #options.set_preference('profile', "/no/such/location")
+    options.add_argument("-profile==/no/such/location")
+    service = Service()
+    with pytest.raises(SessionNotCreatedException):
+        driver = clean_driver(options=options, service=service)
+    assert not service.is_connectable()
+    assert service.process.poll() < 0
+    try:
+        driver.quit()
+    except Exception:
+        pass
 
 
 @pytest.fixture


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

This is a fix for #15634 (for Python only)

### 💥 What does this PR do?

When a driver fails to start the browser, `SessionNotCreatedException` is raised. This PR fixes it so the underlying driver service is explicitly stopped when any exception occurs.

I added tests for this for Chrome, Edge, and Firefox

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Ensures `service.stop()` is called when session creation fails.

- Adds exception handling for `Exception` in `start_session`.

- Adds tests for this


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add exception handling for session creation failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/webdriver.py

<li>Added handling for <code>SessionNotCreatedException</code> in <code>start_session</code>.<br> <li> Ensured <code>service.stop()</code> is called when session creation fails.<br> <li> Improved error handling during session initialization.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15636/files#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>