### PR TITLE
[grid] close the HttpClient after the session is gone

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/DefaultActiveSession.java
+++ b/java/src/org/openqa/selenium/grid/node/DefaultActiveSession.java
@@ -28,14 +28,13 @@ import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.tracing.Tracer;
 
 public class DefaultActiveSession extends BaseActiveSession {
 
-  private final HttpHandler handler;
+  private final ReverseProxyHandler handler;
   private final String killUrl;
 
   protected DefaultActiveSession(
@@ -68,6 +67,6 @@ public class DefaultActiveSession extends BaseActiveSession {
 
   @Override
   public void stop() {
-    // no-op
+    handler.close();
   }
 }

--- a/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java
@@ -190,7 +190,6 @@ public class DriverServiceSessionFactory implements SessionFactory {
         caps = readPrefixedCaps(capabilities, caps);
 
         span.addEvent("Driver service created session", attributeMap);
-        final HttpClient fClient = client;
         return Either.right(
             new DefaultActiveSession(
                 tracer,
@@ -204,9 +203,8 @@ public class DriverServiceSessionFactory implements SessionFactory {
                 Instant.now()) {
               @Override
               public void stop() {
-                try (fClient) {
-                  service.stop();
-                }
+                super.stop();
+                service.stop();
               }
             });
       } catch (Exception e) {

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSession.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSession.java
@@ -67,6 +67,7 @@ public class DockerSession extends DefaultActiveSession {
     }
     saveLogs();
     container.stop(Duration.ofMinutes(1));
+    super.stop();
   }
 
   private void saveLogs() {

--- a/java/src/org/openqa/selenium/grid/router/HandleSession.java
+++ b/java/src/org/openqa/selenium/grid/router/HandleSession.java
@@ -90,6 +90,7 @@ class HandleSession implements HttpHandler, Closeable {
 
     @Override
     public void close() {
+      // must not call super.close() here, to ensure the HttpClient stays alive
       // set the last use here, to ensure we have to calculate the real inactivity of the client
       entry.lastUse = Instant.now();
       entry.inUse.decrementAndGet();

--- a/java/src/org/openqa/selenium/grid/web/ReverseProxyHandler.java
+++ b/java/src/org/openqa/selenium/grid/web/ReverseProxyHandler.java
@@ -33,7 +33,7 @@ import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.tracing.Span;
 import org.openqa.selenium.remote.tracing.Tracer;
 
-public class ReverseProxyHandler implements HttpHandler {
+public class ReverseProxyHandler implements HttpHandler, AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(ReverseProxyHandler.class.getName());
 
@@ -100,5 +100,10 @@ public class ReverseProxyHandler implements HttpHandler {
 
       return resp;
     }
+  }
+
+  @Override
+  public void close() {
+    upstream.close();
   }
 }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
We had some reports about leaking threads in the Router in the past.

### 💥 What does this PR do?
Close the HttpClient after use.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix HttpClient resource leak in Grid sessions

- Add proper close() method to ReverseProxyHandler

- Ensure HttpClient cleanup when sessions end

- Update session factories to call super.stop()


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Session["Active Session"] -- "calls stop()" --> Handler["ReverseProxyHandler"]
  Handler -- "calls close()" --> Client["HttpClient"]
  Client -- "releases resources" --> Cleanup["Resource Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultActiveSession.java</strong><dd><code>Implement proper session cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/DefaultActiveSession.java

<ul><li>Change handler type from HttpHandler to ReverseProxyHandler<br> <li> Implement stop() method to call handler.close()<br> <li> Remove unused HttpHandler import</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16182/files#diff-decdbc37209cc041c8de466210c7bf16278b5e4b1757088bb75b40c8b0a71831">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DriverServiceSessionFactory.java</strong><dd><code>Fix session stop sequence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/config/DriverServiceSessionFactory.java

<ul><li>Call super.stop() before service.stop()<br> <li> Remove try-with-resources block around fClient</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16182/files#diff-97ee0dc4a985c8c1aefa101e1a4099ecd7f5d21d4ed1d217b81903abb495e475">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerSession.java</strong><dd><code>Add parent stop call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerSession.java

- Add super.stop() call after container cleanup


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16182/files#diff-f7834a0f572885e1608f9e41179662462d223459b353547087a5236c3aab3757">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HandleSession.java</strong><dd><code>Document close behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/router/HandleSession.java

<ul><li>Add comment explaining why super.close() is not called<br> <li> Preserve HttpClient lifetime for usage counting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16182/files#diff-3f58425b642a490159052d431ed753fa75cf79a4d5e756ed37dc26039983c59a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReverseProxyHandler.java</strong><dd><code>Add AutoCloseable implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/web/ReverseProxyHandler.java

<ul><li>Implement AutoCloseable interface<br> <li> Add close() method that closes upstream HttpClient</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16182/files#diff-b99a933370c09b3b91a7db513f9a47a2af42ba2137574ff4907ae26fc0787ce4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

