### PR TITLE
[dotnet] Enabling Chrome and Edge driver services to set log level

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriverLogLevel.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverLogLevel.cs
@@ -1,0 +1,61 @@
+// <copyright file="ChromiumDriverLogLevel.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+namespace OpenQA.Selenium.Chromium;
+
+/// <summary>
+/// Represents the valid values of logging levels available with the Chromium based drivers.
+/// </summary>
+public enum ChromiumDriverLogLevel
+{
+    /// <summary>
+    /// Represents the value All, the most detailed logging level available.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Represents the Debug value
+    /// </summary>
+    Debug,
+
+    /// <summary>
+    /// Represents the Info value
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Represents the Warning value
+    /// </summary>
+    Warning ,
+
+    /// <summary>
+    /// Represents the Severe value
+    /// </summary>
+    Severe,
+
+    /// <summary>
+    /// Represents the Off value, nothing gets logged
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Represents that the logging value is unspecified, and should be the default level.
+    /// </summary>
+    Default
+}

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -85,6 +85,11 @@ public abstract class ChromiumDriverService : DriverService
     public bool EnableAppendLog { get; set; }
 
     /// <summary>
+    /// Gets or sets the level at which log output is displayed.
+    /// </summary>
+    public ChromiumDriverLogLevel LogLevel { get; set; } = ChromiumDriverLogLevel.Default;
+
+    /// <summary>
     /// <para>Gets or sets the comma-delimited list of IP addresses that are approved to connect to this instance of the Chrome driver.</para>
     /// <para>A value of <see langword="null"/> or <see cref="string.Empty"/> means only the local loopback address can connect.</para>
     /// </summary>
@@ -153,6 +158,12 @@ public abstract class ChromiumDriverService : DriverService
             {
                 argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -allowed-ips={0}", this.AllowedIPAddresses));
             }
+            
+            if (this.LogLevel != ChromiumDriverLogLevel.Default)
+            {
+                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log-level={0}", this.LogLevel.ToString().ToUpperInvariant()));
+            }
+            
 
             return argsBuilder.ToString();
         }

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -158,12 +158,12 @@ public abstract class ChromiumDriverService : DriverService
             {
                 argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -allowed-ips={0}", this.AllowedIPAddresses));
             }
-            
+
             if (this.LogLevel != ChromiumDriverLogLevel.Default)
             {
                 argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log-level={0}", this.LogLevel.ToString().ToUpperInvariant()));
             }
-            
+
 
             return argsBuilder.ToString();
         }

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -161,7 +161,10 @@ public abstract class ChromiumDriverService : DriverService
 
             if (this.LogLevel != ChromiumDriverLogLevel.Default)
             {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log-level={0}", this.LogLevel.ToString().ToUpperInvariant()));
+                if (Enum.IsDefined(typeof(ChromiumDriverLogLevel), this.LogLevel))
+                {
+                    argsBuilder.Append($" --log-level={this.LogLevel.ToString().ToUpperInvariant()}");
+                }
             }
 
 

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -163,7 +163,7 @@ public abstract class ChromiumDriverService : DriverService
             {
                 if (Enum.IsDefined(typeof(ChromiumDriverLogLevel), this.LogLevel))
                 {
-                    argsBuilder.Append($" --log-level={this.LogLevel.ToString().ToUpperInvariant()}");
+                    argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log-level={0}", this.LogLevel.ToString().ToUpperInvariant()));
                 }
             }
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Helps with #12273

### 💥 What does this PR do?
Enabling Chrome and Edge driver services to set log level

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Added `ChromiumDriverLogLevel` enum with logging levels (All, Debug, Info, Warning, Severe, Off, Default)

- Added `LogLevel` property to `ChromiumDriverService` for configuring driver log output

- Implemented command line argument generation for `--log-level` parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChromiumDriverLogLevel enum"] --> B["ChromiumDriverService.LogLevel property"]
  B --> C["Command line argument --log-level"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromiumDriverLogLevel.cs</strong><dd><code>New ChromiumDriverLogLevel enum definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Chromium/ChromiumDriverLogLevel.cs

<ul><li>Created new enum with 7 logging levels (All, Debug, Info, Warning, <br>Severe, Off, Default)<br> <li> Added comprehensive XML documentation for each enum value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16098/files#diff-2bdcf6a603437854c626cfd17fed40f3e1359bbccd3e4f26b61cc7673274ab73">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChromiumDriverService.cs</strong><dd><code>LogLevel property and command line integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Chromium/ChromiumDriverService.cs

<ul><li>Added LogLevel property with ChromiumDriverLogLevel.Default as default <br>value<br> <li> Modified CommandLineArguments to include --log-level parameter when <br>not default<br> <li> Added XML documentation for the new LogLevel property</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16098/files#diff-7b7a876beec5c5bbf8892cfef44f5d3cc18a1ced78506de3f69ea119d6b80b50">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

