### PR TITLE
[py] Server class to manage (download/run) grid server

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -17,14 +17,11 @@
 
 import os
 import platform
-import socket
-import subprocess
-import time
-from urllib.request import urlopen
 
 import pytest
 
 from selenium import webdriver
+from selenium.webdriver.remote.server import Server
 from test.selenium.webdriver.common.network import get_lan_ip
 from test.selenium.webdriver.common.webserver import SimpleWebServer
 
@@ -125,7 +122,7 @@ def driver(request):
 
     # skip tests in the 'remote' directory if run with a local driver
     if request.node.path.parts[-2] == "remote" and driver_class != "Remote":
-        pytest.skip(f"Remote tests can't be run with driver '{driver_option}'")
+        pytest.skip(f"Remote tests can't be run with driver '{driver_option.lower()}'")
 
     # skip tests that can't run on certain platforms
     _platform = platform.system()
@@ -295,60 +292,21 @@ def server(request):
         yield None
         return
 
-    _host = "localhost"
-    _port = 4444
-    _path = os.path.join(
+    path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         "java/src/org/openqa/selenium/grid/selenium_server_deploy.jar",
     )
 
-    def wait_for_server(url, timeout):
-        start = time.time()
-        while time.time() - start < timeout:
-            try:
-                urlopen(url)
-                return 1
-            except OSError:
-                time.sleep(0.2)
-        return 0
+    remote_env = os.environ.copy()
+    if platform.system() == "Linux":
+        # There are issues with window size/position when running Firefox
+        # under Wayland, so we use XWayland instead.
+        remote_env["MOZ_ENABLE_WAYLAND"] = "0"
 
-    _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    url = f"http://{_host}:{_port}/status"
-    try:
-        _socket.connect((_host, _port))
-        print(
-            "The remote driver server is already running or something else"
-            "is using port {}, continuing...".format(_port)
-        )
-    except Exception:
-        remote_env = os.environ.copy()
-        if platform.system() == "Linux":
-            # There are issues with window size/position when running Firefox
-            # under Wayland, so we use XWayland instead.
-            remote_env["MOZ_ENABLE_WAYLAND"] = "0"
-        print("Starting the Selenium server")
-        process = subprocess.Popen(
-            [
-                "java",
-                "-jar",
-                _path,
-                "standalone",
-                "--port",
-                "4444",
-                "--selenium-manager",
-                "true",
-                "--enable-managed-downloads",
-                "true",
-            ],
-            env=remote_env,
-        )
-        print(f"Selenium server running as process: {process.pid}")
-        assert wait_for_server(url, 10), f"Timed out waiting for Selenium server at {url}"
-        print("Selenium server is ready")
-        yield process
-        process.terminate()
-        process.wait()
-        print("Selenium server has been terminated")
+    server = Server(path=path, env=remote_env)
+    server.start()
+    yield server
+    server.stop()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -292,7 +292,7 @@ def server(request):
         yield None
         return
 
-    path = os.path.join(
+    jar_path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         "java/src/org/openqa/selenium/grid/selenium_server_deploy.jar",
     )
@@ -303,7 +303,12 @@ def server(request):
         # under Wayland, so we use XWayland instead.
         remote_env["MOZ_ENABLE_WAYLAND"] = "0"
 
-    server = Server(path=path, env=remote_env)
+    if os.path.exists(jar_path):
+        # use the grid server built by bazel
+        server = Server(path=jar_path, env=remote_env)
+    else:
+        # use the local grid server (downloads a new one if needed)
+        server = Server(env=remote_env)
     server.start()
     yield server
     server.stop()

--- a/py/docs/source/api.rst
+++ b/py/docs/source/api.rst
@@ -151,6 +151,7 @@ Webdriver.remote
    selenium.webdriver.remote.mobile
    selenium.webdriver.remote.remote_connection
    selenium.webdriver.remote.script_key
+   selenium.webdriver.remote.server
    selenium.webdriver.remote.shadowroot
    selenium.webdriver.remote.switch_to
    selenium.webdriver.remote.utils

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -59,7 +59,11 @@ class Server:
         self.env = env
 
         self.process = None
