### PR TITLE
[py] Bump ruff version for linting/formatting

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -4,41 +4,41 @@
     "binaries": [
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.3/ruff-aarch64-unknown-linux-musl.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-aarch64-unknown-linux-musl.tar.gz",
         "file": "ruff-aarch64-unknown-linux-musl/ruff",
-        "sha256": "7890e49b12c1321688540324a7788457a22711657301598402cba1a9e9be6607",
+        "sha256": "10b43a88fb948aaae538ec9f35e93b4433f144d0379fb3a67d88282595b969f7",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.3/ruff-x86_64-unknown-linux-musl.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-unknown-linux-musl.tar.gz",
         "file": "ruff-x86_64-unknown-linux-musl/ruff",
-        "sha256": "6ee9216ba4f7fd761e68bd5c23958e662c67fcff8f49e511660d557431b4bd7c",
+        "sha256": "dd4e5b8f81547a48975489913a80e0dce6be7f1c455912fe3a5bd5a1f5f1a35d",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.3/ruff-aarch64-apple-darwin.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-aarch64-apple-darwin.tar.gz",
         "file": "ruff-aarch64-apple-darwin/ruff",
-        "sha256": "5769e4841870d1f7c17f12a7d1437222e8035eded52f93c54c035c770dbffebb",
+        "sha256": "72c6abf39f5e87c57faa2d191baf2582e437ff72cdc0f52b7c7e50f26d41b807",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.3/ruff-x86_64-apple-darwin.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-apple-darwin.tar.gz",
         "file": "ruff-x86_64-apple-darwin/ruff",
-        "sha256": "472a4790db11a8bcd79cf7b731fb1c036c376f9cc4e6532099f8f39a6f86b9bb",
+        "sha256": "8619f277921b3e2e56d850c3e203fd4ef10b457bc50f93ab6fe85743eb324de6",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.3/ruff-x86_64-pc-windows-msvc.zip",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-pc-windows-msvc.zip",
         "file": "ruff-x86_64-pc-windows-msvc/ruff.exe",
-        "sha256": "37dc6f2f5756421fc59fe5f841ecaa92beee38a39751dfe5a42bdc13992da3d5",
+        "sha256": "a639e4dee10cb2900bffa7165457766671c59c744ce6b61cc658c35ab33a91fd",
         "os": "windows",
         "cpu": "x86_64"
       }

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -43,7 +43,7 @@ commands =
 [testenv:linting]
 skip_install = true
 deps =
-    ruff==0.12.3
+    ruff==0.12.10
 commands =
     ruff check --fix --show-fixes --exit-non-zero-on-fix .
     ruff format --exit-non-zero-on-format .


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR updates the version of ruff to the latest.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Dev


___

### **PR Type**
Other


___

### **Description**
- Update ruff linter version from 0.12.3 to 0.12.10

- Update binary URLs and SHA256 hashes for all platforms

- Maintain consistent linting/formatting configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ruff 0.12.3"] --> B["ruff 0.12.10"]
  B --> C["Updated binaries"]
  B --> D["Updated tox config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multitool.lock.json</strong><dd><code>Update ruff binary configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

multitool.lock.json

<ul><li>Updated ruff binary URLs from version 0.12.3 to 0.12.10<br> <li> Updated SHA256 hashes for all platform binaries (Linux ARM64/x86_64, <br>macOS ARM64/x86_64, Windows x86_64)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16254/files#diff-b0d31fabc955ed7a7168b0b3f4e51773a38a4b7dd6b97a1b49f3a8a2cb5273e4">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Update ruff version in tox config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/tox.ini

<ul><li>Updated ruff dependency version from 0.12.3 to 0.12.10 in linting <br>environment</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16254/files#diff-27d219400d7f64afbf3d9bceb197e20b299fdd58fb4e84c9b7c2ee7c4e828177">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

