### PR TITLE
[dotnet][py][java][js]: add `default` as a value for SameSite

### DIFF
--- a/dotnet/src/webdriver/BiDi/Network/Cookie.cs
+++ b/dotnet/src/webdriver/BiDi/Network/Cookie.cs
@@ -32,5 +32,6 @@ public enum SameSite
 {
     Strict,
     Lax,
-    None
+    None,
+    Default
 }

--- a/java/src/org/openqa/selenium/bidi/network/Cookie.java
+++ b/java/src/org/openqa/selenium/bidi/network/Cookie.java
@@ -25,7 +25,8 @@ public class Cookie {
   public enum SameSite {
     STRICT("strict"),
     LAX("lax"),
-    NONE("none");
+    NONE("none"),
+    DEFAULT("default");
 
     private final String type;
 

--- a/javascript/selenium-webdriver/bidi/networkTypes.js
+++ b/javascript/selenium-webdriver/bidi/networkTypes.js
@@ -26,6 +26,7 @@ const SameSite = {
   STRICT: 'strict',
   LAX: 'lax',
   NONE: 'none',
+  DEFAULT: 'default',
 
   findByName(name) {
     return (

--- a/py/selenium/webdriver/common/bidi/storage.py
+++ b/py/selenium/webdriver/common/bidi/storage.py
@@ -26,6 +26,7 @@ class SameSite:
     STRICT = "strict"
     LAX = "lax"
     NONE = "none"
+    DEFAULT = "default"
 
 
 class BytesValue:


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Fixes #16128

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds `default` as a possible value for the `Samesite` attribute.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Default` value to `SameSite` enum for cookies

- Implements cookie specification compliance across language bindings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SameSite Enum"] --> B["Add Default Value"]
  B --> C["Cookie Spec Compliance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cookie.cs</strong><dd><code>Add Default to SameSite enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/Cookie.cs

- Add `Default` enum value to `SameSite` enumeration


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16129/files#diff-0d23755a55d2004bac2bc8b8544ff3677553aedc6224a8e8e97c3ecb99d71467">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

