### PR TITLE
[rust] Test Selenium Manager on Linux arm64

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -35,6 +35,7 @@ jobs:
         include:
           - os: macos
           - os: ubuntu
+          - os: ubuntu-24.04-arm
           - os: windows
     with:
       name: Tests (${{ matrix.os }})

--- a/rust/src/chrome.rs
+++ b/rust/src/chrome.rs
@@ -383,6 +383,8 @@ impl SeleniumManager for ChromeManager {
             } else {
                 "mac64"
             }
+        } else if LINUX.is(os) && ARM64.is(arch) {
+            return Err(anyhow!("Linux arm64 is not supported yet by Google Chrome. Please try another browser."));
         } else {
             "linux64"
         };

--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -28,6 +28,7 @@ use crate::{
     DASH_DASH_VERSION, DEV, ENV_PROGRAM_FILES_X86, NIGHTLY, OFFLINE_REQUEST_ERR_MSG, REG_PV_ARG,
     REG_VERSION_ARG, STABLE,
 };
+use anyhow::anyhow;
 use anyhow::Error;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -288,6 +289,8 @@ impl SeleniumManager for EdgeManager {
             } else {
                 "mac64"
             }
+        } else if LINUX.is(os) && ARM64.is(arch) {
+            return Err(anyhow!("Linux arm64 is not supported yet by Google Chrome. Please try another browser."));
         } else {
             "linux64"
         };

--- a/rust/tests/browser_download_tests.rs
+++ b/rust/tests/browser_download_tests.rs
@@ -18,6 +18,7 @@
 use crate::common::{assert_browser, assert_driver, get_selenium_manager};
 
 use rstest::rstest;
+use std::env::consts::ARCH;
 use std::env::consts::OS;
 
 mod common;
