### PR TITLE
[refactor] use constant `CapabilityType.ENABLE_DOWNLOADS` instead of hard-coded value `se:downloadsEnabled`

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
+++ b/java/src/org/openqa/selenium/grid/data/DefaultSlotMatcher.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium.grid.data;
 
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -129,13 +131,13 @@ public class DefaultSlotMatcher implements SlotMatcher, Serializable {
 
   private Boolean managedDownloadsEnabled(Capabilities stereotype, Capabilities capabilities) {
     // First lets check if user wanted a Node with managed downloads enabled
-    Object raw = capabilities.getCapability("se:downloadsEnabled");
+    Object raw = capabilities.getCapability(ENABLE_DOWNLOADS);
     if (raw == null || !Boolean.parseBoolean(raw.toString())) {
       // User didn't ask. So lets move on to the next matching criteria
       return true;
     }
     // User wants managed downloads enabled to be done on this Node, let's check the stereotype
-    raw = stereotype.getCapability("se:downloadsEnabled");
+    raw = stereotype.getCapability(ENABLE_DOWNLOADS);
     // Try to match what the user requested
     return raw != null && Boolean.parseBoolean(raw.toString());
   }

--- a/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium.grid.node.config;
 
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -749,8 +751,7 @@ public class NodeOptions {
               .setCapability("se:noVncPort", noVncPort());
     }
     if (isManagedDownloadsEnabled() && canConfigureDownloadsDir(capabilities)) {
-      capabilities =
-          new PersistentCapabilities(capabilities).setCapability("se:downloadsEnabled", true);
+      capabilities = new PersistentCapabilities(capabilities).setCapability(ENABLE_DOWNLOADS, true);
     }
     return capabilities;
   }

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -23,6 +23,7 @@ import static org.openqa.selenium.grid.data.Availability.DOWN;
 import static org.openqa.selenium.grid.data.Availability.DRAINING;
 import static org.openqa.selenium.grid.data.Availability.UP;
 import static org.openqa.selenium.grid.node.CapabilityResponseEncoder.getEncoder;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 import static org.openqa.selenium.remote.HttpSessionId.getSessionId;
 import static org.openqa.selenium.remote.RemoteTags.CAPABILITIES;
 import static org.openqa.selenium.remote.RemoteTags.SESSION_ID;
