### PR TITLE
[rb] handle issue with selenium manager exit status being nil

### DIFF
--- a/rb/lib/selenium/webdriver/common/selenium_manager.rb
+++ b/rb/lib/selenium/webdriver/common/selenium_manager.rb
@@ -61,25 +61,12 @@ module Selenium
         end
 
         def run(*command)
-          WebDriver.logger.debug("Executing Process #{command}", id: :selenium_manager)
+          stdout, stderr, status = execute_command(*command)
+          result = parse_result_and_log(stdout)
 
-          begin
-            stdout, stderr, status = Open3.capture3(*command)
-          rescue StandardError => e
-            raise Error::WebDriverError, "Unsuccessful command executed: #{command}; #{e.message}"
-          end
+          validate_command_result(command, status, result, stderr)
 
-          json_output = stdout.empty? ? {'logs' => [], 'result' => {}} : JSON.parse(stdout)
-          json_output['logs'].each do |log|
-            level = log['level'].casecmp('info').zero? ? 'debug' : log['level'].downcase
-            WebDriver.logger.send(level, log['message'], id: :selenium_manager)
-          end
-
-          result = json_output['result']
-          return result unless status.exitstatus.positive? || result.nil?
-
-          raise Error::WebDriverError,
-                "Unsuccessful command executed: #{command} - Code #{status.exitstatus}\n#{result}\n#{stderr}"
+          result
         end
 
         def platform_location
@@ -97,6 +84,37 @@ module Selenium
           else
             raise Error::WebDriverError, "unsupported platform: #{Platform.os}"
           end
+        end
+
+        def execute_command(*command)
+          WebDriver.logger.debug("Executing Process #{command}", id: :selenium_manager)
+
+          Open3.capture3(*command)
+        rescue StandardError => e
+          raise Error::WebDriverError, "Unsuccessful command executed: #{command}; #{e.message}"
+        end
+
+        def parse_result_and_log(stdout)
+          json_output = stdout.empty? ? {'logs' => [], 'result' => {}} : JSON.parse(stdout)
+
+          json_output['logs'].each do |log|
+            level = log['level'].casecmp('info').zero? ? 'debug' : log['level'].downcase
+            WebDriver.logger.send(level, log['message'], id: :selenium_manager)
+          end
+
+          json_output['result']
+        end
+
+        def validate_command_result(command, status, result, stderr)
+          if status.nil? || status.exitstatus.nil?
+            WebDriver.logger.info("Invalid process exit status for: #{command}. Assuming success if result is present.",
+                                  id: :selenium_manager)
+          end
+
+          return unless status&.exitstatus&.positive? || result.nil?
+
+          raise Error::WebDriverError,
+                "Unsuccessful command executed: #{command} - Code #{status&.exitstatus}\n#{result}\n#{stderr}"
         end
       end
     end # SeleniumManager

--- a/rb/lib/selenium/webdriver/common/selenium_manager.rb
+++ b/rb/lib/selenium/webdriver/common/selenium_manager.rb
@@ -107,14 +107,15 @@ module Selenium
 
         def validate_command_result(command, status, result, stderr)
           if status.nil? || status.exitstatus.nil?
-            WebDriver.logger.info("Invalid process exit status for: #{command}. Assuming success if result is present.",
+            WebDriver.logger.info("No exit status for: #{command}. Assuming success if result is present.",
                                   id: :selenium_manager)
           end
 
           return unless status&.exitstatus&.positive? || result.nil?
 
+          code = status&.exitstatus || 'exit status not available'
           raise Error::WebDriverError,
-                "Unsuccessful command executed: #{command} - Code #{status&.exitstatus}\n#{result}\n#{stderr}"
+                "Unsuccessful command executed: #{command} - Code #{code}\n#{result}\n#{stderr}"
         end
       end
     end # SeleniumManager

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -100,7 +100,7 @@ module Selenium
 
           expect {
             expect(described_class.send(:run, 'anything')).to eq 'value'
-          }.to have_info(:info)
+          }.to have_info(:selenium_manager)
         end
 
         it 'raises if result is nil even with successful exitstatus' do

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -98,12 +98,9 @@ module Selenium
           stdout = '{"result": "value", "logs": []}'
           allow(Open3).to receive(:capture3).and_return([stdout, 'stderr', status])
 
-          expect(WebDriver.logger).to receive(:info).with(
-            a_string_including('No valid process exit status'),
-            hash_including(id: :selenium_manager)
-          )
-
-          expect(described_class.send(:run, 'anything')).to eq 'value'
+          expect {
+            expect(described_class.send(:run, 'anything')).to eq 'value'
+          }.to have_info(:info)
         end
 
         it 'raises if result is nil even with successful exitstatus' do

--- a/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb
@@ -92,6 +92,29 @@ module Selenium
             described_class.send(:run, 'anything')
           }.to raise_error(Error::WebDriverError, msg)
         end
+
+        it 'succeeds when exitstatus is nil and result is present' do
+          status = instance_double(Process::Status, exitstatus: nil)
+          stdout = '{"result": "value", "logs": []}'
+          allow(Open3).to receive(:capture3).and_return([stdout, 'stderr', status])
+
+          expect(WebDriver.logger).to receive(:info).with(
+            a_string_including('No valid process exit status'),
+            hash_including(id: :selenium_manager)
+          )
+
+          expect(described_class.send(:run, 'anything')).to eq 'value'
+        end
+
+        it 'raises if result is nil even with successful exitstatus' do
+          status = instance_double(Process::Status, exitstatus: 0)
+          stdout = '{"logs": []}'
+          allow(Open3).to receive(:capture3).and_return([stdout, 'stderr', status])
+
+          expect {
+            described_class.send(:run, 'anything')
+          }.to raise_error(Error::WebDriverError, /Unsuccessful command executed/)
+        end
       end
 
       describe '.binary_paths' do


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #14622 
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Logs note when status or exitstatus is `nil`
* Uses result if one exists
* Added tests

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Decided to log note (at info level) instead of just handling the nil so if it errors the user gets additional understanding, and if it doesn't error it still notes that the code is going through an unexpected process. 

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
None

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactored Selenium Manager command execution and error handling
  - Extracted command execution, result parsing, and validation into separate methods
  - Improved logging for nil or invalid process exit statuses
  - Now uses result if present, even if exit status is nil

- Added and updated unit tests for new error handling logic
  - Tests for nil exit status with present result
  - Tests for nil result with successful exit status


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.rb</strong><dd><code>Refactor and improve Selenium Manager command error handling</code></dd></summary>
<hr>

rb/lib/selenium/webdriver/common/selenium_manager.rb

<li>Refactored command execution into helper methods<br> <li> Improved handling and logging for nil exit statuses<br> <li> Enhanced error reporting and result validation


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15676/files#diff-09418c53c432e9827177f67e7fe211062c38ce1b044f88bb1f816f2ed79a41ca">+35/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager_spec.rb</strong><dd><code>Add tests for improved Selenium Manager error handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/common/selenium_manager_spec.rb

<li>Added tests for nil exit status and result handling<br> <li> Verified logging and error raising for new scenarios


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15676/files#diff-d8d9d59af50757d7a68124ac4f3df65fa4d3f72d38417efe27fa48221cc0deb2">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>