### PR TITLE
[py] Use native dict for type annotation

### DIFF
--- a/py/selenium/webdriver/common/bidi/session.py
+++ b/py/selenium/webdriver/common/bidi/session.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Dict, Optional
+from typing import Optional
 
 from selenium.webdriver.common.bidi.common import command_builder
 
@@ -77,7 +77,7 @@ class UserPromptHandler:
         self.file = file
         self.prompt = prompt
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> dict[str, str]:
         """Convert the UserPromptHandler to a dictionary for BiDi protocol.
 
         Returns:


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

Use native `dict` instead of `typing.Dict` for annotation in `py/selenium/webdriver/common/bidi/session.py`.

### 🔧 Implementation Notes

no functional changes

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Other


___

### **Description**
- Replace `typing.Dict` with native `dict` type annotation

- Remove unused `Dict` import from typing module


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session.py</strong><dd><code>Replace typing.Dict with native dict annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/session.py

<ul><li>Removed <code>Dict</code> import from typing module<br> <li> Changed <code>Dict[str, str]</code> to <code>dict[str, str]</code> in method return type</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16157/files#diff-c086bc647c99d76a33470b00dd297fa8a926fe7078b1af611cd78befe968138b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

