### PR TITLE
[py] Fix selenium-manager binary location

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -50,8 +50,9 @@ exclude = ["test*"]
 namespaces = true
 # include-package-data is `true` by default in pyproject.toml
 
-[[tool.setuptools-rust.bins]]
+[[tool.setuptools-rust.ext-modules]]
 target = "selenium.webdriver.common.selenium-manager"
+binding = "Exec"
 
 [tool.setuptools.package-data]
 "*" = [


### PR DESCRIPTION
### **User description**
This build was incorrectly migrated in #14837 as selenium-manager is expected to be in the `selenium/webdriver/common/selenium-manager` library path rather than a binary named `selenium.webdriver.common.selenium-manager` installed in the script path.

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Fixes #14837.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Fixes sdist `selenium-manager` binary name/path.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix


___

### **PR Type**
Bug fix


___

### **Description**
- Fix selenium-manager binary location in Python package

- Change from bins to ext-modules configuration

- Correct path for selenium-manager in library structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["setuptools-rust.bins"] -- "change to" --> B["setuptools-rust.ext-modules"]
  B -- "add binding" --> C["Exec binding"]
  C -- "correct path" --> D["selenium.webdriver.common.selenium-manager"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Fix selenium-manager build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<ul><li>Changed <code>[[tool.setuptools-rust.bins]]</code> to <br><code>[[tool.setuptools-rust.ext-modules]]</code><br> <li> Added <code>binding = "Exec"</code> configuration<br> <li> Fixed selenium-manager target path configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16074/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

