### PR TITLE
[py][docs]: update dead API docs link to API reference in `index.rst`

### DIFF
--- a/py/docs/source/index.rst
+++ b/py/docs/source/index.rst
@@ -9,17 +9,19 @@ Python language bindings for Selenium WebDriver.
 
 The `selenium` package is used to automate web browser interaction from Python.
 
-+-------------------+------------------------------------------------+
-| **Home**:         | https://selenium.dev                           |
-+-------------------+------------------------------------------------+
-| **GitHub**:       | https://github.com/SeleniumHQ/Selenium         |
-+-------------------+------------------------------------------------+
-| **PyPI**:         | https://pypi.org/project/selenium              |
-+-------------------+------------------------------------------------+
-| **IRC/Slack**:    | https://www.selenium.dev/support/#ChatRoom     |
-+-------------------+------------------------------------------------+
-| **API Docs**:     | https://www.selenium.dev/selenium/docs/api/py  |
-+-------------------+------------------------------------------------+
++-------------------+--------------------------------------------------------+
+| **Home**:         | https://selenium.dev                                   |
++-------------------+--------------------------------------------------------+
+| **GitHub**:       | https://github.com/SeleniumHQ/Selenium                 |
++-------------------+--------------------------------------------------------+
+| **PyPI**:         | https://pypi.org/project/selenium                      |
++-------------------+--------------------------------------------------------+
+| **IRC/Slack**:    | https://www.selenium.dev/support/#ChatRoom             |
++-------------------+--------------------------------------------------------+
+| **Docs**:         | https://www.selenium.dev/selenium/docs/api/py          |
++-------------------+--------------------------------------------------------+
+| **API Reference**:| https://www.selenium.dev/selenium/docs/api/py/api.html |
++-------------------+--------------------------------------------------------+
 
 Updated documentation published with each commit is available at: `readthedocs.io <https://selenium-python-api-docs.readthedocs.io/en/latest>`_
 

--- a/py/docs/source/index.rst
+++ b/py/docs/source/index.rst
@@ -18,9 +18,7 @@ The `selenium` package is used to automate web browser interaction from Python.
 +-------------------+------------------------------------------------+
 | **IRC/Slack**:    | https://www.selenium.dev/support/#ChatRoom     |
 +-------------------+------------------------------------------------+
-| **Docs**:         | https://www.selenium.dev/selenium/docs/api/py  |
-+-------------------+------------------------------------------------+
-| **API Docs**:     | `api.html <api.html>`_                         |
+| **API Docs**:     | https://www.selenium.dev/selenium/docs/api/py  |
 +-------------------+------------------------------------------------+
 
 Updated documentation published with each commit is available at: `readthedocs.io <https://selenium-python-api-docs.readthedocs.io/en/latest>`_


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Removes the dead `api.html` link from `index.rst`. This page is rendered in [pypi](https://pypi.org/project/selenium/) and [docs](https://selenium-python-api-docs.readthedocs.io/en/latest/) site, having a dead link at the project docs first page is not ideal.

Removing it and renaming `Docs` to `API Docs` should be good enough.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Documentation


___

### **PR Type**
Documentation


___

### **Description**
- Remove dead `api.html` link from Python documentation index

- Consolidate documentation links by renaming "Docs" to "API Docs"

- Fix broken link displayed on PyPI and ReadTheDocs sites


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["index.rst table"] --> B["Remove dead api.html link"]
  B --> C["Rename 'Docs' to 'API Docs'"]
  C --> D["Clean documentation links"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.rst</strong><dd><code>Fix dead link in documentation table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/docs/source/index.rst

<ul><li>Remove dead <code>api.html</code> link from documentation table<br> <li> Rename "Docs" entry to "API Docs" <br> <li> Consolidate two documentation links into one</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16170/files#diff-2c5a26dfc3d3ae29a17ca6d93cc1397eda3b360017822160ed46218cfefb5651">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

