### PR TITLE
[py] Add missing modules to python API docs

### DIFF
--- a/py/docs/source/api.rst
+++ b/py/docs/source/api.rst
@@ -33,12 +33,15 @@ Webdriver.common
    selenium.webdriver.common.actions.wheel_input
    selenium.webdriver.common.alert
    selenium.webdriver.common.bidi.browser
+   selenium.webdriver.common.bidi.browsing_context
    selenium.webdriver.common.bidi.cdp
    selenium.webdriver.common.bidi.common
    selenium.webdriver.common.bidi.console
+   selenium.webdriver.common.bidi.log
    selenium.webdriver.common.bidi.network
    selenium.webdriver.common.bidi.script
    selenium.webdriver.common.bidi.session
+   selenium.webdriver.common.bidi.storage
    selenium.webdriver.common.bidi.webextension
    selenium.webdriver.common.by
    selenium.webdriver.common.desired_capabilities


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adds the following modules to `py/docs/source/api.rst`:
- `selenium.webdriver.common.bidi.browsing_context`
- `selenium.webdriver.common.bidi.log`
- `selenium.webdriver.common.bidi.storage`

Since they were missing, their documentation was not getting generated in the Python API docs.

### 💡 Additional Considerations

Note to maintainers: Any time a new Python file/module is added, a new entry must be added to `py/docs/source/api.rst` in order for the module's docstrings to get generated into documentation pages.

### 🔄 Types of changes
- Bug fix (backwards compatible)
- Documentation


___

### **PR Type**
Documentation, Bug fix


___

### **Description**
- Add missing BiDi modules to Python API docs

- Ensure documentation generation for new modules

- Improve completeness of API reference documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.rst</strong><dd><code>Add missing BiDi modules to API documentation index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/docs/source/api.rst

<li>Added <code>browsing_context</code>, <code>log</code>, and <code>storage</code> BiDi modules to API docs<br> <li> Ensured new modules are included in documentation generation


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15779/files#diff-7e8f0a6376548281d6c1a5b57121f0a701a76c5f88129fe7def3d89f39b63c43">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>