### PR TITLE
[dotnet] Fix the issue when service wants to write into disposed stream

### DIFF
--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -256,12 +256,14 @@ public abstract class DriverService : ICommandServer
         this.OnDriverProcessStarting(eventArgs);
 
         this.driverServiceProcess.Start();
-        bool serviceAvailable = this.WaitForServiceInitialization();
-        DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
-        this.OnDriverProcessStarted(processStartedEventArgs);
 
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
+
+        bool serviceAvailable = this.WaitForServiceInitialization();
+
+        DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
+        this.OnDriverProcessStarted(processStartedEventArgs);
 
         if (!serviceAvailable)
         {

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -288,12 +288,12 @@ public abstract class DriverService : ICommandServer
             if (disposing)
             {
                 this.Stop();
-            }
 
-            if (this.driverServiceProcess is not null)
-            {
-                this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
-                this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
+                if (this.driverServiceProcess is not null)
+                {
+                    this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
+                    this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
+                }
             }
 
             this.isDisposed = true;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -255,8 +255,8 @@ public abstract class DriverService : ICommandServer
         DriverProcessStartingEventArgs eventArgs = new DriverProcessStartingEventArgs(this.driverServiceProcess.StartInfo);
         this.OnDriverProcessStarting(eventArgs);
 
+        // Important: Start the process and immediately begin reading the output and error streams to avoid IO deadlocks.
         this.driverServiceProcess.Start();
-
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
 

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -290,6 +290,12 @@ public abstract class DriverService : ICommandServer
                 this.Stop();
             }
 
+            if (this.driverServiceProcess is not null)
+            {
+                this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
+                this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
+            }
+
             this.isDisposed = true;
         }
     }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -279,13 +279,13 @@ public sealed class FirefoxDriverService : DriverService
     /// </remarks>
     protected override void Dispose(bool disposing)
     {
+        base.Dispose(disposing);
+
         if (logWriter != null && disposing)
         {
             logWriter.Dispose();
             logWriter = null;
         }
-
-        base.Dispose(disposing);
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -250,7 +250,6 @@ public sealed class FirefoxDriverService : DriverService
     /// </summary>
     /// <param name="sender">The sender of the event.</param>
     /// <param name="args">The data received event arguments.</param>
-    /// <param name="isError">A value indicating whether the data received is from the error stream.</param>
     protected override void OnDriverProcessDataReceived(object sender, DataReceivedEventArgs args)
     {
         if (string.IsNullOrEmpty(args.Data))


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Fix the issue when service wants to write into disposed stream.
Fix possible dual-blocking IO.

### 💡 Additional Considerations
This is core fix.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix disposed stream write issue in driver service

- Prevent dual-blocking IO during initialization

- Reorder disposal calls in Firefox service

- Clean up documentation comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Driver Service Start"] --> B["Begin Output/Error Reading"]
  B --> C["Wait for Initialization"]
  C --> D["Fire Started Event"]
  E["Firefox Service"] --> F["Dispose Base First"]
  F --> G["Dispose Log Writer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverService.cs</strong><dd><code>Fix service initialization order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/DriverService.cs

<ul><li>Reorder service initialization sequence<br> <li> Move output/error reading before waiting for initialization<br> <li> Prevent blocking IO during startup</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16148/files#diff-c38089621d41671b4719164b262303e275d4a4a442125fd9d4ea61eeca855c2b">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverService.cs</strong><dd><code>Fix disposal order and cleanup docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxDriverService.cs

<ul><li>Remove unused parameter documentation<br> <li> Reorder disposal calls to dispose base class first<br> <li> Prevent writing to disposed stream</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16148/files#diff-8a02c4932a0154eb11aafcbf7e736968b70fe5d69dac3df52ac67fa8c8a7c965">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