@@ -575,7 +576,7 @@ public class LocalNode extends Node implements Closeable {
   }
 
   private boolean managedDownloadsRequested(Capabilities capabilities) {
-    Object downloadsEnabled = capabilities.getCapability("se:downloadsEnabled");
+    Object downloadsEnabled = capabilities.getCapability(ENABLE_DOWNLOADS);
     return managedDownloadsEnabled
         && downloadsEnabled != null
         && Boolean.parseBoolean(downloadsEnabled.toString());

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openqa.selenium.chromium.ChromiumDriverLogLevel.OFF;
 import static org.openqa.selenium.chromium.ChromiumDriverLogLevel.SEVERE;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 
 import java.io.File;
@@ -98,7 +99,7 @@ class ChromeOptionsTest {
     assertThat(mappedOptions.get("acceptInsecureCerts")).isEqualTo(true);
     assertThat(mappedOptions.get("pageLoadStrategy")).hasToString("eager");
     assertThat(mappedOptions.get("strictFileInteractability")).isEqualTo(true);
-    assertThat(mappedOptions.get("se:downloadsEnabled")).isEqualTo(true);
+    assertThat(mappedOptions.get(ENABLE_DOWNLOADS)).isEqualTo(true);
 
     Map<String, Long> expectedTimeouts = new HashMap<>();
     expectedTimeouts.put("implicit", 1000L);
@@ -239,7 +240,8 @@ class ChromeOptionsTest {
 
     MutableCapabilities one = new MutableCapabilities();
 
-    ChromeOptions options = new ChromeOptions();
+    org.openqa.selenium.chrome.ChromeOptions options =
+        new org.openqa.selenium.chrome.ChromeOptions();
     options.addArguments("verbose");
     options.addArguments("silent");
     options.setExperimentalOption("opt1", "val1");

--- a/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
+++ b/java/test/org/openqa/selenium/grid/data/DefaultSlotMatcherTest.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.grid.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -198,7 +199,7 @@ class DefaultSlotMatcherTest {
             "firefox",
             CapabilityType.PLATFORM_NAME,
             Platform.WINDOWS,
-            "se:downloadsEnabled",
+            ENABLE_DOWNLOADS,
             true);
     Capabilities capabilities =
         new ImmutableCapabilities(
@@ -206,7 +207,7 @@ class DefaultSlotMatcherTest {
             "firefox",
             CapabilityType.PLATFORM_NAME,
             Platform.WINDOWS,
-            "se:downloadsEnabled",
+            ENABLE_DOWNLOADS,
             true);
     assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
   }
@@ -307,8 +308,7 @@ class DefaultSlotMatcherTest {
   @Test
   void matchDownloadsForRegularTestMatchingAgainstADownloadAwareNode() {
     Capabilities stereotype =
-        new ImmutableCapabilities(
-            CapabilityType.BROWSER_NAME, "chrome", "se:downloadsEnabled", true);
+        new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome", ENABLE_DOWNLOADS, true);
     Capabilities capabilities = new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome");
     assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
   }
@@ -316,11 +316,9 @@ class DefaultSlotMatcherTest {
   @Test
   void matchDownloadsForAutoDownloadTestMatchingAgainstADownloadAwareNode() {
     Capabilities stereotype =
-        new ImmutableCapabilities(
-            CapabilityType.BROWSER_NAME, "chrome", "se:downloadsEnabled", true);
+        new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome", ENABLE_DOWNLOADS, true);
     Capabilities capabilities =
-        new ImmutableCapabilities(
-            CapabilityType.BROWSER_NAME, "chrome", "se:downloadsEnabled", true);
+        new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome", ENABLE_DOWNLOADS, true);
     assertThat(slotMatcher.matches(stereotype, capabilities)).isTrue();
   }
 
@@ -328,8 +326,7 @@ class DefaultSlotMatcherTest {
   void ensureNoMatchFOrDownloadAwareTestMatchingAgainstOrdinaryNode() {
     Capabilities stereotype = new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome");
     Capabilities capabilities =
-        new ImmutableCapabilities(
-            CapabilityType.BROWSER_NAME, "chrome", "se:downloadsEnabled", true);
+        new ImmutableCapabilities(CapabilityType.BROWSER_NAME, "chrome", ENABLE_DOWNLOADS, true);
     assertThat(slotMatcher.matches(stereotype, capabilities)).isFalse();
   }
 

--- a/java/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 import static org.openqa.selenium.remote.http.Contents.string;
 import static org.openqa.selenium.remote.http.HttpMethod.DELETE;
 import static org.openqa.selenium.remote.http.HttpMethod.GET;
@@ -124,8 +125,8 @@ class NodeTest {
     stereotype = new ImmutableCapabilities("browserName", "cheese");
     caps = new ImmutableCapabilities("browserName", "cheese");
     if (isDownloadsTestCase) {
-      stereotype = new ImmutableCapabilities("browserName", "chrome", "se:downloadsEnabled", true);
-      caps = new ImmutableCapabilities("browserName", "chrome", "se:downloadsEnabled", true);
+      stereotype = new ImmutableCapabilities("browserName", "chrome", ENABLE_DOWNLOADS, true);
+      caps = new ImmutableCapabilities("browserName", "chrome", ENABLE_DOWNLOADS, true);
     }
 
     uri = new URI("http://localhost:1234");

--- a/java/test/org/openqa/selenium/grid/node/config/NodeOptionsTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/NodeOptionsTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.StringReader;
@@ -156,7 +157,7 @@ class NodeOptionsTest {
             .filter(caps -> expected.equalsIgnoreCase(caps.getBrowserName()))
             .findFirst()
             .orElseThrow(() -> new AssertionError("Unable to find " + customMsg + " info"));
-    return Optional.ofNullable(found.getCapability("se:downloadsEnabled"))
+    return Optional.ofNullable(found.getCapability(ENABLE_DOWNLOADS))
         .map(value -> Boolean.parseBoolean(value.toString()))
         .orElse(Boolean.FALSE);
   }

--- a/java/test/org/openqa/selenium/grid/router/RemoteWebDriverDownloadTest.java
+++ b/java/test/org/openqa/selenium/grid/router/RemoteWebDriverDownloadTest.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.grid.router;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
@@ -75,8 +76,7 @@ class RemoteWebDriverDownloadTest {
     options.setEnableDownloads(true);
 
     capabilities =
-        new PersistentCapabilities(browser.getCapabilities())
-            .setCapability("se:downloadsEnabled", true);
+        new PersistentCapabilities(browser.getCapabilities()).setCapability(ENABLE_DOWNLOADS, true);
 
     Deployment deployment =
         DeploymentTypes.STANDALONE.start(
@@ -194,7 +194,7 @@ class RemoteWebDriverDownloadTest {
 
     Capabilities caps =
         new PersistentCapabilities(Objects.requireNonNull(browser).getCapabilities())
-            .setCapability("se:downloadsEnabled", false);
+            .setCapability(ENABLE_DOWNLOADS, false);
 
     WebDriver driver = new RemoteWebDriver(gridUrl, caps);
     Assertions.assertThrows(

--- a/java/test/org/openqa/selenium/grid/router/StressTest.java
+++ b/java/test/org/openqa/selenium/grid/router/StressTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 
 import java.io.StringReader;
 import java.util.LinkedList;
@@ -123,8 +124,7 @@ class StressTest {
                         .oneOf(
                             browser
                                 .getCapabilities()
-                                .merge(
-                                    new MutableCapabilities(Map.of("se:downloadsEnabled", true))))
+                                .merge(new MutableCapabilities(Map.of(ENABLE_DOWNLOADS, true))))
                         .address(server.getUrl())
                         .build();
 

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 import static org.openqa.selenium.remote.WebDriverFixture.echoCapabilities;
 import static org.openqa.selenium.remote.WebDriverFixture.errorResponder;
 import static org.openqa.selenium.remote.WebDriverFixture.exceptionResponder;
@@ -814,7 +815,7 @@ class RemoteWebDriverUnitTest {
 
     WebDriverFixture fixture =
         new WebDriverFixture(
-            new ImmutableCapabilities("se:downloadsEnabled", true),
+            new ImmutableCapabilities(ENABLE_DOWNLOADS, true),
             echoCapabilities,
             valueResponder(ImmutableMap.of("names", expectedFiles)));
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
This PR replaces hard-coded value `se:downloadsEnabled` in multiple places by proper constant `CapabilityType.ENABLE_DOWNLOADS`.

### 🔧 Implementation Notes
One place could not be replaced: `org.openqa.selenium.HasDownloads`.
Because it's located in module "selenium-api" which cannot depend on module "selenium-remote" (where `HasDownloads` is located).

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replaced hard-coded `se:downloadsEnabled` with `CapabilityType.ENABLE_DOWNLOADS`
  - Updated all relevant production and test files

- Improved code maintainability and consistency

- Ensured tests use the constant for download capability


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>DefaultSlotMatcher.java</strong><dd><code>Use ENABLE_DOWNLOADS constant for managed downloads capability</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-08612f5a21ea03efdd38ead8885dd4b72be486ea76f0de8f0a4dce609f34af0d">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeOptions.java</strong><dd><code>Replace hard-coded downloads capability with constant</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-6e8d739c2d4c51a731e66ed587b852c2788e19b8fd325b3c90fb0bad5e53e594">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalNode.java</strong><dd><code>Use ENABLE_DOWNLOADS constant in managed downloads check</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-edc2e1943a5d89fa45151a9d214cc608551c61101f237ca9a5993d6dd157b57b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>ChromeOptionsTest.java</strong><dd><code>Update test to use ENABLE_DOWNLOADS constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-a2da4c56efda1ff71535e17798b3e48b6599280a2e215d9837d082182061a584">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DefaultSlotMatcherTest.java</strong><dd><code>Refactor tests to use ENABLE_DOWNLOADS constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-efbc947cb2db3c8fe94ef12f0e57d80901e86d3e3992611966b165c1e9543445">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeTest.java</strong><dd><code>Use ENABLE_DOWNLOADS constant in test capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-7fc2523b1e86e098543cf0def812b38114ce596668c61b8259ead0e1dba56a10">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeOptionsTest.java</strong><dd><code>Update test to check downloads capability using constant</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-ea9c3f272f388de0c0ac5d0c0a06d66c5b195599b3d19af1994f859cb484d737">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteWebDriverDownloadTest.java</strong><dd><code>Use ENABLE_DOWNLOADS constant for download capability in tests</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-9fa7853865f740f79749383d114b7a744996f2a7c93af7872c6e5ef9aa8739c0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StressTest.java</strong><dd><code>Refactor test to use ENABLE_DOWNLOADS constant in capabilities</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-4ea80f9d5d5a8dd086429a9cf2e190352a6cb3ef3e900c959ce4ea352d2f7755">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteWebDriverUnitTest.java</strong><dd><code>Use ENABLE_DOWNLOADS constant in remote driver test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15867/files#diff-0147a1bff443d7a62982143a4a8ff2a51826670b30a8bc03356a0414226ae5a8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>