### PR TITLE
[py] Lint and format all python files

### DIFF
--- a/py/tox.ini
+++ b/py/tox.ini
@@ -37,5 +37,5 @@ skip_install = true
 deps =
   ruff==0.11.12
 commands =
-  ruff check --fix --show-fixes --exit-non-zero-on-fix selenium/ test/ conftest.py
-  ruff format --exit-non-zero-on-format selenium/ test/ conftest.py
+  ruff check --fix --show-fixes --exit-non-zero-on-fix .
+  ruff format --exit-non-zero-on-format .


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adjusts the linting/formatting (ruff) settings in `./py/tox.ini` so it scans the entire `./py` directory tree, not just specific directories. Previously, it was skipping files in the directory root. This brings tox in line with how we do linting in CI via bazel.

### 🔄 Types of changes
- internal/build infrastructure


___

### **PR Type**
Enhancement


___

### **Description**
- Update ruff linting to cover all Python files

- Change ruff commands to scan entire `./py` directory

- Align tox linting with CI (bazel) behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Update tox ruff commands to lint all Python files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/tox.ini

<li>Modified ruff lint and format commands to target all files in the <br>directory<br> <li> Replaced specific file/directory targets with a dot (.)<br> <li> Ensures no Python files are skipped during linting/formatting


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15828/files#diff-27d219400d7f64afbf3d9bceb197e20b299fdd58fb4e84c9b7c2ee7c4e828177">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>