### PR TITLE
fixed error in selenium/webdriver/common/bidi/common.py:19

### DIFF
--- a/py/selenium/webdriver/common/bidi/common.py
+++ b/py/selenium/webdriver/common/bidi/common.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Generator, Optional
 
-
-def command_builder(method: str, params: dict = None) -> dict:
+def command_builder(method: str, params: Optional[dict] = None) -> Generator[dict, dict, dict]:
     """Build a command iterator to send to the BiDi protocol.
 
     Parameters:

--- a/py/selenium/webdriver/common/bidi/common.py
+++ b/py/selenium/webdriver/common/bidi/common.py
@@ -16,6 +16,7 @@
 # under the License.
 from typing import Generator, Optional
 
+
 def command_builder(method: str, params: Optional[dict] = None) -> Generator[dict, dict, dict]:
     """Build a command iterator to send to the BiDi protocol.
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
fixed selenium/webdriver/common/bidi/common.py:19
### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects the function signature for `command_builder`

- Adds type hints for generator and optional parameters

- Improves BiDi protocol command construction typing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.py</strong><dd><code>Update command_builder signature and type hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/common.py

<li>Adds <code>Generator</code> and <code>Optional</code> imports from typing<br> <li> Updates <code>command_builder</code> signature to use generator return type<br> <li> Specifies <code>params</code> as Optional[dict] in function signature


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15814/files#diff-d38471cbc3bd4a86a19ba1a6c8ea1673298440fa4409ce3e24e2cd581fd3cc6a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>