### PR TITLE
[dotnet] [bidi] Serialize base64 encoded string directly to bytes

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Communication;
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
@@ -56,9 +57,9 @@ public sealed record BoxClipRectangle(double X, double Y, double Width, double H
 
 public sealed record ElementClipRectangle(Script.ISharedReference Element) : ClipRectangle;
 
-public sealed record CaptureScreenshotResult(string Data) : EmptyResult
+public sealed record CaptureScreenshotResult(ReadOnlyMemory<byte> Data) : EmptyResult
 {
     public static implicit operator byte[](CaptureScreenshotResult captureScreenshotResult) => captureScreenshotResult.ToByteArray();
 
-    public byte[] ToByteArray() => System.Convert.FromBase64String(Data);
+    public byte[] ToByteArray() => Data.ToArray();
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
@@ -112,7 +112,7 @@ public readonly record struct PrintPageRange(int? Start, int? End)
 #endif
 }
 
-public sealed record PrintResult(string Data) : EmptyResult
+public sealed record PrintResult(ReadOnlyMemory<byte> Data) : EmptyResult
 {
-    public byte[] ToByteArray() => Convert.FromBase64String(Data);
+    public byte[] ToByteArray() => Data.ToArray();
 }

--- a/dotnet/src/webdriver/BiDi/Network/BytesValue.cs
+++ b/dotnet/src/webdriver/BiDi/Network/BytesValue.cs
@@ -28,9 +28,9 @@ namespace OpenQA.Selenium.BiDi.Network;
 public abstract record BytesValue
 {
     public static implicit operator BytesValue(string value) => new StringBytesValue(value);
-    public static implicit operator BytesValue(byte[] value) => new Base64BytesValue(Convert.ToBase64String(value));
+    public static implicit operator BytesValue(byte[] value) => new Base64BytesValue(value);
 }
 
 public sealed record StringBytesValue(string Value) : BytesValue;
 
-public sealed record Base64BytesValue(string Value) : BytesValue;
+public sealed record Base64BytesValue(ReadOnlyMemory<byte> Value) : BytesValue;

--- a/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Communication;
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.WebExtension;
@@ -35,7 +36,7 @@ public abstract record ExtensionData;
 
 public sealed record ExtensionArchivePath(string Path) : ExtensionData;
 
-public sealed record ExtensionBase64Encoded(string Value) : ExtensionData;
+public sealed record ExtensionBase64Encoded(ReadOnlyMemory<byte> Value) : ExtensionData;
 
 public sealed record ExtensionPath(string Path) : ExtensionData;
 

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextTest.cs
@@ -250,7 +250,7 @@ class BrowsingContextTest : BiDiTestFixture
         var screenshot = await context.CaptureScreenshotAsync();
 
         Assert.That(screenshot, Is.Not.Null);
-        Assert.That(screenshot.Data, Is.Not.Empty);
+        Assert.That(screenshot.Data.Length, Is.Not.Zero);
     }
 
     [Test]
@@ -263,7 +263,7 @@ class BrowsingContextTest : BiDiTestFixture
         });
 
         Assert.That(screenshot, Is.Not.Null);
-        Assert.That(screenshot.Data, Is.Not.Empty);
+        Assert.That(screenshot.Data.Length, Is.Not.Zero);
     }
 
     [Test]
@@ -276,7 +276,7 @@ class BrowsingContextTest : BiDiTestFixture
         });
 
         Assert.That(screenshot, Is.Not.Null);
-        Assert.That(screenshot.Data, Is.Not.Empty);
+        Assert.That(screenshot.Data.Length, Is.Not.Zero);
     }
 
     [Test]
@@ -292,7 +292,7 @@ class BrowsingContextTest : BiDiTestFixture
         });
 
         Assert.That(screenshot, Is.Not.Null);
-        Assert.That(screenshot.Data, Is.Not.Empty);
+        Assert.That(screenshot.Data.Length, Is.Not.Zero);
     }
 
     [Test]
@@ -313,6 +313,6 @@ class BrowsingContextTest : BiDiTestFixture
         var pdf = await context.PrintAsync();
 
         Assert.That(pdf, Is.Not.Null);
-        Assert.That(pdf.Data, Is.Not.Empty);
+        Assert.That(pdf.Data.Length, Is.Not.Zero);
     }
 }

--- a/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
+++ b/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
@@ -64,9 +64,9 @@ class WebExtensionTest : BiDiTestFixture
     {
         var path = LocateRelativePath("common/extensions/webextensions-selenium-example.zip");
 
-        string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+        var bytes = File.ReadAllBytes(path);
 
-        var result = await bidi.WebExtension.InstallAsync(new ExtensionBase64Encoded(base64));
+        var result = await bidi.WebExtension.InstallAsync(new ExtensionBase64Encoded(bytes));
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Extension, Is.Not.Null);


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
There is no reason to keep base64 encoded string as `System.String` type, in any case it will be materialized to `byte[]`. So let's do it.

### 💡 Additional Considerations
It also reduces memory allocation, capturing screenshot: before **824.87 KB**, after **655.86 KB**

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace base64 string handling with direct byte arrays

- Reduce memory allocation by ~20% for screenshot operations

- Update BiDi commands to use `ReadOnlyMemory<byte>` type

- Eliminate unnecessary base64 string conversions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Base64 String"] --> B["ReadOnlyMemory<byte>"]
  B --> C["Reduced Memory Usage"]
  B --> D["Direct Byte Operations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaptureScreenshotCommand.cs</strong><dd><code>Update screenshot result to use byte memory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs

<ul><li>Changed <code>CaptureScreenshotResult.Data</code> from <code>string</code> to <code>ReadOnlyMemory<byte></code><br> <li> Updated <code>ToByteArray()</code> to use direct array conversion<br> <li> Added <code>System</code> namespace import</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16203/files#diff-c5aad25cc091f0f7c77824775cdbf1b4e6df374b1017eb840beec6e639919212">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PrintCommand.cs</strong><dd><code>Update print result to use byte memory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs

<ul><li>Changed <code>PrintResult.Data</code> from <code>string</code> to <code>ReadOnlyMemory<byte></code><br> <li> Updated <code>ToByteArray()</code> method implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16203/files#diff-c958f8fa7ee62020e37f049e6d4e3a02ca7468c9a36d050e3ffbbd6d189a0c26">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BytesValue.cs</strong><dd><code>Update bytes value to use memory type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/BytesValue.cs

<ul><li>Changed <code>Base64BytesValue.Value</code> from <code>string</code> to <code>ReadOnlyMemory<byte></code><br> <li> Updated implicit operator to work with byte arrays directly</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16203/files#diff-fec96be883c81e7e55f3a4558932f35aecd4319f05de422087328b138f3c2646">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InstallCommand.cs</strong><dd><code>Update extension data to use byte memory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs

<ul><li>Changed <code>ExtensionBase64Encoded.Value</code> from <code>string</code> to <code>ReadOnlyMemory<byte></code><br> <li> Added <code>System</code> namespace import</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16203/files#diff-4dbc55b4a7d1228ad5e491d1ff2f0126a4bf836dd59d718223b42bb805884123">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebExtensionTest.cs</strong><dd><code>Update test for direct byte usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs

<ul><li>Updated test to pass byte array directly instead of base64 string<br> <li> Removed unnecessary base64 conversion step</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16203/files#diff-fd6bd42f706660eae4316fd107cd6a0d72b36b16c91e19dd8b03a89d16bb6bf7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

