### PR TITLE
[rb] Leverage existing URI::Generic and Net::HTTP code for proxy handling

### DIFF
--- a/rb/lib/selenium/webdriver/common/proxy.rb
+++ b/rb/lib/selenium/webdriver/common/proxy.rb
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# For more information on the proxy settings, see: https://www.w3.org/TR/webdriver2/#dfn-proxy-configuration
+
 module Selenium
   module WebDriver
     class Proxy
@@ -89,7 +91,11 @@ module Selenium
 
       def no_proxy=(value)
         self.type = :manual
-        @no_proxy = value
+        @no_proxy = if value.is_a?(String)
+                      value.scan(/([^:,\s]+)(:\d+)?/).map(&:join) # adapted from URI::Generic.use_proxy?
+                    else
+                      value
+                    end
       end
 
       def ssl=(value)
@@ -145,7 +151,7 @@ module Selenium
           'proxyType' => TYPES[type].downcase,
           'ftpProxy' => ftp,
           'httpProxy' => http,
-          'noProxy' => no_proxy.is_a?(String) ? no_proxy.split(', ') : no_proxy,
+          'noProxy' => no_proxy,
           'proxyAutoconfigUrl' => pac,
           'sslProxy' => ssl,
           'autodetect' => auto_detect,

--- a/rb/lib/selenium/webdriver/firefox/profile.rb
+++ b/rb/lib/selenium/webdriver/firefox/profile.rb
@@ -138,7 +138,8 @@ module Selenium
             set_manual_proxy_preference 'ssl', proxy.ssl
             set_manual_proxy_preference 'socks', proxy.socks
 
-            self['network.proxy.no_proxies_on'] = proxy.no_proxy || ''
+            # cf. http://kb.mozillazine.org/Network.proxy.no_proxies_on
+            self['network.proxy.no_proxies_on'] = proxy.no_proxy&.join(',') || ''
           when :pac
             self['network.proxy.type'] = 2
             self['network.proxy.autoconfig_url'] = proxy.pac

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -119,6 +119,8 @@ module Selenium
           end
 
           def new_http_client
+            raise Error::WebDriverError, 'server_url not set' unless server_url
+
             if proxy
               url = proxy.http
               unless proxy.respond_to?(:http) && url

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-require 'ipaddr'
+require 'uri/generic'
 
 module Selenium
   module WebDriver
@@ -88,7 +88,7 @@ module Selenium
               sleep 2
               retry
             rescue Errno::ECONNREFUSED => e
-              raise e.class, "using proxy: #{proxy.http}" if use_proxy?
+              raise e.class, "using proxy: #{http.proxy_uri}" if http.proxy?
 
               raise
             end
@@ -119,18 +119,20 @@ module Selenium
           end
 
           def new_http_client
-            if use_proxy?
-              url = @proxy.http
+            if proxy
+              url = proxy.http
               unless proxy.respond_to?(:http) && url
                 raise Error::WebDriverError,
-                      "expected HTTP proxy, got #{@proxy.inspect}"
+                      "expected HTTP proxy, got #{proxy.inspect}"
               end
 
-              proxy = URI.parse(url)
+              proxy_url = URI.parse(url)
 
-              Net::HTTP.new(server_url.host, server_url.port, proxy.host, proxy.port, proxy.user, proxy.password)
+              Net::HTTP.new(server_url.host, server_url.port,
+                            proxy_url.host, proxy_url.port, proxy_url.user, proxy_url.password,
+                            proxy.no_proxy&.join(','))
             else
-              Net::HTTP.new server_url.host, server_url.port
+              Net::HTTP.new(server_url.host, server_url.port, nil)
             end
           end
 
@@ -143,27 +145,6 @@ module Selenium
                 proxy = "http://#{proxy}" unless proxy.start_with?('http://')
                 Proxy.new(http: proxy, no_proxy: no_proxy)
               end
-            end
-          end
-
-          def use_proxy?
-            return false if proxy.nil?
-
-            if proxy.no_proxy
-              ignored = proxy.no_proxy.split(',').any? do |host|
-                host == '*' ||
-                  host == server_url.host || (
-                begin
-                  IPAddr.new(host).include?(server_url.host)
-                rescue ArgumentError
-                  false
-                end
-              )
-              end
-
-              !ignored
-            else
-              true
             end
           end
         end # Default

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -88,9 +88,7 @@ module Selenium
               sleep 2
               retry
             rescue Errno::ECONNREFUSED => e
