### PR TITLE
Fix various typos in comments

### DIFF
--- a/java/src/org/openqa/selenium/json/JsonOutput.java
+++ b/java/src/org/openqa/selenium/json/JsonOutput.java
@@ -264,7 +264,7 @@ public class JsonOutput implements Closeable {
   }
 
   /**
-   * Specify whether the serialized JSON object should br formatted with line breaks and indention
+   * Specify whether the serialized JSON object should br formatted with line breaks and indentation
    * ("pretty printed").
    *
    * @param enablePrettyPrinting {@code false} for compact format; {@code true} for "pretty

--- a/java/src/org/openqa/selenium/json/JsonOutput.java
+++ b/java/src/org/openqa/selenium/json/JsonOutput.java
@@ -264,7 +264,7 @@ public class JsonOutput implements Closeable {
   }
 
   /**
-   * Specify whether the serialized JSON object should br formatted with line breaks and indentation
+   * Specify whether the serialized JSON object should be formatted with line breaks and indentation
    * ("pretty printed").
    *
    * @param enablePrettyPrinting {@code false} for compact format; {@code true} for "pretty

--- a/java/src/org/openqa/selenium/remote/http/RetryRequest.java
+++ b/java/src/org/openqa/selenium/remote/http/RetryRequest.java
@@ -38,7 +38,7 @@ public class RetryRequest implements Filter {
   @Override
   public HttpHandler apply(HttpHandler next) {
     return req -> {
-      // start to preform the request in a loop, to allow retries
+      // start to perform the request in a loop, to allow retries
       for (int i = 0; i < NEEDED_ATTEMPTS; i++) {
         HttpResponse response;
 

--- a/scripts/update_py_dependencies.sh
+++ b/scripts/update_py_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script updates the development dependendencies used for the Python bindings.
+# This script updates the development dependencies used for the Python bindings.
 #
 # When you run it, it will:
 # - create and activate a temporary virtual env


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Fix typos in java & scripts

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->


___

### **PR Type**
Other


___

### **Description**
- Fix typos in Java documentation and script comments

- Correct "indention" to "indentation" in JsonOutput

- Fix "preform" to "perform" in RetryRequest

- Correct "dependendencies" to "dependencies" in shell script


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Java Files"] --> B["Fix Documentation Typos"]
  C["Shell Script"] --> D["Fix Comment Typos"]
  B --> E["Improved Code Quality"]
  D --> E
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonOutput.java</strong><dd><code>Fix documentation typo in JsonOutput</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/JsonOutput.java

- Fixed typo "indention" to "indentation" in JavaDoc comment


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16022/files#diff-485ff6f728b6d1cae51348f1ddadea136005881d1a1fe98772fdec1cbca078fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RetryRequest.java</strong><dd><code>Fix comment typo in RetryRequest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/http/RetryRequest.java

- Fixed typo "preform" to "perform" in inline comment


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16022/files#diff-7f5ed1fae9402073cf64bccd57826c564147c32fc4a40641751c7a8172b78264">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update_py_dependencies.sh</strong><dd><code>Fix typo in shell script comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/update_py_dependencies.sh

<li>Fixed typo "dependendencies" to "dependencies" in script header <br>comment


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16022/files#diff-de4138ba942918b6dfd7079f93fac0134d89af3d8552123604c2afb9655e756f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>