### PR TITLE
[dotnet] [bidi] Add AcceptInsecureCerts and Proxy options when create new user context

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Browser/BrowserModule.cs
@@ -17,7 +17,6 @@
 // under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenQA.Selenium.BiDi.Communication;
 
@@ -32,7 +31,9 @@ public sealed class BrowserModule(Broker broker) : Module(broker)
 
     public async Task<UserContextInfo> CreateUserContextAsync(CreateUserContextOptions? options = null)
     {
-        return await Broker.ExecuteCommandAsync<CreateUserContextCommand, UserContextInfo>(new CreateUserContextCommand(), options).ConfigureAwait(false);
+        var @params = new CreateUserContextCommandParameters(options?.AcceptInsecureCerts, options?.Proxy);
+
+        return await Broker.ExecuteCommandAsync<CreateUserContextCommand, UserContextInfo>(new CreateUserContextCommand(@params), options).ConfigureAwait(false);
     }
 
     public async Task<GetUserContextsResult> GetUserContextsAsync(GetUserContextsOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/Modules/Browser/CreateUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Browser/CreateUserContextCommand.cs
@@ -21,7 +21,14 @@ using OpenQA.Selenium.BiDi.Communication;
 
 namespace OpenQA.Selenium.BiDi.Modules.Browser;
 
-internal class CreateUserContextCommand()
-    : Command<CommandParameters, UserContextInfo>(CommandParameters.Empty, "browser.createUserContext");
+internal class CreateUserContextCommand(CreateUserContextCommandParameters @params)
+    : Command<CreateUserContextCommandParameters, UserContextInfo>(@params, "browser.createUserContext");
 
-public record CreateUserContextOptions : CommandOptions;
+internal record CreateUserContextCommandParameters(bool? AcceptInsecureCerts, Session.ProxyConfiguration? Proxy) : CommandParameters;
+
+public record CreateUserContextOptions : CommandOptions
+{
+    public bool? AcceptInsecureCerts { get; set; }
+
+    public Session.ProxyConfiguration? Proxy { get; set; }
+}


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?

Implements https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext

```csharp
var userContext = await bidi.Browser.CreateUserContextAsync(new()
{
    AcceptInsecureCerts = true,
    Proxy = new Modules.Session.AutoDetectProxyConfiguration()
});
```

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add AcceptInsecureCerts and Proxy options to CreateUserContext

- Update command parameter handling for user context creation

- Enhance .NET BiDi BrowserModule for flexible user context setup


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserModule.cs</strong><dd><code>Support AcceptInsecureCerts and Proxy in CreateUserContextAsync</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Browser/BrowserModule.cs

<li>Pass AcceptInsecureCerts and Proxy options to CreateUserContext <br>command<br> <li> Construct command parameters from options for user context creation<br> <li> Improve flexibility of CreateUserContextAsync method


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15795/files#diff-86caaf6e49143087617df0dc7d08a9f02255487cfb47afe9c683405cb1c4a340">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateUserContextCommand.cs</strong><dd><code>Add command parameters and options for user context creation</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Modules/Browser/CreateUserContextCommand.cs

<li>Add CreateUserContextCommandParameters record for new options<br> <li> Update CreateUserContextCommand to accept parameters<br> <li> Extend CreateUserContextOptions with AcceptInsecureCerts and Proxy <br>properties


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15795/files#diff-9834041492b18356f4ce7647d7d120630d1844bcd88b9bd5a4e7b13dcd7a8891">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>