### PR TITLE
[dotnet] [bidi] Preserve BiDi global options when instantiating BiDi

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDiOptions.cs
+++ b/dotnet/src/webdriver/BiDi/BiDiOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="WebDriver.Extensions.cs" company="Selenium Committers">
+// <copyright file="BiDiOptions.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -17,28 +17,8 @@
 // under the License.
 // </copyright>
 
-using System;
-using System.Threading.Tasks;
-
 namespace OpenQA.Selenium.BiDi;
 
-public static class WebDriverExtensions
+public sealed class BiDiOptions
 {
-    public static async Task<BiDi> AsBiDiAsync(this IWebDriver webDriver, BiDiOptions? options = null)
-    {
-        if (webDriver is null) throw new ArgumentNullException(nameof(webDriver));
-
-        string? webSocketUrl = null;
-
-        if (webDriver is IHasCapabilities hasCapabilities)
-        {
-            webSocketUrl = hasCapabilities.Capabilities.GetCapability("webSocketUrl")?.ToString();
-        }
-
-        if (webSocketUrl is null) throw new BiDiException("The driver is not compatible with bidirectional protocol or \"webSocketUrl\" not enabled in driver options.");
-
-        var bidi = await BiDi.ConnectAsync(webSocketUrl).ConfigureAwait(false);
-
-        return bidi;
-    }
 }


### PR DESCRIPTION
### **User description**
It will be used to setting some global options, like command timeout (30 secs by default as for now).

### 💥 What does this PR do?
Preserving method signature for further improvements without any breaking changes.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `BiDiOptions` class for future BiDi configuration

- Update `AsBiDiAsync` method to accept optional BiDi options

- Preserve method signature for backwards compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BiDiOptions class"] --> B["AsBiDiAsync method"]
  B --> C["Future configuration support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiOptions.cs</strong><dd><code>Create BiDiOptions configuration class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BiDiOptions.cs

<ul><li>Create new <code>BiDiOptions</code> sealed class<br> <li> Add standard Apache License header<br> <li> Empty class ready for future configuration properties</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16080/files#diff-125fd0b2bdaf1633bd8e826109903372566ce7c105342841c83b47b93fac026c">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebDriver.Extensions.cs</strong><dd><code>Update AsBiDiAsync method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs

<ul><li>Add optional <code>BiDiOptions</code> parameter to <code>AsBiDiAsync</code> method<br> <li> Maintain backwards compatibility with default null value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16080/files#diff-74a59237dd909eaf45f31d8157e01415e5ddd6cd33066dd22a753f7741175769">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

