### PR TITLE
[rb] Feat 15905/deprecate ftp proxy

### DIFF
--- a/rb/lib/selenium/webdriver/common/proxy.rb
+++ b/rb/lib/selenium/webdriver/common/proxy.rb
@@ -77,7 +77,7 @@ module Selenium
       alias eql? ==
 
       def ftp=(value)
-        warn "[DEPRECATED] FTP proxy support is deprecated and will be removed in the 4.37 version."
+        WebDriver.logger.deprecate('FTP proxy support', nil, id: :ftp_proxy)
         self.type = :manual
         @ftp = value
       end

--- a/rb/lib/selenium/webdriver/common/proxy.rb
+++ b/rb/lib/selenium/webdriver/common/proxy.rb
@@ -77,6 +77,7 @@ module Selenium
       alias eql? ==
 
       def ftp=(value)
+        warn "[DEPRECATED] FTP proxy support is deprecated and will be removed in the 4.37 version."
         self.type = :manual
         @ftp = value
       end


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
fixes #15905 

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
This pull request introduces a deprecation notice for FTP proxy support in the `ftp=` method of the `Proxy` class in `rb/lib/selenium/webdriver/common/proxy.rb`. 

Deprecation notice:

* [`rb/lib/selenium/webdriver/common/proxy.rb`](diffhunk://#diff-095eb654427ce5add2dcff9cee2ba6b3af101725fe97a9a8466468214026324aR80): Added a logger deprecation warning for FTP proxy support in the `ftp=` method, signaling that this feature will no longer be supported in the future.
### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Add deprecation warning for FTP proxy support in Ruby bindings

- Use WebDriver logger to notify users of upcoming removal


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Deprecation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proxy.rb</strong><dd><code>Add FTP proxy deprecation warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/proxy.rb

<li>Added deprecation warning using WebDriver.logger.deprecate() in ftp= <br>method<br> <li> Warning indicates FTP proxy support will be removed in future versions


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15926/files#diff-095eb654427ce5add2dcff9cee2ba6b3af101725fe97a9a8466468214026324a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>