### PR TITLE
[js][bidi]: fix flaky bidi network test - `can request cookies`

### DIFF
--- a/javascript/selenium-webdriver/test/bidi/network_test.js
+++ b/javascript/selenium-webdriver/test/bidi/network_test.js
@@ -69,6 +69,7 @@ suite(
         await driver.navigate().refresh()
 
         assert.equal(beforeRequestEvent.request.method, 'GET')
+        await driver.wait(() => beforeRequestEvent.request.cookies.length > 0, 2000)
         assert.equal(beforeRequestEvent.request.cookies[0].name, 'north')
         assert.equal(beforeRequestEvent.request.cookies[0].value.value, 'biryani')
         const url = beforeRequestEvent.request.url
@@ -80,6 +81,7 @@ suite(
         })
         await driver.navigate().refresh()
 
+        await driver.wait(() => beforeRequestEvent.request.cookies.length > 1, 2000)
         assert.equal(beforeRequestEvent.request.cookies[1].name, 'south')
         assert.equal(beforeRequestEvent.request.cookies[1].value.value, 'dosa')
       })


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Fixes the flaky `can request cookies` test in `network_test.js` by waiting for cookies to load completely.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
The async method doesn't waits for cookie to load completely, adding a driver wait fixes it.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix flaky BiDi network test by adding wait conditions

- Ensure cookies are loaded before assertions in test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add Cookie"] --> B["Navigate Refresh"] --> C["Wait for Cookies"] --> D["Assert Cookie Values"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_test.js</strong><dd><code>Add wait conditions for cookie loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/test/bidi/network_test.js

<ul><li>Added <code>driver.wait()</code> calls to ensure cookies are loaded before <br>assertions<br> <li> Wait for cookie array length to be greater than expected count<br> <li> Prevents race conditions in async cookie loading</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16141/files#diff-8a8a6edc66e9eef1d7062233f08beb8a645b77c3ee4d06c018f4e039633f029d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

