### PR TITLE
[grid] Replace Guava with Java equivalent in sessionmap, session queue, and web packages

### DIFF
--- a/java/src/org/openqa/selenium/grid/sessionmap/AddToSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/AddToSessionMap.java
@@ -24,7 +24,7 @@ import static org.openqa.selenium.remote.http.Contents.string;
 import static org.openqa.selenium.remote.tracing.HttpTracing.newSpanAsChildOf;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_REQUEST;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Objects;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.internal.Require;
@@ -61,7 +61,7 @@ class AddToSessionMap implements HttpHandler {
 
       sessions.add(session);
 
-      return new HttpResponse().setContent(asJson(ImmutableMap.of("value", true)));
+      return new HttpResponse().setContent(asJson(Map.of("value", true)));
     }
   }
 }

--- a/java/src/org/openqa/selenium/grid/sessionmap/GetFromSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/GetFromSessionMap.java
@@ -23,7 +23,7 @@ import static org.openqa.selenium.remote.http.Contents.asJson;
 import static org.openqa.selenium.remote.tracing.HttpTracing.newSpanAsChildOf;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_REQUEST;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.SessionId;
@@ -56,7 +56,7 @@ class GetFromSessionMap implements HttpHandler {
       CAPABILITIES.accept(span, session.getCapabilities());
       span.setAttribute("session.uri", session.getUri().toString());
 
-      return new HttpResponse().setContent(asJson(ImmutableMap.of("value", session)));
+      return new HttpResponse().setContent(asJson(Map.of("value", session)));
     }
   }
 }

