### PR TITLE
[dotnet] Add `WebDriverWait` constructor for specifying a sleep interval without a clock

### DIFF
--- a/dotnet/src/support/UI/PopupWindowFinder.cs
+++ b/dotnet/src/support/UI/PopupWindowFinder.cs
@@ -130,7 +130,7 @@ public class PopupWindowFinder
 
         ReadOnlyCollection<string> existingHandles = this.driver.WindowHandles;
         popupMethod();
-        WebDriverWait wait = new WebDriverWait(SystemClock.Instance, this.driver, this.timeout, this.sleepInterval);
+        var wait = new WebDriverWait(this.driver, this.timeout, this.sleepInterval);
         string popupHandle = wait.Until(driver =>
         {
             ReadOnlyCollection<string> newHandles = driver.WindowHandles;

--- a/dotnet/src/webdriver/Support/WebDriverWait.cs
+++ b/dotnet/src/webdriver/Support/WebDriverWait.cs
@@ -58,5 +58,17 @@ public class WebDriverWait : DefaultWait<IWebDriver>
         this.IgnoreExceptionTypes(typeof(NotFoundException));
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebDriverWait"/> class.
+    /// </summary>
+    /// <param name="driver">The WebDriver instance used to wait.</param>
+    /// <param name="timeout">The timeout value indicating how long to wait for the condition.</param>
+    /// <param name="sleepInterval">A <see cref="TimeSpan"/> value indicating how often to check for the condition to be true.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="driver"/> is <see langword="null"/>.</exception>
+    public WebDriverWait(IWebDriver driver, TimeSpan timeout, TimeSpan sleepInterval)
+        : this(SystemClock.Instance, driver, timeout, DefaultSleepTimeout)
+    {
+    }
+
     private static TimeSpan DefaultSleepTimeout => TimeSpan.FromMilliseconds(500);
 }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

Fixes https://github.com/SeleniumHQ/selenium/issues/15314

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

Adds a constructor to `WebDriverWait` for specifying a sleep interval without a clock. Use it in a test.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

Note that the Java implementation already has this feature.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add new `WebDriverWait` constructor without clock parameter

- Update usage in `PopupWindowFinder` to use new constructor

- Improve API parity with Java bindings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebDriverWait.cs</strong><dd><code>Add WebDriverWait constructor without clock parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Support/WebDriverWait.cs

<li>Add new constructor to <code>WebDriverWait</code> accepting driver, timeout, and <br>sleepInterval<br> <li> Document new constructor and its parameters<br> <li> Calls existing constructor with default clock and sleep timeout


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15838/files#diff-2f7168510ade381bd4db9bd984447f576ece0eb81fa277420622eeab59094fd1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PopupWindowFinder.cs</strong><dd><code>Use new WebDriverWait constructor in PopupWindowFinder</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/support/UI/PopupWindowFinder.cs

<li>Update to use new <code>WebDriverWait</code> constructor without clock<br> <li> Simplify instantiation of <code>WebDriverWait</code> in popup handling


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15838/files#diff-dd6ffe40e72f1d545f6b38706ecb9497f048fa22c61207874081a94e0e89cbfe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>