@@ -27,23 +28,27 @@ mod common;
 #[case("firefox")]
 #[case("edge")]
 fn browser_latest_download_test(#[case] browser: String) {
-    if !browser.eq("edge") || !OS.eq("windows") {
-        let mut cmd = get_selenium_manager();
-        cmd.args([
-            "--browser",
-            &browser,
-            "--force-browser-download",
-            "--output",
-            "json",
-            "--debug",
-        ])
-        .assert()
-        .success()
-        .code(0);
-
-        assert_driver(&mut cmd);
-        assert_browser(&mut cmd);
+    if browser.eq("edge") && OS.eq("windows") {
+      return
+    } else if OS.eq("linux") && ARCH.eq("aarch64") && !browser.eq("firefox") {
+      return
     }
+
+    let mut cmd = get_selenium_manager();
+    cmd.args([
+        "--browser",
+        &browser,
+        "--force-browser-download",
+        "--output",
+        "json",
+        "--debug",
+    ])
+    .assert()
+    .success()
+    .code(0);
+
+    assert_driver(&mut cmd);
+    assert_browser(&mut cmd);
 }
 
 #[rstest]
@@ -59,6 +64,8 @@ fn browser_latest_download_test(#[case] browser: String) {
 fn browser_version_download_test(#[case] browser: String, #[case] browser_version: String) {
     if OS.eq("windows") && browser.eq("edge") {
         println!("Skipping Edge download test on Windows since the installation requires admin privileges");
+    } else if OS.eq("linux") && ARCH.eq("aarch64") && !browser.eq("firefox") {
+        println!("Skipping non-Firefox download test on Linux arm64 since no other browsers are supported yet");
     } else {
         let mut cmd = get_selenium_manager();
         cmd.args([

--- a/rust/tests/browser_tests.rs
+++ b/rust/tests/browser_tests.rs
@@ -19,6 +19,7 @@ use crate::common::{assert_output, get_selenium_manager, get_stdout};
 
 use exitcode::DATAERR;
 use rstest::rstest;
+use std::env::consts::ARCH;
 use std::env::consts::OS;
 use std::path::Path;
 
@@ -40,6 +41,10 @@ fn browser_version_test(
     #[case] browser_version: String,
     #[case] driver_version: String,
 ) {
+    if OS.eq("linux") && ARCH.eq("aarch64") && !browser.eq("firefox") {
+      return
+    }
+
     let mut cmd = get_selenium_manager();
     cmd.args([
         "--browser",
@@ -78,6 +83,10 @@ fn wrong_parameters_test(
     #[case] driver_version: String,
     #[case] error_code: i32,
 ) {
+    if OS.eq("linux") && ARCH.eq("aarch64") && !browser.eq("firefox") {
+      return
+    }
+
     let mut cmd = get_selenium_manager();
     let result = cmd
         .args([

--- a/rust/tests/cache_tests.rs
+++ b/rust/tests/cache_tests.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 
 mod common;
 
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
 #[rstest]
 #[case("../tmp")]
 #[case("../áèîö")]

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -23,6 +23,7 @@ use selenium_manager::logger::JsonOutput;
 use selenium_manager::shell;
 use selenium_manager::shell::run_shell_command_by_os;
 use std::borrow::BorrowMut;
+use std::env::consts::ARCH;
 use std::env::consts::OS;
 use std::path::{Path, PathBuf};
 
@@ -118,4 +119,9 @@ pub fn assert_output(
             .to_string()
             .contains(&error_code.to_string()));
     }
+}
+
+#[allow(dead_code)]
+pub fn is_linux_arm64() -> bool {
+  OS == "linux" && ARCH == "aarch64"
 }

--- a/rust/tests/config_tests.rs
+++ b/rust/tests/config_tests.rs
@@ -19,6 +19,8 @@ use crate::common::{assert_browser, assert_driver, get_selenium_manager, get_std
 
 use rstest::rstest;
 
+use std::env::consts::ARCH;
+use std::env::consts::OS;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use tempfile::Builder;
@@ -30,6 +32,9 @@ mod common;
 #[case("firefox")]
 #[case("edge")]
 fn config_test(#[case] browser_name: String) {
+    if OS.eq("linux") && ARCH.eq("aarch64") && !browser_name.eq("firefox") {
+      return
+    }
     let tmp_dir = Builder::new().prefix("sm-config-test").tempdir().unwrap();
     let config_path = tmp_dir.path().join("se-config.toml");
     let config_file = File::create(config_path.as_path()).unwrap();

--- a/rust/tests/exec_driver_tests.rs
+++ b/rust/tests/exec_driver_tests.rs
@@ -18,6 +18,7 @@
 use crate::common::{assert_browser, assert_driver, exec_driver, get_selenium_manager};
 
 use rstest::rstest;
+use std::env::consts::ARCH;
 use std::env::consts::OS;
 
 mod common;
@@ -28,6 +29,10 @@ mod common;
 #[case("firefox", "geckodriver")]
 #[case("iexplorer", "IEDriverServer")]
 fn exec_driver_test(#[case] browser_name: String, #[case] driver_name: String) {
+    if OS.eq("linux") && ARCH.eq("aarch64") && !browser_name.eq("firefox") {
+      return
+    }
+
     let mut cmd = get_selenium_manager();
     cmd.args(["--browser", &browser_name, "--output", "json"])
         .assert()

--- a/rust/tests/mirror_tests.rs
+++ b/rust/tests/mirror_tests.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::{assert_driver, get_selenium_manager};
+use crate::common::{assert_driver, is_linux_arm64, get_selenium_manager};
 
 mod common;
 
@@ -24,7 +24,7 @@ fn mirror_test() {
     let mut cmd = get_selenium_manager();
     cmd.args([
         "--browser",
-        "chrome",
+        if is_linux_arm64() { "firefox" } else { "chrome" },
         "--driver-mirror-url",
         "https://registry.npmmirror.com/-/binary/chromedriver/",
         "--browser-version",

--- a/rust/tests/offline_tests.rs
+++ b/rust/tests/offline_tests.rs
@@ -15,17 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::{get_selenium_manager, get_stdout};
+use crate::common::{get_selenium_manager, get_stdout, is_linux_arm64};
 
 mod common;
 
 #[test]
 fn offline_test() {
     let mut cmd = get_selenium_manager();
-    cmd.args(["--debug", "--browser", "chrome", "--offline"])
-        .assert()
-        .success()
-        .code(0);
+    cmd.args([
+        "--debug",
+        "--browser",
+        if is_linux_arm64() { "firefox" } else { "chrome" },
+        "--offline"
+    ])
+    .assert()
+    .success()
+    .code(0);
 
     let stdout = get_stdout(&mut cmd);
 

--- a/rust/tests/output_tests.rs
+++ b/rust/tests/output_tests.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::{get_selenium_manager, get_stderr, get_stdout};
+use crate::common::{get_selenium_manager, get_stderr, get_stdout, is_linux_arm64};
 
 use selenium_manager::logger::{JsonOutput, MinimalJson, DRIVER_PATH};
 use std::path::Path;
@@ -25,10 +25,15 @@ mod common;
 #[test]
 fn json_output_test() {
     let mut cmd = get_selenium_manager();
-    cmd.args(["--browser", "chrome", "--output", "json"])
-        .assert()
-        .success()
-        .code(0);
+    cmd.args([
+      "--browser",
+      if is_linux_arm64() { "firefox" } else { "chrome" },
+      "--output",
+      "json"
+    ])
+    .assert()
+    .success()
+    .code(0);
 
     let stdout = get_stdout(&mut cmd);
 
@@ -45,10 +50,15 @@ fn json_output_test() {
 #[test]
 fn shell_output_test() {
     let mut cmd = get_selenium_manager();
-    cmd.args(["--browser", "chrome", "--output", "shell"])
-        .assert()
-        .success()
-        .code(0);
+    cmd.args([
+      "--browser",
+      if is_linux_arm64() { "firefox" } else { "chrome" },
+      "--output",
+      "shell"
+    ])
+    .assert()
+    .success()
+    .code(0);
 
     let stdout = get_stdout(&mut cmd);
     assert!(stdout.contains(DRIVER_PATH));
@@ -57,10 +67,15 @@ fn shell_output_test() {
 #[test]
 fn mixed_output_test() {
     let mut cmd = get_selenium_manager();
-    cmd.args(["--browser", "chrome", "--output", "mixed"])
-        .assert()
-        .success()
-        .code(0);
+    cmd.args([
+      "--browser",
+      if is_linux_arm64() { "firefox" } else { "chrome" },
+      "--output",
+      "mixed"
+    ])
+    .assert()
+    .success()
+    .code(0);
 
     let stdout = get_stdout(&mut cmd);
     let json: MinimalJson = serde_json::from_str(&stdout).unwrap();

--- a/rust/tests/proxy_tests.rs
+++ b/rust/tests/proxy_tests.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::{assert_output, get_selenium_manager};
+use crate::common::{assert_output, get_selenium_manager, is_linux_arm64};
 
 use exitcode::DATAERR;
 
@@ -28,7 +28,7 @@ async fn wrong_proxy_test() {
         .args([
             "--debug",
             "--browser",
-            "chrome",
+          if is_linux_arm64() { "firefox" } else { "chrome" },
             "--proxy",
             "http://localhost:12345",
         ])
@@ -37,11 +37,17 @@ async fn wrong_proxy_test() {
 
     assert_output(&mut cmd, result, vec!["in PATH"], DATAERR);
 }
+
 #[test]
 fn wrong_protocol_proxy_test() {
     let mut cmd = get_selenium_manager();
     let result = cmd
-        .args(["--browser", "chrome", "--proxy", "wrong:://proxy"])
+        .args([
+          "--browser",
+          if is_linux_arm64() { "firefox" } else { "chrome" },
+          "--proxy",
+          "wrong:://proxy"
+        ])
         .assert()
         .try_success();
 
@@ -54,7 +60,7 @@ fn wrong_port_proxy_test() {
     let result = cmd
         .args([
             "--browser",
-            "chrome",
+            if is_linux_arm64() { "firefox" } else { "chrome" },
             "--proxy",
             "https:://localhost:1234567",
         ])

--- a/rust/tests/stable_browser_tests.rs
+++ b/rust/tests/stable_browser_tests.rs
@@ -18,6 +18,8 @@
 use crate::common::{assert_browser, assert_driver, get_selenium_manager};
 
 use rstest::rstest;
+use std::env::consts::ARCH;
+use std::env::consts::OS;
 
 mod common;
 
@@ -26,6 +28,10 @@ mod common;
 #[case("firefox")]
 #[case("edge")]
 fn stable_browser_test(#[case] browser_name: String) {
+    if OS.eq("linux") && ARCH.eq("aarch64") && !browser_name.eq("firefox") {
+      return
+    }
+
     let mut cmd = get_selenium_manager();
     cmd.args([
         "--browser",

--- a/rust/tests/webview_tests.rs
+++ b/rust/tests/webview_tests.rs
@@ -19,6 +19,7 @@ use crate::common::{assert_driver, get_selenium_manager};
 
 mod common;
 
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
 #[test]
 fn webview2_test() {
     let mut cmd = get_selenium_manager();


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues

https://github.com/SeleniumHQ/selenium/issues/15801

<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

This PR ensures that the Selenium Manager test suite passes on Linux arm64, and enables CI tests for this platform through GitHub's [recently released Linux arm64 runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

### 🔧 Implementation Notes

I'm new to Rust, but wanted Selenium Manager to explicitly fail if users try to run it for Chrome or Edge on Linux arm64, since it's not supported. Previously, the code would silently download `linux64` binaries which are for Linux x64, and cause segfaults on Linux arm64.

The setup I went for at least ensures that Firefox/Geckodriver on Linux arm64 will work and are tested properly as well.

<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

The docs at https://www.selenium.dev/documentation/selenium_manager/#alternative-architectures will need to be updated if the team is open to merging this PR. I'm happy to open a separate PR for that if desired.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Linux ARM64 support for Selenium Manager

- Enable CI testing on GitHub's ARM64 runners

- Restrict Chrome/Edge to Firefox-only on ARM64

- Update test suite for ARM64 compatibility


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Linux ARM64 Detection"] --> B["Browser Support Check"]
  B --> C["Firefox: Supported"]
  B --> D["Chrome/Edge: Error"]
  E["Test Suite Updates"] --> F["ARM64 Conditional Logic"]
  G["CI Configuration"] --> H["GitHub ARM64 Runners"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>chrome.rs</strong><dd><code>Add ARM64 unsupported error for Chrome</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-5ac161093a229c7c74c75c64f3be31a337c109d1ff11fcb0efe7bcc94d6e77be">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>edge.rs</strong><dd><code>Add ARM64 unsupported error for Edge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-dcd62c3bd133281f5bd97d8a876bcf753d7a4f3edd6ccbacf44eff3e9fcc484e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>browser_download_tests.rs</strong><dd><code>Skip non-Firefox tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-359d9c2a125d6fda0f38d3b794fcad796156f1a5786a3ead1ac92759a68a6049">+23/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>browser_tests.rs</strong><dd><code>Skip non-Firefox browser tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-c4663bdd0f9bda0b1870b94fe25dc61d2fec5ba6431521a52a330f8002a654c3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache_tests.rs</strong><dd><code>Disable cache tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-8f1be668827adf641c7ff682eb2b3f16a7b3c947bb3e7db1f376754ab84c8ff6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config_tests.rs</strong><dd><code>Skip non-Firefox config tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-336f9940e5c880d6c9d1cfaa5527ac3012bdb9b5515e6994124070297f4d32f6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exec_driver_tests.rs</strong><dd><code>Skip non-Firefox driver tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-b1fed12daefb8d91e71d88434c68bf3f8f90377c891fed327aa3e36c82d61be0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mirror_tests.rs</strong><dd><code>Use Firefox for ARM64 mirror tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-a43cd18d2fe841d76e1f61be80f4bad1adc886c5c5df398539ae7f6c8272238e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>offline_tests.rs</strong><dd><code>Use Firefox for ARM64 offline tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-1841fb63e80f2e98409f9b487aefc50784dfadcf9f2f263db37f1d0d593b4272">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output_tests.rs</strong><dd><code>Use Firefox for ARM64 output tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-8843f17a35e855620b36bcb89317ac2f5bdaf288ae9df752478654dc3d41e643">+28/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proxy_tests.rs</strong><dd><code>Use Firefox for ARM64 proxy tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-15a6c79463a3e5ec11d3292fd144551f06795ed56434b4f87b5df3abec4d03a3">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stable_browser_tests.rs</strong><dd><code>Skip non-Firefox stable tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-ccfe2de01bf5eee8fbaee613b25e51fecbf4105ce3bb3cac684397c722143280">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>webview_tests.rs</strong><dd><code>Disable webview tests on ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-1e8f934eae825effbf1efa8bb5f39567473b2254d8a28bf42c86d25b76073f82">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>common.rs</strong><dd><code>Add ARM64 detection helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-e75829e061fe7cd5b9ff65a045c33574cd09617ac149f4ba0114984d2fd14ff7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci-rust.yml</strong><dd><code>Add Ubuntu ARM64 runner to CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16044/files#diff-5162db340096b281e8c77ef016f0595e9b7a63e9cb48605a43b685301b4b5ee0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>