### PR TITLE
[dotnet] Change default internal log level to Warn

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -31,7 +31,7 @@ internal class LogContextManager
     {
         var defaulLogHandler = new TextWriterHandler(Console.Error);
 
-        GlobalContext = new LogContext(LogEventLevel.Info, null, null, [defaulLogHandler]);
+        GlobalContext = new LogContext(LogEventLevel.Warn, null, null, [defaulLogHandler]);
     }
 
     public ILogContext GlobalContext { get; }


### PR DESCRIPTION
### **User description**
Currently default internal logging level is `Info`, meaning that all log messages with `Info`, `Warn`, `Error` levels go to user's output by default. It doesn't look rational when we speak about the library should be silent as possible.

Warning and Errors are OK to be revealed by default, meaning "hey dear user, please pay attention". But it doesn't make sense for `Info` level. Now it is clear why Selenium has no Info messages at all.

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/15785

### 💥 What does this PR do?
Change default internal logging level.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)


___

### **PR Type**
Other


___

### **Description**
- Change default internal log level from Info to Warn

- Reduce verbosity of library output by default

- Keep warnings and errors visible to users


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LogContextManager"] --> B["Default Log Level"]
  B --> C["Info Level"] 
  B --> D["Warn Level"]
  C -.-> D
  D --> E["Less Verbose Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogContextManager.cs</strong><dd><code>Update default log level configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Logging/LogContextManager.cs

<ul><li>Modified LogContextManager constructor to use LogEventLevel.Warn <br>instead of LogEventLevel.Info<br> <li> Changed default logging behavior to be less verbose</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16126/files#diff-259c2c4f3567044d233aa46147d492b89964cbe4bc5e45fd976a03c88674007f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

