### PR TITLE
[grid] Reduce redundant logs of find slots and retry queue requests by the Distributor

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -512,8 +512,14 @@ public class LocalDistributor extends Distributor implements Closeable {
     try {
       return model.getSnapshot().stream()
           .filter(
-              node ->
-                  !DOWN.equals(node.getAvailability()) && !DRAINING.equals(node.getAvailability()))
+              node -> {
+                // Only consider UP nodes (not DOWN, DRAINING, etc.)
+                if (!UP.equals(node.getAvailability())) {
+                  return false;
+                }
+                // Consider node has at least one free slot
+                return node.getSlots().stream().anyMatch(slot -> slot.getSession() == null);
+              })
           .collect(toImmutableSet());
     } finally {
       readLock.unlock();
@@ -704,8 +710,7 @@ public class LocalDistributor extends Distributor implements Closeable {
   }
 
   private boolean isNotSupported(Capabilities caps) {
-    return getAvailableNodes().stream()
-        .noneMatch(node -> node.hasCapability(caps, slotMatcher) && node.getAvailability() == UP);
+    return getAvailableNodes().stream().noneMatch(node -> node.hasCapability(caps, slotMatcher));
   }
 
   private boolean reserve(SlotId id) {
@@ -795,7 +800,7 @@ public class LocalDistributor extends Distributor implements Closeable {
         // up starving a session request.
         Map<Capabilities, Long> stereotypes =
             getAvailableNodes().stream()
-                .filter(node -> node.hasCapacity() && node.getAvailability() == UP)
+                .filter(NodeStatus::hasCapacity)
                 .flatMap(node -> node.getSlots().stream().map(Slot::getStereotype))
                 .collect(
                     Collectors.groupingBy(ImmutableCapabilities::copyOf, Collectors.counting()));

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
@@ -361,15 +361,8 @@ public class LocalNodeRegistry implements NodeRegistry {
     readLock.lock();
     try {
       return model.getSnapshot().stream()
-          .filter(
-              node -> {
-                // Only consider UP nodes (not DOWN, DRAINING, etc.)
-                if (!UP.equals(node.getAvailability())) {
-                  return false;
-                }
-                // Consider node has at least one free slot
-                return node.getSlots().stream().anyMatch(slot -> slot.getSession() == null);
-              })
+          // Filter nodes are UP and have capacity (available slots)
+          .filter(node -> UP.equals(node.getAvailability()) && node.hasCapacity())
           .collect(ImmutableSet.toImmutableSet());
     } finally {
       readLock.unlock();


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
- When all Nodes with status UP are busy (no available slots to distribute new requests), and the SessionQueue has many pending sessions.
- In a situation, all those busy Nodes will still be returned to iterate to check the capability match with the request queue for creating a session. It leads to lots of logs and unnecessary retries could be seen as below.

> 07:00:47.623 INFO [LocalDistributor.newSession] - Session request received by the Distributor: 
 [Capabilities {acceptInsecureCerts: true, browserName: firefox, moz:debuggerAddress: true, ...
07:00:47.623 INFO [LocalDistributor.newSession] - Unable to find a free slot for request 17f228d9-364b-4d66-9450-6e64be3fef40. 
 Capabilities {acceptInsecureCerts: true, browserName: firefox, moz:debuggerAddress: true, ...
07:00:47.623 INFO [LocalDistributor.newSession] - Unable to find a free slot for request aab1b19d-a567-4b0b-83ba-85b72ec8807e. 
 Capabilities {acceptInsecureCerts: true, browserName: firefox, moz:debuggerAddress: true, ... 
07:00:47.624 WARN [SeleniumSpanExporter$1.lambda$export$1] - Will retry session 17f228d9-364b-4d66-9450-6e64be3fef40

- To reduce those logs and unnecessary checks when the bandwidth is full, update the list `getAvailableNodes()` to include a condition that has at least 1 available Slot. Once the return Nodes are narrowed down, the check `hasCapability()` can be optimized.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize node selection to only return nodes with free slots

- Reduce redundant logging and capability checks for busy nodes

- Add comprehensive test coverage for node filtering logic

- Fix JMX bean cleanup in LocalNewSessionQueue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Session Request"] --> B["getAvailableNodes()"]
  B --> C["Filter UP nodes only"]
  C --> D["Check for free slots"]
  D --> E["Return filtered nodes"]
  E --> F["Reduced redundant checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributor.java</strong><dd><code>Enhanced node filtering for available slots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java

<ul><li>Modified <code>getAvailableNodes()</code> to filter nodes with at least one free <br>slot<br> <li> Simplified <code>isNotSupported()</code> method by removing redundant UP status <br>check<br> <li> Updated session polling logic to remove duplicate availability check</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16155/files#diff-024d7dccb0a4ff87c444dc3549032e7c6b2595f582f4f267cdf48c7f8c2f87c1">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalNewSessionQueue.java</strong><dd><code>Added JMX bean cleanup functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java

<ul><li>Added JMX bean management with proper cleanup<br> <li> Store MBean reference for unregistration on close<br> <li> Import MBean class for proper resource management</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16155/files#diff-c8368b85bb5b5312e2e4a0f3fb8b378b768eeff9de49368b77672db0b3720c80">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributorTest.java</strong><dd><code>Comprehensive test coverage for node filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java

<ul><li>Added test for nodes with free slots filtering<br> <li> Added test for excluding draining nodes<br> <li> Added test for excluding down nodes<br> <li> Added test for reducing redundant slot checks<br> <li> Added test for handling fully occupied nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16155/files#diff-2b9b6b96ab14f541e617736c0d98d1d2904e13ddc2117e05177d580ab2141da2">+345/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

