### PR TITLE
[py] Fix import for type hint

### DIFF
--- a/py/selenium/webdriver/common/bidi/common.py
+++ b/py/selenium/webdriver/common/bidi/common.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Generator, Optional
+
+from collections.abc import Generator
+from typing import Optional
 
 
 def command_builder(method: str, params: Optional[dict] = None) -> Generator[dict, dict, dict]:


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

Fixes type hint import so `Generator` is imported from `collections.abc` instead of `typing`.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix import of `Generator` for type hinting

- Use `collections.abc` instead of deprecated `typing`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.py</strong><dd><code>Corrected `Generator` import for type hinting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/common.py

<li>Changed import of <code>Generator</code> from <code>typing</code> to <code>collections.abc</code><br> <li> Ensured type hinting uses the correct module


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15817/files#diff-d38471cbc3bd4a86a19ba1a6c8ea1673298440fa4409ce3e24e2cd581fd3cc6a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>