### PR TITLE
[py] Remove unused xfail on chrome/edge service tests

### DIFF
--- a/py/test/selenium/webdriver/chrome/chrome_service_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_service_tests.py
@@ -21,11 +21,9 @@ from unittest.mock import patch
 
 import pytest
 
-from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.service import Service
 
 
-@pytest.mark.xfail_chrome(raises=WebDriverException)
 @pytest.mark.no_driver_after_test
 def test_uses_chromedriver_logging(clean_driver, driver_executable) -> None:
     log_file = "chromedriver.log"

--- a/py/test/selenium/webdriver/edge/edge_service_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_service_tests.py
@@ -21,11 +21,9 @@ from unittest.mock import patch
 
 import pytest
 
-from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.edge.service import Service
 
 
-@pytest.mark.xfail_edge(raises=WebDriverException)
 @pytest.mark.no_driver_after_test
 def test_uses_edgedriver_logging(clean_driver, driver_executable) -> None:
     log_file = "msedgedriver.log"


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR removes the `xfail_chrome` PyTest marker from the following tests:
```
py/test/selenium/webdriver/edge/edge_service_tests.py::test_uses_edgedriver_logging
py/test/selenium/webdriver/edge/edge_service_tests.py::::test_uses_chromedriver_logging
```
These tests were fixed in #15605 and #15579 and run properly now.

(The marker wasn't working correctly anyway)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Removed unused `xfail_chrome` marker from Chrome service test.

- Removed unused `xfail_edge` marker from Edge service test.

- Cleaned up test files for Chrome and Edge services.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome_service_tests.py</strong><dd><code>Removed unused `xfail_chrome` marker in Chrome tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/chrome/chrome_service_tests.py

<li>Removed <code>xfail_chrome</code> marker from a test.<br> <li> Simplified test annotations for Chrome service.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15637/files#diff-fbe1b874fe96cac5a42b60be25d1e54cbdc42deb26168bd9ff2e1c33d2da5857">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge_service_tests.py</strong><dd><code>Removed unused `xfail_edge` marker in Edge tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/edge/edge_service_tests.py

<li>Removed <code>xfail_edge</code> marker from a test.<br> <li> Simplified test annotations for Edge service.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15637/files#diff-9ba4cbc1f50e44a2b01e9ffda260a45177281d243a43e3466cc12808d2aca955">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>