### PR TITLE
fix(firefox): handle null args in FirefoxOptions.merge() (#15991)

### DIFF
--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -305,7 +305,8 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
         List<String> arguments = (List<String>) (capabilities.getCapability(("args")));
         arguments.forEach(
             arg -> {
-              if (!((List<String>) newInstance.firefoxOptions.get(Keys.ARGS.key())).contains(arg)) {
+              List<String> existingArgs = (List<String>) newInstance.firefoxOptions.get(Keys.ARGS.key());
+              if (existingArgs == null || !existingArgs.contains(arg)) {
                 newInstance.addArguments(arg);
               }
             });
@@ -367,7 +368,8 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
 
         arguments.forEach(
             arg -> {
-              if (!((List<String>) newInstance.firefoxOptions.get(Keys.ARGS.key())).contains(arg)) {
+              List<String> existingArgs = (List<String>) newInstance.firefoxOptions.get(Keys.ARGS.key());
+              if (existingArgs == null || !existingArgs.contains(arg)) {
                 newInstance.addArguments(arg);
               }
             });


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #15991

### 💥 What does this PR do?
Adds a null check to prevent a `NullPointerException` in `FirefoxOptions.merge()` when merging user-defined `moz:firefoxOptions`.

The issue occurred because `.contains(...)` was called on a null list when "args" was present but not properly initialized. This fix ensures the list is not null before using it.

### 🔧 Implementation Notes
Used a simple null check before iterating over arguments:

```java
if (arguments != null) {
  ...
}
```

___

### **PR Type**
Bug fix


___

### **Description**
- Fix NullPointerException in FirefoxOptions.merge() method

- Add null checks before accessing existing arguments list

- Prevent crashes when merging user-defined moz:firefoxOptions


___

### **Changes diagram**

```mermaid
flowchart LR
  A["FirefoxOptions.merge()"] --> B["Check existing args"]
  B --> C["Add null check"]
  C --> D["Safe argument merging"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxOptions.java</strong><dd><code>Add null safety to argument merging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/firefox/FirefoxOptions.java

<li>Added null checks before accessing existing arguments list<br> <li> Extracted list reference to variable for cleaner code<br> <li> Applied fix to two locations in merge() method


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16043/files#diff-d011ae7f625544736a498af510308e81e40d69d9d85e7fee18c14aedc4ed4d9b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>