### PR TITLE
Don't silence stderr in format.sh

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,7 +6,7 @@ section() {
     echo "- $*" >&2
 }
 
-WORKSPACE_ROOT="$(bazel info workspace 2>/dev/null)"
+WORKSPACE_ROOT="$(bazel info workspace)"
 
 GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR removes the silencing of stderr when calling bazel in `./scripts/format.sh`. Without this, if you run the format script and don't have bazel installed, it just fails silently. This will make it more visible by not hiding the error.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- build/tooling


___

### **PR Type**
Enhancement


___

### **Description**
- Stop silencing stderr in `format.sh` Bazel calls

- Improve error visibility when Bazel is missing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format.sh</strong><dd><code>Make Bazel errors visible in format.sh script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/format.sh

<li>Removed redirection of stderr to /dev/null for Bazel workspace info<br> <li> Errors from Bazel are now visible to users


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15804/files#diff-3a9054a1963ff6cd07b6054d4feecbb4a17b3e4fe87ac71aeb2db3f2524552fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>