### PR TITLE
[py] Fix flaky WebDriverWait tests

### DIFF
--- a/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -39,14 +39,14 @@ def throw_sere(driver):
 def test_should_fail_with_invalid_selector_exception(driver, pages):
     pages.load("dynamic.html")
     with pytest.raises(InvalidSelectorException):
-        WebDriverWait(driver, 0.7).until(EC.presence_of_element_located((By.XPATH, "//*[contains(@id,'something'")))
+        WebDriverWait(driver, 1).until(EC.presence_of_element_located((By.XPATH, "//*[contains(@id,'something'")))
 
 
 def test_should_explicitly_wait_for_a_single_element(driver, pages):
     pages.load("dynamic.html")
     add = driver.find_element(By.ID, "adder")
     add.click()
-    WebDriverWait(driver, 3).until(
+    WebDriverWait(driver, 5).until(
         EC.presence_of_element_located((By.ID, "box0"))
     )  # All is well if this doesn't throw.
 
@@ -54,7 +54,7 @@ def test_should_explicitly_wait_for_a_single_element(driver, pages):
 def test_should_still_fail_to_find_an_element_with_explicit_wait(driver, pages):
     pages.load("dynamic.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.presence_of_element_located((By.ID, "box0")))
+        WebDriverWait(driver, 0.01).until(EC.presence_of_element_located((By.ID, "box0")))
 
 
 def test_should_explicitly_wait_until_at_least_one_element_is_found_when_searching_for_many(driver, pages):
@@ -64,14 +64,14 @@ def test_should_explicitly_wait_until_at_least_one_element_is_found_when_searchi
     add.click()
     add.click()
 
-    elements = WebDriverWait(driver, 3).until(EC.presence_of_all_elements_located((By.CLASS_NAME, "redbox")))
+    elements = WebDriverWait(driver, 5).until(EC.presence_of_all_elements_located((By.CLASS_NAME, "redbox")))
     assert len(elements) >= 1
 
 
 def test_should_fail_to_find_elements_when_explicit_waiting(driver, pages):
     pages.load("dynamic.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.presence_of_all_elements_located((By.CLASS_NAME, "redbox")))
+        WebDriverWait(driver, 0.01).until(EC.presence_of_all_elements_located((By.CLASS_NAME, "redbox")))
 
 
 def test_should_wait_until_at_least_one_visible_elements_is_found_when_searching_for_many(driver, pages):
@@ -91,14 +91,14 @@ def test_should_wait_until_at_least_one_visible_elements_is_found_when_searching
             elements = [element for element in driver.find_elements(*self.locator) if EC._element_if_visible(element)]
             return elements if len(elements) == 2 else False
 
-    elements = WebDriverWait(driver, 3).until(wait_for_two_elements((By.CLASS_NAME, "redbox")))
+    elements = WebDriverWait(driver, 5).until(wait_for_two_elements((By.CLASS_NAME, "redbox")))
     assert len(elements) == 2
 
 
 def test_should_fail_to_find_visible_elements_when_explicit_waiting(driver, pages):
     pages.load("hidden_partially.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.visibility_of_any_elements_located((By.CLASS_NAME, "redbox")))
+        WebDriverWait(driver, 0.01).until(EC.visibility_of_any_elements_located((By.CLASS_NAME, "redbox")))
 
 
 def test_should_wait_until_all_visible_elements_are_found_when_searching_for_many(driver, pages):
@@ -108,7 +108,7 @@ def test_should_wait_until_all_visible_elements_are_found_when_searching_for_man
     add_visible.click()
     add_visible.click()
 
-    elements = WebDriverWait(driver, 3).until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "redbox")))
+    elements = WebDriverWait(driver, 5).until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "redbox")))
     assert len(elements) == 2
 
 
@@ -120,7 +120,7 @@ def test_should_fail_if_not_all_elements_are_visible(driver, pages):
     add_visible.click()
     add_hidden.click()
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "redbox")))
+        WebDriverWait(driver, 0.01).until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "redbox")))
 
 
 def test_should_wait_only_as_long_as_timeout_specified_when_implicit_waits_are_set(driver, pages):
@@ -145,44 +145,44 @@ def test_wait_until_not_returns_if_evaluates_to_false(driver, pages):
 def test_wait_should_still_fail_if_produce_ignored_exception(driver, pages):
     ignored = (InvalidElementStateException, StaleElementReferenceException)
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1, 0.7, ignored_exceptions=ignored).until(throw_sere)
+        WebDriverWait(driver, 0.01, ignored_exceptions=ignored).until(throw_sere)
 
 
 def test_wait_should_still_fail_if_produce_child_of_ignored_exception(driver, pages):
     ignored = WebDriverException
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1, 0.7, ignored_exceptions=ignored).until(throw_sere)
+        WebDriverWait(driver, 0.01, ignored_exceptions=ignored).until(throw_sere)
 
 
 def test_wait_until_not_should_not_fail_if_produce_ignored_exception(driver, pages):
     ignored = (InvalidElementStateException, StaleElementReferenceException)
