### PR TITLE
[dotnet] Remove client side validation of well-known Options

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumOptions.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumOptions.cs
@@ -56,29 +56,6 @@ public abstract class ChromiumOptions : DriverOptions
     private ChromiumMobileEmulationDeviceSettings? mobileEmulationDeviceSettings;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ChromiumOptions"/> class.
-    /// </summary>
-    public ChromiumOptions() : base()
-    {
-        this.AddKnownCapabilityName(this.CapabilityName, "current ChromiumOptions class instance");
-        this.AddKnownCapabilityName(CapabilityType.LoggingPreferences, "SetLoggingPreference method");
-        this.AddKnownCapabilityName(this.LoggingPreferencesChromeOption, "SetLoggingPreference method");
-        this.AddKnownCapabilityName(ChromiumOptions.ArgumentsChromeOption, "AddArguments method");
-        this.AddKnownCapabilityName(ChromiumOptions.BinaryChromeOption, "BinaryLocation property");
-        this.AddKnownCapabilityName(ChromiumOptions.ExtensionsChromeOption, "AddExtensions method");
-        this.AddKnownCapabilityName(ChromiumOptions.LocalStateChromeOption, "AddLocalStatePreference method");
-        this.AddKnownCapabilityName(ChromiumOptions.PreferencesChromeOption, "AddUserProfilePreference method");
-        this.AddKnownCapabilityName(ChromiumOptions.DetachChromeOption, "LeaveBrowserRunning property");
-        this.AddKnownCapabilityName(ChromiumOptions.DebuggerAddressChromeOption, "DebuggerAddress property");
-        this.AddKnownCapabilityName(ChromiumOptions.ExcludeSwitchesChromeOption, "AddExcludedArgument property");
-        this.AddKnownCapabilityName(ChromiumOptions.MinidumpPathChromeOption, "MinidumpPath property");
-        this.AddKnownCapabilityName(ChromiumOptions.MobileEmulationChromeOption, "EnableMobileEmulation method");
-        this.AddKnownCapabilityName(ChromiumOptions.PerformanceLoggingPreferencesChromeOption, "PerformanceLoggingPreferences property");
-        this.AddKnownCapabilityName(ChromiumOptions.WindowTypesChromeOption, "AddWindowTypes method");
-        this.AddKnownCapabilityName(ChromiumOptions.UseSpecCompliantProtocolOption, "UseSpecCompliantProtocol property");
-    }
-
-    /// <summary>
     /// Gets the vendor prefix to apply to Chromium-specific capability names.
     /// </summary>
     protected abstract string VendorPrefix { get; }

--- a/dotnet/src/webdriver/DriverOptions.cs
+++ b/dotnet/src/webdriver/DriverOptions.cs
@@ -22,7 +22,6 @@ using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 namespace OpenQA.Selenium;
 
