### PR TITLE
[py] Fix pytest_ignore_collect hook to respect --ignore

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -90,7 +90,9 @@ def pytest_ignore_collect(collection_path, config):
     _drivers = set(drivers).difference(drivers_opt or drivers)
     if drivers_opt:
         _drivers.add("unit")
-    return len([d for d in _drivers if d.lower() in collection_path.parts]) > 0
+    if len([d for d in _drivers if d.lower() in collection_path.parts]) > 0:
+        return True
+    return None
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

### 💥 What does this PR do?
Fix the `pytest_ignore_collect` hook to respect `--ignore` specified by the user.


### 🔧 Implementation Notes
Returning `False` stops pytest from consulting additional hooks, including its default hooks that are necessary to process `--ignore` option.  By returning `True` or `None`, the hook combines files ignored by default with ignores specified by the user.

### 💡 Additional Considerations
This is a pure test change.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes `pytest_ignore_collect` to respect `--ignore` option

- Ensures default pytest ignores are combined with custom ignores

- Prevents premature stopping of hook processing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Fix test collection ignore logic for pytest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Modified <code>pytest_ignore_collect</code> to return <code>True</code> or <code>None</code> instead of <code>False</code><br> <li> Ensures compatibility with pytest's <code>--ignore</code> option<br> <li> Prevents stopping further hook processing by pytest


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15787/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>