### PR TITLE
[py] do not use global var for devtools, allows multiple devtools to run

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -443,6 +443,19 @@ def clean_driver(request):
     except (AttributeError, TypeError):
         raise Exception("This test requires a --driver to be specified.")
     driver_reference = getattr(webdriver, driver_class)
+
+    # conditionally mark tests as expected to fail based on driver
+    marker = request.node.get_closest_marker(f"xfail_{driver_class.lower()}")
+    if marker is not None:
+        if "run" in marker.kwargs:
+            if marker.kwargs["run"] is False:
+                pytest.skip()
+                yield
+                return
+        if "raises" in marker.kwargs:
+            marker.kwargs.pop("raises")
+        pytest.xfail(**marker.kwargs)
+
     yield driver_reference
     if request.node.get_closest_marker("no_driver_after_test"):
         driver_reference = None

--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import pytest
+
 from selenium.webdriver.support.ui import WebDriverWait
 
 

--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import pytest
-
 from selenium.webdriver.support.ui import WebDriverWait
 
 
@@ -38,3 +37,16 @@ def test_check_console_messages(driver, pages, recwarn):
     assert console_api_calls[0].args[0].value == "I love cheese"
     assert console_api_calls[1].type_ == "error"
     assert console_api_calls[1].args[0].value == "I love bread"
+
+
+@pytest.mark.xfail_safari
+@pytest.mark.xfail_firefox
+@pytest.mark.xfail_remote
+def test_check_start_twice(clean_driver, clean_options, clean_service):
+    driver1 = clean_driver(options=clean_options, service=clean_service)
+    devtools1, connection1 = driver1.start_devtools()
+    driver1.quit()
+
+    driver2 = clean_driver(options=clean_options, service=clean_service)
+    devtools2, connection2 = driver2.start_devtools()
+    driver2.quit()

--- a/py/test/selenium/webdriver/common/devtools_tests.py
+++ b/py/test/selenium/webdriver/common/devtools_tests.py
@@ -43,11 +43,11 @@ def test_check_console_messages(driver, pages, recwarn):
 @pytest.mark.xfail_safari
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_remote
-def test_check_start_twice(clean_driver, clean_options, clean_service):
-    driver1 = clean_driver(options=clean_options, service=clean_service)
+def test_check_start_twice(clean_driver, clean_options):
+    driver1 = clean_driver(options=clean_options)
     devtools1, connection1 = driver1.start_devtools()
     driver1.quit()
 
-    driver2 = clean_driver(options=clean_options, service=clean_service)
+    driver2 = clean_driver(options=clean_options)
     devtools2, connection2 = driver2.start_devtools()
     driver2.quit()


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

Fixes https://github.com/SeleniumHQ/selenium/issues/15816

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

Removes `global devtools` entirely and use `devtool` member in `WebDriver` for whatever use

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactored devtools from global to WebDriver instance member

- Fixed bug allowing multiple devtools sessions per driver

- Added test for starting devtools on multiple drivers


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Refactor devtools to instance member and fix multi-driver support</code></dd></summary>
<hr>

py/selenium/webdriver/remote/webdriver.py

<li>Removed global devtools variable and logic<br> <li> Made devtools an instance member (_devtools) of WebDriver<br> <li> Refactored start_devtools to use instance member and support multiple <br>drivers<br> <li> Improved error handling and code clarity in devtools startup<br> <li> Minor docstring formatting improvements


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15881/files#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985">+26/-31</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devtools_tests.py</strong><dd><code>Add test for multiple devtools sessions per driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/devtools_tests.py

<li>Added test to verify start_devtools works on multiple drivers<br> <li> Ensured test covers regression for global devtools bug


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15881/files#diff-800b0102b563606add570f812f89944831fc639473425183366834ab7a754c0f">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>