### PR TITLE
[bazel] Bump most rulesets to the latest versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,15 +1,15 @@
 module(name = "selenium")
 
 bazel_dep(name = "apple_rules_lint", version = "0.4.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
-bazel_dep(name = "aspect_rules_esbuild", version = "0.21.0")
-bazel_dep(name = "aspect_rules_js", version = "2.3.7")
-bazel_dep(name = "aspect_rules_ts", version = "3.6.0")
-bazel_dep(name = "bazel_features", version = "1.23.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
+bazel_dep(name = "aspect_rules_esbuild", version = "0.22.1")
+bazel_dep(name = "aspect_rules_js", version = "2.4.2")
+bazel_dep(name = "aspect_rules_ts", version = "3.7.0")
+bazel_dep(name = "bazel_features", version = "1.35.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
 bazel_dep(name = "contrib_rules_jvm", version = "0.27.0")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 
 # Required for the closure rules
 bazel_dep(name = "protobuf", version = "29.2", dev_dependency = True, repo_name = "com_google_protobuf")
@@ -17,16 +17,16 @@ bazel_dep(name = "protobuf", version = "29.2", dev_dependency = True, repo_name 
 # Required for rules_rust to import the crates properly
 bazel_dep(name = "rules_cc", version = "0.2.0", dev_dependency = True)
 
-bazel_dep(name = "rules_dotnet", version = "0.17.5")
+bazel_dep(name = "rules_dotnet", version = "0.19.2")
 bazel_dep(name = "rules_java", version = "8.7.1")
 bazel_dep(name = "rules_jvm_external", version = "6.8")
-bazel_dep(name = "rules_multitool", version = "1.3.0")
-bazel_dep(name = "rules_nodejs", version = "6.3.2")
-bazel_dep(name = "rules_oci", version = "1.8.0")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_python", version = "1.5.0")
-bazel_dep(name = "rules_proto", version = "7.0.2")
-bazel_dep(name = "rules_ruby", version = "0.19.0")
+bazel_dep(name = "rules_multitool", version = "1.9.0")
+bazel_dep(name = "rules_nodejs", version = "6.5.0")
+bazel_dep(name = "rules_oci", version = "2.2.6")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
+bazel_dep(name = "rules_python", version = "1.5.3")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_ruby", version = "0.20.1")
 
 # Until `rules_jvm_external` 6.8 ships
 single_version_override(

--- a/deploys/docker/docker.bzl
+++ b/deploys/docker/docker.bzl
@@ -1,4 +1,4 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 
 def docker_image(name, repo_tags = [], ports = [], visibility = None, **kwargs):
     if len(ports) != 0:
@@ -10,9 +10,10 @@ def docker_image(name, repo_tags = [], ports = [], visibility = None, **kwargs):
         **kwargs
     )
 
-    oci_tarball(
-        name = "%s.tar" % name,
+    oci_push(
+        name = "%s.push" % name,
         image = ":%s" % name,
-        repo_tags = repo_tags,
+        remote_tags = repo_tags,
+        repository = "index.docker.io/shs/%s" % name,
         visibility = visibility,
     )


### PR DESCRIPTION
### **User description**
Except `contrib_rules_jvm`, which has a changed parameter I've not yet investigated.


___

### **PR Type**
Other


___

### **Description**
- Update Bazel rulesets to latest versions

- Bump 15+ dependencies including aspect_bazel_lib, rules_dotnet

- Modernize build system dependencies

- Skip contrib_rules_jvm due to parameter changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MODULE.bazel"] --> B["Update 15+ Bazel dependencies"]
  B --> C["Latest ruleset versions"]
  B --> D["Skip contrib_rules_jvm"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Bump Bazel rulesets to latest versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Update 15+ Bazel ruleset dependencies to latest versions<br> <li> Major version bumps for buildifier_prebuilt, rules_oci, platforms<br> <li> Minor version updates for aspect rules and other build tools<br> <li> Keep contrib_rules_jvm unchanged due to parameter investigation needed</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16249/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