-    assert WebDriverWait(driver, 1, 0.7, ignored_exceptions=ignored).until_not(throw_sere)
+    assert WebDriverWait(driver, 0.01, ignored_exceptions=ignored).until_not(throw_sere)
 
 
 def test_expected_condition_title_is(driver, pages):
     pages.load("blank.html")
     WebDriverWait(driver, 1).until(EC.title_is("blank"))
     driver.execute_script("setTimeout(function(){document.title='not blank'}, 200)")
-    WebDriverWait(driver, 2).until(EC.title_is("not blank"))
+    WebDriverWait(driver, 1).until(EC.title_is("not blank"))
     assert driver.title == "not blank"
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.title_is("blank"))
+        WebDriverWait(driver, 0.01).until(EC.title_is("blank"))
 
 
 def test_expected_condition_title_contains(driver, pages):
     pages.load("blank.html")
     driver.execute_script("setTimeout(function(){document.title='not blank'}, 200)")
-    WebDriverWait(driver, 2).until(EC.title_contains("not"))
+    WebDriverWait(driver, 1).until(EC.title_contains("not"))
     assert driver.title == "not blank"
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.title_contains("blanket"))
+        WebDriverWait(driver, 0.01).until(EC.title_contains("blanket"))
 
 
 @pytest.mark.xfail_safari
 def test_expected_condition_visibility_of_element_located(driver, pages):
     pages.load("javascriptPage.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.visibility_of_element_located((By.ID, "clickToHide")))
+        WebDriverWait(driver, 0.01).until(EC.visibility_of_element_located((By.ID, "clickToHide")))
     driver.find_element(By.ID, "clickToShow").click()
     element = WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.ID, "clickToHide")))
     assert element.is_displayed() is True
@@ -193,7 +193,7 @@ def test_expected_condition_visibility_of(driver, pages):
     pages.load("javascriptPage.html")
     hidden = driver.find_element(By.ID, "clickToHide")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.visibility_of(hidden))
+        WebDriverWait(driver, 0.01).until(EC.visibility_of(hidden))
     driver.find_element(By.ID, "clickToShow").click()
     element = WebDriverWait(driver, 5).until(EC.visibility_of(hidden))
     assert element.is_displayed() is True
