### PR TITLE
[py] Fix another broken test

### DIFF
--- a/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -283,7 +283,7 @@ def test_should_not_find_element_by_class_when_the_name_queried_is_shorter_than_
 @pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_empty_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
-    msg = r"\/errors#invalid-selector-exception"
+    msg = r"\/errors#invalidselectorexception"
     with pytest.raises(InvalidSelectorException, match=msg):
         driver.find_element(By.CLASS_NAME, "")
 

--- a/py/test/selenium/webdriver/common/stale_reference_tests.py
+++ b/py/test/selenium/webdriver/common/stale_reference_tests.py
@@ -25,7 +25,7 @@ def test_old_page(driver, pages):
     pages.load("simpleTest.html")
     elem = driver.find_element(by=By.ID, value="links")
     pages.load("xhtmlTest.html")
-    msg = r"\/errors#stale-element-reference-exception"
+    msg = r"\/errors#staleelementreferenceexception"
     with pytest.raises(StaleElementReferenceException, match=msg):
         elem.click()
 


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fix 2 tests broken by #15862


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes incorrect regex in test exception matching patterns

- Updates tests to match new error URL formats


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver_element_finding_tests.py</strong><dd><code>Update regex for InvalidSelectorException in test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/driver_element_finding_tests.py

<li>Corrects regex for InvalidSelectorException error URL in test<br> <li> Ensures test matches updated error URL format


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15866/files#diff-fbb67405b6649ea729096144d30f91182c94e53ff2ef43f42dcc3ad811c50320">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stale_reference_tests.py</strong><dd><code>Update regex for StaleElementReferenceException in test</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/stale_reference_tests.py

<li>Updates regex for StaleElementReferenceException error URL in test<br> <li> Aligns test with new error URL format


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15866/files#diff-b8079f7602971e690813f0815205586d5b8bed2200c33b826baa4b94f19d78b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>