### PR TITLE
[build] Support bazel test on Windows for .NET

### DIFF
--- a/dotnet/test/common/BUILD.bazel
+++ b/dotnet/test/common/BUILD.bazel
@@ -51,9 +51,9 @@ csharp_library(
     ],
     deps = [
         "//dotnet/src/webdriver:webdriver-net8.0",
-        "@rules_dotnet//tools/runfiles",
         framework("nuget", "Newtonsoft.Json"),
         framework("nuget", "NUnit"),
+        framework("nuget", "Runfiles"),
     ],
 )
 
@@ -92,5 +92,6 @@ dotnet_nunit_test_suite(
         framework("nuget", "BenderProxy"),
         framework("nuget", "Newtonsoft.Json"),
         framework("nuget", "NUnit"),
+        framework("nuget", "Runfiles"),
     ],
 )

--- a/dotnet/test/common/Environment/TestWebServer.cs
+++ b/dotnet/test/common/Environment/TestWebServer.cs
@@ -52,7 +52,15 @@ public class TestWebServer
             try
             {
                 var runfiles = Runfiles.Create();
-                standaloneAppserverPath = runfiles.Rlocation(@"_main/java/test/org/openqa/selenium/environment/appserver");
+
+                if (OperatingSystem.IsWindows())
+                {
+                    standaloneAppserverPath = runfiles.Rlocation(@"_main/java/test/org/openqa/selenium/environment/appserver.exe");
+                }
+                else
+                {
+                    standaloneAppserverPath = runfiles.Rlocation(@"_main/java/test/org/openqa/selenium/environment/appserver");
+                }
             }
             catch (FileNotFoundException)
             {

--- a/dotnet/test/common/Environment/TestWebServer.cs
+++ b/dotnet/test/common/Environment/TestWebServer.cs
@@ -53,14 +53,14 @@ public class TestWebServer
             {
                 var runfiles = Runfiles.Create();
 
+                var standaloneAppserverProbingPath = @"_main/java/test/org/openqa/selenium/environment/appserver";
+
                 if (OperatingSystem.IsWindows())
                 {
-                    standaloneAppserverPath = runfiles.Rlocation(@"_main/java/test/org/openqa/selenium/environment/appserver.exe");
+                    standaloneAppserverProbingPath += ".exe";
                 }
-                else
-                {
-                    standaloneAppserverPath = runfiles.Rlocation(@"_main/java/test/org/openqa/selenium/environment/appserver");
-                }
+
+                standaloneAppserverPath = runfiles.Rlocation(standaloneAppserverProbingPath);
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
### **User description**
Finally I can do `bazel test //dotnet/test/common:AlertsTest-chrome` on Windows, and use IDE.

### 💥 What does this PR do?
- Use `Runtimes` dependency managed by nuget
- Determine test web server binary properly on Windows under bazel

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
• Add Windows support for bazel test execution in .NET
• Fix test web server binary path resolution on Windows
• Update dependency management to use nuget Runfiles


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestWebServer.cs</strong><dd><code>Add Windows executable path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Environment/TestWebServer.cs

• Add Windows-specific path resolution for appserver binary<br> • Use .exe <br>extension for Windows executable path<br> • Maintain cross-platform <br>compatibility with OS detection


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15923/files#diff-9b1522ed8b7052b3c0e172fa95173cec4340245fe34caf1ca94cf17376a10dca">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update Runfiles dependency management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BUILD.bazel

• Replace rules_dotnet runfiles with nuget Runfiles dependency<br> • Add <br>Runfiles framework dependency to test suite<br> • Update dependency <br>management approach


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15923/files#diff-42c4bbda3788fb91b43ddd7ed9dce8876478e3d5dac2eb88274d6bdc184ff625">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>