### PR TITLE
[dotnet] [bidi] Declare allowed nullable objects in constructors type

### DIFF
--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/BrowsingContextInfo.cs
@@ -22,8 +22,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 
-// TODO: Split it to separate class with just info and event args
-public record BrowsingContextInfo(BiDi BiDi, IReadOnlyList<BrowsingContextInfo> Children, Browser.ClientWindow ClientWindow, BrowsingContext Context, BrowsingContext OriginalOpener, string Url, Browser.UserContext UserContext)
+public record BrowsingContextInfo(BiDi BiDi, IReadOnlyList<BrowsingContextInfo>? Children, Browser.ClientWindow ClientWindow, BrowsingContext Context, BrowsingContext? OriginalOpener, string Url, Browser.UserContext UserContext)
     : BrowsingContextEventArgs(BiDi, Context)
 {
     [JsonInclude]

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigateCommand.cs
@@ -38,4 +38,4 @@ public enum ReadinessState
     Complete
 }
 
-public record NavigateResult(Navigation Navigation, string Url) : EmptyResult;
+public record NavigateResult(Navigation? Navigation, string Url) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigationInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/BrowsingContext/NavigationInfo.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.BrowsingContext;
 
-public record NavigationInfo(BiDi BiDi, BrowsingContext Context, Navigation Navigation, DateTimeOffset Timestamp, string Url)
+public record NavigationInfo(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
     : BrowsingContextEventArgs(BiDi, Context);

--- a/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Log/LogEntry.cs
@@ -27,19 +27,19 @@ namespace OpenQA.Selenium.BiDi.Modules.Log;
 //[JsonDerivedType(typeof(GenericLogEntry))] // Fallback when discriminator is not recognized, we have to double check
 //[JsonDerivedType(typeof(ConsoleLogEntry), "console")]
 //[JsonDerivedType(typeof(JavascriptLogEntry), "javascript")]
-public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
     : EventArgs(BiDi)
 {
     public Script.StackTrace? StackTrace { get; set; }
 }
 
-public record GenericLogEntry(BiDi BiDi, string Type, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+public record GenericLogEntry(BiDi BiDi, string Type, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
     : LogEntry(BiDi, Level, Source, Text, Timestamp);
 
-public record ConsoleLogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
+public record ConsoleLogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
     : LogEntry(BiDi, Level, Source, Text, Timestamp);
 
-public record JavascriptLogEntry(BiDi BiDi, Level Level, Script.Source Source, string Text, DateTimeOffset Timestamp)
+public record JavascriptLogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
     : LogEntry(BiDi, Level, Source, Text, Timestamp);
 
 public enum Level

--- a/dotnet/src/webdriver/BiDi/Modules/Network/AuthRequiredEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/AuthRequiredEventArgs.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record AuthRequiredEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, BrowsingContext.Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response) :
+public record AuthRequiredEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response) :
     BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp);

--- a/dotnet/src/webdriver/BiDi/Modules/Network/BaseParametersEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/BaseParametersEventArgs.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public abstract record BaseParametersEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, BrowsingContext.Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp)
+public abstract record BaseParametersEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp)
     : BrowsingContextEventArgs(BiDi, Context)
 {
     [JsonInclude]

--- a/dotnet/src/webdriver/BiDi/Modules/Network/BeforeRequestSentEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/BeforeRequestSentEventArgs.cs
@@ -22,5 +22,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record BeforeRequestSentEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator)
+public record BeforeRequestSentEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator)
     : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp);

--- a/dotnet/src/webdriver/BiDi/Modules/Network/FetchErrorEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/FetchErrorEventArgs.cs
@@ -22,5 +22,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record FetchErrorEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, string ErrorText)
+public record FetchErrorEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, string ErrorText)
     : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp);

--- a/dotnet/src/webdriver/BiDi/Modules/Network/NetworkModule.HighLevel.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/NetworkModule.HighLevel.cs
@@ -58,7 +58,7 @@ public record InterceptResponseOptions : AddInterceptOptions;
 
 public record InterceptAuthOptions : AddInterceptOptions;
 
-public record InterceptedRequest(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, BrowsingContext.Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator)
+public record InterceptedRequest(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator)
     : BeforeRequestSentEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Initiator)
 {
     public Task ContinueAsync(ContinueRequestOptions? options = null)
@@ -77,7 +77,7 @@ public record InterceptedRequest(BiDi BiDi, BrowsingContext.BrowsingContext Cont
     }
 }
 
