### PR TITLE
[dotnet] Truncate log and set profile root in Firefox (GeckoDriver)

### DIFF
--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -107,6 +107,11 @@ public sealed class FirefoxDriverService : DriverService
     /// Disable truncation of long log lines in GeckoDriver.
     /// </summary>
     public bool LogTruncate { get; set; }
+    
+    /// <summary>
+    /// Directory in which GeckoDriver creates profiles.
+    /// </summary>
+    public string? ProfileRoot { get; set; }
 
     /// <summary>
     /// Gets or sets the level at which log output is displayed.
@@ -198,6 +203,16 @@ public sealed class FirefoxDriverService : DriverService
             {
                 argsBuilder.Append(" --log-no-truncate");
             }
+
+            if (!string.IsNullOrEmpty(this.ProfileRoot))
+            {
+                if (!Directory.Exists(this.ProfileRoot))
+                {
+                    throw new ArgumentException($"Profile root directory does not exist: {this.ProfileRoot}", nameof(ProfileRoot));
+                }
+    
+                argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --profile-root \"{0}\"", this.ProfileRoot);
+            }            
 
             return argsBuilder.ToString().Trim();
         }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -106,7 +106,7 @@ public sealed class FirefoxDriverService : DriverService
     /// <summary>
     /// Disable truncation of long log lines in GeckoDriver.
     /// </summary>
-    public bool LogTruncate { get; set; }
+    public bool LogNoTruncate { get; set; }
 
     /// <summary>
     /// Directory in which GeckoDriver creates profiles.
@@ -199,7 +199,7 @@ public sealed class FirefoxDriverService : DriverService
                 argsBuilder.Append(" --jsdebugger");
             }
 
-            if (this.LogTruncate)
+            if (this.LogNoTruncate)
             {
                 argsBuilder.Append(" --log-no-truncate");
             }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -102,12 +102,12 @@ public sealed class FirefoxDriverService : DriverService
     /// offer a way to specify a log file path directly.
     /// </remarks>
     public string? LogPath { get; set; }
-    
+
     /// <summary>
     /// Disable truncation of long log lines in GeckoDriver.
     /// </summary>
     public bool LogTruncate { get; set; }
-    
+
     /// <summary>
     /// Directory in which GeckoDriver creates profiles.
     /// </summary>
@@ -210,9 +210,9 @@ public sealed class FirefoxDriverService : DriverService
                 {
                     throw new ArgumentException($"Profile root directory does not exist: {this.ProfileRoot}", nameof(ProfileRoot));
                 }
-    
+
                 argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --profile-root \"{0}\"", this.ProfileRoot);
-            }            
+            }
 
             return argsBuilder.ToString().Trim();
         }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -102,6 +102,11 @@ public sealed class FirefoxDriverService : DriverService
     /// offer a way to specify a log file path directly.
     /// </remarks>
     public string? LogPath { get; set; }
+    
+    /// <summary>
+    /// Disable truncation of long log lines in GeckoDriver.
+    /// </summary>
+    public bool LogTruncate { get; set; }
 
     /// <summary>
     /// Gets or sets the level at which log output is displayed.
@@ -187,6 +192,11 @@ public sealed class FirefoxDriverService : DriverService
             if (this.OpenBrowserToolbox)
             {
                 argsBuilder.Append(" --jsdebugger");
+            }
+
+            if (this.LogTruncate)
+            {
+                argsBuilder.Append(" --log-no-truncate");
             }
 
             return argsBuilder.ToString().Trim();


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Helps with #12273

### 💥 What does this PR do?
Allows Firefox to set truncated logs and set profile root
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `LogTruncate` property to control GeckoDriver log truncation

- Add `ProfileRoot` property to specify profile directory

- Include directory validation for profile root path

- Update command line argument generation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FirefoxDriverService"] --> B["LogTruncate Property"]
  A --> C["ProfileRoot Property"]
  B --> D["--log-no-truncate Argument"]
  C --> E["--profile-root Argument"]
  C --> F["Directory Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverService.cs</strong><dd><code>Add log truncation and profile root configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxDriverService.cs

<ul><li>Added <code>LogTruncate</code> boolean property for controlling log truncation<br> <li> Added <code>ProfileRoot</code> string property for specifying profile directory<br> <li> Added directory existence validation for ProfileRoot<br> <li> Updated CommandLineArguments to include new command line flags</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16131/files#diff-8a02c4932a0154eb11aafcbf7e736968b70fe5d69dac3df52ac67fa8c8a7c965">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

