### PR TITLE
[dotnet] Enhance Selenium Manager platform detection

### DIFF
--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -61,7 +61,7 @@ namespace OpenQA.Selenium
                 {
                     platform = SupportedPlatform.MacOS;
                 }
-#elif NETSTANDARD2_0
+#else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     platform = SupportedPlatform.Windows;

--- a/dotnet/src/webdriver/SeleniumManager.cs
+++ b/dotnet/src/webdriver/SeleniumManager.cs
@@ -46,24 +46,46 @@ namespace OpenQA.Selenium
             string? binaryFullPath = Environment.GetEnvironmentVariable("SE_MANAGER_PATH");
             if (binaryFullPath == null)
             {
-                var currentDirectory = AppContext.BaseDirectory;
+                SupportedPlatform? platform = null;
+
+#if NET8_0_OR_GREATER
+                if (OperatingSystem.IsWindows())
+                {
+                    platform = SupportedPlatform.Windows;
+                }
+                else if (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD())
+                {
+                    platform = SupportedPlatform.Linux;
+                }
+                else if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+                {
+                    platform = SupportedPlatform.MacOS;
+                }
+#elif NETSTANDARD2_0
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "windows", "selenium-manager.exe");
+                    platform = SupportedPlatform.Windows;
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "linux", "selenium-manager");
+                    platform = SupportedPlatform.Linux;
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    binaryFullPath = Path.Combine(currentDirectory, "selenium-manager", "macos", "selenium-manager");
+                    platform = SupportedPlatform.MacOS;
                 }
-                else
+#endif
+
+                var currentDirectory = AppContext.BaseDirectory;
+
+                binaryFullPath = platform switch
                 {
-                    throw new PlatformNotSupportedException(
-                        $"Selenium Manager doesn't support your runtime platform: {RuntimeInformation.OSDescription}");
-                }
+                    SupportedPlatform.Windows => Path.Combine(currentDirectory, "selenium-manager", "windows", "selenium-manager.exe"),
+                    SupportedPlatform.Linux => Path.Combine(currentDirectory, "selenium-manager", "linux", "selenium-manager"),
+                    SupportedPlatform.MacOS => Path.Combine(currentDirectory, "selenium-manager", "macos", "selenium-manager"),
+                    _ => throw new PlatformNotSupportedException(
+                                            $"Selenium Manager doesn't support your runtime platform: {RuntimeInformation.OSDescription}"),
+                };
             }
 
             if (!File.Exists(binaryFullPath))
@@ -225,4 +247,11 @@ namespace OpenQA.Selenium
     [JsonSerializable(typeof(SeleniumManagerResponse))]
     [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
     internal sealed partial class SeleniumManagerSerializerContext : JsonSerializerContext;
+
+    internal enum SupportedPlatform
+    {
+        Windows,
+        Linux,
+        MacOS
+    }
 }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

Fixes #15646

### 💥 What does this PR do?
For .NET 8 target framework we use new `OperatingSystem.Is*()` API, and fallback to `RuntimeInformation.IsOSPlatform()` in netstandard 2.0.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored platform detection for Selenium Manager in .NET
  - Uses `OperatingSystem.Is*()` API for .NET 8+
  - Falls back to `RuntimeInformation.IsOSPlatform()` for netstandard2.0

- Introduced `SupportedPlatform` enum for clearer platform handling

- Improved maintainability and clarity of platform-specific binary selection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumManager.cs</strong><dd><code>Refactor and enhance platform detection logic in SeleniumManager</code></dd></summary>
<hr>

dotnet/src/webdriver/SeleniumManager.cs

<li>Refactored platform detection logic for .NET 8 and netstandard2.0<br> <li> Added <code>SupportedPlatform</code> enum for platform abstraction<br> <li> Used switch expression for binary path selection<br> <li> Improved error handling for unsupported platforms


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15649/files#diff-df9a0140c4ef310382b15de2b26d228971d00530d18f4c1bd3c74f735c3af665">+37/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>