### PR TITLE
[java] arbitrary directory creation during archive extraction to a pathname to a restricted directory

### DIFF
--- a/java/src/org/openqa/selenium/io/Zip.java
+++ b/java/src/org/openqa/selenium/io/Zip.java
@@ -102,6 +102,11 @@ public class Zip {
       while ((entry = zis.getNextEntry()) != null) {
         File file = new File(outputDir, entry.getName());
         if (entry.isDirectory()) {
+          String canonicalOutputDirPath = outputDir.getCanonicalPath();
+          String canonicalDirPath = file.getCanonicalPath();
+          if (!canonicalDirPath.startsWith(canonicalOutputDirPath + File.separator)) {
+            throw new IOException("Directory entry is outside of the target dir: " + entry.getName());
+          }
           FileHandler.createDir(file);
           continue;
         }


### PR DESCRIPTION
### **User description**
https://github.com/SeleniumHQ/selenium/blob/37449292e9b267a1d518d14ba6993a7d84d295e5/java/src/org/openqa/selenium/io/Zip.java#L103-L103

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated.zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.


fix the issue, we need to validate the paths of directories being created in the `unzip` method. Specifically:
- Before calling `FileHandler.createDir` for a directory entry, ensure that the canonical path of the directory is within the canonical path of the output directory.
- Use `File.getCanonicalPath()` to normalize paths and compare them using `String.startsWith()` to ensure the directory is within the intended output directory.

This fix will prevent directory traversal attacks by ensuring that no directories or files are created outside the intended output directory.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix directory traversal vulnerability in zip extraction

- Add canonical path validation for directory entries

- Prevent malicious archives from creating files outside target directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zip Entry"] --> B["Get Canonical Path"]
  B --> C["Validate Path"]
  C --> D{"Path within target?"}
  D -->|Yes| E["Create Directory"]
  D -->|No| F["Throw IOException"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Zip.java</strong><dd><code>Add directory traversal protection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/io/Zip.java

<ul><li>Add canonical path validation before directory creation<br> <li> Check if directory path is within target output directory<br> <li> Throw IOException for paths outside target directory</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16087/files#diff-3e596a9120e7662c9a57ecd465b4b000f7334902bda6060447332370cb2b1498">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

