### PR TITLE
[py]: return `message` as part of exception in `execute` method

### DIFF
--- a/py/selenium/webdriver/remote/websocket_connection.py
+++ b/py/selenium/webdriver/remote/websocket_connection.py
@@ -22,6 +22,8 @@ from time import sleep
 
 from websocket import WebSocketApp  # type: ignore
 
+from selenium.common import WebDriverException
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,9 +70,9 @@ class WebSocketConnection:
             error = response["error"]
             if "message" in response:
                 error_msg = f"{error}: {response['message']}"
-                raise Exception(error_msg)
+                raise WebDriverException(error_msg)
             else:
-                raise Exception(error)
+                raise WebDriverException(error)
         else:
             result = response["result"]
             return self._deserialize_result(result, command)
@@ -102,7 +104,7 @@ class WebSocketConnection:
     def _deserialize_result(self, result, command):
         try:
             _ = command.send(result)
-            raise Exception("The command's generator function did not exit when expected!")
+            raise WebDriverException("The command's generator function did not exit when expected!")
         except StopIteration as exit:
             return exit.value
 

--- a/py/selenium/webdriver/remote/websocket_connection.py
+++ b/py/selenium/webdriver/remote/websocket_connection.py
@@ -64,10 +64,13 @@ class WebSocketConnection:
         self._wait_until(lambda: current_id in self._messages)
         response = self._messages.pop(current_id)
 
-        error = response["error"]
-        if "message" in response:
-            error_msg = f"{error}: {response['message']}"
-            raise Exception(error_msg)
+        if "error" in response:
+            error = response["error"]
+            if "message" in response:
+                error_msg = f"{error}: {response['message']}"
+                raise Exception(error_msg)
+            else:
+                raise Exception(error)
         else:
             result = response["result"]
             return self._deserialize_result(result, command)

--- a/py/selenium/webdriver/remote/websocket_connection.py
+++ b/py/selenium/webdriver/remote/websocket_connection.py
@@ -64,8 +64,10 @@ class WebSocketConnection:
         self._wait_until(lambda: current_id in self._messages)
         response = self._messages.pop(current_id)
 
-        if "error" in response:
-            raise Exception(response["error"])
+        error = response["error"]
+        if "message" in response:
+            error_msg = f"{error}: {response['message']}"
+            raise Exception(error_msg)
         else:
             result = response["result"]
             return self._deserialize_result(result, command)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Returns a meaningful error and message when an exception is raised in the WebSocketConnection `execute` method.

Earlier only `'error': 'unknown error'` exception was raised which doesn't provides any good error message.

Now, its much better:
```
Exception: unknown error: No such file or directory: /private/var/tmp/_bazel_navinchandra/a5b294e127f7c14e5d2a4b14aeba0f68/....
```

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Improve exception handling in WebSocketConnection `execute`

- Include error message in raised exceptions for clarity

- Enhance debugging by surfacing server-side error details


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>websocket_connection.py</strong><dd><code>Enhance exception message handling in WebSocketConnection</code></dd></summary>
<hr>

py/selenium/webdriver/remote/websocket_connection.py

<li>Enhanced exception to include error message if present<br> <li> Now raises detailed error combining 'error' and 'message' fields<br> <li> Improves clarity of exceptions from WebSocket responses


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15751/files#diff-7db8ccff1907ae8f1040877b71b60dc4a77bd10ad6838e2eca856d2faf8d4794">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>