### PR TITLE
[py] Adjust xfail markers for window size/position tests

### DIFF
--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -239,7 +239,8 @@ def test_is_element_displayed(driver, pages):
     assert not not_visible
 
 
-@pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
+@pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
 @pytest.mark.xfail_safari
 def test_move_window_position(driver, pages):
     pages.load("blank.html")

--- a/py/test/selenium/webdriver/common/window_tests.py
+++ b/py/test/selenium/webdriver/common/window_tests.py
@@ -45,6 +45,7 @@ def test_should_get_the_size_of_the_current_window(driver):
     assert size.get("height") > 0
 
 
+@pytest.mark.xfail_edge
 def test_should_set_the_size_of_the_current_window(driver):
     size = driver.get_window_size()
 
@@ -57,13 +58,15 @@ def test_should_set_the_size_of_the_current_window(driver):
     assert new_size.get("height") == target_height
 
 
-@pytest.mark.xfail_chrome
 def test_should_get_the_position_of_the_current_window(driver):
     position = driver.get_window_position()
     assert position.get("x") >= 0
     assert position.get("y") >= 0
 
 
+@pytest.mark.xfail_chrome
+@pytest.mark.xfail_edge
+@pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
 def test_should_set_the_position_of_the_current_window(driver):
     position = driver.get_window_position()
 
@@ -81,7 +84,6 @@ def test_should_set_the_position_of_the_current_window(driver):
 
 
 @pytest.mark.xfail_safari(raises=WebDriverException, reason="Get Window Rect command not implemented")
-@pytest.mark.xfail_chrome
 def test_should_get_the_rect_of_the_current_window(driver):
     rect = driver.get_window_rect()
     assert rect.get("x") >= 0
@@ -90,6 +92,8 @@ def test_should_get_the_rect_of_the_current_window(driver):
     assert rect.get("height") >= 0
 
 
+@pytest.mark.xfail_edge
+@pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
 @pytest.mark.xfail_safari(raises=WebDriverException, reason="Get Window Rect command not implemented")
 def test_should_set_the_rect_of_the_current_window(driver):
     rect = driver.get_window_rect()


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adds some `xfail` markers and removes some `xfail` markers on Python tests to reflect the state of window sizing and positioning in current browser versions.

Window positioning is broken for Firefox on Linux, so we are getting failures in CI. This has been reported to Mozilla.

Edge still has some known issues with window sizing and positioning, so those are now marked.

Chrome has fixed some window positioning issues, so markers were removed.

(This hopefully makes CI green again)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Adjusted `xfail` markers for window size/position tests.

- Added `xfail` markers for Firefox and Edge due to known issues.

- Removed outdated `xfail` markers for Chrome.

- Updated test annotations to reflect current browser behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_example_tests.py</strong><dd><code>Adjust `xfail` markers for `test_move_window_position`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/api_example_tests.py

<li>Changed <code>xfail</code> marker from Chrome to Edge for <br><code>test_move_window_position</code>.<br> <li> Added <code>xfail</code> marker for Firefox with a specific issue reference.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15638/files#diff-c750a83d4b24d0fbebc7e45219d9976215b2c7ff2df066f796c29be4a9ca84b3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>window_tests.py</strong><dd><code>Update `xfail` markers for window-related tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/window_tests.py

<li>Added <code>xfail</code> markers for Edge and Firefox for multiple tests.<br> <li> Removed outdated <code>xfail</code> markers for Chrome.<br> <li> Updated test annotations to align with current browser issues.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15638/files#diff-353dbb22282fdb450da3dbf635018696f756b7c0351d5199c2777cf4a14e9c32">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>