### PR TITLE
[py] Fix driver service stop when starting browser fails

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -354,7 +354,7 @@ class WebDriver(BaseWebDriver):
             self.session_id = response.get("sessionId")
             self.caps = response.get("capabilities")
         except Exception:
-            if self.service is not None:
+            if hasattr(self, "service") and self.service is not None:
                 self.service.stop()
             raise
 


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes an error introduced in #15636

### 💥 What does this PR do?

This PR fixes an issue when trying to stop the driver service if the browser fails to start. It makes sure the webdriver instance has a `service` attribute before calling `service.stop()`

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes driver service stop when browser start fails

- Checks for `service` attribute before calling `stop()`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add attribute check before stopping driver service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/webdriver.py

<li>Adds check for <code>service</code> attribute before stopping service<br> <li> Prevents AttributeError if <code>service</code> is missing on failure


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15656/files#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>