### PR TITLE
[py] Remove support for GLOBAL_DEFAULT_TIMEOUT environment variable

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -399,6 +399,13 @@ def clean_driver(request):
 
 @pytest.fixture
 def firefox_options(request):
+    try:
+        driver_option = request.config.option.drivers[0]
+    except (AttributeError, TypeError):
+        raise Exception("This test requires a --driver to be specified")
+    # skip tests in the 'remote' directory if run with a local driver
+    if request.node.path.parts[-2] == "remote" and get_driver_class(driver_option) != "Remote":
+        pytest.skip(f"Remote tests can't be run with driver '{driver_option}'")
     options = webdriver.FirefoxOptions()
     if request.config.option.headless:
         options.add_argument("-headless")

--- a/py/selenium/webdriver/remote/client_config.py
+++ b/py/selenium/webdriver/remote/client_config.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import base64
 import os
 import socket
@@ -104,15 +105,7 @@ class ClientConfig:
         self.user_agent = user_agent
         self.extra_headers = extra_headers
 
-        self.timeout = (
-            (
-                float(os.getenv("GLOBAL_DEFAULT_TIMEOUT", str(socket.getdefaulttimeout())))
-                if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
-                else socket.getdefaulttimeout()
-            )
-            if timeout is None
-            else timeout
-        )
+        self.timeout = socket.getdefaulttimeout() if timeout is None else timeout
 
         self.ca_certs = (
             (os.getenv("REQUESTS_CA_BUNDLE") if "REQUESTS_CA_BUNDLE" in os.environ else certifi.where())

--- a/py/selenium/webdriver/remote/client_config.py
+++ b/py/selenium/webdriver/remote/client_config.py
@@ -97,15 +97,13 @@ class ClientConfig:
         self.proxy = proxy
         self.ignore_certificates = ignore_certificates
         self.init_args_for_pool_manager = init_args_for_pool_manager or {}
-        self.timeout = timeout
+        self.timeout = socket.getdefaulttimeout() if timeout is None else timeout
         self.username = username
         self.password = password
         self.auth_type = auth_type
         self.token = token
         self.user_agent = user_agent
         self.extra_headers = extra_headers
-
-        self.timeout = socket.getdefaulttimeout() if timeout is None else timeout
 
         self.ca_certs = (
             (os.getenv("REQUESTS_CA_BUNDLE") if "REQUESTS_CA_BUNDLE" in os.environ else certifi.where())

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -152,11 +152,7 @@ class RemoteConnection:
 
     import certifi
 
-    _timeout = (
-        float(os.getenv("GLOBAL_DEFAULT_TIMEOUT", str(socket.getdefaulttimeout())))
-        if os.getenv("GLOBAL_DEFAULT_TIMEOUT") is not None
-        else socket.getdefaulttimeout()
-    )
+    _timeout = socket.getdefaulttimeout()
     _ca_certs = os.getenv("REQUESTS_CA_BUNDLE") if "REQUESTS_CA_BUNDLE" in os.environ else certifi.where()
     _client_config: ClientConfig = None
 

--- a/py/test/selenium/webdriver/remote/remote_connection_tests.py
+++ b/py/test/selenium/webdriver/remote/remote_connection_tests.py
@@ -18,6 +18,12 @@
 import base64
 
 import filetype
+import pytest
+from urllib3.exceptions import ReadTimeoutError
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.client_config import ClientConfig
 
 
 def test_browser_specific_method(driver, pages):
@@ -27,3 +33,21 @@ def test_browser_specific_method(driver, pages):
     result = base64.b64decode(screenshot)
     kind = filetype.guess(result)
     assert kind is not None and kind.mime == "image/png"
+
+
+def test_remote_webdriver_with_http_timeout(firefox_options, webserver):
+    """This test starts a remote webdriver with an http client timeout
+    set less than the implicit wait timeout, and verifies the http timeout
+    is triggered first when waiting for an element.
+    """
+    http_timeout = 6
+    wait_timeout = 8
+    server_addr = f"http://{webserver.host}:{webserver.port}"
+    client_config = ClientConfig(remote_server_addr=server_addr, timeout=http_timeout)
+    assert client_config.timeout == http_timeout
+    driver = webdriver.Remote(options=firefox_options, client_config=client_config)
+    driver.get(f"{server_addr}/simpleTest.html")
+    driver.implicitly_wait(wait_timeout)
+    with pytest.raises(ReadTimeoutError):
+        driver.find_element(By.ID, "no_element_to_be_found")
+    driver.quit()

--- a/py/test/selenium/webdriver/remote/remote_connection_tests.py
+++ b/py/test/selenium/webdriver/remote/remote_connection_tests.py
@@ -45,9 +45,8 @@ def test_remote_webdriver_with_http_timeout(firefox_options, webserver):
     server_addr = f"http://{webserver.host}:{webserver.port}"
     client_config = ClientConfig(remote_server_addr=server_addr, timeout=http_timeout)
     assert client_config.timeout == http_timeout
-    driver = webdriver.Remote(options=firefox_options, client_config=client_config)
-    driver.get(f"{server_addr}/simpleTest.html")
-    driver.implicitly_wait(wait_timeout)
-    with pytest.raises(ReadTimeoutError):
-        driver.find_element(By.ID, "no_element_to_be_found")
-    driver.quit()
+    with webdriver.Remote(options=firefox_options, client_config=client_config) as driver:
+        driver.get(f"{server_addr}/simpleTest.html")
+        driver.implicitly_wait(wait_timeout)
+        with pytest.raises(ReadTimeoutError):
+            driver.find_element(By.ID, "no_element_to_be_found")


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #15604
Supersedes #15628 

### 💥 What does this PR do?

This PR remove support for GLOBAL_DEFAULT_TIMEOUT environment variable (which is currently not working anyway).

I also added a test to verify that you can set the HTTP client timeout on `webdriver.Remote`. This doesn't currently work for other drivers (see: #15672)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove support for GLOBAL_DEFAULT_TIMEOUT environment variable

- Update timeout logic to use socket default only

- Add test verifying HTTP client timeout in Remote WebDriver

- Improve test skipping logic for remote driver tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_config.py</strong><dd><code>Remove GLOBAL_DEFAULT_TIMEOUT and simplify timeout logic</code>&nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/client_config.py

<li>Remove logic for GLOBAL_DEFAULT_TIMEOUT environment variable<br> <li> Set timeout to socket default if not specified


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15673/files#diff-421b55d14e80d4473c60003a3f53c9fa819375d52cb45b6c40403f481a9b8925">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Remove GLOBAL_DEFAULT_TIMEOUT from RemoteConnection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<li>Remove GLOBAL_DEFAULT_TIMEOUT environment variable usage<br> <li> Use socket default timeout for _timeout


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15673/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection_tests.py</strong><dd><code>Add test for Remote WebDriver HTTP timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/remote/remote_connection_tests.py

<li>Add test for HTTP client timeout in Remote WebDriver<br> <li> Import necessary modules for new test


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15673/files#diff-10c82760157398bc5a3ab5ba815d2eb37ed7763ce4999b93379552545d70131d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Improve remote test skipping in firefox_options fixture</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Enhance firefox_options fixture to skip remote tests with local <br>drivers<br> <li> Raise exception if --driver not specified


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15673/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>