@@ -202,35 +202,35 @@ def test_expected_condition_visibility_of(driver, pages):
 def test_expected_condition_text_to_be_present_in_element(driver, pages):
     pages.load("booleanAttributes.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.text_to_be_present_in_element((By.ID, "unwrappable"), "Expected"))
+        WebDriverWait(driver, 0.01).until(EC.text_to_be_present_in_element((By.ID, "unwrappable"), "Expected"))
     driver.execute_script(
         "setTimeout(function(){var el = document.getElementById('unwrappable'); el.textContent = el.innerText = 'Unwrappable Expected text'}, 200)"
     )
-    WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element((By.ID, "unwrappable"), "Expected"))
+    WebDriverWait(driver, 5).until(EC.text_to_be_present_in_element((By.ID, "unwrappable"), "Expected"))
     assert "Unwrappable Expected text" == driver.find_element(By.ID, "unwrappable").text
 
 
 def test_expected_condition_text_to_be_present_in_element_value(driver, pages):
     pages.load("booleanAttributes.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1).until(EC.text_to_be_present_in_element_value((By.ID, "inputRequired"), "Expected"))
+        WebDriverWait(driver, 0.01).until(EC.text_to_be_present_in_element_value((By.ID, "inputRequired"), "Expected"))
     driver.execute_script(
         "setTimeout(function(){document.getElementById('inputRequired').value = 'Example Expected text'}, 200)"
     )
-    WebDriverWait(driver, 2).until(EC.text_to_be_present_in_element_value((By.ID, "inputRequired"), "Expected"))
+    WebDriverWait(driver, 5).until(EC.text_to_be_present_in_element_value((By.ID, "inputRequired"), "Expected"))
     assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_attribute("value")
 
 
 def test_expected_condition_text_to_be_present_in_element_attribute(driver, pages):
     pages.load("booleanAttributes.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1).until(
+        WebDriverWait(driver, 0.01).until(
             EC.text_to_be_present_in_element_attribute((By.ID, "inputRequired"), "value", "Expected")
         )
     driver.execute_script(
         "setTimeout(function(){document.getElementById('inputRequired').value = 'Example Expected text'}, 200)"
     )
-    WebDriverWait(driver, 2).until(
+    WebDriverWait(driver, 5).until(
         EC.text_to_be_present_in_element_attribute((By.ID, "inputRequired"), "value", "Expected")
     )
     assert "Example Expected text" == driver.find_element(By.ID, "inputRequired").get_attribute("value")
@@ -239,13 +239,13 @@ def test_expected_condition_text_to_be_present_in_element_attribute(driver, page
 def test_expected_condition_frame_to_be_available_and_switch_to_it_by_locator(driver, pages):
     pages.load("blank.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1).until(EC.frame_to_be_available_and_switch_to_it((By.ID, "myFrame")))
+        WebDriverWait(driver, 0.01).until(EC.frame_to_be_available_and_switch_to_it((By.ID, "myFrame")))
     driver.execute_script(
         "setTimeout(function(){var f = document.createElement('iframe'); f.id='myFrame'; f.src = '"
         + pages.url("iframeWithAlert.html")
         + "'; document.body.appendChild(f)}, 200)"
     )
-    WebDriverWait(driver, 2).until(EC.frame_to_be_available_and_switch_to_it((By.ID, "myFrame")))
+    WebDriverWait(driver, 5).until(EC.frame_to_be_available_and_switch_to_it((By.ID, "myFrame")))
     assert "click me" == driver.find_element(By.ID, "alertInFrame").text
 
 
@@ -254,9 +254,9 @@ def test_expected_condition_invisiblity_of_element(driver, pages):
     target = driver.find_element(By.ID, "clickToHide")
     driver.execute_script("delayedShowHide(0, true)")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.invisibility_of_element(target))
+        WebDriverWait(driver, 0.01).until(EC.invisibility_of_element(target))
     driver.execute_script("delayedShowHide(200, false)")
-    element = WebDriverWait(driver, 2).until(EC.invisibility_of_element(target))
+    element = WebDriverWait(driver, 5).until(EC.invisibility_of_element(target))
     assert element.is_displayed() is False
     assert target == element
 
@@ -265,9 +265,9 @@ def test_expected_condition_invisiblity_of_element_located(driver, pages):
     pages.load("javascriptPage.html")
     driver.execute_script("delayedShowHide(0, true)")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
+        WebDriverWait(driver, 0.01).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
     driver.execute_script("delayedShowHide(200, false)")
-    element = WebDriverWait(driver, 2).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
+    element = WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
     assert element.is_displayed() is False
 
 
@@ -275,12 +275,12 @@ def test_expected_condition_invisiblity_of_element_located(driver, pages):
 def test_expected_condition_element_to_be_clickable(driver, pages):
     pages.load("javascriptPage.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.element_to_be_clickable((By.ID, "clickToHide")))
+        WebDriverWait(driver, 0.01).until(EC.element_to_be_clickable((By.ID, "clickToHide")))
     driver.execute_script("delayedShowHide(200, true)")
-    WebDriverWait(driver, 2).until(EC.element_to_be_clickable((By.ID, "clickToHide")))
+    WebDriverWait(driver, 5).until(EC.element_to_be_clickable((By.ID, "clickToHide")))
     element = driver.find_element(By.ID, "clickToHide")
     element.click()
-    WebDriverWait(driver, 4.5).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
+    WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
     assert element.is_displayed() is False
 
 
@@ -288,10 +288,10 @@ def test_expected_condition_staleness_of(driver, pages):
     pages.load("dynamicallyModifiedPage.html")
     element = driver.find_element(By.ID, "element-to-remove")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.staleness_of(element))
+        WebDriverWait(driver, 0.01).until(EC.staleness_of(element))
     driver.find_element(By.ID, "buttonDelete").click()
     assert "element" == element.text
-    WebDriverWait(driver, 2).until(EC.staleness_of(element))
+    WebDriverWait(driver, 5).until(EC.staleness_of(element))
     with pytest.raises(StaleElementReferenceException):
         element.text
 
@@ -300,9 +300,9 @@ def test_expected_condition_element_to_be_selected(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "checky")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.element_to_be_selected(element))
+        WebDriverWait(driver, 0.01).until(EC.element_to_be_selected(element))
     driver.execute_script("setTimeout(function(){document.getElementById('checky').checked = true}, 200)")
-    WebDriverWait(driver, 2).until(EC.element_to_be_selected(element))
+    WebDriverWait(driver, 5).until(EC.element_to_be_selected(element))
     assert element.is_selected() is True
 
 
@@ -310,42 +310,42 @@ def test_expected_condition_element_located_to_be_selected(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "checky")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.element_located_to_be_selected((By.ID, "checky")))
+        WebDriverWait(driver, 0.01).until(EC.element_located_to_be_selected((By.ID, "checky")))
     driver.execute_script("setTimeout(function(){document.getElementById('checky').checked = true}, 200)")
-    WebDriverWait(driver, 2).until(EC.element_located_to_be_selected((By.ID, "checky")))
+    WebDriverWait(driver, 5).until(EC.element_located_to_be_selected((By.ID, "checky")))
     assert element.is_selected() is True
 
 
 def test_expected_condition_element_selection_state_to_be(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "checky")
-    WebDriverWait(driver, 0.7).until(EC.element_selection_state_to_be(element, False))
+    WebDriverWait(driver, 0.01).until(EC.element_selection_state_to_be(element, False))
     assert element.is_selected() is False
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.element_selection_state_to_be(element, True))
+        WebDriverWait(driver, 0.01).until(EC.element_selection_state_to_be(element, True))
     driver.execute_script("setTimeout(function(){document.getElementById('checky').checked = true}, 200)")
-    WebDriverWait(driver, 2).until(EC.element_selection_state_to_be(element, True))
+    WebDriverWait(driver, 5).until(EC.element_selection_state_to_be(element, True))
     assert element.is_selected() is True
 
 
 def test_expected_condition_element_located_selection_state_to_be(driver, pages):
     pages.load("formPage.html")
     element = driver.find_element(By.ID, "checky")
-    WebDriverWait(driver, 0.7).until(EC.element_located_selection_state_to_be((By.ID, "checky"), False))
+    WebDriverWait(driver, 0.01).until(EC.element_located_selection_state_to_be((By.ID, "checky"), False))
     assert element.is_selected() is False
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.element_located_selection_state_to_be((By.ID, "checky"), True))
+        WebDriverWait(driver, 0.01).until(EC.element_located_selection_state_to_be((By.ID, "checky"), True))
     driver.execute_script("setTimeout(function(){document.getElementById('checky').checked = true}, 200)")
