### PR TITLE
[java][refactor] Remove Empty Space in CommandPayload

### DIFF
--- a/java/src/org/openqa/selenium/remote/CommandPayload.java
+++ b/java/src/org/openqa/selenium/remote/CommandPayload.java
@@ -25,7 +25,6 @@ public class CommandPayload {
   private final Map<String, ?> parameters;
 
   public CommandPayload(String name, Map<String, ?> parameters) {
-
     this.name = name;
     this.parameters = parameters;
   }


### PR DESCRIPTION
### **User description**
This is a simple PR to improve code quality. 
- Remove an empty space in the constructor.

### 💡 Additional Considerations
While cleaning the class I noticed that SonarCube was complaining about the use of a Generic wildcard in the class:
`private final Map<String, ?> parameters;`.

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Remove unnecessary empty line in `CommandPayload` constructor


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPayload.java</strong><dd><code>Remove unnecessary whitespace in constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/CommandPayload.java

<li>Remove empty line between constructor declaration and implementation


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15934/files#diff-c2f86cd50ab206d6a153828fc61848c1f90741755187ec3dcd5f57ee583ad15a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>