@@ -115,23 +114,6 @@ public abstract class DriverOptions
 {
     private readonly Dictionary<string, object> additionalCapabilities = new Dictionary<string, object>();
     private readonly Dictionary<string, LogLevel> loggingPreferences = new Dictionary<string, LogLevel>();
-    private readonly Dictionary<string, string> knownCapabilityNames = new Dictionary<string, string>();
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DriverOptions"/> class.
-    /// </summary>
-    protected DriverOptions()
-    {
-        this.AddKnownCapabilityName(CapabilityType.BrowserName, "BrowserName property");
-        this.AddKnownCapabilityName(CapabilityType.BrowserVersion, "BrowserVersion property");
-        this.AddKnownCapabilityName(CapabilityType.PlatformName, "PlatformName property");
-        this.AddKnownCapabilityName(CapabilityType.Proxy, "Proxy property");
-        this.AddKnownCapabilityName(CapabilityType.UnhandledPromptBehavior, "UnhandledPromptBehavior property");
-        this.AddKnownCapabilityName(CapabilityType.PageLoadStrategy, "PageLoadStrategy property");
-        this.AddKnownCapabilityName(CapabilityType.UseStrictFileInteractability, "UseStrictFileInteractability property");
-        this.AddKnownCapabilityName(CapabilityType.WebSocketUrl, "UseWebSocketUrl property");
-        this.AddKnownCapabilityName(CapabilityType.EnableDownloads, "EnableDownloads property");
-    }
 
     /// <summary>
     /// Gets or sets the name of the browser.
@@ -361,71 +343,6 @@ public abstract class DriverOptions
         {
             throw new ArgumentException("Capability name may not be null an empty string.", nameof(capabilityName));
         }
-
-        if (this.TryGetKnownCapability(capabilityName!, out string? typeSafeOptionName))
-        {
-            string message = string.Format(CultureInfo.InvariantCulture, "There is already an option for the {0} capability. Please use the {1} instead.", capabilityName, typeSafeOptionName);
-            throw new ArgumentException(message, nameof(capabilityName));
-        }
-    }
-
-    /// <summary>
-    /// Adds a known capability to the list of known capabilities and associates it
-    /// with the type-safe property name of the options class to be used instead.
-    /// </summary>
-    /// <param name="capabilityName">The name of the capability.</param>
-    /// <param name="typeSafeOptionName">The name of the option property or method to be used instead.</param>
-    protected void AddKnownCapabilityName(string capabilityName, string typeSafeOptionName)
-    {
-        this.knownCapabilityNames[capabilityName] = typeSafeOptionName;
-    }
-
-    /// <summary>
-    /// Remove a capability from the list of known capabilities
-    /// </summary>
-    /// <param name="capabilityName">The name of the capability to be removed.</param>
-    protected void RemoveKnownCapabilityName(string? capabilityName)
-    {
-        if (capabilityName is not null)
-        {
-            this.knownCapabilityNames.Remove(capabilityName);
-        }
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the specified capability name is a known capability name which has a type-safe option.
-    /// </summary>
-    /// <param name="capabilityName">The name of the capability to check.</param>
-    /// <returns><see langword="true"/> if the capability name is known; otherwise <see langword="false"/>.</returns>
-    protected bool IsKnownCapabilityName(string capabilityName)
-    {
-        return this.knownCapabilityNames.ContainsKey(capabilityName);
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the specified capability name is a known capability name which has a type-safe option.
-    /// </summary>
-    /// <param name="capabilityName">The name of the capability to check.</param>
-    /// <param name="typeSafeOptionName">The name of the type-safe option for the given capability name, or <see langword="null"/> if not found.</param>
-    /// <returns><see langword="true"/> if the capability name is known; otherwise <see langword="false"/>.</returns>
-    protected bool TryGetKnownCapability(string capabilityName, [NotNullWhen(true)] out string? typeSafeOptionName)
-    {
-        return this.knownCapabilityNames.TryGetValue(capabilityName, out typeSafeOptionName);
-    }
-
-    /// <summary>
-    /// Gets the name of the type-safe option for a given capability name.
-    /// </summary>
-    /// <param name="capabilityName">The name of the capability to check.</param>
-    /// <returns>The name of the type-safe option for the given capability name.</returns>
-    protected string GetTypeSafeOptionName(string capabilityName)
-    {
-        if (!this.IsKnownCapabilityName(capabilityName))
-        {
-            return string.Empty;
-        }
-
-        return this.knownCapabilityNames[capabilityName];
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/DriverOptions.cs
+++ b/dotnet/src/webdriver/DriverOptions.cs
@@ -336,7 +336,7 @@ public abstract class DriverOptions
     {
         if (capabilityName is null || string.IsNullOrEmpty(capabilityName))
         {
-            throw new ArgumentException("Capability name may not be null an empty string.", nameof(capabilityName));
+            throw new ArgumentException("Capability name may not be null or an empty string.", nameof(capabilityName));
         }
     }
 

--- a/dotnet/src/webdriver/Firefox/FirefoxOptions.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxOptions.cs
@@ -72,17 +72,7 @@ public class FirefoxOptions : DriverOptions
         : base()
     {
         this.BrowserName = BrowserNameValue;
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxOptionsCapability, "current FirefoxOptions class instance");
-        this.AddKnownCapabilityName(FirefoxOptions.IsMarionetteCapability, "UseLegacyImplementation property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxProfileCapability, "Profile property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxBinaryCapability, "BrowserExecutableLocation property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxArgumentsCapability, "AddArguments method");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxPrefsCapability, "SetPreference method");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxEnvCapability, "SetEnvironmentVariable method");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxLogCapability, "LogLevel property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxLegacyProfileCapability, "Profile property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxLegacyBinaryCapability, "BrowserExecutableLocation property");
-        this.AddKnownCapabilityName(FirefoxOptions.FirefoxEnableDevToolsProtocolCapability, "EnableDevToolsProtocol property");
+
         // https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/.
         // Enable BiDi only
         this.SetPreference("remote.active-protocols", 1);

--- a/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerOptions.cs
@@ -102,27 +102,6 @@ public class InternetExplorerOptions : DriverOptions
     {
         this.BrowserName = BrowserNameValue;
         this.PlatformName = "windows";
-        this.AddKnownCapabilityName(Capability, "current InterentExplorerOptions class instance");
-        this.AddKnownCapabilityName(IgnoreProtectedModeSettingsCapability, "IntroduceInstabilityByIgnoringProtectedModeSettings property");
-        this.AddKnownCapabilityName(IgnoreZoomSettingCapability, "IgnoreZoomLevel property");
-        this.AddKnownCapabilityName(CapabilityType.HasNativeEvents, "EnableNativeEvents property");
-        this.AddKnownCapabilityName(InitialBrowserUrlCapability, "InitialBrowserUrl property");
-        this.AddKnownCapabilityName(ElementScrollBehaviorCapability, "ElementScrollBehavior property");
-        this.AddKnownCapabilityName(CapabilityType.UnexpectedAlertBehavior, "UnhandledPromptBehavior property");
-        this.AddKnownCapabilityName(EnablePersistentHoverCapability, "EnablePersistentHover property");
-        this.AddKnownCapabilityName(RequireWindowFocusCapability, "RequireWindowFocus property");
-        this.AddKnownCapabilityName(BrowserAttachTimeoutCapability, "BrowserAttachTimeout property");
-        this.AddKnownCapabilityName(ForceCreateProcessApiCapability, "ForceCreateProcessApi property");
-        this.AddKnownCapabilityName(ForceShellWindowsApiCapability, "ForceShellWindowsApi property");
-        this.AddKnownCapabilityName(BrowserCommandLineSwitchesCapability, "BrowserComaandLineArguments property");
-        this.AddKnownCapabilityName(UsePerProcessProxyCapability, "UsePerProcessProxy property");
-        this.AddKnownCapabilityName(EnsureCleanSessionCapability, "EnsureCleanSession property");
-        this.AddKnownCapabilityName(FileUploadDialogTimeoutCapability, "FileUploadDialogTimeout property");
-        this.AddKnownCapabilityName(EnableFullPageScreenshotCapability, "EnableFullPageScreenshot property");
-        this.AddKnownCapabilityName(LegacyFileUploadDialogHandlingCapability, "LegacyFileUploadDialogHanlding property");
-        this.AddKnownCapabilityName(AttachToEdgeChromeCapability, "AttachToEdgeChrome property");
-        this.AddKnownCapabilityName(EdgeExecutablePathCapability, "EdgeExecutablePath property");
-        this.AddKnownCapabilityName(IgnoreProcessMatchCapability, "IgnoreProcessMatch property");
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/Safari/SafariOptions.cs
+++ b/dotnet/src/webdriver/Safari/SafariOptions.cs
@@ -53,8 +53,6 @@ public class SafariOptions : DriverOptions
     {
         this.BrowserName = BrowserNameValue;
         this.TechnologyPreview = false;
-        this.AddKnownCapabilityName(SafariOptions.EnableAutomaticInspectionSafariOption, "EnableAutomaticInspection property");
-        this.AddKnownCapabilityName(SafariOptions.EnableAutomaticProfilingSafariOption, "EnableAutomaticProfiling property");
     }
 
     /// <summary>


### PR DESCRIPTION
### **User description**
This resolves design issue in .NET driver options class. Options class is a wrapper of well-known supported remote-end options, usually via strong typing. But meanwhile there is `AddAdditionalOption(...)` method which allows user to do what he wants.

The issue in design is that `AddAdditionalOption(...)` method doesn't allow user what he wants because this method dictates to use another API. This is really bad, at compile time user is going to do something legible, but gets weird exception in runtime.

### 🔗 Related Issues
It contributes to https://github.com/SeleniumHQ/selenium/issues/16102, but doesn't resolve completely.

### 💥 What does this PR do?
Do not validate that user uses Selenium library improperly, he uses it correctly.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove client-side validation preventing legitimate API usage

- Clean up constructor code removing capability name tracking

- Simplify `ValidateCapabilityName` method implementation

- Fix design issue with `AddAdditionalOption` method restrictions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DriverOptions Constructor"] -- "removes" --> B["Known Capability Tracking"]
  C["ValidateCapabilityName Method"] -- "simplifies" --> D["Basic Null Check Only"]
  E["ChromiumOptions Constructor"] -- "removes" --> F["Capability Name Registration"]
  G["FirefoxOptions Constructor"] -- "removes" --> H["Capability Name Registration"]
  I["InternetExplorerOptions Constructor"] -- "removes" --> J["Capability Name Registration"]
  K["SafariOptions Constructor"] -- "removes" --> L["Capability Name Registration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverOptions.cs</strong><dd><code>Remove capability validation infrastructure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/DriverOptions.cs

<ul><li>Remove constructor and known capability tracking system<br> <li> Simplify <code>ValidateCapabilityName</code> to only check for null/empty<br> <li> Remove methods for managing known capabilities<br> <li> Clean up unused imports</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16120/files#diff-3a23deddc7c714feb41423be7a50f6e63df3541f4a50e21c28286d52fa3584fa">+0/-83</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChromiumOptions.cs</strong><dd><code>Remove ChromiumOptions constructor validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Chromium/ChromiumOptions.cs

<ul><li>Remove entire constructor that registered known capabilities<br> <li> Eliminate all <code>AddKnownCapabilityName</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16120/files#diff-1bebb439ebb7947cd5181f1e1fc8f50b99ce097f6cbd3524d0d4a5ee94241def">+0/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxOptions.cs</strong><dd><code>Clean up FirefoxOptions constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxOptions.cs

<ul><li>Remove all <code>AddKnownCapabilityName</code> calls from constructor<br> <li> Keep BiDi protocol preference setting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16120/files#diff-da881317f3769a9a71754fee962dbf127ebbd3e223aaee2e6ee0c972cbd3b1bf">+1/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InternetExplorerOptions.cs</strong><dd><code>Clean up InternetExplorerOptions constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/IE/InternetExplorerOptions.cs

<ul><li>Remove all <code>AddKnownCapabilityName</code> calls from constructor<br> <li> Keep browser name and platform settings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16120/files#diff-725269c6f5591d8b08538177287887d5a751bded84a6cb60ef841a3b3b18eb28">+0/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SafariOptions.cs</strong><dd><code>Clean up SafariOptions constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Safari/SafariOptions.cs

<ul><li>Remove <code>AddKnownCapabilityName</code> calls from constructor<br> <li> Keep browser name and technology preview settings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16120/files#diff-335a466bb947f92659e7e18e8c4c92b8e4f0c15a560c0a001ea74c25c757caca">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

