### PR TITLE
[java] deprecate FtpProxy

### DIFF
--- a/java/src/org/openqa/selenium/Proxy.java
+++ b/java/src/org/openqa/selenium/Proxy.java
@@ -67,7 +67,7 @@ public class Proxy {
   }
 
   private static final String PROXY_TYPE = "proxyType";
-  private static final String FTP_PROXY = "ftpProxy";
+  @Deprecated private static final String FTP_PROXY = "ftpProxy";
   private static final String HTTP_PROXY = "httpProxy";
   private static final String NO_PROXY = "noProxy";
   private static final String SSL_PROXY = "sslProxy";
@@ -80,7 +80,7 @@ public class Proxy {
 
   private ProxyType proxyType = ProxyType.UNSPECIFIED;
   private boolean autodetect = false;
-  private @Nullable String ftpProxy;
+  @Deprecated private @Nullable String ftpProxy;
   private @Nullable String httpProxy;
   private @Nullable String noProxy;
   private @Nullable String sslProxy;
@@ -225,7 +225,9 @@ public class Proxy {
    * Gets the FTP proxy.
    *
    * @return the FTP proxy hostname if present, or null if not set
+   * @deprecated getFtpProxy is deprecated and will be removed in a future release.
    */
+  @Deprecated
   public @Nullable String getFtpProxy() {
     return ftpProxy;
   }
@@ -235,7 +237,9 @@ public class Proxy {
    *
    * @param ftpProxy the proxy host, expected format is <code>hostname.com:1234</code>
    * @return reference to self
+   * @deprecated setFtpProxy is deprecated and will be removed in a future release.
    */
+  @Deprecated
   public Proxy setFtpProxy(String ftpProxy) {
     verifyProxyTypeCompatibility(ProxyType.MANUAL);
     this.proxyType = ProxyType.MANUAL;


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

Fixes https://github.com/SeleniumHQ/selenium/issues/15905 for Java binding

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

Deprecates FTP Proxy as it is no longer supported by browsers

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

Uses `@Deprecated` attribute to mark symbols deprecated

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
• Deprecate FTP proxy support in Java binding
• Mark FTP proxy constants and methods with @Deprecated annotation
• Add deprecation warnings to getFtpProxy and setFtpProxy methods


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Proxy.java</strong><dd><code>Deprecate FTP proxy constants and methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/Proxy.java

• Added @Deprecated annotation to FTP_PROXY constant<br> • Added <br>@Deprecated annotation to ftpProxy field<br> • Added @Deprecated <br>annotation and deprecation warnings to getFtpProxy() method<br> • Added <br>@Deprecated annotation and deprecation warnings to setFtpProxy() <br>method


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15907/files#diff-539c08d6257d45b8ab7ea3a880153cc8f303943a2ecfc54cda26d31fb0736b33">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>