### PR TITLE
[py] Missing Headers Assignment in Network Class’s _on_request()

### DIFF
--- a/py/selenium/webdriver/common/bidi/network.py
+++ b/py/selenium/webdriver/common/bidi/network.py
@@ -135,6 +135,7 @@ class Network:
                 body_size=event_data.params["request"].get("bodySize", None),
                 cookies=event_data.params["request"].get("cookies", None),
                 resource_type=event_data.params["request"].get("goog:resourceType", None),
+                headers=event_data.params["request"].get("headers", None),
                 headers_size=event_data.params["request"].get("headersSize", None),
                 timings=event_data.params["request"].get("timings", None),
                 url=event_data.params["request"].get("url", None),


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
 #15735 

### 💥 What does this PR do?
Addresses missing header assignment discovered in #15735 using https://w3c.github.io/webdriver-bidi/#module-network-definition

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes missing `headers` assignment in Network class's `_on_request`

- Ensures request headers are properly captured in BiDi events


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.py</strong><dd><code>Add missing headers assignment in BiDi Network event handling</code></dd></summary>
<hr>

py/selenium/webdriver/common/bidi/network.py

<li>Adds assignment of <code>headers</code> from event data to Request object in <br><code>_on_request</code> callback.<br> <li> Ensures headers are included when creating Request instances for <br>network events.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15736/files#diff-d04fc5573acd6ca5bcc8167940f134f1a3ead8a5230c066c077a1319a1ffe1d4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>