### PR TITLE
[dotnet] [bidi] Make cookie expiry as TimeSpan

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -84,6 +84,7 @@ public sealed class Broker : IAsyncDisposable
                 new RealmConverter(_bidi),
                 new RealmTypeConverter(),
                 new DateTimeOffsetConverter(),
+                new TimeSpanConverter(),
                 new PrintPageRangeConverter(),
                 new InputOriginConverter(),
                 new WebExtensionConverter(_bidi),

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/DateTimeOffsetConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/DateTimeOffsetConverter.cs
@@ -27,16 +27,7 @@ internal class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        // Workaround: it should be Int64, chrome uses double for `expiry` like "expiry":1737379944.308351
-
-        if (reader.TryGetInt64(out long unixTime) is false)
-        {
-            var doubleValue = reader.GetDouble();
-
-            unixTime = Convert.ToInt64(doubleValue);
-        }
-
-        return DateTimeOffset.FromUnixTimeMilliseconds(unixTime);
+        return DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64());
     }
 
     public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/TimeSpanConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/TimeSpanConverter.cs
@@ -1,4 +1,4 @@
-// <copyright file="Cookie.cs" company="Selenium Committers">
+// <copyright file="TimeSpanConverter.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -18,20 +18,27 @@
 // </copyright>
 
 using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace OpenQA.Selenium.BiDi.Network;
+namespace OpenQA.Selenium.BiDi.Communication.Json.Converters;
 
-public sealed record Cookie(string Name, BytesValue Value, string Domain, string Path, long Size, bool HttpOnly, bool Secure, SameSite SameSite)
+internal class TimeSpanConverter : JsonConverter<TimeSpan>
 {
-    [JsonInclude]
-    public TimeSpan? Expiry { get; internal set; }
-}
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TryGetInt64(out long milliseconds) is false)
+        {
+            var doubleValue = reader.GetDouble();
 
-public enum SameSite
-{
-    Strict,
-    Lax,
-    None,
-    Default
+            milliseconds = Convert.ToInt64(doubleValue);
+        }
+
+        return TimeSpan.FromMilliseconds(milliseconds);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value.TotalMilliseconds);
+    }
 }

--- a/dotnet/src/webdriver/BiDi/Network/Cookie.cs
+++ b/dotnet/src/webdriver/BiDi/Network/Cookie.cs
@@ -18,15 +18,10 @@
 // </copyright>
 
 using System;
-using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public sealed record Cookie(string Name, BytesValue Value, string Domain, string Path, long Size, bool HttpOnly, bool Secure, SameSite SameSite)
-{
-    [JsonInclude]
-    public TimeSpan? Expiry { get; internal set; }
-}
+public sealed record Cookie(string Name, BytesValue Value, string Domain, string Path, long Size, bool HttpOnly, bool Secure, SameSite SameSite, TimeSpan? Expiry);
 
 public enum SameSite
 {


### PR DESCRIPTION
### **User description**
Finally Firefox and Chromium are aligned.

### 💥 What does this PR do?
`Expiry` means how long cookie lives in milliseconds.

### 🔧 Implementation Notes
Added new TimeSpan converter.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Change cookie expiry from DateTimeOffset to TimeSpan

- Add TimeSpan JSON converter for BiDi communication

- Align Firefox and Chromium cookie handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cookie.Expiry Property"] --> B["DateTimeOffset → TimeSpan"]
  B --> C["TimeSpanConverter"]
  C --> D["Broker Registration"]
  D --> E["Aligned Browser Support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Register TimeSpan converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Broker.cs

- Register new TimeSpanConverter in the broker's converter list


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16204/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimeSpanConverter.cs</strong><dd><code>Add TimeSpan JSON converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/Converters/TimeSpanConverter.cs

<ul><li>Create new JSON converter for TimeSpan type<br> <li> Handle milliseconds conversion from/to JSON<br> <li> Support both integer and double value parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16204/files#diff-ae5d7eb83f48889ac672837632f8442bf57d922efbddb30ce06f6f99c524e74a">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cookie.cs</strong><dd><code>Update cookie expiry type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/Cookie.cs

- Change Expiry property type from DateTimeOffset to TimeSpan


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16204/files#diff-0d23755a55d2004bac2bc8b8544ff3677553aedc6224a8e8e97c3ecb99d71467">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

