### PR TITLE
[py] Fix Remote Firefox tests on Linux/Wayland

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -159,9 +159,10 @@ def driver(request):
     if driver_instance is None:
         if driver_class == "Firefox":
             options = get_options(driver_class, request.config)
-            # There are issues with window size/position when running Firefox
-            # under Wayland, so we use XWayland instead.
-            os.environ["MOZ_ENABLE_WAYLAND"] = "0"
+            if platform.system() == "Linux":
+                # There are issues with window size/position when running Firefox
+                # under Wayland, so we use XWayland instead.
+                os.environ["MOZ_ENABLE_WAYLAND"] = "0"
         if driver_class == "Chrome":
             options = get_options(driver_class, request.config)
         if driver_class == "Edge":
@@ -174,9 +175,6 @@ def driver(request):
             options = get_options("Firefox", request.config) or webdriver.FirefoxOptions()
             options.set_capability("moz:firefoxOptions", {})
             options.enable_downloads = True
-            # There are issues with window size/position when running Firefox
-            # under Wayland, so we use XWayland instead.
-            os.environ["MOZ_ENABLE_WAYLAND"] = "0"
         if driver_path is not None:
             kwargs["service"] = get_service(driver_class, driver_path)
         if options is not None:
@@ -315,6 +313,11 @@ def server(request):
             "is using port {}, continuing...".format(_port)
         )
     except Exception:
+        if platform.system() == "Linux":
+            # There are issues with window size/position when running Firefox
+            # under Wayland, so we use XWayland instead.
+            remote_env = os.environ.copy()
+            remote_env["MOZ_ENABLE_WAYLAND"] = "0"
         print("Starting the Selenium server")
         process = subprocess.Popen(
             [
@@ -328,7 +331,8 @@ def server(request):
                 "true",
                 "--enable-managed-downloads",
                 "true",
-            ]
+            ],
+            env=remote_env,
         )
         print(f"Selenium server running as process: {process.pid}")
         assert wait_for_server(url, 10), f"Timed out waiting for Selenium server at {url}"

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -313,10 +313,10 @@ def server(request):
             "is using port {}, continuing...".format(_port)
         )
     except Exception:
+        remote_env = os.environ.copy()
         if platform.system() == "Linux":
             # There are issues with window size/position when running Firefox
             # under Wayland, so we use XWayland instead.
-            remote_env = os.environ.copy()
             remote_env["MOZ_ENABLE_WAYLAND"] = "0"
         print("Starting the Selenium server")
         process = subprocess.Popen(

--- a/py/test/selenium/webdriver/common/api_example_tests.py
+++ b/py/test/selenium/webdriver/common/api_example_tests.py
@@ -239,6 +239,7 @@ def test_is_element_displayed(driver, pages):
 
 @pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
+@pytest.mark.xfail_remote(reason="https://github.com/mozilla/geckodriver/issues/2224")
 @pytest.mark.xfail_safari
 def test_move_window_position(driver, pages):
     pages.load("blank.html")

--- a/py/test/selenium/webdriver/common/window_tests.py
+++ b/py/test/selenium/webdriver/common/window_tests.py
@@ -67,6 +67,7 @@ def test_should_get_the_position_of_the_current_window(driver):
 @pytest.mark.xfail_chrome
 @pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
+@pytest.mark.xfail_remote(reason="https://github.com/mozilla/geckodriver/issues/2224")
 def test_should_set_the_position_of_the_current_window(driver):
     position = driver.get_window_position()
 
@@ -94,6 +95,7 @@ def test_should_get_the_rect_of_the_current_window(driver):
 
 @pytest.mark.xfail_edge
 @pytest.mark.xfail_firefox(reason="https://github.com/mozilla/geckodriver/issues/2224")
+@pytest.mark.xfail_remote(reason="https://github.com/mozilla/geckodriver/issues/2224")
 @pytest.mark.xfail_safari(raises=WebDriverException, reason="Get Window Rect command not implemented")
 def test_should_set_the_rect_of_the_current_window(driver):
     rect = driver.get_window_rect()


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

#15601
#15638

### 💥 What does this PR do?

This PR fixes some issues in the internal Python test suite that are failing in CI.

- Remote WebDriver tests were failing for the same reason as #15601 because the environment variable to disable Wayland for Firefox was set in the wrong place
- Only try to disable Wayland for Firefox when running on Linux
- Set `xfail_remote` markers on WebDriver Remote tests for the same issues as in #15638

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Firefox/Remote WebDriver tests on Linux/Wayland
  - Set `MOZ_ENABLE_WAYLAND=0` only on Linux
  - Pass environment variable to Selenium server process

- Mark Remote WebDriver tests as expected failures for known issues


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Linux-specific handling for Firefox/Remote Wayland issues</code></dd></summary>
<hr>

py/conftest.py

<li>Set <code>MOZ_ENABLE_WAYLAND=0</code> only on Linux for Firefox and Remote drivers<br> <li> Pass environment variable to Selenium server process on Linux<br> <li> Remove unconditional setting of Wayland variable for Remote


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15648/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_example_tests.py</strong><dd><code>Mark Remote WebDriver window position test as expected failure</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/api_example_tests.py

<li>Add <code>xfail_remote</code> marker to window position test for known GeckoDriver <br>issue


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15648/files#diff-c750a83d4b24d0fbebc7e45219d9976215b2c7ff2df066f796c29be4a9ca84b3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>window_tests.py</strong><dd><code>Mark Remote WebDriver window tests as expected failures</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/window_tests.py

<li>Add <code>xfail_remote</code> marker to window position and rect tests for <br>GeckoDriver issue


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15648/files#diff-353dbb22282fdb450da3dbf635018696f756b7c0351d5199c2777cf4a14e9c32">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>