### PR TITLE
[py][bidi]: enable edge bidi storage test - `test_get_all_cookies`

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_storage_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_storage_tests.py
@@ -263,7 +263,6 @@ class TestBidiStorage:
         assert key.user_context is not None
         assert key.user_context == "default"
 
-    @pytest.mark.xfail_edge
     def test_get_all_cookies(self, driver, pages, webserver):
         """Test getting all cookies."""
         assert_no_cookies_are_present(driver)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Enables bidi storage test - `test_get_all_cookies` for Edge browser.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Tests


___

### **Description**
- Enable BiDi storage test `test_get_all_cookies` for Edge

- Remove `xfail_edge` marker from the test


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_storage_tests.py</strong><dd><code>Enable Edge for BiDi storage test_get_all_cookies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_storage_tests.py

<li>Removed the <code>@pytest.mark.xfail_edge</code> decorator from <br><code>test_get_all_cookies</code><br> <li> Now runs this test for Edge browser as well


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15859/files#diff-ac7443731473ddac8564f38e57a5bf485ea4935786dfef9c04e0b961bed67ec3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>