-    WebDriverWait(driver, 2).until(EC.element_located_selection_state_to_be((By.ID, "checky"), True))
+    WebDriverWait(driver, 5).until(EC.element_located_selection_state_to_be((By.ID, "checky"), True))
     assert element.is_selected() is True
 
 
 def test_expected_condition_alert_is_present(driver, pages):
     pages.load("blank.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 0.7).until(EC.alert_is_present())
+        WebDriverWait(driver, 0.01).until(EC.alert_is_present())
     driver.execute_script("setTimeout(function(){alert('alerty')}, 200)")
-    WebDriverWait(driver, 2).until(EC.alert_is_present())
+    WebDriverWait(driver, 5).until(EC.alert_is_present())
     alert = driver.switch_to.alert
     assert "alerty" == alert.text
     alert.dismiss()
@@ -354,6 +354,6 @@ def test_expected_condition_alert_is_present(driver, pages):
 def test_expected_condition_attribute_to_be_include_in_element(driver, pages):
     pages.load("booleanAttributes.html")
     with pytest.raises(TimeoutException):
-        WebDriverWait(driver, 1).until(EC.element_attribute_to_include((By.ID, "inputRequired"), "test"))
-    value = WebDriverWait(driver, 2).until(EC.element_attribute_to_include((By.ID, "inputRequired"), "value"))
+        WebDriverWait(driver, 0.01).until(EC.element_attribute_to_include((By.ID, "inputRequired"), "test"))
+    value = WebDriverWait(driver, 5).until(EC.element_attribute_to_include((By.ID, "inputRequired"), "value"))
     assert value is not None


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adjusts many of the wait times in our internal tests for `WebDriverWait` (in `webdriverwait_tests.py`) to make the tests less flaky. These tests are very timing dependent and sometimes fail on slow systems (we often get CI failures due to this).

These changes raise most wait times to 5 seconds to account for elements loading too slow, and reduces wait times to 0.01 seconds in tests for timeouts so the timeouts occur more consistently.

Overall, this should reduce flakiness and keep CI green more often.

### 💡 Additional Considerations

The tests could still be flaky on very slow systems. There's no real way around this without making the tests extremely slow all the time.

### 🔄 Types of changes
- Internal/CI
- Bug fix (backwards compatible)


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Increased wait times in positive WebDriverWait tests to 5 seconds

- Decreased wait times in negative/timeout tests to 0.01 seconds

- Reduces test flakiness, especially in CI environments

- No production code changes; test-only improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriverwait_tests.py</strong><dd><code>Adjust WebDriverWait timeouts to improve test reliability</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/webdriverwait_tests.py

<li>Increased wait durations for positive/element-present tests to 5 <br>seconds<br> <li> Decreased wait durations for negative/timeout tests to 0.01 seconds<br> <li> Updated all relevant WebDriverWait usages for consistency<br> <li> No changes to test logic or production code


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15650/files#diff-cdc0b4528a21c95e4bbede1854baf3eb1580438660127c75e9cca47693bb8691">+49/-49</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>