-        self.status_url = f"http://{self.host}:{self.port}/status"
+        self.status_url = self._get_status_url()
+
+    def _get_status_url(self):
+        host = self.host if self.host is not None else "localhost"
+        return f"http://{host}:{self.port}/status"
 
     def _validate_path(self, path):
         if path and not os.path.exists(path):

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections
 import os
 import re
 import shutil
@@ -47,8 +48,8 @@ class Server:
     log_level : str
         Logging level to control logging output ("INFO" if not specified)
         Available levels: "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST"
-    env: dict
-        Environment variables passed to server environment
+    env: collections.abc.Mapping
+        Mapping that defines the environment variables for the server process
     """
 
     def __init__(self, host=None, port=4444, path=None, version=None, log_level="INFO", env=None):
@@ -96,8 +97,8 @@ class Server:
         return log_level
 
     def _validate_env(self, env):
-        if env is not None or isinstance(env, dict):
-            raise TypeError("env must be a dict")
+        if env is not None and not isinstance(env, collections.abc.Mapping):
+            raise TypeError("env must be a mapping of environment variables")
         return env
 
     def _wait_for_server(self, timeout=10):

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -35,8 +35,8 @@ class Server:
     -----------
     host : str
         Hostname or IP address to bind to (determined automatically if not specified)
-    port : str
-        Port to listen on ('4444' if not specified)
+    port : int or str
+        Port to listen on (4444 if not specified)
     path : str
         Path/filename of existing server .jar file (Selenium Manager is used if not specified)
     version : str
@@ -45,12 +45,12 @@ class Server:
         Environment variables passed to server environment
     """
 
-    def __init__(self, host=None, port="4444", path=None, version=None, env=None):
+    def __init__(self, host=None, port=4444, path=None, version=None, env=None):
         if path and version:
             raise TypeError("Not allowed to specify a version when using an existing server path")
 
         self.host = host
-        self.port = port
+        self.port = self._validate_port(port)
         self.path = self._validate_path(path)
         self.version = self._validate_version(version)
         self.env = env
@@ -63,10 +63,19 @@ class Server:
             raise OSError(f"Can't find server .jar located at {path}")
         return path
 
+    def _validate_port(self, port):
+        try:
+            port = int(port)
+        except ValueError:
+            raise TypeError(f"{__class__.__name__}.__init__() got an invalid port: '{port}'")
+        if not (0 <= port <= 65535):
+            raise ValueError("port must be 0-65535")
+        return port
+
     def _validate_version(self, version):
         if version:
             if not re.match(r"^\d+\.\d+\.\d+$", str(version)):
-                raise TypeError(f"{__class__}.__init__() invalid version argument: '{version}'")
+                raise TypeError(f"{__class__.__name__}.__init__() got an invalid version: '{version}'")
         return version
 
     def _wait_for_server(self, timeout=10):
@@ -99,7 +108,7 @@ class Server:
             self.path,
             "standalone",
             "--port",
-            self.port,
+            str(self.port),
             "--selenium-manager",
             "true",
             "--enable-managed-downloads",
@@ -111,7 +120,7 @@ class Server:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         host = self.host if self.host is not None else "localhost"
         try:
-            sock.connect((host, int(self.port)))
+            sock.connect((host, self.port))
             raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
             print(f"Starting Selenium server at: {self.path}")

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -95,18 +95,23 @@ class Server:
                 time.sleep(0.2)
         return False
 
+    def download_if_needed(self, version=None):
+        """Download the server if it doesn't already exist.
+
+        Latest version is downloaded unless specified.
+        """
+        args = ["--grid"]
+        if version is not None:
+            args.append(version)
+        return SeleniumManager().binary_paths(args)["driver_path"]
+
     def start(self):
         """Start the server.
 
         Selenium Manager will detect the server location and download it if necessary,
         unless an existing server path was specified.
         """
-        if self.path is None:
-            selenium_manager = SeleniumManager()
-            args = ["--grid"]
-            if self.version:
-                args.append(self.version)
-            self.path = selenium_manager.binary_paths(args)["driver_path"]
+        path = self.download_if_needed(self.version) if self.path is None else self.path
 
         java_path = shutil.which("java")
         if java_path is None:
