### PR TITLE
[grid] Silent fail on invalid log level

### DIFF
--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -76,7 +76,9 @@ public class LoggingOptions {
     try {
       level = Level.parse(configLevel.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
-      throw new ConfigException("Unable to determine log level from " + configLevel);
+      // Logger is not configured yet
+      new ConfigException("Unable to determine log level from " + configLevel +
+       ". Using default " + DEFAULT_LOG_LEVEL).printStackTrace();
     }
   }
 

--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -77,8 +77,14 @@ public class LoggingOptions {
       level = Level.parse(configLevel.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       // Logger is not configured yet
-      new ConfigException("Unable to determine log level from " + configLevel +
-       ". Using default " + DEFAULT_LOG_LEVEL).printStackTrace();
+      new ConfigException(
+              "Unable to determine log level from "
+                  + configLevel
+                  + ". Using default "
+                  + DEFAULT_LOG_LEVEL
+                  + ". Available log levels can be found at"
+                  + " https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/Level.html")
+          .printStackTrace();
     }
   }
 

--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -49,6 +50,17 @@ public class LoggingOptions {
   private final Config config;
   private Level level = Level.INFO;
   public static final String DEFAULT_LOG_TIMESTAMP_FORMAT = "HH:mm:ss.SSS";
+  private static final List<Level> DEFAULT_LOG_LEVELS =
+      Arrays.asList(
+          Level.ALL,
+          Level.INFO,
+          Level.CONFIG,
+          Level.FINE,
+          Level.FINER,
+          Level.FINEST,
+          Level.OFF,
+          Level.SEVERE,
+          Level.WARNING);
 
   public LoggingOptions(Config config) {
     this.config = Require.nonNull("Config", config);
@@ -82,8 +94,8 @@ public class LoggingOptions {
                   + configLevel
                   + ". Using default "
                   + DEFAULT_LOG_LEVEL
-                  + ". Available log levels can be found at"
-                  + " https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/Level.html")
+                  + ". Available log levels are: "
+                  + DEFAULT_LOG_LEVELS)
           .printStackTrace();
     }
   }


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #15790

### 💥 What does this PR do?
Fixing issue where providing an invalid log level to Grid will fail silently.

### 🔧 Implementation Notes
Since the logger is not yet configured a stacktrace with the exception is printed to console and we continue since the default log level is already configured.

I've considered percolating the exception up to the TemplateGrid.java, configure() method and doing a try catch there but to me it's unnecessarily complicated.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Print stacktrace when invalid log level is provided

- Prevent silent failure by notifying via console output

- Default log level is used if invalid value is given


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LoggingOptions.java</strong><dd><code>Handle invalid log level with stacktrace and fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/log/LoggingOptions.java

<li>Catches invalid log level and prints stacktrace to console<br> <li> Continues with default log level instead of failing silently


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15796/files#diff-df04b67d453fdda127e86957b1cb29596a05a07e711f9081cfa4af5ed7094a1b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>