### PR TITLE
[py] Fix: Mypy type annotation errors

### DIFF
--- a/py/selenium/webdriver/common/bidi/storage.py
+++ b/py/selenium/webdriver/common/bidi/storage.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
+
 from selenium.webdriver.common.bidi.common import command_builder
 
 
@@ -88,10 +89,10 @@ class Cookie:
         name = data.get("name")
         if not name:
             raise ValueError("name is required and cannot be empty")
-        domain = data.get("domain") 
+        domain = data.get("domain")
         if not domain:
             raise ValueError("domain is required and cannot be empty")
-        
+
         value = BytesValue(data.get("value", {}).get("type"), data.get("value", {}).get("value"))
         return cls(
             name=str(name),

--- a/py/selenium/webdriver/common/bidi/storage.py
+++ b/py/selenium/webdriver/common/bidi/storage.py
@@ -84,12 +84,19 @@ class Cookie:
         -------
             Cookie: A new instance of Cookie.
         """
+        # Validation for empty strings
+        name = data.get("name")
+        if not name:
+            raise ValueError("name is required and cannot be empty")
+        domain = data.get("domain") 
+        if not domain:
+            raise ValueError("domain is required and cannot be empty")
+        
         value = BytesValue(data.get("value", {}).get("type"), data.get("value", {}).get("value"))
-
         return cls(
-            name=str(data.get("name") or ""),
+            name=str(name),
             value=value,
-            domain=str(data.get("domain") or ""),
+            domain=str(domain),
             path=data.get("path"),
             size=data.get("size"),
             http_only=data.get("httpOnly"),

--- a/py/selenium/webdriver/common/bidi/storage.py
+++ b/py/selenium/webdriver/common/bidi/storage.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional, Union
-
+from typing import Optional, Union, Any
 from selenium.webdriver.common.bidi.common import command_builder
 
 
@@ -88,9 +87,9 @@ class Cookie:
         value = BytesValue(data.get("value", {}).get("type"), data.get("value", {}).get("value"))
 
         return cls(
-            name=data.get("name"),
+            name = str(data.get("name") or ""),
             value=value,
-            domain=data.get("domain"),
+            domain = str(data.get("domain") or ""),
             path=data.get("path"),
             size=data.get("size"),
             http_only=data.get("httpOnly"),
@@ -125,14 +124,14 @@ class CookieFilter:
         self.same_site = same_site
         self.expiry = expiry
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Converts the CookieFilter to a dictionary.
 
         Returns:
         -------
             Dict: A dictionary representation of the CookieFilter.
         """
-        result = {}
+        result: dict[str, Any] = {}
         if self.name is not None:
             result["name"] = self.name
         if self.value is not None:
@@ -242,14 +241,14 @@ class PartialCookie:
         self.same_site = same_site
         self.expiry = expiry
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Converts the PartialCookie to a dictionary.
 
         Returns:
         -------
             Dict: A dictionary representation of the PartialCookie.
         """
-        result = {
+        result: dict[str, Any]  = {
             "name": self.name,
             "value": self.value.to_dict(),
             "domain": self.domain,

--- a/py/selenium/webdriver/common/bidi/storage.py
+++ b/py/selenium/webdriver/common/bidi/storage.py
@@ -87,9 +87,9 @@ class Cookie:
         value = BytesValue(data.get("value", {}).get("type"), data.get("value", {}).get("value"))
 
         return cls(
-            name = str(data.get("name") or ""),
+            name=str(data.get("name") or ""),
             value=value,
-            domain = str(data.get("domain") or ""),
+            domain=str(data.get("domain") or ""),
             path=data.get("path"),
             size=data.get("size"),
             http_only=data.get("httpOnly"),
@@ -248,7 +248,7 @@ class PartialCookie:
         -------
             Dict: A dictionary representation of the PartialCookie.
         """
-        result: dict[str, Any]  = {
+        result: dict[str, Any] = {
             "name": self.name,
             "value": self.value.to_dict(),
             "domain": self.domain,

--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -422,7 +422,7 @@ class BaseOptions(metaclass=ABCMeta):
         self._caps = self.default_capabilities
         self._proxy = None
         self.set_capability("pageLoadStrategy", PageLoadStrategy.normal)
-        self.mobile_options: dict[str, str] = {}
+        self.mobile_options: Optional[dict[str, str]] = None
         self._ignore_local_proxy = False
 
     @property

--- a/py/selenium/webdriver/common/options.py
+++ b/py/selenium/webdriver/common/options.py
@@ -422,7 +422,7 @@ class BaseOptions(metaclass=ABCMeta):
         self._caps = self.default_capabilities
         self._proxy = None
         self.set_capability("pageLoadStrategy", PageLoadStrategy.normal)
-        self.mobile_options = None
+        self.mobile_options: dict[str, str] = {}
         self._ignore_local_proxy = False
 
     @property

--- a/py/selenium/webdriver/common/virtual_authenticator.py
+++ b/py/selenium/webdriver/common/virtual_authenticator.py
@@ -24,17 +24,17 @@ from typing import Any, Optional, Union
 class Protocol(str, Enum):
     """Protocol to communicate with the authenticator."""
 
-    CTAP2: str = "ctap2"
-    U2F: str = "ctap1/u2f"
+    CTAP2 = "ctap2"
+    U2F = "ctap1/u2f"
 
 
 class Transport(str, Enum):
     """Transport method to communicate with the authenticator."""
 
-    BLE: str = "ble"
-    USB: str = "usb"
-    NFC: str = "nfc"
-    INTERNAL: str = "internal"
+    BLE = "ble"
+    USB = "usb"
+    NFC = "nfc"
+    INTERNAL = "internal"
 
 
 class VirtualAuthenticatorOptions:


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes some issues in #15697

### 💥 What does this PR do?
This PR fixes several type annotation errors reported by Mypy in the following files:
- `py/selenium/webdriver/common/bidi/storage.py`
-  `py/selenium/webdriver/common/options.py` 
-  `py/selenium/webdriver/common/virtual_authenticator.py`

It improves static typing correctness, which will help catch bugs early and improve code readability and maintainability.

### 🔧 Implementation Notes
Fixed a few type hints for the above files.

### 💡 Additional Considerations
Will submit more small PRs to fix type annotations across the codebase.

### 🔄 Types of changes
- Cleanup (type annotation fixes, no behavior changes)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Mypy type annotation errors in three modules

- Update type hints for class attributes and methods

- Improve static typing for dictionary and Enum usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.py</strong><dd><code>Add and correct type hints for Mypy compliance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/storage.py

<li>Added explicit type hints for dictionaries and method returns<br> <li> Ensured string conversion for certain fields in <code>from_dict</code><br> <li> Updated method signatures for better static typing<br> <li> Improved code clarity for Mypy compatibility


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15841/files#diff-78d3bedb1c2d56ac544e86e0f671fb4d54b166af2dbdcc9643e24952bfcb93b4">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>options.py</strong><dd><code>Specify type for mobile_options attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/options.py

<li>Changed <code>mobile_options</code> attribute to have explicit dict type<br> <li> Improved type safety for attribute initialization


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15841/files#diff-5ff2f2a84a79fce9e04511b572dcaab921c08e956345f4c41b7e701d4d018589">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>virtual_authenticator.py</strong><dd><code>Simplify Enum member type annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/virtual_authenticator.py

<li>Removed redundant type annotations from Enum members<br> <li> Simplified Enum class definitions for Mypy compatibility


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15841/files#diff-5da367f7e3363010c619d8097422a270cd228eb9af198d8d4ee7482a0c647b66">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>