### PR TITLE
Let firefox choose the bidi port by default

### DIFF
--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -28,9 +28,9 @@ module Selenium
 
         def initialize(path: nil, port: nil, log: nil, args: nil)
           args ||= []
-          unless args.any? { |arg| arg.include?('--connect-existing') }
+          unless args.any? { |arg| arg.include?('--connect-existing') || arg.include?('--websocket-port') }
             args << '--websocket-port'
-            args << WebDriver::PortProber.above(9222).to_s
+            args << '0'
           end
           super
         end

--- a/rb/spec/integration/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/firefox/service_spec.rb
@@ -39,21 +39,6 @@ module Selenium
         it 'can be started outside driver' do
           expect(service_manager.uri).to be_a(URI)
         end
-
-        context 'with BiDi enabled', exclusive: {bidi: true, reason: 'only executed when bidi is enabled'} do
-          it 'ensures two service instances use different websocket port' do
-            service1 = described_class.new
-            service2 = described_class.new
-
-            ws_index1 = service1.args.index('--websocket-port')
-            ws_index2 = service2.args.index('--websocket-port')
-
-            port1 = service1.args[ws_index1 + 1].to_i
-            port2 = service2.args[ws_index2 + 1].to_i
-
-            expect(port1).not_to eq(port2)
-          end
-        end
       end
     end # Firefox
   end # WebDriver

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -77,11 +77,11 @@ module Selenium
             expect(service.extra_args).to include(*%w[--foo --bar])
           end
 
-          it 'there is a random port for websocket' do
+          it 'there is a zero port for websocket' do
             service = described_class.new
             ws_index = service.extra_args.index('--websocket-port')
             port = service.extra_args[ws_index + 1].to_i
-            expect(port).to be_positive
+            expect(port).to be_zero
           end
 
           context 'with connect existing' do
@@ -89,6 +89,14 @@ module Selenium
               service = described_class.new(args: ['--connect-existing'])
               expect(service.extra_args).not_to include('--websocket-port')
               expect(service.extra_args).to eq(['--connect-existing'])
+            end
+          end
+
+          context 'with websocket port' do
+            it 'does not add websocket-port' do
+              service = described_class.new(args: ['--websocket-port=1234'])
+              expect(service.extra_args).not_to include('--websocket-port=0')
+              expect(service.extra_args).to eq(['--websocket-port=1234'])
             end
           end
         end


### PR DESCRIPTION
### **User description**
If the user hasn't asked for a specific port then just let firefox choose a random one.

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #15707.
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Prevents race conditions choosing a bidi port by letting firefox choose.
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
Implementation is as suggested in https://github.com/SeleniumHQ/selenium/issues/15707#issuecomment-2860784278.
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
None.
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Let Firefox choose BiDi port by default to avoid race conditions

- Update service initialization to use '--websocket-port=0' unless specified

- Remove and revise tests for websocket port assignment logic

- Add new unit tests for argument handling in service initialization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rb</strong><dd><code>Default to Firefox-chosen BiDi port in service initialization</code></dd></summary>
<hr>

rb/lib/selenium/webdriver/firefox/service.rb

<li>Change default '--websocket-port' argument to '0' unless specified<br> <li> Prevents manual port probing and potential race conditions<br> <li> Adjust logic to skip adding argument if already present


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15727/files#diff-2311788d16c9242f68586a131842f15bd0df08ceccd992c0711042f4c70a51bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_spec.rb</strong><dd><code>Remove integration test for random websocket port assignment</code></dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/firefox/service_spec.rb

<li>Remove test asserting different websocket ports for two services<br> <li> Clean up BiDi port assignment expectations in integration tests


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15727/files#diff-a1129b5a02aae5ef978f7c7b352a43af7b576952aebc9ccdda8397cdae5d4f65">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_spec.rb</strong><dd><code>Revise and add unit tests for websocket port argument handling</code></dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/firefox/service_spec.rb

<li>Update test to expect websocket port '0' by default<br> <li> Add test to ensure custom websocket port is respected<br> <li> Add test to ensure '--websocket-port' is not duplicated


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15727/files#diff-a133977d57f0aa19dd9fef9bc8d99afeae9b60b14e67f28051d2a82cde6dd5d0">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>