### PR TITLE
Change flag for Chrome/Edge headless mode in tests

### DIFF
--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -116,7 +116,7 @@ class EdgeDriverFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void canSetPermissionHeadless() {
     EdgeOptions options = new EdgeOptions();
-    options.addArguments("--headless=new");
+    options.addArguments("--headless");
 
     localDriver = new WebDriverBuilder().get(options);
     HasPermissions permissions = (HasPermissions) localDriver;

--- a/java/test/org/openqa/selenium/testing/drivers/Browser.java
+++ b/java/test/org/openqa/selenium/testing/drivers/Browser.java
@@ -50,7 +50,7 @@ public enum Browser {
       }
 
       if (Boolean.getBoolean("webdriver.headless")) {
-        options.addArguments("--headless=new");
+        options.addArguments("--headless");
       }
 
       options.addArguments(
@@ -84,7 +84,7 @@ public enum Browser {
       }
 
       if (Boolean.getBoolean("webdriver.headless")) {
-        options.addArguments("--headless=new");
+        options.addArguments("--headless");
       }
 
       options.addArguments(

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -229,7 +229,7 @@ def get_options(driver_class, config):
 
     if headless:
         if driver_class == "Chrome" or driver_class == "Edge":
-            options.add_argument("--headless=new")
+            options.add_argument("--headless")
         if driver_class == "Firefox":
             options.add_argument("-headless")
 
@@ -393,6 +393,6 @@ def chromium_options(request):
         options = webdriver.EdgeOptions()
 
     if request.config.option.headless:
-        options.add_argument("--headless=new")
+        options.add_argument("--headless")
 
     return options


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR changes the flag for setting headless mode in Chrome/Edge from `--headless=new` to `--headless` in places where it was used in internal tests.

Since Chrome 132, "new" headless mode is the default and `--headless=new` will eventually be removed.
- https://developer.chrome.com/blog/removing-headless-old-from-chrome

We should probably update the docs to mention this. Specifically:
- https://www.selenium.dev/documentation/webdriver/browsers/chrome/
- https://www.selenium.dev/blog/2023/headless-is-going-away/

### 🔄 Types of changes
- internal testing


___

### **PR Type**
Tests


___

### **Description**
- Update headless flag to `--headless` for Chrome/Edge tests

- Remove deprecated `--headless=new` usage in test code

- Ensure compatibility with Chrome 132+ headless mode changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EdgeDriverFunctionalTest.java</strong><dd><code>Update Edge headless flag in functional test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java

<li>Changed Edge headless mode argument from <code>--headless=new</code> to <code>--headless</code> <br>in test.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15831/files#diff-9b41e954ffa07a702247ef4ea6b0ca2d9b2a4eca9cf9686c8b2416550e29db83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Browser.java</strong><dd><code>Update headless flag for Chrome/Edge in driver options</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/drivers/Browser.java

<li>Changed ChromeOptions and EdgeOptions headless argument from <br><code>--headless=new</code> to <code>--headless</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15831/files#diff-2bec381385968c618aa7e17ad604523bee97b78fa8fd694c7004e97ffe627a46">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Use `--headless` for Chrome/Edge in Python test config</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<li>Updated headless argument for Chrome/Edge from <code>--headless=new</code> to <br><code>--headless</code> in test setup.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15831/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>