### PR TITLE
[dotnet] Add readable timestamps to log in Chromium browsers

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -94,6 +94,11 @@ public abstract class ChromiumDriverService : DriverService
     /// <para>A value of <see langword="null"/> or <see cref="string.Empty"/> means only the local loopback address can connect.</para>
     /// </summary>
     public string? AllowedIPAddresses { get; set; }
+    
+    /// <summary>
+    /// Adds readable timestamps to log
+    /// </summary>
+    public bool ReadableTimestamp { get; set; }
 
     /// <summary>
     /// Gets the command-line arguments for the driver service.
@@ -126,6 +131,11 @@ public abstract class ChromiumDriverService : DriverService
             if (this.EnableAppendLog)
             {
                 argsBuilder.Append(" --append-log");
+            }
+
+            if (this.ReadableTimestamp)
+            {
+                argsBuilder.Append(" --readable-timestamp");
             }
 
             if (!string.IsNullOrEmpty(this.LogPath))

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -94,7 +94,7 @@ public abstract class ChromiumDriverService : DriverService
     /// <para>A value of <see langword="null"/> or <see cref="string.Empty"/> means only the local loopback address can connect.</para>
     /// </summary>
     public string? AllowedIPAddresses { get; set; }
-    
+
     /// <summary>
     /// Adds readable timestamps to log
     /// </summary>


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Helps with #12273

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ReadableTimestamp` property to ChromiumDriverService

- Enable readable timestamp logging via `--readable-timestamp` command line argument


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChromiumDriverService"] --> B["ReadableTimestamp Property"]
  B --> C["--readable-timestamp CLI Argument"]
  C --> D["Enhanced Log Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromiumDriverService.cs</strong><dd><code>Add readable timestamp logging support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Chromium/ChromiumDriverService.cs

<ul><li>Added <code>ReadableTimestamp</code> boolean property with XML documentation<br> <li> Modified <code>CommandLineArguments</code> to append <code>--readable-timestamp</code> flag when <br>enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16133/files#diff-7b7a876beec5c5bbf8892cfef44f5d3cc18a1ced78506de3f69ea119d6b80b50">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