-              raise e.class, "using proxy: #{http.proxy_uri}" if http.proxy?
-
-              raise
+              handle_connection_refused(e)
             end
 
             if response.is_a? Net::HTTPRedirection
@@ -102,6 +100,12 @@ module Selenium
               WebDriver.logger.debug("   <<<  #{response.instance_variable_get(:@header).inspect}", id: :header)
               create_response response.code, response.body, response.content_type
             end
+          end
+
+          def handle_connection_refused(error)
+            raise error.class, "using proxy: #{http.proxy_uri}" if http.proxy?
+
+            raise
           end
 
           def new_request_for(verb, url, headers, payload)

--- a/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
@@ -39,8 +39,6 @@ module Selenium
           def new_http_client: () -> untyped
 
           def proxy: () -> untyped
-
-          def use_proxy?: () -> untyped
         end
       end
     end

--- a/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
@@ -32,6 +32,8 @@ module Selenium
 
           def request: (untyped verb, untyped url, untyped headers, untyped payload, ?::Integer redirects) -> untyped
 
+          def handle_connection_refused: (Errno::ECONNREFUSED exception) -> untyped
+
           def new_request_for: (untyped verb, untyped url, untyped headers, untyped payload) -> untyped
 
           def response_for: (untyped request) -> untyped

--- a/rb/spec/unit/selenium/webdriver/proxy_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/proxy_spec.rb
@@ -26,7 +26,7 @@ module Selenium
         {
           ftp: 'mythicalftpproxy:21',
           http: 'mythicalproxy:80',
-          no_proxy: 'noproxy',
+          no_proxy: 'noproxy,noproxy2,noproxy3:443,127.0.0.1,127.0.0.1:80',
           ssl: 'mythicalsslproxy',
           socks: 'mythicalsocksproxy:65555',
           socks_username: 'test',
@@ -59,12 +59,18 @@ module Selenium
 
         expect(proxy.ftp).to            eq(proxy_settings[:ftp])
         expect(proxy.http).to           eq(proxy_settings[:http])
-        expect(proxy.no_proxy).to       eq(proxy_settings[:no_proxy])
+        expect(proxy.no_proxy).to       eq(%w[noproxy noproxy2 noproxy3:443 127.0.0.1 127.0.0.1:80])
         expect(proxy.ssl).to            eq(proxy_settings[:ssl])
         expect(proxy.socks).to          eq(proxy_settings[:socks])
         expect(proxy.socks_username).to eq(proxy_settings[:socks_username])
         expect(proxy.socks_password).to eq(proxy_settings[:socks_password])
         expect(proxy.socks_version).to  eq(proxy_settings[:socks_version])
+      end
+
+      it 'allows different kinds of separator for no_proxy string list', :aggregate_failures do
+        proxy = described_class.new({no_proxy: 'noproxy,noproxy2, noproxy3:443 127.0.0.1 , 127.0.0.1:80'})
+
+        expect(proxy.no_proxy).to eq(%w[noproxy noproxy2 noproxy3:443 127.0.0.1 127.0.0.1:80])
       end
 
       it 'returns a hash of the json properties to serialize', :aggregate_failures do
@@ -73,7 +79,7 @@ module Selenium
         expect(proxy_json['proxyType']).to     eq('manual')
         expect(proxy_json['ftpProxy']).to      eq(proxy_settings[:ftp])
         expect(proxy_json['httpProxy']).to     eq(proxy_settings[:http])
-        expect(proxy_json['noProxy']).to       eq([proxy_settings[:no_proxy]])
+        expect(proxy_json['noProxy']).to       eq(%w[noproxy noproxy2 noproxy3:443 127.0.0.1 127.0.0.1:80])
         expect(proxy_json['sslProxy']).to      eq(proxy_settings[:ssl])
         expect(proxy_json['socksProxy']).to    eq(proxy_settings[:socks])
         expect(proxy_json['socksUsername']).to eq(proxy_settings[:socks_username])
@@ -95,7 +101,7 @@ module Selenium
         expect(proxy_json['autodetect']).to be true
       end
 
-      it 'onlies add settings that are not nil', :aggregate_failures do
+      it 'only add settings that are not nil', :aggregate_failures do
         settings = {type: :manual, http: 'http proxy'}
 
         proxy = described_class.new(settings)

--- a/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
@@ -26,7 +26,7 @@ module Selenium
         describe Default do
           let(:client) do
             client = described_class.new
-            client.server_url = URI.parse('http://example.com')
+            client.server_url = URI.parse('http://test.example.com')
 
             client
           end
@@ -60,7 +60,7 @@ module Selenium
             expect(http.proxy_user).to eq('foo')
             expect(http.proxy_pass).to eq('bar')
 
-            expect(http.address).to eq('example.com')
+            expect(http.address).to eq('test.example.com')
           end
 
           it 'raises an error if the proxy is not an HTTP proxy' do
@@ -96,10 +96,23 @@ module Selenium
                 http = client.send :http
                 expect(http).not_to be_proxy
               end
+
+              with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => 'test.example.com') do
+                http = client.send :http
+                expect(http).not_to be_proxy
+              end
             end
 
             it "ignores the #{no_proxy_var} environment variable when not matching" do
               with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => 'foo.com') do
