### PR TITLE
Fix type error for attribute in remote_connection.py

### DIFF
--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -145,7 +145,7 @@ class RemoteConnection:
     https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
     """
 
-    browser_name = None
+    browser_name: Optional[str] = None
     # Keep backward compatibility for AppiumConnection - https://github.com/SeleniumHQ/selenium/issues/14694
     import os
     import socket


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
This update resolves type inconsistencies related to the browser_name variable in `webdriver/remote/remote_connection.py`. Previously, browser_name was initialized with None, while other parts of the codebase expected it to always be a str, leading to mypy errors such as:
`error: Argument "browser_name" to "ChromiumRemoteConnection" has incompatible type "str | None"; expected "str"`

### Fix
The fix involves updating the type annotation of browser_name to Optional[str], aligning with its usage and ensuring compatibility with static type checking. This change eliminates related type errors and moves the codebase closer to full mypy compliance.
___

### **PR Type**
Bug fix


___

### **Description**
- Fixes type annotation for `browser_name` in `remote_connection.py`

- Changes `browser_name` to `Optional[str]` to resolve Mypy errors

- Addresses part of the static typing issues in Python bindings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Correct type annotation for browser_name attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<li>Updates <code>browser_name</code> attribute type to <code>Optional[str]</code><br> <li> Resolves type error flagged by Mypy static analysis


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15810/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>