--- a/java/src/org/openqa/selenium/grid/sessionmap/httpd/DefaultSessionMapConfig.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/httpd/DefaultSessionMapConfig.java
@@ -17,21 +17,21 @@
 
 package org.openqa.selenium.grid.sessionmap.httpd;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.openqa.selenium.grid.config.MapConfig;
 
 class DefaultSessionMapConfig extends MapConfig {
 
   public DefaultSessionMapConfig() {
     super(
-        ImmutableMap.of(
+        Map.of(
             "events",
-                ImmutableMap.of(
+                Map.of(
                     "publish", "tcp://*:4442",
                     "subscribe", "tcp://*:4443"),
             "sessions",
-                ImmutableMap.of(
+                Map.of(
                     "implementation", "org.openqa.selenium.grid.sessionmap.local.LocalSessionMap"),
-            "server", ImmutableMap.of("port", 5556)));
+            "server", Map.of("port", 5556)));
   }
 }

--- a/java/src/org/openqa/selenium/grid/sessionmap/httpd/SessionMapServer.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/httpd/SessionMapServer.java
@@ -26,12 +26,11 @@ import static org.openqa.selenium.remote.http.Contents.asJson;
 import static org.openqa.selenium.remote.http.Route.get;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,7 +63,7 @@ public class SessionMapServer extends TemplateGridServerCommand {
 
   @Override
   public Set<Role> getConfigurableRoles() {
-    return ImmutableSet.of(EVENT_BUS_ROLE, HTTPD_ROLE, SESSION_MAP_ROLE);
+    return Set.of(EVENT_BUS_ROLE, HTTPD_ROLE, SESSION_MAP_ROLE);
   }
 
   @Override
@@ -100,9 +99,9 @@ public class SessionMapServer extends TemplateGridServerCommand {
                                 .addHeader("Content-Type", JSON_UTF_8)
                                 .setContent(
                                     asJson(
-                                        ImmutableMap.of(
+                                        Map.of(
                                             "value",
-                                            ImmutableMap.of(
+                                            Map.of(
                                                 "ready",
                                                 true,
                                                 "message",

--- a/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
@@ -23,12 +23,12 @@ import static org.openqa.selenium.remote.RemoteTags.SESSION_ID;
 import static org.openqa.selenium.remote.RemoteTags.SESSION_ID_EVENT;
 import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
 
-import com.google.common.collect.ImmutableMap;
 import io.lettuce.core.KeyValue;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
@@ -139,7 +139,7 @@ public class RedisBackedSessionMap extends SessionMap {
 
       span.addEvent("Inserted into the database", attributeMap);
       connection.mset(
-          ImmutableMap.of(
+          Map.of(
               uriKey, uriValue,
               stereotypeKey, stereotypeJson,
               capabilitiesKey, capabilitiesJson,

--- a/java/src/org/openqa/selenium/grid/sessionqueue/ClearSessionQueue.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/ClearSessionQueue.java
@@ -23,7 +23,7 @@ import static org.openqa.selenium.remote.tracing.HttpTracing.newSpanAsChildOf;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_REQUEST;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_RESPONSE;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.HttpRequest;
@@ -56,14 +56,14 @@ public class ClearSessionQueue implements HttpHandler {
       if (value != 0) {
         response.setContent(
             asJson(
-                ImmutableMap.of(
+                Map.of(
                     "value", value,
                     "message", "Cleared the new session request queue",
                     "cleared_requests", value)));
       } else {
         response.setContent(
             asJson(
-                ImmutableMap.of(
+                Map.of(
                     "value",
                     value,
                     "message",
@@ -81,7 +81,7 @@ public class ClearSessionQueue implements HttpHandler {
               .setStatus((HTTP_INTERNAL_ERROR))
               .setContent(
                   asJson(
-                      ImmutableMap.of(
+                      Map.of(
                           "value",
                           0,
                           "message",

--- a/java/src/org/openqa/selenium/grid/sessionqueue/httpd/DefaultNewSessionQueueConfig.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/httpd/DefaultNewSessionQueueConfig.java
@@ -17,12 +17,12 @@
 
 package org.openqa.selenium.grid.sessionqueue.httpd;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.openqa.selenium.grid.config.MapConfig;
 
 class DefaultNewSessionQueueConfig extends MapConfig {
 
   DefaultNewSessionQueueConfig() {
-    super(ImmutableMap.of("server", ImmutableMap.of("port", 5559)));
+    super(Map.of("server", Map.of("port", 5559)));
   }
 }

--- a/java/src/org/openqa/selenium/grid/sessionqueue/httpd/NewSessionQueueServer.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/httpd/NewSessionQueueServer.java
@@ -25,12 +25,11 @@ import static org.openqa.selenium.remote.http.Contents.asJson;
 import static org.openqa.selenium.remote.http.Route.get;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,7 +64,7 @@ public class NewSessionQueueServer extends TemplateGridServerCommand {
 
   @Override
   public Set<Role> getConfigurableRoles() {
-    return ImmutableSet.of(HTTPD_ROLE, SESSION_QUEUE_ROLE);
+    return Set.of(HTTPD_ROLE, SESSION_QUEUE_ROLE);
   }
 
   @Override
@@ -100,9 +99,9 @@ public class NewSessionQueueServer extends TemplateGridServerCommand {
                                 .addHeader("Content-Type", JSON_UTF_8)
                                 .setContent(
                                     asJson(
-                                        ImmutableMap.of(
+                                        Map.of(
                                             "value",
-                                            ImmutableMap.of(
+                                            Map.of(
                                                 "ready",
                                                 true,
                                                 "message",

--- a/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
@@ -22,8 +22,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.openqa.selenium.concurrent.ExecutorServices.shutdownGracefully;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
@@ -180,7 +178,7 @@ public class LocalNewSessionQueue extends NewSessionQueue implements Closeable {
                                   sessionRequest.getRequestId().equals(entry.getKey())))
               .filter(entry -> isTimedOut(now, entry.getValue()))
               .map(Map.Entry::getKey)
-              .collect(ImmutableSet.toImmutableSet());
+              .collect(Collectors.toSet());
     } finally {
       readLock.unlock();
     }
@@ -258,9 +256,9 @@ public class LocalNewSessionQueue extends NewSessionQueue implements Closeable {
         res.setStatus(HTTP_INTERNAL_ERROR)
             .setContent(
                 Contents.asJson(
-                    ImmutableMap.of(
+                    Map.of(
                         "value",
-                        ImmutableMap.of(
+                        Map.of(
                             "error", "session not created",
                             "message", result.left().getMessage(),
                             "stacktrace", result.left().getStackTrace()))));

--- a/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
@@ -25,8 +25,10 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -178,7 +180,10 @@ public class LocalNewSessionQueue extends NewSessionQueue implements Closeable {
                                   sessionRequest.getRequestId().equals(entry.getKey())))
               .filter(entry -> isTimedOut(now, entry.getValue()))
               .map(Map.Entry::getKey)
-              .collect(Collectors.toSet());
+              .collect(
+          Collectors.collectingAndThen(
+              Collectors.toCollection(LinkedHashSet::new),
+              set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
     } finally {
       readLock.unlock();
     }

--- a/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/local/LocalNewSessionQueue.java
@@ -181,9 +181,9 @@ public class LocalNewSessionQueue extends NewSessionQueue implements Closeable {
               .filter(entry -> isTimedOut(now, entry.getValue()))
               .map(Map.Entry::getKey)
               .collect(
-          Collectors.collectingAndThen(
-              Collectors.toCollection(LinkedHashSet::new),
-              set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
+                  Collectors.collectingAndThen(
+                      Collectors.toCollection(LinkedHashSet::new),
+                      set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
     } finally {
       readLock.unlock();
     }

--- a/java/src/org/openqa/selenium/grid/web/CheckContentTypeHeader.java
+++ b/java/src/org/openqa/selenium/grid/web/CheckContentTypeHeader.java
@@ -19,9 +19,8 @@ package org.openqa.selenium.grid.web;
 
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.net.MediaType;
+import java.util.Map;
 import java.util.Set;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.Contents;
@@ -36,9 +35,9 @@ public class CheckContentTypeHeader implements Filter {
           .setStatus(HTTP_INTERNAL_ERROR)
           .setContent(
               Contents.asJson(
-                  ImmutableMap.of(
+                  Map.of(
                       "value",
-                      ImmutableMap.of(
+                      Map.of(
                           "error", "unknown error",
                           "message", "Content-Type header is missing",
                           "stacktrace", ""))));
@@ -46,8 +45,7 @@ public class CheckContentTypeHeader implements Filter {
   private final Set<String> skipChecksOn;
 
   public CheckContentTypeHeader(Set<String> skipChecksOn) {
-    this.skipChecksOn =
-        ImmutableSet.copyOf(Require.nonNull("URLs where checks are skipped", skipChecksOn));
+    this.skipChecksOn = Set.copyOf(Require.nonNull("URLs where checks are skipped", skipChecksOn));
   }
 
   @Override
@@ -81,9 +79,9 @@ public class CheckContentTypeHeader implements Filter {
         .setStatus(HTTP_INTERNAL_ERROR)
         .setContent(
             Contents.asJson(
-                ImmutableMap.of(
+                Map.of(
                     "value",
-                    ImmutableMap.of(
+                    Map.of(
                         "error", "unknown error",
                         "message",
                             "Content-Type header does not indicate utf-8 encoded json: " + type,

--- a/java/src/org/openqa/selenium/grid/web/CheckOriginHeader.java
+++ b/java/src/org/openqa/selenium/grid/web/CheckOriginHeader.java
@@ -20,9 +20,8 @@ package org.openqa.selenium.grid.web;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static org.openqa.selenium.json.Json.JSON_UTF_8;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.Contents;
@@ -37,9 +36,8 @@ public class CheckOriginHeader implements Filter {
 
   public CheckOriginHeader(Collection<String> allowedOriginHosts, Set<String> skipChecksOn) {
     Require.nonNull("Allowed origins list", allowedOriginHosts);
-    allowedHosts = ImmutableSet.copyOf(allowedOriginHosts);
-    this.skipChecksOn =
-        ImmutableSet.copyOf(Require.nonNull("URLs where checks are skipped", skipChecksOn));
+    allowedHosts = Set.copyOf(allowedOriginHosts);
+    this.skipChecksOn = Set.copyOf(Require.nonNull("URLs where checks are skipped", skipChecksOn));
   }
 
   @Override
@@ -58,9 +56,9 @@ public class CheckOriginHeader implements Filter {
             .addHeader("Content-Type", JSON_UTF_8)
             .setContent(
                 Contents.asJson(
-                    ImmutableMap.of(
+                    Map.of(
                         "value",
-                        ImmutableMap.of(
+                        Map.of(
                             "error", "unknown error",
                             "message", "Origin not allowed: " + origin,
                             "stacktrace", ""))));

--- a/java/src/org/openqa/selenium/grid/web/JarFileResource.java
+++ b/java/src/org/openqa/selenium/grid/web/JarFileResource.java
@@ -21,6 +21,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarFile;
@@ -100,7 +102,10 @@ public class JarFileResource implements Resource {
         .filter(e -> !e.getName().equals(prefix))
         .filter(e -> e.getName().split("/").length == count)
         .map(e -> new JarFileResource(jarFile, e.getName(), prefix))
-        .collect(Collectors.toUnmodifiableSet());
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toCollection(LinkedHashSet::new),
+                set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/web/JarFileResource.java
+++ b/java/src/org/openqa/selenium/grid/web/JarFileResource.java
@@ -17,7 +17,6 @@
 
 package org.openqa.selenium.grid.web;
 
-import com.google.common.collect.ImmutableSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import org.openqa.selenium.internal.Require;
 
@@ -88,7 +88,7 @@ public class JarFileResource implements Resource {
   @Override
   public Set<Resource> list() {
     if (!isDirectory()) {
-      return ImmutableSet.of();
+      return Set.of();
     }
 
     String prefix = entryName.endsWith("/") ? entryName : entryName + "/";
@@ -100,7 +100,7 @@ public class JarFileResource implements Resource {
         .filter(e -> !e.getName().equals(prefix))
         .filter(e -> e.getName().split("/").length == count)
         .map(e -> new JarFileResource(jarFile, e.getName(), prefix))
-        .collect(ImmutableSet.toImmutableSet());
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/web/MergedResource.java
+++ b/java/src/org/openqa/selenium/grid/web/MergedResource.java
@@ -17,7 +17,8 @@
 
 package org.openqa.selenium.grid.web;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.openqa.selenium.internal.Require;
@@ -66,10 +67,9 @@ public class MergedResource implements Resource {
 
   @Override
   public Set<Resource> list() {
-    ImmutableSet.Builder<Resource> resources = ImmutableSet.builder();
-    resources.addAll(base.list());
+    Set<Resource> resources = new HashSet<>(base.list());
     next.ifPresent(res -> resources.addAll(res.list()));
-    return resources.build();
+    return Collections.unmodifiableSet(resources);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/web/MergedResource.java
+++ b/java/src/org/openqa/selenium/grid/web/MergedResource.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.grid.web;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;

--- a/java/src/org/openqa/selenium/grid/web/MergedResource.java
+++ b/java/src/org/openqa/selenium/grid/web/MergedResource.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.grid.web;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.openqa.selenium.internal.Require;
@@ -67,9 +68,9 @@ public class MergedResource implements Resource {
 
   @Override
   public Set<Resource> list() {
-    Set<Resource> resources = new HashSet<>(base.list());
+    Set<Resource> resources = new LinkedHashSet<>(base.list());
     next.ifPresent(res -> resources.addAll(res.list()));
-    return Collections.unmodifiableSet(resources);
+    return Collections.unmodifiableSet(new LinkedHashSet<>(resources));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/web/NoHandler.java
+++ b/java/src/org/openqa/selenium/grid/web/NoHandler.java
@@ -22,7 +22,6 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.openqa.selenium.remote.http.Contents.bytes;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +47,7 @@ public class NoHandler implements HttpHandler {
     responseMap.put("sessionId", null);
     responseMap.put(
         "value",
-        ImmutableMap.of(
+        Map.of(
             "error", "unknown command",
             "message",
                 String.format(

--- a/java/src/org/openqa/selenium/grid/web/PathResource.java
+++ b/java/src/org/openqa/selenium/grid/web/PathResource.java
@@ -22,6 +22,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -88,7 +90,10 @@ public class PathResource implements Resource {
       return files
           .filter(allowedSubpaths)
           .map(PathResource::new)
-          .collect(Collectors.toUnmodifiableSet());
+          .collect(
+          Collectors.collectingAndThen(
+              Collectors.toCollection(LinkedHashSet::new),
+              set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/java/src/org/openqa/selenium/grid/web/PathResource.java
+++ b/java/src/org/openqa/selenium/grid/web/PathResource.java
@@ -91,9 +91,9 @@ public class PathResource implements Resource {
           .filter(allowedSubpaths)
           .map(PathResource::new)
           .collect(
-          Collectors.collectingAndThen(
-              Collectors.toCollection(LinkedHashSet::new),
-              set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
+              Collectors.collectingAndThen(
+                  Collectors.toCollection(LinkedHashSet::new),
+                  set -> Collections.unmodifiableSet(new LinkedHashSet<>(set))));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/java/src/org/openqa/selenium/grid/web/PathResource.java
+++ b/java/src/org/openqa/selenium/grid/web/PathResource.java
@@ -17,8 +17,6 @@
 
 package org.openqa.selenium.grid.web;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -27,6 +25,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.openqa.selenium.internal.Require;
 
@@ -86,7 +85,10 @@ public class PathResource implements Resource {
   @Override
   public Set<Resource> list() {
     try (Stream<Path> files = Files.list(base)) {
-      return files.filter(allowedSubpaths).map(PathResource::new).collect(toImmutableSet());
+      return files
+          .filter(allowedSubpaths)
+          .map(PathResource::new)
+          .collect(Collectors.toUnmodifiableSet());
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/java/src/org/openqa/selenium/grid/web/ReverseProxyHandler.java
+++ b/java/src/org/openqa/selenium/grid/web/ReverseProxyHandler.java
@@ -21,9 +21,9 @@ import static org.openqa.selenium.remote.tracing.HttpTracing.newSpanAsChildOf;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_REQUEST;
 import static org.openqa.selenium.remote.tracing.Tags.HTTP_RESPONSE;
 
-import com.google.common.collect.ImmutableSet;
 import java.io.UncheckedIOException;
 import java.util.Locale;
+import java.util.Set;
 import java.util.logging.Logger;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.HttpClient;
@@ -37,19 +37,18 @@ public class ReverseProxyHandler implements HttpHandler, AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(ReverseProxyHandler.class.getName());
 
-  private static final ImmutableSet<String> IGNORED_REQ_HEADERS =
-      ImmutableSet.<String>builder()
-          .add("connection")
-          .add("http2-settings")
-          .add("keep-alive")
-          .add("proxy-authorization")
-          .add("proxy-authenticate")
-          .add("proxy-connection")
-          .add("te")
-          .add("trailer")
-          .add("transfer-encoding")
-          .add("upgrade")
-          .build();
+  private static final Set<String> IGNORED_REQ_HEADERS =
+      Set.of(
+          "connection",
+          "http2-settings",
+          "keep-alive",
+          "proxy-authorization",
+          "proxy-authenticate",
+          "proxy-connection",
+          "te",
+          "trailer",
+          "transfer-encoding",
+          "upgrade");
 
   private final Tracer tracer;
   private final HttpClient upstream;

--- a/java/src/org/openqa/selenium/grid/web/RoutableHttpClientFactory.java
+++ b/java/src/org/openqa/selenium/grid/web/RoutableHttpClientFactory.java
@@ -19,10 +19,10 @@ package org.openqa.selenium.grid.web;
 
 import static org.openqa.selenium.remote.http.Contents.asJson;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Map;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.ClientConfig;
@@ -61,7 +61,7 @@ public class RoutableHttpClientFactory implements HttpClient.Factory {
             response.setStatus(404);
             response.setContent(
                 asJson(
-                    ImmutableMap.of(
+                    Map.of(
                         "value", request.getUri(),
                         "message", "Unable to route " + request,
                         "error", UnsupportedCommandException.class.getName())));


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Continuation of https://github.com/SeleniumHQ/selenium/pull/16206.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Replacing Guava's Immutable Set and Map usage with Java 11 or other equivalent in the Grid.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