+                http = client.send :http
+
+                expect(http).to be_proxy
+                expect(http.proxy_address).to eq('proxy.org')
+                expect(http.proxy_port).to eq(8080)
+              end
+
+              with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => 'ample.com') do
                 http = client.send :http
 
                 expect(http).to be_proxy
@@ -115,12 +128,31 @@ module Selenium
               end
             end
 
+            it "understands a space separated list of domains in #{no_proxy_var}" do
+              with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => 'example.com foo.com') do
+                http = client.send :http
+                expect(http).not_to be_proxy
+              end
+            end
+
             it "understands subnetting in #{no_proxy_var}" do
               with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => 'localhost,127.0.0.0/8') do
                 client.server_url = URI.parse('http://127.0.0.1:4444/wd/hub')
 
                 http = client.send :http
                 expect(http).not_to be_proxy
+              end
+            end
+
+            it "uses the specified proxy if the wildcard character is used in #{no_proxy_var}" do
+              with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => '*') do
+                http = client.send :http
+                expect(http).to be_proxy
+              end
+
+              with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => '*.example.com') do
+                http = client.send :http
+                expect(http).to be_proxy
               end
             end
           end

--- a/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
@@ -144,7 +144,7 @@ module Selenium
               end
             end
 
-            it "uses the specified proxy if the wildcard character is used in #{no_proxy_var}" do
+            it "ignores wildcard characters in #{no_proxy_var} and uses the proxy" do
               with_env('http_proxy' => 'proxy.org:8080', no_proxy_var => '*') do
                 http = client.send :http
                 expect(http).to be_proxy


