### PR TITLE
[py][java][rb][ci]: use pinned browsers in CI

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -23,7 +23,7 @@ jobs:
       java-version: 17
       run: |
         fsutil 8dot3name set 0
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest `
+        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest `
             //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest `
             //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest `
             //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest `
@@ -47,7 +47,7 @@ jobs:
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
       run: |
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote \
+        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote \
             //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest \
           //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest \
             //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest \
@@ -71,4 +71,4 @@ jobs:
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
       run: |
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -89,8 +89,8 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:common-${{ matrix.browser }}-bidi
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:test-${{ matrix.browser }}
 
   safari-tests:
     name: Browser Tests
@@ -108,4 +108,4 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -84,7 +84,7 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}
-        ${{ matrix.os != 'windows' && '--pin_browsers' || '' }}
+        --pin_browsers
         //rb/spec/...
 
   integration-tests-remote:
@@ -111,5 +111,5 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}-remote
-        ${{ matrix.os != 'windows' && '--pin_browsers' || '' }}
+        --pin_browsers
         //rb/spec/...

--- a/java/test/org/openqa/selenium/federatedcredentialmanagement/FederatedCredentialManagementTest.java
+++ b/java/test/org/openqa/selenium/federatedcredentialmanagement/FederatedCredentialManagementTest.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.environment.InProcessTestEnvironment;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.testing.Ignore;
 
 class FederatedCredentialManagementTest {
 
@@ -87,6 +88,7 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
+  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testDismissDialog() {
     fedcmDriver.setDelayEnabled(false);
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
@@ -110,6 +112,7 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
+  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testSelectAccount() {
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
 
@@ -130,6 +133,7 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
+  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testGetAccounts() {
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
 

--- a/java/test/org/openqa/selenium/federatedcredentialmanagement/FederatedCredentialManagementTest.java
+++ b/java/test/org/openqa/selenium/federatedcredentialmanagement/FederatedCredentialManagementTest.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoAlertPresentException;
@@ -39,8 +40,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.environment.InProcessTestEnvironment;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.testing.Ignore;
 
+@Disabled("https://issues.chromium.org/u/0/issues/425801332")
 class FederatedCredentialManagementTest {
 
   private HasFederatedCredentialManagement fedcmDriver;
@@ -88,7 +89,6 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
-  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testDismissDialog() {
     fedcmDriver.setDelayEnabled(false);
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
@@ -112,7 +112,6 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
-  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testSelectAccount() {
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
 
@@ -133,7 +132,6 @@ class FederatedCredentialManagementTest {
   }
 
   @Test
-  @Ignore(value = CHROME, reason = "https://issues.chromium.org/u/0/issues/425801332")
   void testGetAccounts() {
     assertNull(fedcmDriver.getFederatedCredentialManagementDialog());
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Allows bazel to use pinned browsers in CI so the tests run against the latest browsers specified in `repositories.bzl` file.

GitHub runners don't get the latest stable browser immediately after release, it usually takes a few weeks. This hinders development since tests don't pass.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--pin_browsers=true` flag to Python CI tests

- Ensures tests run against latest browsers from `repositories.bzl`

- Fixes CI failures due to delayed browser updates on GitHub runners


___

### **Changes diagram**

```mermaid
flowchart LR
  A["GitHub CI Runners"] --> B["Python Tests"]
  B --> C["Bazel Test Commands"]
  C --> D["Add --pin_browsers=true"]
  D --> E["Use Latest Browsers"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-python.yml</strong><dd><code>Add pinned browsers flag to CI tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-python.yml

<li>Added <code>--pin_browsers=true</code> flag to all bazel test commands<br> <li> Applied to both browser integration tests and Safari tests<br> <li> Ensures CI uses pinned browser versions from repositories.bzl


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15987/files#diff-a7ec86144013d78c9f1d734aa65a898e66b609638aa7b872491ee3858ebebbeb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>