### PR TITLE
[py] Fix python API docs publishing at readthedocs

### DIFF
--- a/py/docs/.readthedocs.yaml
+++ b/py/docs/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   commands:
     - pip install -r py/docs/requirements.txt
     - pip install -r py/requirements.txt
-    - PYTHONPATH=py python3 py/generate_api_module_listing.py
+    - cd py && python3 generate_api_module_listing.py && cd
     - PYTHONPATH=py sphinx-autogen -o $READTHEDOCS_OUTPUT/html py/docs/source/api.rst
     - PYTHONPATH=py sphinx-build -b html -d build/docs/doctrees py/docs/source $READTHEDOCS_OUTPUT/html
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

I broke our readthedocs configuration in #15828 for publishing the Python API docs.
This attempts to fix it.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes Python API docs generation command for ReadTheDocs

- Updates `.readthedocs.yaml` to correct script execution path


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.readthedocs.yaml</strong><dd><code>Fix ReadTheDocs build command for Python API docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/docs/.readthedocs.yaml

<li>Corrects the command to run <code>generate_api_module_listing.py</code> by changing <br>to the <code>py</code> directory before execution.<br> <li> Ensures the script is executed in the correct context for ReadTheDocs <br>builds.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15832/files#diff-df4530b9c40490890c4701b6677913f80370ee72b32c13d02e6764827f50526d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>