### PR DESCRIPTION
### **User description**
Details:
- Replaced custom `use_proxy?` method with [URI::Generic.use_proxy?](https://github.com/ruby/ruby/blob/v3_2_8/lib/uri/generic.rb#L1564) to use already existing functionality for handling the `no_proxy` string, which can include a list of comma- or space-separated elements.
- Take advantage of the `p_no_proxy` variable in [Net::HTTP](https://github.com/search?q=repo%3Aruby%2Fnet-http+proxy+path%3A%2F%5Elib%5C%2Fnet%5C%2F%2F&type=code) to maintain environment variables related to proxy settings.
- Note: With this change, wildcards are no longer usable to bypass the proxy due to limitations in the existing proxy code.

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

Related to #5004 

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

It changes the way the `new_http_client` is built to leverage what is already done in [URI::Generic](https://github.com/search?q=repo%3Aruby%2Fruby+proxy+path%3Alib%2Furi&type=code) and [Net::HTTP](https://github.com/search?q=repo%3Aruby%2Fnet-http+proxy+path%3A%2F%5Elib%5C%2Fnet%5C%2F%2F&type=code) about the condition to use the proxy or not.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

I tried to look up for a standardized way of using `no_proxy` but didn't find any. It seems like we are in the jungle and everyone has its own opinion.
However, the most common format I have found for `no_proxy` was a comma-separated list of strings:
- https://www.w3.org/Daemon/User/Proxies/ProxyClients.html
- https://www.w3.org/TR/webdriver2/#dfn-proxy-configuration
- https://www.browserstack.com/guide/no_proxy-environment-variable
- https://kb.mozillazine.org/Network.proxy.no_proxies_on
- https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/ (referenced also on [Docker](https://docs.docker.com/engine/cli/proxy/))

Also, I used only components that are already part of the project and things could been done differently.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

If wildcards need to be allowed, then it would most likely implies a change on URI::Generic first. However, I don't get why it could be useful to have it since we could use no proxy instead.

As alternative for the `no_proxy` value, I could have kept a string in the setter method, and transformed it to Array for the `as_json` method.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming): 
  - `no_proxy` value is considered as an Array directly in its setter method
- Bug fix (backwards compatible):
  - `no_proxy` value can be passed as a space-separated elements, or comma-plus-space-separated elements
- New feature (non-breaking change which adds functionality *and tests!*):
  - domain names can be specified partially (using second-level domain) and it can cover multiple subdomains
- Breaking change (fix or feature that would cause existing functionality to change):
  - Global wildcard (`*`) is not supported anymore


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored proxy handling to use `URI::Generic` and `Net::HTTP`
  - Removed custom proxy logic in favor of Ruby stdlib methods
  - Improved parsing of `no_proxy` to handle lists per WebDriver spec

- Updated serialization and Firefox profile to treat `no_proxy` as a list

- Enhanced and expanded unit tests for proxy and `no_proxy` handling

- Removed deprecated and redundant proxy code


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proxy.rb</strong><dd><code>Refactor and spec-compliant handling of no_proxy in Proxy class</code></dd></summary>
<hr>

rb/lib/selenium/webdriver/common/proxy.rb

<li>Updated <code>no_proxy=</code> to parse strings into lists per spec<br> <li> Adjusted JSON serialization to output <code>no_proxy</code> as a list<br> <li> Added reference to WebDriver proxy spec


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-095eb654427ce5add2dcff9cee2ba6b3af101725fe97a9a8466468214026324a">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>profile.rb</strong><dd><code>Update Firefox profile to use list-based no_proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/firefox/profile.rb

<li>Set Firefox <code>network.proxy.no_proxies_on</code> using joined list from <br><code>no_proxy</code><br> <li> Ensured compatibility with new list-based <code>no_proxy</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-7ee189046cdbd95200c1e7f74f56b9ccde5f779876e7df363e44dd1be4f46915">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default.rb</strong><dd><code>Refactor HTTP proxy logic to use stdlib and support no_proxy lists</code></dd></summary>
<hr>

rb/lib/selenium/webdriver/remote/http/default.rb

<li>Switched to using <code>URI::Generic</code> for proxy logic<br> <li> Refactored proxy client creation to support list-based <code>no_proxy</code><br> <li> Removed custom <code>use_proxy?</code> logic in favor of stdlib<br> <li> Improved error messages and proxy environment handling


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-52c65654bea150f9c1c523f1ca349a4bf3f8984cd6fbd17496ed66e39e1d5004">+10/-29</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proxy_spec.rb</strong><dd><code>Update and expand Proxy spec for list-based no_proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/proxy_spec.rb

<li>Updated tests to expect <code>no_proxy</code> as a list<br> <li> Added tests for various <code>no_proxy</code> separators and formats<br> <li> Improved test coverage for serialization and input handling


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-1a25485b3461ee21aaaf94aff92758ea7e32ba5ca64302444a7301274e3ba321">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default_spec.rb</strong><dd><code>Expand HTTP Default spec for robust no_proxy handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb

<li>Enhanced tests for proxy and <code>no_proxy</code> environment variable handling<br> <li> Added cases for space-separated, subnet, and wildcard <code>no_proxy</code><br> <li> Improved test clarity and coverage


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-ed0ec7d55a614ebf5f4ce695e58c10b2d29f3b7f12707d89a97b21e1a5542e67">+34/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.rbs</strong><dd><code>Remove deprecated proxy method signature from RBS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/remote/http/default.rbs

<li>Removed signature for deprecated <code>use_proxy?</code> method<br> <li> Updated type signatures to match refactored code


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15782/files#diff-be817817d2ce1b167dc85aa59740e89ddaf4a3325d8854667f95d036fb31f995">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>