### PR TITLE
[py] Fix path in unit test so it works cross-platform

### DIFF
--- a/py/test/unit/selenium/webdriver/remote/remote_connection_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/remote_connection_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 from unittest.mock import patch
 from urllib import parse
 
@@ -222,7 +223,7 @@ def test_get_connection_manager_for_certs_and_timeout():
     conn = remote_connection._get_connection_manager()
     assert conn.connection_pool_kw["timeout"] == 10
     assert conn.connection_pool_kw["cert_reqs"] == "CERT_REQUIRED"
-    assert "certifi/cacert.pem" in conn.connection_pool_kw["ca_certs"]
+    assert f"certifi{os.path.sep}cacert.pem" in conn.connection_pool_kw["ca_certs"]
 
 
 def test_default_socket_timeout_is_correct():


### PR DESCRIPTION

### 💥 What does this PR do?

This PR fixes the `test_get_connection_manager_for_certs_and_timeout` test. It was failing on Windows due to a hardcoded path separator.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Unit tests
- Bug fix (backwards compatible)




___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>