### PR TITLE
[py] Add missing 'id' property to ShadowRoot class

### DIFF
--- a/py/selenium/webdriver/remote/shadowroot.py
+++ b/py/selenium/webdriver/remote/shadowroot.py
@@ -39,6 +39,10 @@ class ShadowRoot:
             type(self), self.session.session_id, self._id
         )
 
+    @property
+    def id(self) -> str:
+        return self._id
+
     def find_element(self, by: str = By.ID, value: str = None):
         """Find an element inside a shadow root given a By strategy and
         locator.


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #15734
Fixes #15732

### 💥 What does this PR do?

This PR adds an `id` property to the `selenium.webdriver.remote.shadowroot.ShadowRoot` class.

This attribute was missing and causing errors when trying to access `shadow_root`

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `id` property to `ShadowRoot` class

- Fix errors when accessing `shadow_root.id`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shadowroot.py</strong><dd><code>Add `id` property to ShadowRoot class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/shadowroot.py

<li>Added an <code>id</code> property to the <code>ShadowRoot</code> class<br> <li> Ensures access to the shadow root's internal id<br> <li> Addresses errors when accessing <code>shadow_root.id</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15739/files#diff-b6c6d35c2a913783cdc1b9f6624fcd28b75756f3b123197f9fae2027c33ed4a5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>