### PR TITLE
[py] Fix vendor prefix for Edge browser

### DIFF
--- a/py/selenium/webdriver/edge/remote_connection.py
+++ b/py/selenium/webdriver/edge/remote_connection.py
@@ -34,7 +34,7 @@ class EdgeRemoteConnection(ChromiumRemoteConnection):
     ) -> None:
         super().__init__(
             remote_server_addr=remote_server_addr,
-            vendor_prefix="goog",
+            vendor_prefix="ms",
             browser_name=EdgeRemoteConnection.browser_name,
             keep_alive=keep_alive,
             ignore_proxy=ignore_proxy,


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #16077 

### 💥 What does this PR do?

This PR changes the vendor prefix for Edge to `ms` (from `goog`) so `webdriver.Remote` methods work correctly with Edge.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix vendor prefix for Edge browser from `goog` to `ms`

- Enables proper functionality of `webdriver.Remote` methods with Edge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Edge Remote Connection"] --> B["Vendor Prefix Change"]
  B --> C["goog → ms"]
  C --> D["Fixed Remote Methods"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Update vendor prefix for Edge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/edge/remote_connection.py

<ul><li>Changed vendor prefix parameter from "goog" to "ms" in <br>EdgeRemoteConnection constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16078/files#diff-5a67094bffec603deb765bf51f75448d4eae1d43c3449eb251592cd48c547fc1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

