### PR TITLE
[dotnet] Fix race condition for .net framework when internal tracing enabled

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -440,7 +440,7 @@ public class HttpCommandExecutor : ICommandExecutor
         /// <returns>The http response message content.</returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var responseTask = base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             StringBuilder requestLogMessageBuilder = new();
             requestLogMessageBuilder.AppendFormat(">> {0} RequestUri: {1}, Content: {2}, Headers: {3}",
@@ -451,20 +451,27 @@ public class HttpCommandExecutor : ICommandExecutor
 
             if (request.Content != null)
             {
+#if NET8_0_OR_GREATER
+                var requestContent = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
                 var requestContent = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
                 requestLogMessageBuilder.AppendFormat("{0}{1}", Environment.NewLine, requestContent);
             }
 
             _logger.Trace(requestLogMessageBuilder.ToString());
-
-            var response = await responseTask.ConfigureAwait(false);
 
             StringBuilder responseLogMessageBuilder = new();
             responseLogMessageBuilder.AppendFormat("<< StatusCode: {0}, ReasonPhrase: {1}, Content: {2}, Headers: {3}", (int)response.StatusCode, response.ReasonPhrase, response.Content, response.Headers?.Count());
 
             if (!response.IsSuccessStatusCode && response.Content != null)
             {
+#if NET8_0_OR_GREATER
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
                 var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
                 responseLogMessageBuilder.AppendFormat("{0}{1}", Environment.NewLine, responseContent);
             }
 

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -440,8 +440,6 @@ public class HttpCommandExecutor : ICommandExecutor
         /// <returns>The http response message content.</returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-
             StringBuilder requestLogMessageBuilder = new();
             requestLogMessageBuilder.AppendFormat(">> {0} RequestUri: {1}, Content: {2}, Headers: {3}",
                 request.Method,
@@ -461,7 +459,10 @@ public class HttpCommandExecutor : ICommandExecutor
 
             _logger.Trace(requestLogMessageBuilder.ToString());
 
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
             StringBuilder responseLogMessageBuilder = new();
+
             responseLogMessageBuilder.AppendFormat("<< StatusCode: {0}, ReasonPhrase: {1}, Content: {2}, Headers: {3}", (int)response.StatusCode, response.ReasonPhrase, response.Content, response.Headers?.Count());
 
             if (!response.IsSuccessStatusCode && response.Content != null)


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
```csharp
using var driver = new ChromeDriver();

for (int 0 .. 100)
  driver.FindElement(By.CssSelector("div"));
```

Sometimes the exception is raised:
```
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at System.Net.Http.Headers.HttpHeaders.AddHeaderToStore(String name, HeaderStoreItemInfo info)
   at System.Net.Http.Headers.HttpHeaders.CreateAndAddHeaderToStore(String name)
   at System.Net.Http.Headers.HttpHeaders.GetOrCreateHeaderInfo(String name, Boolean parseRawValues)
   at System.Net.Http.Headers.HttpHeaders.SetParsedValue(String name, Object value)
   at System.Net.Http.Headers.HttpContentHeaders.get_ContentLength()
   at System.Net.Http.HttpClientHandler.PrepareAndStartContentUpload(RequestState state)
```

### 💥 What does this PR do?
This exception might be happened in .NET Framework only. On .NET Core it works smoothly.

### 🔧 Implementation Notes
This is because we send and read HTTP Request Content in parallel. The implementation of network module in .NET Framework doesn't like it.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix race condition in .NET Framework HTTP logging

- Await HTTP response before reading request content

- Add conditional compilation for .NET 8+ cancellation token

- Prevent concurrent access to HTTP headers dictionary


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Send Request"]
  B --> C["Await Response"]
  C --> D["Read Request Content"]
  D --> E["Log Request"]
  E --> F["Log Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpCommandExecutor.cs</strong><dd><code>Fix HTTP logging race condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Remote/HttpCommandExecutor.cs

<ul><li>Changed parallel execution to sequential for HTTP request/response <br>logging<br> <li> Added conditional compilation for .NET 8+ cancellation token support<br> <li> Fixed race condition by awaiting response before reading request <br>content<br> <li> Improved thread safety for .NET Framework compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16091/files#diff-7e90084c9f3e8c994cbbfabdbc93ecd024159b65ca59d9f6efc53cace50e7b10">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

