### PR TITLE
[dotnet] [bidi] Remove obsolete unsubscribing by attributes

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -275,27 +275,7 @@ public sealed class Broker : IAsyncDisposable
 
         eventHandlers.Remove(eventHandler);
 
-        if (subscription is not null)
-        {
-            await _bidi.SessionModule.UnsubscribeAsync([subscription]).ConfigureAwait(false);
-        }
-        else
-        {
-            if (eventHandler.Contexts is not null)
-            {
-                if (!eventHandlers.Any(h => eventHandler.Contexts.Equals(h.Contexts)) && !eventHandlers.Any(h => h.Contexts is null))
-                {
-                    await _bidi.SessionModule.UnsubscribeAsync([eventHandler.EventName], new() { Contexts = eventHandler.Contexts }).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                if (!eventHandlers.Any(h => h.Contexts is not null) && !eventHandlers.Any(h => h.Contexts is null))
-                {
-                    await _bidi.SessionModule.UnsubscribeAsync([eventHandler.EventName]).ConfigureAwait(false);
-                }
-            }
-        }
+        await _bidi.SessionModule.UnsubscribeAsync([subscription]).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -78,7 +78,6 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Session.SubscribeCommand))]
 [JsonSerializable(typeof(Session.SubscribeResult))]
 [JsonSerializable(typeof(Session.UnsubscribeByIdCommand))]
-[JsonSerializable(typeof(Session.UnsubscribeByAttributesCommand))]
 
 [JsonSerializable(typeof(Browser.CloseCommand), TypeInfoPropertyName = "Browser_CloseCommand")]
 [JsonSerializable(typeof(Browser.CreateUserContextCommand))]

--- a/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
@@ -44,13 +44,6 @@ internal sealed class SessionModule(Broker broker) : Module(broker)
         return await Broker.ExecuteCommandAsync<UnsubscribeByIdCommand, EmptyResult>(new UnsubscribeByIdCommand(@params), options).ConfigureAwait(false);
     }
 
-    public async Task<EmptyResult> UnsubscribeAsync(IEnumerable<string> eventNames, UnsubscribeByAttributesOptions? options = null)
-    {
-        var @params = new UnsubscribeByAttributesParameters(eventNames, options?.Contexts);
-
-        return await Broker.ExecuteCommandAsync<UnsubscribeByAttributesCommand, EmptyResult>(new UnsubscribeByAttributesCommand(@params), options).ConfigureAwait(false);
-    }
-
     public async Task<NewResult> NewAsync(CapabilitiesRequest capabilitiesRequest, NewOptions? options = null)
     {
         var @params = new NewParameters(capabilitiesRequest);

--- a/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
@@ -28,8 +28,3 @@ internal sealed class UnsubscribeByIdCommand(UnsubscribeByIdParameters @params)
 internal sealed record UnsubscribeByIdParameters(IEnumerable<Subscription> Subscriptions) : Parameters;
 
 public sealed class UnsubscribeByIdOptions : CommandOptions;
-
-public sealed class UnsubscribeByAttributesOptions : CommandOptions
-{
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
-}

--- a/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
@@ -18,7 +18,6 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Communication;
-using System;
 using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Session;
@@ -26,18 +25,9 @@ namespace OpenQA.Selenium.BiDi.Session;
 internal sealed class UnsubscribeByIdCommand(UnsubscribeByIdParameters @params)
     : Command<UnsubscribeByIdParameters, EmptyResult>(@params, "session.unsubscribe");
 
-internal sealed class UnsubscribeByAttributesCommand(UnsubscribeByAttributesParameters @params)
-    : Command<UnsubscribeByAttributesParameters, EmptyResult>(@params, "session.unsubscribe");
-
 internal sealed record UnsubscribeByIdParameters(IEnumerable<Subscription> Subscriptions) : Parameters;
 
 public sealed class UnsubscribeByIdOptions : CommandOptions;
-
-internal sealed record UnsubscribeByAttributesParameters(
-    IEnumerable<string> Events,
-    [property: Obsolete("Contexts param is deprecated and will be removed in the future versions")]
-    // https://w3c.github.io/webdriver-bidi/#type-session-UnsubscribeByAttributesRequest
-    IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 
 public sealed class UnsubscribeByAttributesOptions : CommandOptions
 {


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Other


___

### **Description**
- Remove obsolete unsubscribe by attributes functionality

- Simplify broker unsubscribe logic to use subscription IDs only

- Clean up unused JSON serialization attributes

- Remove deprecated context parameter handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Broker.UnsubscribeAsync"] --> B["Remove complex attribute logic"]
  B --> C["Use subscription ID only"]
  D["SessionModule"] --> E["Remove UnsubscribeByAttributes method"]
  F["UnsubscribeCommand"] --> G["Remove attributes command class"]
  H["JsonSerializerContext"] --> I["Remove serialization attribute"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Simplify unsubscribe logic to subscription ID only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Broker.cs

<ul><li>Remove complex conditional logic for unsubscribing by attributes<br> <li> Simplify to use subscription ID only approach<br> <li> Remove context-based unsubscribe handling</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16205/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+1/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Remove obsolete JSON serialization attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<ul><li>Remove JsonSerializable attribute for UnsubscribeByAttributesCommand</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16205/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionModule.cs</strong><dd><code>Remove unsubscribe by attributes method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Session/SessionModule.cs

<ul><li>Remove UnsubscribeAsync method that accepts event names<br> <li> Remove support for unsubscribing by attributes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16205/files#diff-31b1c3c5b298bcc68ac630c0af2fe9ecd548a737be8b5fa14574317f6eff3ff3">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UnsubscribeCommand.cs</strong><dd><code>Remove attributes-based unsubscribe command classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs

<ul><li>Remove UnsubscribeByAttributesCommand class<br> <li> Remove UnsubscribeByAttributesParameters record<br> <li> Remove deprecated contexts parameter handling</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16205/files#diff-e55885c439ccfb15daf710e1b61feaace8b8d6d0d949f8a2d863d1a42ba703b1">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