-public record InterceptedResponse(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, BrowsingContext.Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
+public record InterceptedResponse(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
     : ResponseStartedEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Response)
 {
     public Task ContinueAsync(ContinueResponseOptions? options = null)
@@ -86,7 +86,7 @@ public record InterceptedResponse(BiDi BiDi, BrowsingContext.BrowsingContext Con
     }
 }
 
-public record InterceptedAuth(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, BrowsingContext.Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
+public record InterceptedAuth(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
     : AuthRequiredEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Response)
 {
     public Task ContinueAsync(AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/Modules/Network/RequestData.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/RequestData.cs
@@ -21,4 +21,4 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record RequestData(Request Request, string Url, string Method, IReadOnlyList<Header> Headers, IReadOnlyList<Cookie> Cookies, long HeadersSize, long? BodySize, FetchTimingInfo Timings);
+public record RequestData(Request Request, string Url, string Method, IReadOnlyList<Header> Headers, IReadOnlyList<Cookie> Cookies, long? HeadersSize, long? BodySize, string Destination, string? InitiatorType, FetchTimingInfo Timings);

--- a/dotnet/src/webdriver/BiDi/Modules/Network/ResponseCompletedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/ResponseCompletedEventArgs.cs
@@ -22,5 +22,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record ResponseCompletedEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
+public record ResponseCompletedEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
     : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp);

--- a/dotnet/src/webdriver/BiDi/Modules/Network/ResponseStartedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Modules/Network/ResponseStartedEventArgs.cs
@@ -22,5 +22,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.Modules.Network;
 
-public record ResponseStartedEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context, bool IsBlocked, Navigation Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
+public record ResponseStartedEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response)
     : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp);


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/15561

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Make DTO constructor parameters nullable where allowed by spec

- Update BiDi event and data records to accept null values

- Add missing properties to network request data records

- Improve type safety for optional BiDi fields


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>BrowsingContextInfo.cs</strong><dd><code>Make Children and OriginalOpener parameters nullable in </code><br><code>BrowsingContextInfo</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-ba6a0304d454dc4d738adc17687a636b78a4cfeca864c8400998012da04513ae">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavigateCommand.cs</strong><dd><code>Allow Navigation parameter to be nullable in NavigateResult</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-d48dbcfaf24ffa9a0d0d3b45800f99381806de34aaaf7085b8c173f4d47c59ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavigationInfo.cs</strong><dd><code>Make Navigation parameter nullable in NavigationInfo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-54d39fbfbce326059970d4ac11f8d0faae2ee4a9c6013acc64a52ab32360113a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogEntry.cs</strong><dd><code>Allow Text parameter to be nullable in all LogEntry records</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-4b9875950fb3e46b82d0ee93e78c35eec6750f42ba48da0202118a824e4be150">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AuthRequiredEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in </code><br><code>AuthRequiredEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-bc2a41ac71ef6757a7fdfd0194fdf0d4690ca0006b50f34ea890ae996f91d7f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BaseParametersEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in </code><br><code>BaseParametersEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-437bfd6fb16acb52cf83fbd2dd5f35b7531c5f2be5dcaaeee75f36d9616b2b63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BeforeRequestSentEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in </code><br><code>BeforeRequestSentEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-0d7707ce0fa0dc73e7e664fe0d0e1c28bd5566be1f2413f9e57f8a6977390542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FetchErrorEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in FetchErrorEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-d32541a99228f28208f406a34d2c55f2d61843355a5e44edc9de8b5de56227d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RequestData.cs</strong><dd><code>Add Destination and InitiatorType, make HeadersSize nullable in </code><br><code>RequestData</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-671812a806bdf4cb0039769c01cb49b4fabfff07d06a920def88f5c944c81a95">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseCompletedEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in </code><br><code>ResponseCompletedEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-b407824672bb996664f6ba634c1048393598d70dd7e51a088318a05ed32150a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseStartedEventArgs.cs</strong><dd><code>Make Context and Navigation parameters nullable in </code><br><code>ResponseStartedEventArgs</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15809/files#diff-30fdfd77221d2a28470098e6499826df51a98edbd7018b1e995794f348df1f2a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>