### PR TITLE
[dotnet] [bidi] Remove NavigateBack and NavigateForward as not a part…

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -91,16 +91,6 @@ public sealed class BrowsingContext
         return BiDi.BrowsingContext.TraverseHistoryAsync(this, delta, options);
     }
 
-    public Task NavigateBackAsync(TraverseHistoryOptions? options = null)
-    {
-        return TraverseHistoryAsync(-1, options);
-    }
-
-    public Task NavigateForwardAsync(TraverseHistoryOptions? options = null)
-    {
-        return TraverseHistoryAsync(1, options);
-    }
-
     public Task SetViewportAsync(SetViewportOptions? options = null)
     {
         return BiDi.BrowsingContext.SetViewportAsync(this, options);


### PR DESCRIPTION
### **User description**
… of low level

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/15612

### 💥 What does this PR do?
Remove unnecessary extra methods from low-level BiDi API.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `NavigateBackAsync` and `NavigateForwardAsync` methods from BiDi BrowsingContext

- Simplify low-level BiDi API by removing convenience methods

- Users should use `TraverseHistoryAsync` with delta values directly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BrowsingContext"] --> B["NavigateBackAsync (removed)"]
  A --> C["NavigateForwardAsync (removed)"]
  A --> D["TraverseHistoryAsync (kept)"]
  B -.-> D
  C -.-> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Remove navigation convenience methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Removed <code>NavigateBackAsync</code> method that called <code>TraverseHistoryAsync(-1)</code><br> <li> Removed <code>NavigateForwardAsync</code> method that called <br><code>TraverseHistoryAsync(1)</code><br> <li> Kept core <code>TraverseHistoryAsync</code> method for history navigation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16068/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

