### PR TITLE
[py] Increase timeout in devtools test

### DIFF
--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -32,7 +32,7 @@ def test_check_console_messages(driver, pages, recwarn):
     connection.on(devtools.runtime.ConsoleAPICalled, console_api_calls.append)
     driver.execute_script("console.log('I love cheese')")
     driver.execute_script("console.error('I love bread')")
-    WebDriverWait(driver, 5).until(lambda _: len(console_api_calls) == 2)
+    WebDriverWait(driver, 10).until(lambda _: len(console_api_calls) == 2)
 
     assert console_api_calls[0].type_ == "log"
     assert console_api_calls[0].args[0].value == "I love cheese"


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR increases the timeout to wait for devtools console messages in `py/test/selenium/webdriver/common/devtools_tests.py` because it keeps failing on RBE.


### 🔄 Types of changes
- Internal test infrastructure


___

### **PR Type**
Tests


___

### **Description**
- Increased timeout for devtools console message test

- Aims to reduce test failures on RBE infrastructure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devtools_tests.py</strong><dd><code>Increase WebDriverWait timeout in devtools test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/devtools_tests.py

<li>Increased WebDriverWait timeout from 5 to 10 seconds in console <br>message test<br> <li> Addresses intermittent test failures due to timing issues


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15793/files#diff-800b0102b563606add570f812f89944831fc639473425183366834ab7a754c0f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>