### PR TITLE
fix: correct typo in until_not docstring

### DIFF
--- a/py/selenium/webdriver/support/wait.py
+++ b/py/selenium/webdriver/support/wait.py
@@ -138,10 +138,10 @@ class WebDriverWait(Generic[D]):
         raise TimeoutException(message, screen, stacktrace)
 
     def until_not(self, method: Callable[[D], T], message: str = "") -> Union[T, Literal[True]]:
-        """Wait until the method returns a value that is not False.
+        """Wait until the method returns a value that is False.
 
         Calls the method provided with the driver as an argument until the
-        return value does not evaluate to ``False``.
+        return value evaluates to ``False``.
 
         Parameters:
         -----------


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Fix typos in python

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Other


___

### **PR Type**
Documentation


___

### **Description**
- Fixed incorrect docstring for `until_not` method

- Corrected description to reflect method waits for False value


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wait.py</strong><dd><code>Fix until_not method docstring accuracy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/support/wait.py

<ul><li>Corrected docstring for <code>until_not</code> method to accurately describe it <br>waits for False value<br> <li> Fixed misleading documentation that incorrectly stated method waits <br>for non-False values</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16252/files#diff-05701a62e85680067a4d733d62203e430375996bb49dc1cea4d554286ddafb5c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

