### PR TITLE
[py][bidi]: use bidi `navigate` command in network tests

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
 
+from selenium.webdriver.common.bidi.browsing_context import ReadinessState
 from selenium.webdriver.common.bidi.network import Request
 from selenium.webdriver.common.by import By
 
@@ -68,29 +68,26 @@ def test_clear_request_handlers(driver, pages):
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
 
 
-@pytest.mark.xfail_chrome
-@pytest.mark.xfail_edge
 def test_continue_request(driver, pages):
     def callback(request: Request):
         request.continue_request()
 
     callback_id = driver.network.add_request_handler("before_request", callback)
     assert callback_id is not None, "Request handler not added"
-    pages.load("formPage.html")
+    url = pages.url("formPage.html")
+    driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
 
 
-@pytest.mark.xfail_chrome
-@pytest.mark.xfail_edge
 def test_continue_with_auth(driver):
-    callback_id = driver.network.add_auth_handler("user", "passwd")
+    callback_id = driver.network.add_auth_handler("postman", "password")
     assert callback_id is not None, "Request handler not added"
-    driver.get("https://httpbin.org/basic-auth/user/passwd")
+    driver.browsing_context.navigate(
+        context=driver.current_window_handle, url="https://postman-echo.com/basic-auth", wait=ReadinessState.COMPLETE
+    )
     assert "authenticated" in driver.page_source, "Authorization failed"
 
 
-@pytest.mark.xfail_chrome
-@pytest.mark.xfail_edge
 def test_remove_auth_handler(driver):
     callback_id = driver.network.add_auth_handler("user", "passwd")
     assert callback_id is not None, "Request handler not added"


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Fixes and enables some tests in `bidi_network_tests.py` for chrome and edge.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
1. We can say that it is a bug in chromium, if we navigate to a page using a classic command like `driver.get()` (which we were doing in our tests), continue request won't work, it is working when we navigate using BiDi commands - `driver.browsing_context.navigate`. At the time of network PR, we didn't have the browsing context module so it was skipped.
2. For the auth test, seems like httpbin is not working (TLS issue), swapping it with https://postman-echo.com/basic-auth works well. We can also run a docker container in the CI to avoid dependency on this site - https://hub.docker.com/r/kennethreitz/httpbin/ but I think it will be complex to add it to all workflows. 

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Tests


___

### **Description**
- Fix BiDi network tests by using BiDi navigate command

- Switch from httpbin to postman-echo for auth testing

- Remove xfail markers for Chrome and Edge tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Classic driver.get()"] -- "Replace with" --> B["BiDi navigate command"]
  C["httpbin.org"] -- "Switch to" --> D["postman-echo.com"]
  E["Failing tests"] -- "Enable" --> F["Working tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_network_tests.py</strong><dd><code>Fix BiDi network tests navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_network_tests.py

<ul><li>Replace classic navigation with BiDi <code>browsing_context.navigate()</code><br> <li> Switch from httpbin to postman-echo for auth testing<br> <li> Remove xfail markers for Chrome and Edge<br> <li> Add ReadinessState import for navigation waiting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16251/files#diff-97c8d35b88402ef5de934c8fb95da5f7c7c04039a79baf20cc8fd6c91379dac7">+7/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

