### PR TITLE
[dotnet] [bidi] Add UnhandledPromptBehavior option to create User Context

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
@@ -31,7 +31,7 @@ public sealed class BrowserModule(Broker broker) : Module(broker)
 
     public async Task<UserContextInfo> CreateUserContextAsync(CreateUserContextOptions? options = null)
     {
-        var @params = new CreateUserContextCommandParameters(options?.AcceptInsecureCerts, options?.Proxy);
+        var @params = new CreateUserContextCommandParameters(options?.AcceptInsecureCerts, options?.Proxy, options?.UnhandledPromptBehavior);
 
         return await Broker.ExecuteCommandAsync<CreateUserContextCommand, UserContextInfo>(new CreateUserContextCommand(@params), options).ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
@@ -24,11 +24,13 @@ namespace OpenQA.Selenium.BiDi.Browser;
 internal sealed class CreateUserContextCommand(CreateUserContextCommandParameters @params)
     : Command<CreateUserContextCommandParameters, UserContextInfo>(@params, "browser.createUserContext");
 
-internal sealed record CreateUserContextCommandParameters(bool? AcceptInsecureCerts, Session.ProxyConfiguration? Proxy) : CommandParameters;
+internal sealed record CreateUserContextCommandParameters(bool? AcceptInsecureCerts, Session.ProxyConfiguration? Proxy, Session.UserPromptHandler? UnhandledPromptBehavior) : CommandParameters;
 
 public sealed class CreateUserContextOptions : CommandOptions
 {
     public bool? AcceptInsecureCerts { get; set; }
 
     public Session.ProxyConfiguration? Proxy { get; set; }
+
+    public Session.UserPromptHandler? UnhandledPromptBehavior { get; set; }
 }


### PR DESCRIPTION
### **User description**
Spec: https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext

### 🔧 Implementation Notes
Easy change.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add UnhandledPromptBehavior option to BiDi CreateUserContext command

- Update command parameters and options to support prompt handling configuration


___

### **Changes diagram**

```mermaid
flowchart LR
  A["CreateUserContextOptions"] --> B["UnhandledPromptBehavior property"]
  B --> C["CreateUserContextCommandParameters"]
  C --> D["BrowserModule.CreateUserContextAsync"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserModule.cs</strong><dd><code>Pass UnhandledPromptBehavior to command parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs

<li>Update CreateUserContextAsync method to pass UnhandledPromptBehavior <br>parameter<br> <li> Modify CreateUserContextCommandParameters constructor call


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16034/files#diff-8e4bcc00ef63cf737c6e26397ac40f1e18d960e4ff47589fee1bae1b9fe8cdc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateUserContextCommand.cs</strong><dd><code>Add UnhandledPromptBehavior support to command structure</code>&nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs

<li>Add UnhandledPromptBehavior parameter to <br>CreateUserContextCommandParameters record<br> <li> Add UnhandledPromptBehavior property to CreateUserContextOptions class


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16034/files#diff-2888885776226315e2b0f4658f38f4afcdfafae4772789dfd38b3a0f0510d1ab">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>