### PR TITLE
[py] Use pinned browsers for bidi webextension tests

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_webextension_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_webextension_tests.py
@@ -132,10 +132,12 @@ class TestChromiumWebExtension:
 
         if driver_option == "chrome":
             browser_class = webdriver.Chrome
+            browser_service = webdriver.ChromeService
         elif driver_option == "edge":
             browser_class = webdriver.Edge
+            browser_service = webdriver.EdgeService
 
-        temp_dir = tempfile.mkdtemp(prefix="chrome-profile-")
+        temp_dir = tempfile.mkdtemp(prefix="chromium-profile-")
 
         chromium_options.enable_bidi = True
         chromium_options.enable_webextensions = True
@@ -143,7 +145,17 @@ class TestChromiumWebExtension:
         chromium_options.add_argument("--no-sandbox")
         chromium_options.add_argument("--disable-dev-shm-usage")
 
-        chromium_driver = browser_class(options=chromium_options)
+        binary = request.config.option.binary
+        if binary:
+            chromium_options.binary_location = binary
+
+        executable = request.config.option.executable
+        if executable:
+            service = browser_service(executable_path=executable)
+        else:
+            service = browser_service()
+
+        chromium_driver = browser_class(options=chromium_options, service=service)
 
         yield chromium_driver
         chromium_driver.quit()


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR updates the `chromium_driver` fixture used in the tests in `bidi_webextension_tests.py` so they use the `--browser-binary` and `--driver-binary` args passed by bazel. This will allow these tests to use pinned browsers when running in RBE.

### 🔄 Types of changes
- Build/Test


___

### **PR Type**
Tests


___

### **Description**
- Update chromium driver fixture to use pinned browsers

- Add support for browser binary and driver executable paths

- Enable RBE compatibility for BiDi webextension tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Configuration"] --> B["Browser Binary Path"]
  A --> C["Driver Executable Path"]
  B --> D["Chromium Options"]
  C --> E["Browser Service"]
  D --> F["Chromium Driver"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_webextension_tests.py</strong><dd><code>Configure pinned browser support for chromium driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_webextension_tests.py

<ul><li>Added browser service class selection for Chrome/Edge<br> <li> Implemented binary location configuration from test options<br> <li> Added executable path support for driver service<br> <li> Updated temp directory prefix to be more generic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16071/files#diff-6e579bdd2c5a63ae03a0572188781b474610491e5b14c4ea1eaf65dc35750851">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

