### PR TITLE
[py] Remove logging API for non-Chromium browsers 

### DIFF
--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -19,6 +19,7 @@ from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnecti
 from selenium.webdriver.common.driver_finder import DriverFinder
 from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.common.service import Service
+from selenium.webdriver.remote.command import Command
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 
@@ -148,6 +149,36 @@ class ChromiumDriver(RemoteWebDriver):
         """:Returns: An error message when there is any issue in a Cast
         session."""
         return self.execute("getIssueMessage")["value"]
+
+
+    @property
+    def log_types(self):
+        """Gets a list of the available log types.
+
+        Example:
+        --------
+        >>> driver.log_types
+        """
+        return self.execute(Command.GET_AVAILABLE_LOG_TYPES)["value"]
+
+
+    def get_log(self, log_type):
+        """Gets the log for a given log type.
+
+        Parameters:
+        -----------
+        log_type : str
+            - Type of log that which will be returned
+
+        Example:
+        --------
+        >>> driver.get_log('browser')
+        >>> driver.get_log('driver')
+        >>> driver.get_log('client')
+        >>> driver.get_log('server')
+        """
+        return self.execute(Command.GET_LOG, {"type": log_type})["value"]
+
 
     def set_sink_to_use(self, sink_name: str) -> dict:
         """Sets a specific sink, using its name, as a Cast session receiver

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -150,7 +150,6 @@ class ChromiumDriver(RemoteWebDriver):
         session."""
         return self.execute("getIssueMessage")["value"]
 
-
     @property
     def log_types(self):
         """Gets a list of the available log types.
@@ -160,7 +159,6 @@ class ChromiumDriver(RemoteWebDriver):
         >>> driver.log_types
         """
         return self.execute(Command.GET_AVAILABLE_LOG_TYPES)["value"]
-
 
     def get_log(self, log_type):
         """Gets the log for a given log type.
@@ -178,7 +176,6 @@ class ChromiumDriver(RemoteWebDriver):
         >>> driver.get_log('server')
         """
         return self.execute(Command.GET_LOG, {"type": log_type})["value"]
-
 
     def set_sink_to_use(self, sink_name: str) -> dict:
         """Sets a specific sink, using its name, as a Cast session receiver

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1174,33 +1174,6 @@ class WebDriver(BaseWebDriver):
         else:
             raise WebDriverException("You can only set the orientation to 'LANDSCAPE' and 'PORTRAIT'")
 
-    @property
-    def log_types(self):
-        """Gets a list of the available log types. This only works with w3c
-        compliant browsers.
-
-        Example:
-        --------
-        >>> driver.log_types
-        """
-        return self.execute(Command.GET_AVAILABLE_LOG_TYPES)["value"]
-
-    def get_log(self, log_type):
-        """Gets the log for a given log type.
-
-        Parameters:
-        -----------
-        log_type : str
-            - Type of log that which will be returned
-
-        Example:
-        --------
-        >>> driver.get_log('browser')
-        >>> driver.get_log('driver')
-        >>> driver.get_log('client')
-        >>> driver.get_log('server')
-        """
-        return self.execute(Command.GET_LOG, {"type": log_type})["value"]
 
     def start_devtools(self):
         global devtools

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1174,7 +1174,6 @@ class WebDriver(BaseWebDriver):
         else:
             raise WebDriverException("You can only set the orientation to 'LANDSCAPE' and 'PORTRAIT'")
 
-
     def start_devtools(self):
         global devtools
         if self._websocket_connection:

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -274,17 +274,23 @@ def test_change_window_size(driver, pages):
     assert size["height"] == newSize[1]
 
 
-@pytest.mark.xfail_firefox(raises=WebDriverException)
-@pytest.mark.xfail_remote
-@pytest.mark.xfail_safari
+@pytest.mark.xfail_ie(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_firefox(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_remote(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_safari(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_webkitgtk(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_wpewebkit(raises=AttributeError, reason="Logging API is no longer available")
 def test_get_log_types(driver, pages):
     pages.load("blank.html")
     assert isinstance(driver.log_types, list)
 
 
-@pytest.mark.xfail_firefox(raises=WebDriverException)
-@pytest.mark.xfail_remote
-@pytest.mark.xfail_safari
+@pytest.mark.xfail_ie(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_firefox(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_remote(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_safari(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_webkitgtk(raises=AttributeError, reason="Logging API is no longer available")
+@pytest.mark.xfail_wpewebkit()(raises=AttributeError, reason="Logging API is no longer available")
 def test_get_log(driver, pages):
     pages.load("blank.html")
     for log_type in driver.log_types:

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -15,11 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 import pytest
 
 from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #15588 
Fixes #15589
Fixes #15587
Fixes #15586

### 💥 What does this PR do?

This PR changes the logging API in the Python bindings so it only works on Chromium based browsers (Chrome/Edge), as discussed in: https://github.com/SeleniumHQ/selenium/issues/15588

It removes the related methods from the `selenium.webdriver.remote.webdriver.WebDriver` class and adds them to `selenium.webdriver.chromium/webdriver.WebDriver`.

Relevant tests have been updated so the are expected failures on all non-Chromium browsers.

This will bring the Python bindings in line with other language bindings where this has already been removed from most browsers. 

### 🔄 Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement

