### PR TITLE
[py] Lint Python with ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ py/selenium/webdriver/remote/getAttribute.js
 py/selenium/webdriver/remote/isDisplayed.js
 py/docs/build/
 py/docs/source/**/*
+!py/docs/source/conf.py
 py/build/
 py/LICENSE
 py/pytestdebug.log

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,6 @@
 module(name = "selenium")
 
 bazel_dep(name = "apple_rules_lint", version = "0.4.0")
-bazel_dep(name = "aspect_rules_lint", version = "1.4.2")
 bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.21.0")
 bazel_dep(name = "aspect_rules_js", version = "2.3.7")
@@ -21,6 +20,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)
 bazel_dep(name = "rules_dotnet", version = "0.17.5")
 bazel_dep(name = "rules_java", version = "8.7.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
+bazel_dep(name = "rules_multitool", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "6.3.2")
 bazel_dep(name = "rules_oci", version = "1.8.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
@@ -36,6 +36,10 @@ git_override(
     patches = ["//java:rules_jvm_external_javadoc.patch"],
     remote = "https://github.com/bazel-contrib/rules_jvm_external.git",
 )
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")
 
 linter = use_extension("@apple_rules_lint//lint:extensions.bzl", "linter")
 linter.configure(

--- a/javascript/private/gen_file.py
+++ b/javascript/private/gen_file.py
@@ -48,7 +48,6 @@ def write_atom_literal(out, name, contents, lang, utf8):
     name = get_atom_name(name)
 
     if "cc" == lang or "hh" == lang:
-        string_type = "std::string" if utf8 else "std::wstring"
         char_type = "char" if utf8 else "wchar_t"
         out.write("const %s* const %s[] = {\n" % (char_type, name))
     elif "java" == lang:

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "ruff": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.11.11/ruff-aarch64-unknown-linux-musl.tar.gz",
+        "file": "ruff-aarch64-unknown-linux-musl/ruff",
+        "sha256": "3ca33d9b68b8b0bc7e3673b7638910ac2f7c5399303b37bec4d13c005481a78a",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.11.11/ruff-x86_64-unknown-linux-musl.tar.gz",
+        "file": "ruff-x86_64-unknown-linux-musl/ruff",
+        "sha256": "bb64b083767a5fd0a62e10e9a35614974ad53025e2878cf14a0c698680e6c30c",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.11.11/ruff-aarch64-apple-darwin.tar.gz",
+        "file": "ruff-aarch64-apple-darwin/ruff",
+        "sha256": "814ccb26bed9c027bfc20ac88d33494ab0be62721757c73be70e26c23efbb3f7",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.11.11/ruff-x86_64-apple-darwin.tar.gz",
+        "file": "ruff-x86_64-apple-darwin/ruff",
+        "sha256": "8bef00e82bc07ea26b45adcffc3d55b2d0821f3a3e4d5f441f4dd4ad608fc1be",
+        "os": "macos",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.11.11/ruff-x86_64-pc-windows-msvc.zip",
+        "file": "ruff-x86_64-pc-windows-msvc/ruff.exe",
+        "sha256": "b7619ff27098a4d7f37c52fb8fc61ccfe677aaade7722a385b40f8d5273ebddd",
+        "os": "windows",
+        "cpu": "x86_64"
+      }
+    ]
+  }
+}

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
-load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@py_dev_requirements//:requirements.bzl", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
@@ -11,11 +10,6 @@ load("//common:defs.bzl", "copy_file")
 load("//py:defs.bzl", "generate_devtools", "py_test_suite")
 load("//py/private:browsers.bzl", "BROWSERS")
 load("//py/private:import.bzl", "py_import")
-
-format_multirun(
-    name = "format",
-    python = "@aspect_rules_lint//format:ruff",
-)
 
 py_binary(
     name = "selenium-release",

--- a/py/docs/source/conf.py
+++ b/py/docs/source/conf.py
@@ -16,9 +16,9 @@
 # under the License.
 
 
-import sys
 import os
 import os.path
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/py/release-selenium.py
+++ b/py/release-selenium.py
@@ -17,6 +17,7 @@
 
 
 import sys
+
 from twine import cli
 
 

--- a/py/test/selenium/webdriver/common/bidi_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
 
 from selenium.webdriver.common.bidi.log import LogLevel
 from selenium.webdriver.common.by import By

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -35,7 +35,7 @@ commands = mypy --install-types {posargs}
 [testenv:linting]
 skip_install = true
 deps =
-  ruff==0.11.10
+  ruff==0.11.11
 commands =
   ruff check --fix --show-fixes --exit-non-zero-on-fix selenium/ test/ conftest.py
   ruff format --exit-non-zero-on-format selenium/ test/ conftest.py

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -33,7 +33,8 @@ bazel run @rules_rust//:rustfmt
 
 section "Python"
 echo "    python - ruff" >&2
-bazel run //py:format
+bazel run @multitool//tools/ruff:cwd -- check --fix --show-fixes
+bazel run @multitool//tools/ruff:cwd -- format
 
 section "Copyright"
 bazel run //scripts:update_copyright

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -205,7 +205,6 @@ def edge():
     linux_hash = None
     mac = None
     mac_hash = None
-    version = None
 
     for data in all_data:
         if not "Stable" == data.get("product"):

--- a/scripts/selenium_manager.py
+++ b/scripts/selenium_manager.py
@@ -15,7 +15,7 @@ http = urllib3.PoolManager()
 def get_url():
     r = http.request(
         "GET",
-        f"https://github.com/SeleniumHQ/selenium_manager_artifacts/releases/latest",
+        "https://github.com/SeleniumHQ/selenium_manager_artifacts/releases/latest",
     )
     return r.url.replace("tag", "download")
 
@@ -23,7 +23,7 @@ def get_url():
 def get_sha_json():
     r = http.request(
         "GET",
-        f"https://raw.githubusercontent.com/SeleniumHQ/selenium_manager_artifacts/trunk/latest.json",
+        "https://raw.githubusercontent.com/SeleniumHQ/selenium_manager_artifacts/trunk/latest.json",
     )
     return json.loads(r.data)
 

--- a/scripts/update_cdp.py
+++ b/scripts/update_cdp.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
 import argparse
-import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import urllib3


### PR DESCRIPTION
Use Ruff directly to format and lint Python source code files.