### PR TITLE
[py] Remove ability to set env var for SE_SAFARIDRIVER

### DIFF
--- a/py/selenium/webdriver/safari/service.py
+++ b/py/selenium/webdriver/safari/service.py
@@ -47,7 +47,6 @@ class Service(service.Service):
         **kwargs,
     ) -> None:
         self.service_args = service_args or []
-        driver_path_env_key = driver_path_env_key or "SE_SAFARIDRIVER"
 
         if enable_logging:
             self.service_args.append("--diagnose")


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

#15849

### 💥 What does this PR do?

This PR removes the ability to set `SE_SAFARIDRIVER` environment variable to control the location of safaridriver, since it is not possible to change its location. This brings the Python bindings into alignment with others (i.e. Java bindings) that do not respect this environment variable.

Note: you can still pass a key name in the constructor to specify driver location, but I didn't want to change the public API. However, setting a key name is not useful because you can't have safaridriver in an alternate location. 
___

### **PR Type**
Enhancement


___

### **Description**
- Remove support for `SE_SAFARIDRIVER` environment variable

- Align Python Safari driver behavior with other bindings

- Simplify `Service` class initialization logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Remove SE_SAFARIDRIVER env var support from Safari Service</code></dd></summary>
<hr>

py/selenium/webdriver/safari/service.py

<li>Removed default use of <code>SE_SAFARIDRIVER</code> env var for driver path<br> <li> Cleaned up constructor logic for driver path environment key


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15855/files#diff-1cdf7e9efaf8bfb650b4f4cffa398b690201451a702a3f93bf1c4ab840ddcc36">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>