### PR TITLE
[dotnet] Remove deprecated DevTools capabilities from Firefox options

### DIFF
--- a/dotnet/src/webdriver/Firefox/FirefoxOptions.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxOptions.cs
@@ -59,7 +59,6 @@ public class FirefoxOptions : DriverOptions
     private const string FirefoxPrefsCapability = "prefs";
     private const string FirefoxEnvCapability = "env";
     private const string FirefoxOptionsCapability = "moz:firefoxOptions";
-    private const string FirefoxEnableDevToolsProtocolCapability = "moz:debuggerAddress";
     private readonly List<string> firefoxArguments = new List<string>();
     private readonly Dictionary<string, object> profilePreferences = new Dictionary<string, object>();
     private readonly Dictionary<string, object> additionalFirefoxOptions = new Dictionary<string, object>();
@@ -82,7 +81,6 @@ public class FirefoxOptions : DriverOptions
         this.AddKnownCapabilityName(FirefoxOptions.FirefoxLogCapability, "LogLevel property");
         this.AddKnownCapabilityName(FirefoxOptions.FirefoxLegacyProfileCapability, "Profile property");
         this.AddKnownCapabilityName(FirefoxOptions.FirefoxLegacyBinaryCapability, "BrowserExecutableLocation property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxEnableDevToolsProtocolCapability, "EnableDevToolsProtocol property");
         // https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/.
         // Enable BiDi only
         this.SetPreference("remote.active-protocols", 1);
@@ -112,11 +110,6 @@ public class FirefoxOptions : DriverOptions
     /// Gets or sets the logging level of the Firefox driver.
     /// </summary>
     public FirefoxDriverLogLevel LogLevel { get; set; } = FirefoxDriverLogLevel.Default;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to enable the DevTools protocol for the launched browser.
-    /// </summary>
-    public bool EnableDevToolsProtocol { get; set; }
 
     /// <summary>
     /// Gets or sets the options for automating Firefox on Android.
@@ -268,10 +261,6 @@ public class FirefoxOptions : DriverOptions
         IWritableCapabilities capabilities = GenerateDesiredCapabilities(true);
         Dictionary<string, object> firefoxOptions = this.GenerateFirefoxOptionsDictionary();
         capabilities.SetCapability(FirefoxOptionsCapability, firefoxOptions);
-        if (this.EnableDevToolsProtocol)
-        {
-            capabilities.SetCapability(FirefoxEnableDevToolsProtocolCapability, true);
-        }
 
         return capabilities.AsReadOnly();
     }

--- a/dotnet/test/common/CustomDriverConfigs/NightlyChannelFirefoxDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/NightlyChannelFirefoxDriver.cs
@@ -42,6 +42,6 @@ public class NightlyChannelFirefoxDriver : FirefoxDriver
 
     public static FirefoxOptions DefaultOptions
     {
-        get { return new FirefoxOptions() { BrowserVersion = "nightly", AcceptInsecureCertificates = true, EnableDevToolsProtocol = true }; }
+        get { return new FirefoxOptions() { BrowserVersion = "nightly", AcceptInsecureCertificates = true }; }
     }
 }

--- a/dotnet/test/common/CustomDriverConfigs/StableChannelFirefoxDriver.cs
+++ b/dotnet/test/common/CustomDriverConfigs/StableChannelFirefoxDriver.cs
@@ -42,6 +42,6 @@ public class StableChannelFirefoxDriver : FirefoxDriver
 
     public static FirefoxOptions DefaultOptions
     {
-        get { return new FirefoxOptions() { AcceptInsecureCertificates = true, EnableDevToolsProtocol = true }; }
+        get { return new FirefoxOptions() { AcceptInsecureCertificates = true }; }
     }
 }


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
As I remember Firefox doesn't support CDP.

### 🔧 Implementation Notes
Just remove any mentions about DevTools in Firefox Options class.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Other


___

### **Description**
- Remove deprecated DevTools capabilities from Firefox options

- Clean up Firefox driver configuration classes

- Remove EnableDevToolsProtocol property and related constants


___

### **Changes diagram**

```mermaid
flowchart LR
  A["FirefoxOptions class"] -- "remove" --> B["EnableDevToolsProtocol property"]
  A -- "remove" --> C["DevTools capability constant"]
  A -- "remove" --> D["DevTools capability registration"]
  E["Test configuration classes"] -- "remove" --> F["EnableDevToolsProtocol usage"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxOptions.cs</strong><dd><code>Remove DevTools protocol support from Firefox options</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxOptions.cs

<li>Remove <code>FirefoxEnableDevToolsProtocolCapability</code> constant<br> <li> Remove <code>EnableDevToolsProtocol</code> property and its documentation<br> <li> Remove DevTools capability registration in constructor<br> <li> Remove DevTools capability setting in <code>ToCapabilities()</code> method


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16047/files#diff-da881317f3769a9a71754fee962dbf127ebbd3e223aaee2e6ee0c972cbd3b1bf">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NightlyChannelFirefoxDriver.cs</strong><dd><code>Clean up nightly Firefox driver configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/CustomDriverConfigs/NightlyChannelFirefoxDriver.cs

- Remove `EnableDevToolsProtocol = true` from default options


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16047/files#diff-23c298c2e9d527b227fd184f1d6e73f284b549ec695c276e40bc1d4f68f82450">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StableChannelFirefoxDriver.cs</strong><dd><code>Clean up stable Firefox driver configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/CustomDriverConfigs/StableChannelFirefoxDriver.cs

- Remove `EnableDevToolsProtocol = true` from default options


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16047/files#diff-9e2f3f1376cd6496f8b7736a71cebf2e1174d1d6fe733913b04c4ccf18612339">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>