### PR TITLE
[build] allow manually rerunning RBE with cache disabled

### DIFF
--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - trunk
   workflow_dispatch:
+    inputs:
+      disable_test_cache:
+        description: 'Force re-run of tests (disable test cache)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   format:
@@ -26,4 +32,4 @@ jobs:
       name: All RBE tests
       caching: false
       ruby-version: jruby-9.4.12.0
-      run: ./scripts/github-actions/ci-build.sh
+      run: ./scripts/github-actions/ci-build.sh ${{ github.event.inputs.disable_test_cache }}

--- a/scripts/github-actions/ci-build.sh
+++ b/scripts/github-actions/ci-build.sh
@@ -4,11 +4,20 @@ set -eufo pipefail
 # We want to see what's going on
 set -x
 
+# Default to auto if no parameter is provided
+CACHE_RESULTS="auto"
+
+# If "disable test cache" is passed in and true
+if [ $# -gt 0 ] && [ "$1" = "true" ]; then
+  CACHE_RESULTS="no"
+fi
+
 # Now run the tests. The engflow build uses pinned browsers
 # so this should be fine
 # shellcheck disable=SC2046
 bazel test --config=rbe-ci --build_tests_only \
   --keep_going --flaky_test_attempts=2 \
+  --cache_test_results=${CACHE_RESULTS} \
   //... -- $(cat .skipped-tests | tr '\n' ' ')
 
 # Build the packages we want to ship to users


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
n/a

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
allows manually executing remote build from GitHub to force rerunning all tests

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
No change to PR or trunk push, just an added checkbox if kicking off manually

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
This shouldn't be necessary? But sometimes things fail in PRs and I wonder if the cache in trunk is hiding something?

If this doesn't add value, we shouldn't merge it.
@p0deje / @shs96c is there value to this?

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