@@ -115,7 +120,7 @@ class Server:
         command = [
             java_path,
             "-jar",
-            self.path,
+            path,
             "standalone",
             "--port",
             str(self.port),

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -129,7 +129,7 @@ class Server:
             if not self._wait_for_server():
                 f"Timed out waiting for Selenium server at {self.status_url}"
             print("Selenium server is ready")
-            return self.process
+        return self.process
 
     def stop(self):
         """Stop the server."""

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -136,7 +136,8 @@ class Server:
         if self.process is None:
             raise RuntimeError("Selenium server isn't running")
         else:
-            self.process.terminate()
-            self.process.wait()
+            if self.process.poll() is None:
+                self.process.terminate()
+                self.process.wait()
             self.process = None
             print("Selenium server has been terminated")

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -117,10 +117,11 @@ class Server:
         if self.host is not None:
             command.extend(["--host", self.host])
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         host = self.host if self.host is not None else "localhost"
+
         try:
-            sock.connect((host, self.port))
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.connect((host, self.port))
             raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
             print(f"Starting Selenium server at: {self.path}")

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -27,9 +27,12 @@ from selenium.webdriver.common.selenium_manager import SeleniumManager
 
 
 class Server:
-    """Manage the Selenium Remote (Grid) Server.
+    """Manage a Selenium Grid (Remote) Server in standalone mode.
 
-    Selenium Manager will detect the server location and download it if necessary, unless an existing server path is specified.
+    This class contains functionality for downloading the server and starting/stopping it.
+
+    For more information on Selenium Grid, see:
+        - https://www.selenium.dev/documentation/grid/getting_started/
 
     Parameters:
     -----------
@@ -89,8 +92,11 @@ class Server:
         return False
 
     def start(self):
-        """Start the server."""
+        """Start the server.
 
+        Selenium Manager will detect the server location and download it if necessary,
+        unless an existing server path was specified.
+        """
         if self.path is None:
             selenium_manager = SeleniumManager()
             args = ["--grid"]

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -157,7 +157,7 @@ class Server:
                 sock.connect((host, self.port))
             raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
-            print(f"Starting Selenium server at: {self.path}")
+            print(f"Starting Selenium server: {self.path}")
             self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -157,7 +157,7 @@ class Server:
                 sock.connect((host, self.port))
             raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
-            print(f"Starting Selenium server...")
+            print("Starting Selenium server...")
             self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -127,7 +127,7 @@ class Server:
             self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():
-                f"Timed out waiting for Selenium server at {self.status_url}"
+                raise ConnectionError(f"Timed out waiting for Selenium server at {self.status_url}")
             print("Selenium server is ready")
         return self.process
 

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -157,7 +157,7 @@ class Server:
                 sock.connect((host, self.port))
             raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
-            print(f"Starting Selenium server: {self.path}")
+            print(f"Starting Selenium server...")
             self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -44,11 +44,14 @@ class Server:
         Path/filename of existing server .jar file (Selenium Manager is used if not specified)
     version : str
         Version of server to download (latest version if not specified)
+    log_level : str
+        Logging level to control logging output ("INFO" if not specified)
+        Available levels: "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST"
     env: dict
         Environment variables passed to server environment
     """
 
-    def __init__(self, host=None, port=4444, path=None, version=None, env=None):
+    def __init__(self, host=None, port=4444, path=None, version=None, log_level="INFO", env=None):
         if path and version:
             raise TypeError("Not allowed to specify a version when using an existing server path")
 
@@ -56,7 +59,8 @@ class Server:
         self.port = self._validate_port(port)
         self.path = self._validate_path(path)
         self.version = self._validate_version(version)
-        self.env = env
+        self.log_level = self._validate_log_level(log_level)
+        self.env = self._validate_env(env)
 
         self.process = None
         self.status_url = self._get_status_url()
@@ -84,6 +88,17 @@ class Server:
             if not re.match(r"^\d+\.\d+\.\d+$", str(version)):
                 raise TypeError(f"{__class__.__name__}.__init__() got an invalid version: '{version}'")
         return version
+
+    def _validate_log_level(self, log_level):
+        levels = ("SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST")
+        if log_level not in levels:
+            raise TypeError(f"log_level must be one of: {", ".join(levels)}")
+        return log_level
+
+    def _validate_env(self, env):
+        if env is not None or isinstance(env, dict):
+            raise TypeError("env must be a dict")
+        return env
 
     def _wait_for_server(self, timeout=10):
         start = time.time()
@@ -124,6 +139,8 @@ class Server:
             "standalone",
             "--port",
             str(self.port),
+            "--log-level",
+            self.log_level,
             "--selenium-manager",
             "true",
             "--enable-managed-downloads",

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -92,7 +92,7 @@ class Server:
     def _validate_log_level(self, log_level):
         levels = ("SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST")
         if log_level not in levels:
-            raise TypeError(f"log_level must be one of: {", ".join(levels)}")
+            raise TypeError(f"log_level must be one of: {', '.join(levels)}")
         return log_level
 
     def _validate_env(self, env):

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -1,0 +1,128 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import re
+import shutil
+import socket
+import subprocess
+import time
+import urllib
+
+from selenium.webdriver.common.selenium_manager import SeleniumManager
+
+
+class Server:
+    """Manage the Selenium Remote (Grid) Server.
+
+    Parameters:
+    -----------
+    host : str
+        Hostname or IP address to bind to.
+    port : str
+        Port to listen on.
+    path : str
+        Path/filename of existing server .jar file (if not specified, server will be downloaded).
+    version : str
+        Version of server to download (if not specified, latest will be downloaded).
+    env: dict
+        Environment variables passed to server environment.
+    """
+
+    def __init__(self, host="localhost", port="4444", path=None, version=None, env=None):
+        if path and version:
+            raise TypeError("Not allowed to specify a version when using an existing server path")
+
+        self.host = host
+        self.port = port
+        self.path = self._validate_path(path)
+        self.version = self._validate_version(version)
+        self.env = env
+
+        self.process = None
+        self.status_url = f"http://{self.host}:{self.port}/status"
+
+    def _validate_path(self, path):
+        if path and not os.path.exists(path):
+            raise OSError(f"Can't find server .jar located at {path}")
+        return path
+
+    def _validate_version(self, version):
+        if version:
+            if not re.match(r"^\d+\.\d+\.\d+$", str(version)):
+                raise TypeError(f"{__class__}.__init__() invalid version argument: '{version}'")
+        return version
+
+    def _wait_for_server(self, timeout=10):
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                urllib.request.urlopen(self.status_url)
+                return True
+            except urllib.error.URLError:
+                time.sleep(0.2)
+        return False
+
+    def start(self):
+        """Start the server."""
+        if not self.path:
+            selenium_manager = SeleniumManager()
+            args = ["--grid"]
+            if self.version:
+                args.append(self.version)
+            self.path = selenium_manager.binary_paths(args)["driver_path"]
+        java = shutil.which("java")
+        if java is None:
+            raise OSError("Can't find java on system PATH. JRE is required to run the Selenium server")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((self.host, int(self.port)))
+            raise ConnectionError(
+                f"The remote driver server is already running or something else is using port {self.port}"
+            )
+        except ConnectionRefusedError:
+            print("Starting Selenium server")
+            self.process = subprocess.Popen(
+                [
+                    "java",
+                    "-jar",
+                    self.path,
+                    "standalone",
+                    "--port",
+                    self.port,
+                    "--selenium-manager",
+                    "true",
+                    "--enable-managed-downloads",
+                    "true",
+                ],
+                env=self.env,
+            )
+            print(f"Selenium server running as process: {self.process.pid}")
+            if not self._wait_for_server():
+                f"Timed out waiting for Selenium server at {self.status_url}"
+            print("Selenium server is ready")
+            return self.process
+
+    def stop(self):
+        """Stop the server."""
+        if self.process is None:
+            raise RuntimeError("Selenium server isn't running")
+        else:
+            self.process.terminate()
+            self.process.wait()
+            self.process = None
+            print("Selenium server has been terminated")

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -29,21 +29,23 @@ from selenium.webdriver.common.selenium_manager import SeleniumManager
 class Server:
     """Manage the Selenium Remote (Grid) Server.
 
+    Selenium Manager will detect the server location and download it if necessary, unless an existing server path is specified.
+
     Parameters:
     -----------
     host : str
-        Hostname or IP address to bind to.
+        Hostname or IP address to bind to (determined automatically if not specified)
     port : str
-        Port to listen on.
+        Port to listen on ('4444' if not specified)
     path : str
-        Path/filename of existing server .jar file (if not specified, server will be downloaded).
+        Path/filename of existing server .jar file (Selenium Manager is used if not specified)
     version : str
-        Version of server to download (if not specified, latest will be downloaded).
+        Version of server to download (latest version if not specified)
     env: dict
-        Environment variables passed to server environment.
+        Environment variables passed to server environment
     """
 
-    def __init__(self, host="localhost", port="4444", path=None, version=None, env=None):
+    def __init__(self, host=None, port="4444", path=None, version=None, env=None):
         if path and version:
             raise TypeError("Not allowed to specify a version when using an existing server path")
 
@@ -79,38 +81,41 @@ class Server:
 
     def start(self):
         """Start the server."""
-        if not self.path:
+
+        if self.path is None:
             selenium_manager = SeleniumManager()
             args = ["--grid"]
             if self.version:
                 args.append(self.version)
             self.path = selenium_manager.binary_paths(args)["driver_path"]
-        java = shutil.which("java")
-        if java is None:
+
+        java_path = shutil.which("java")
+        if java_path is None:
             raise OSError("Can't find java on system PATH. JRE is required to run the Selenium server")
+
+        command = [
+            java_path,
+            "-jar",
+            self.path,
+            "standalone",
+            "--port",
+            self.port,
+            "--selenium-manager",
+            "true",
+            "--enable-managed-downloads",
+            "true",
+        ]
+        if self.host is not None:
+            command.extend(["--host", self.host])
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        host = self.host if self.host is not None else "localhost"
         try:
-            sock.connect((self.host, int(self.port)))
-            raise ConnectionError(
-                f"The remote driver server is already running or something else is using port {self.port}"
-            )
+            sock.connect((host, int(self.port)))
+            raise ConnectionError(f"Selenium server is already running, or something else is using port {self.port}")
         except ConnectionRefusedError:
-            print("Starting Selenium server")
-            self.process = subprocess.Popen(
-                [
-                    "java",
-                    "-jar",
-                    self.path,
-                    "standalone",
-                    "--port",
-                    self.port,
-                    "--selenium-manager",
-                    "true",
-                    "--enable-managed-downloads",
-                    "true",
-                ],
-                env=self.env,
-            )
+            print(f"Starting Selenium server at: {self.path}")
+            self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():
                 f"Timed out waiting for Selenium server at {self.status_url}"

--- a/py/selenium/webdriver/remote/server.py
+++ b/py/selenium/webdriver/remote/server.py
@@ -127,7 +127,7 @@ class Server:
             self.process = subprocess.Popen(command, env=self.env)
             print(f"Selenium server running as process: {self.process.pid}")
             if not self._wait_for_server():
-                raise ConnectionError(f"Timed out waiting for Selenium server at {self.status_url}")
+                raise TimeoutError(f"Timed out waiting for Selenium server at {self.status_url}")
             print("Selenium server is ready")
         return self.process
 

--- a/py/test/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/selenium/webdriver/remote/remote_server_tests.py
@@ -1,0 +1,44 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+from selenium.webdriver.remote.server import Server
+
+
+@pytest.fixture
+def standalone_server():
+    server = Server()
+    server_path = server.download_if_needed()
+    remove_file(server_path)
+    yield server
+    remove_file(server_path)
+
+
+def remove_file(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def test_download_latest_server(standalone_server):
+    server_path = standalone_server.download_if_needed()
+    assert os.path.exists(server_path)
+    assert os.path.getsize(server_path) > 0

--- a/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
@@ -15,11 +15,50 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import re
 
 import pytest
 
 from selenium.webdriver.remote.server import Server
+
+
+def test_server_with_defaults():
+    server = Server()
+    assert server.host is None
+    assert server.port == 4444
+    assert server.path is None
+    assert server.version is None
+    assert server.log_level == "INFO"
+    assert server.env is None
+
+
+def test_server_with_args():
+    server = Server("foo", 9999)
+    assert server.host == "foo"
+    assert server.port == 9999
+
+
+def test_server_with_kwargs():
+    server = Server(host="foo", port=9999, version="1.1.1", log_level="WARNING", env={"FOO": "bar"})
+    assert server.host == "foo"
+    assert server.port == 9999
+    assert server.path is None
+    assert server.version == "1.1.1"
+    assert server.log_level == "WARNING"
+    assert server.env == {"FOO": "bar"}
+
+
+def test_server_with_invalid_port():
+    port = "invalid"
+    msg = f"Server.__init__() got an invalid port: '{port}'"
+    with pytest.raises(TypeError, match=re.escape(msg)):
+        Server(port=port)
+
+
+def test_server_with_port_out_of_range():
+    with pytest.raises(ValueError, match="port must be 0-65535"):
+        Server(port=99999)
 
 
 def test_server_with_bad_path():
@@ -37,26 +76,26 @@ def test_server_with_invalid_version():
             Server(version=version)
 
 
-def test_server_with_invalid_port():
-    port = "invalid"
-    msg = f"Server.__init__() got an invalid port: '{port}'"
-    with pytest.raises(TypeError, match=re.escape(msg)):
-        Server(port=port)
-
-
-def test_server_with_port_out_of_range():
-    with pytest.raises(ValueError, match="port must be 0-65535"):
-        Server(port=99999)
-
-
 def test_server_with_invalid_log_level():
     msg = ", ".join(("SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST"))
     with pytest.raises(TypeError, match=f"log_level must be one of: {msg}"):
         Server(log_level="BAD")
 
 
+def test_server_with_env_os_environ():
+    server = Server(env=os.environ)
+    assert isinstance(server.env, os._Environ)
+
+
+def test_server_with_env_dict():
+    env = {}
+    server = Server(env=env)
+    assert isinstance(server.env, dict)
+    assert server.env == {}
+
+
 def test_server_with_invalid_env():
-    with pytest.raises(TypeError, match="env must be a dict"):
+    with pytest.raises(TypeError, match="env must be a mapping of environment variables"):
         Server(env=[])
 
 

--- a/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
@@ -1,0 +1,46 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+
+import pytest
+
+from selenium.webdriver.remote.server import Server
+
+
+def test_server_with_bad_path():
+    path = "/path/to/nowhere"
+    msg = f"Can't find server .jar located at {path}"
+    with pytest.raises(OSError, match=re.escape(msg)):
+        Server(path=path)
+
+def test_server_with_invalid_version():
+    versions = ("0.0", "invalid")
+    for version in versions:
+        msg = f"Server.__init__() got an invalid version: '{version}'"
+        with pytest.raises(TypeError, match=re.escape(msg)):
+            Server(version=version)
+
+def test_server_with_invalid_port():
+    port = "invalid"
+    msg = f"Server.__init__() got an invalid port: '{port}'"
+    with pytest.raises(TypeError, match=re.escape(msg)):
+        Server(port=port)
+
+def test_server_with_port_out_of_range():
+    with pytest.raises(ValueError, match="port must be 0-65535"):
+        Server(port=99999)

--- a/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
@@ -44,3 +44,9 @@ def test_server_with_invalid_port():
 def test_server_with_port_out_of_range():
     with pytest.raises(ValueError, match="port must be 0-65535"):
         Server(port=99999)
+
+def test_stopping_server_thats_not_running():
+    server = Server()
+    with pytest.raises(RuntimeError, match="Selenium server isn't running"):
+        server.stop()
+    assert server.process is None

--- a/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
@@ -49,6 +49,17 @@ def test_server_with_port_out_of_range():
         Server(port=99999)
 
 
+def test_server_with_invalid_log_level():
+    msg = ", ".join(("SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST"))
+    with pytest.raises(TypeError, match=f"log_level must be one of: {msg}"):
+        Server(log_level="BAD")
+
+
+def test_server_with_invalid_env():
+    with pytest.raises(TypeError, match="env must be a dict"):
+        Server(env=[])
+
+
 def test_stopping_server_thats_not_running():
     server = Server()
     with pytest.raises(RuntimeError, match="Selenium server isn't running"):

--- a/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_server_tests.py
@@ -28,6 +28,7 @@ def test_server_with_bad_path():
     with pytest.raises(OSError, match=re.escape(msg)):
         Server(path=path)
 
+
 def test_server_with_invalid_version():
     versions = ("0.0", "invalid")
     for version in versions:
@@ -35,15 +36,18 @@ def test_server_with_invalid_version():
         with pytest.raises(TypeError, match=re.escape(msg)):
             Server(version=version)
 
+
 def test_server_with_invalid_port():
     port = "invalid"
     msg = f"Server.__init__() got an invalid port: '{port}'"
     with pytest.raises(TypeError, match=re.escape(msg)):
         Server(port=port)
 
+
 def test_server_with_port_out_of_range():
     with pytest.raises(ValueError, match="port must be 0-65535"):
         Server(port=99999)
+
 
 def test_stopping_server_thats_not_running():
     server = Server()


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

This is the Python implementation for #12305 

### 💥 What does this PR do?

This PR adds a new `selenium.webdriver.remote.server` module with a `Server` class. It is used for downloading/starting/stopping the grid server in standalone mode.

It uses Selenium Manager to download and locate the server jar file. To use the `start()` method, you must have a Java JRE on your system (or it will give you an error message).

This also updates the PyTest configuration (`py/conftest.py`) to use this class to replace the code for launching the server for remote tests. It uses the existing local server instead of downloading one, since it is already built locally and CI is setup to use it.

----

### Example usage:

```
from selenium import webdriver
from selenium.webdriver.remote.server import Server

server = Server()
server.start()
driver = webdriver.Remote(options=webdriver.ChromeOptions())
# do some webdrivery stuff
driver.quit()
server.stop()
```

### More examples:

- download the latest server and run it:
```
from selenium.webdriver.remote.server import Server

server = Server()
server.start()
server.stop()
```

- download a specific version of the server and run it:
```
from selenium.webdriver.remote.server import Server

server = Server(version="4.30.0")
server.start()
server.stop()
```

- download the latest server and run it on a specified ip/port:
```
from selenium.webdriver.remote.server import Server

server = Server(host="127.0.0.1", port=8888)
server.start()
server.stop()
```

- download the latest server and run it with an environment variable set:
```
import os
from selenium.webdriver.remote.server import Server

env = os.environ.copy()
env["MY_VARIABLE"] = "special"
server = Server(env=env)
server.start()
server.stop()
```

- run an existing server without downloading:
```
from selenium.webdriver.remote.server import Server
server = Server(path="/path/to/selenium-server-4.31.0.jar")
server.start()
server.stop()
```

### 💡 Additional Considerations

I added some unit tests, but they aren't comprehensive because it's a pain to mock selenium manager and the subprocess call... I'll figure that out later.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduces `Server` class for managing Selenium Grid server.
  - Supports downloading, starting, and stopping the server.
  - Allows specifying host, port, version, path, and environment.

- Refactors pytest fixture to use new `Server` class for remote tests.

- Adds unit tests for `Server` class error handling and validation.

- Updates API documentation to include new `server` module.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add Server class for Selenium Grid server management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/server.py

<li>Adds new <code>Server</code> class for managing Selenium Grid server lifecycle.<br> <li> Implements validation for path, port, and version.<br> <li> Handles server startup, shutdown, and error scenarios.<br> <li> Integrates with Selenium Manager for automatic server download.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15666/files#diff-f402a040be51e4850063837cff55fc5b6b6817bf4c242c37e51ad8b2dcc02b3b">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Refactor pytest server fixture to use Server class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Refactors remote server pytest fixture to use new <code>Server</code> class.<br> <li> Removes legacy subprocess/socket logic for server startup.<br> <li> Ensures environment variables are handled for Linux compatibility.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15666/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+13/-55</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_server_tests.py</strong><dd><code>Add unit tests for Server class validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/unit/selenium/webdriver/remote/remote_server_tests.py

<li>Adds unit tests for <code>Server</code> class input validation and error handling.<br> <li> Tests invalid path, version, port, and stopping server not running.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15666/files#diff-778bf38c1d07a3bffb033ebe6e9b546b7a14e1dc02f7541d11e72e8a515dd845">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.rst</strong><dd><code>Document remote.server module in API docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/docs/source/api.rst

<li>Documents new <code>selenium.webdriver.remote.server</code> module in API <br>reference.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15666/files#diff-7e8f0a6376548281d6c1a5b57121f0a701a76c5f88129fe7def3d89f39b63c43">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>