### PR TITLE
[rust] Update base URL for Edge web driver

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -45,7 +45,7 @@ pub const EDGE_NAMES: &[&str] = &[
 ];
 pub const EDGEDRIVER_NAME: &str = "msedgedriver";
 pub const WEBVIEW2_NAME: &str = "webview2";
-const DRIVER_URL: &str = "https://msedgedriver.azureedge.net/";
+const DRIVER_URL: &str = "https://msedgedriver.microsoft.com/";
 const LATEST_STABLE: &str = "LATEST_STABLE";
 const LATEST_RELEASE: &str = "LATEST_RELEASE";
 const BROWSER_URL: &str = "https://edgeupdates.microsoft.com/api/products/";


### PR DESCRIPTION
### **User description**
Adjust URL to download MS Edge drivers.

### 🔗 Related Issues
Related to https://github.com/SeleniumHQ/selenium/issues/16055

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Update Edge WebDriver download URL to new Microsoft domain


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old URL: msedgedriver.azureedge.net"] --> B["New URL: msedgedriver.microsoft.com"]
  B --> C["Edge WebDriver Downloads"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge.rs</strong><dd><code>Update Edge WebDriver download URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/edge.rs

<li>Changed DRIVER_URL constant from azureedge.net to microsoft.com domain


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16056/files#diff-dcd62c3bd133281f5bd97d8a876bcf753d7a4f3edd6ccbacf44eff3e9fcc484e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>