### PR TITLE
[dotnet] Fix find port for IPv4 only environments

### DIFF
--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -33,30 +33,19 @@ public static class PortUtilities
     /// <returns>A random, free port to be listened on.</returns>
     public static int FindFreePort()
     {
-        // Prefer IPv6 dual-mode when available, but fall back robustly to IPv4
+        // Prefer IPv4, but fall back robustly to IPv6
         try
         {
-            using var ipV6socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-
-            // Some platforms may not support DualMode or IPv6 at all; ignore failures and let bind decide
-            try
-            {
-                ipV6socket.DualMode = true;
-            }
-            catch
-            {
-                // Ignored; we'll still attempt to bind to IPv6 loopback
-            }
-
-            ipV6socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
-            return ((IPEndPoint)ipV6socket.LocalEndPoint!).Port;
-        }
-        catch(SocketException)
-        {
-            // If creating/binding the IPv6 socket fails for any reason, fall back to IPv4
             using var ipV4socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             ipV4socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
             return ((IPEndPoint)ipV4socket.LocalEndPoint!).Port;
+        }
+        catch (SocketException)
+        {
+            // If creating/binding the IPv4 socket fails for any reason, fall back to IPv6
+            using var ipV6socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+            ipV6socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+            return ((IPEndPoint)ipV6socket.LocalEndPoint!).Port;
         }
     }
 }

--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -28,12 +28,11 @@ namespace OpenQA.Selenium.Internal;
 public static class PortUtilities
 {
     /// <summary>
-    /// Finds a random, free port to be listened on.
+    /// Finds a random, free port to be listened on. Prefers IPv4, but falls back to IPv6 if necessary.
     /// </summary>
     /// <returns>A random, free port to be listened on.</returns>
     public static int FindFreePort()
     {
-        // Prefer IPv4, but fall back robustly to IPv6
         try
         {
             using var ipV4socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -42,7 +41,6 @@ public static class PortUtilities
         }
         catch (SocketException)
         {
-            // If creating/binding the IPv4 socket fails for any reason, fall back to IPv6
             using var ipV6socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
             ipV6socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
             return ((IPEndPoint)ipV6socket.LocalEndPoint!).Port;

--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -28,8 +28,11 @@ namespace OpenQA.Selenium.Internal;
 public static class PortUtilities
 {
     /// <summary>
-    /// Finds a random, free port to be listened on. Prefers IPv4, but falls back to IPv6 if necessary.
+    /// Finds a random, free port to be listened on.
     /// </summary>
+    /// <remarks>
+    /// Prefers IPv4, but falls back to IPv6 if necessary.
+    /// </remarks>
     /// <returns>A random, free port to be listened on.</returns>
     public static int FindFreePort()
     {

--- a/dotnet/src/webdriver/Internal/PortUtilities.cs
+++ b/dotnet/src/webdriver/Internal/PortUtilities.cs
@@ -33,10 +33,30 @@ public static class PortUtilities
     /// <returns>A random, free port to be listened on.</returns>
     public static int FindFreePort()
     {
-        using var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-        socket.DualMode = true;
-        socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
-        return (socket.LocalEndPoint as IPEndPoint)!.Port;
+        // Prefer IPv6 dual-mode when available, but fall back robustly to IPv4
+        try
+        {
+            using var ipV6socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
 
+            // Some platforms may not support DualMode or IPv6 at all; ignore failures and let bind decide
+            try
+            {
+                ipV6socket.DualMode = true;
+            }
+            catch
+            {
+                // Ignored; we'll still attempt to bind to IPv6 loopback
+            }
+
+            ipV6socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+            return ((IPEndPoint)ipV6socket.LocalEndPoint!).Port;
+        }
+        catch(SocketException)
+        {
+            // If creating/binding the IPv6 socket fails for any reason, fall back to IPv4
+            using var ipV4socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            ipV4socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            return ((IPEndPoint)ipV4socket.LocalEndPoint!).Port;
+        }
     }
 }


### PR DESCRIPTION
### **User description**
Continuation of https://github.com/SeleniumHQ/selenium/pull/16016

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/16214

### 💥 What does this PR do?
Fall back to IPv4

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Add IPv4 fallback for port finding in IPv6-disabled environments

- Implement robust error handling for socket creation and binding

- Maintain IPv6 dual-mode preference with graceful degradation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FindFreePort()"] --> B["Try IPv6 dual-mode socket"]
  B --> C{IPv6 Success?}
  C -->|Yes| D["Return IPv6 port"]
  C -->|No| E["Fallback to IPv4 socket"]
  E --> F["Return IPv4 port"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PortUtilities.cs</strong><dd><code>Add IPv4 fallback to port utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/PortUtilities.cs

<ul><li>Replace simple IPv6 socket creation with try-catch fallback logic<br> <li> Add IPv4 fallback when IPv6 socket creation or binding fails<br> <li> Implement graceful handling of DualMode property failures<br> <li> Maintain existing functionality while adding robustness</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16216/files#diff-c7ae823e95550e8b18f454f1f6199dc420a1d64263398ae151b13dae264a89c6">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

