### PR TITLE
[java] Feat 14291/jspecify nullable annotation chrome driver såervice

### DIFF
--- a/java/src/org/openqa/selenium/chrome/BUILD.bazel
+++ b/java/src/org/openqa/selenium/chrome/BUILD.bazel
@@ -20,5 +20,6 @@ java_export(
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/manager",
         "//java/src/org/openqa/selenium/remote",
+        "@maven//:org_jspecify_jspecify",
     ],
 )

--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
@@ -102,11 +103,11 @@ public class ChromeDriverService extends DriverService {
    * @throws IOException If an I/O error occurs.
    */
   public ChromeDriverService(
-      File executable,
+      @Nullable File executable,
       int port,
-      Duration timeout,
-      List<String> args,
-      Map<String, String> environment)
+      @Nullable Duration timeout,
+      @Nullable List<String> args,
+      @Nullable Map<String, String> environment)
       throws IOException {
     super(
         executable,
@@ -151,13 +152,13 @@ public class ChromeDriverService extends DriverService {
   public static class Builder
       extends DriverService.Builder<ChromeDriverService, ChromeDriverService.Builder> {
 
-    private Boolean disableBuildCheck;
-    private Boolean readableTimestamp;
-    private Boolean appendLog;
-    private Boolean verbose;
-    private Boolean silent;
-    private String allowedListIps;
-    private ChromiumDriverLogLevel logLevel;
+    private @Nullable Boolean disableBuildCheck;
+    private @Nullable Boolean readableTimestamp;
+    private @Nullable Boolean appendLog;
+    private @Nullable Boolean verbose;
+    private @Nullable Boolean silent;
+    private @Nullable String allowedListIps;
+    private @Nullable ChromiumDriverLogLevel logLevel;
 
     @Override
     public int score(Capabilities capabilities) {
@@ -202,7 +203,7 @@ public class ChromeDriverService extends DriverService {
      * @param logLevel {@link ChromiumDriverLogLevel} for desired log level output.
      * @return A self reference.
      */
-    public Builder withLogLevel(ChromiumDriverLogLevel logLevel) {
+    public Builder withLogLevel(@Nullable ChromiumDriverLogLevel logLevel) {
       this.logLevel = logLevel;
       this.silent = false;
       this.verbose = false;
@@ -244,7 +245,7 @@ public class ChromeDriverService extends DriverService {
      * @param allowedListIps Comma-separated list of remote IPv4 addresses.
      * @return A self reference.
      */
-    public Builder withAllowedListIps(String allowedListIps) {
+    public Builder withAllowedListIps(@Nullable String allowedListIps) {
       this.allowedListIps = allowedListIps;
       return this;
     }
@@ -255,7 +256,7 @@ public class ChromeDriverService extends DriverService {
      * @param readableTimestamp Whether the timestamp of the log is readable.
      * @return A self reference.
      */
-    public Builder withReadableTimestamp(Boolean readableTimestamp) {
+    public Builder withReadableTimestamp(@Nullable Boolean readableTimestamp) {
       this.readableTimestamp = readableTimestamp;
       return this;
     }
@@ -321,7 +322,11 @@ public class ChromeDriverService extends DriverService {
 
     @Override
     protected ChromeDriverService createDriverService(
-        File exe, int port, Duration timeout, List<String> args, Map<String, String> environment) {
+        @Nullable File exe, 
+        int port, 
+        @Nullable Duration timeout, 
+        @Nullable List<String> args, 
+        @Nullable Map<String, String> environment) {
       try {
         return new ChromeDriverService(exe, port, timeout, args, environment);
       } catch (IOException e) {

--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -322,10 +322,10 @@ public class ChromeDriverService extends DriverService {
 
     @Override
     protected ChromeDriverService createDriverService(
-        @Nullable File exe, 
-        int port, 
-        @Nullable Duration timeout, 
-        @Nullable List<String> args, 
+        @Nullable File exe,
+        int port,
+        @Nullable Duration timeout,
+        @Nullable List<String> args,
         @Nullable Map<String, String> environment) {
       try {
         return new ChromeDriverService(exe, port, timeout, args, environment);


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
fixes #14291 

### 💥 What does this PR do?
This pull request introduces changes to improve nullability annotations in the `ChromeDriverService` class and its associated methods, enhancing type safety and clarity in handling nullable parameters. Additionally, a dependency on `org_jspecify_jspecify` is added to the Bazel build file to support these annotations.

### Nullability Enhancements in `ChromeDriverService`:

* **Constructor and Method Parameters**: Updated the `ChromeDriverService` constructor and several builder methods to include `@Nullable` annotations for parameters that can accept null values, ensuring better clarity and type safety. (`java/src/org/openqa/selenium/chrome/ChromeDriverService.java`) [[1]](diffhunk://#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8L105-R110) [[2]](diffhunk://#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8L205-R206) [[3]](diffhunk://#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8L247-R248) [[4]](diffhunk://#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8L258-R259) [[5]](diffhunk://#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8L324-R329)
* **Builder Class Fields**: Added `@Nullable` annotations to fields in the `Builder` class to reflect their potential nullability. (`java/src/org/openqa/selenium/chrome/ChromeDriverService.java`)

### Dependency Updates:

* **Bazel Build File**: Added a dependency on `@maven//:org_jspecify_jspecify` in the Bazel build file to support `@Nullable` annotations. (`java/src/org/openqa/selenium/chrome/BUILD.bazel`)

### Import Statements:

* **Added Import for `@Nullable`**: Included the necessary import statement for `org.jspecify.annotations.Nullable` in the `ChromeDriverService` class. (`java/src/org/openqa/selenium/chrome/ChromeDriverService.java`)

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Add JSpecify nullable annotations to ChromeDriverService parameters

- Update constructor and builder methods with @Nullable annotations

- Add JSpecify dependency to Bazel build configuration

- Improve type safety for nullable parameters


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ChromeDriverService"] --> B["Add @Nullable annotations"]
  B --> C["Constructor parameters"]
  B --> D["Builder methods"]
  B --> E["Builder fields"]
  F["BUILD.bazel"] --> G["Add JSpecify dependency"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeDriverService.java</strong><dd><code>Add nullable annotations to parameters and fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/chrome/ChromeDriverService.java

<li>Import JSpecify nullable annotation<br> <li> Add @Nullable to constructor parameters (executable, timeout, args, <br>environment)<br> <li> Add @Nullable to Builder class fields (disableBuildCheck, <br>readableTimestamp, etc.)<br> <li> Add @Nullable to Builder method parameters (logLevel, allowedListIps, <br>readableTimestamp)<br> <li> Update createDriverService method signature with @Nullable parameters


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15998/files#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8">+20/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add JSpecify dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/chrome/BUILD.bazel

- Add JSpecify dependency to Maven dependencies list


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/15998/files#diff-f25ffdf405fac68f13a5e81508bd41bc1659192d901ef242e9fb601b0178ec6a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>