### PR TITLE
[py] Loosen dependency specifiers in package config

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -328,11 +328,11 @@ py_wheel(
     python_tag = "py3",
     requires = [
         "urllib3[socks]>=2.5.0,<3.0",
-        "trio~=0.30.0",
-        "trio-websocket~=0.12.2",
+        "trio>=0.30.0,<1.0",
+        "trio-websocket>=0.12.2,<1.0",
         "certifi>=2025.6.15",
-        "typing_extensions~=4.14.0",
-        "websocket-client~=1.8.0",
+        "typing_extensions>=4.14.0,<5.0",
+        "websocket-client>=1.8.0<2.0",
     ],
     strip_path_prefixes = [
         "py/",

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -332,7 +332,7 @@ py_wheel(
         "trio-websocket>=0.12.2,<1.0",
         "certifi>=2025.6.15",
         "typing_extensions>=4.14.0,<5.0",
-        "websocket-client>=1.8.0<2.0",
+        "websocket-client>=1.8.0,<2.0",
     ],
     strip_path_prefixes = [
         "py/",

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
     ]
 dependencies = [
     "urllib3[socks]>=2.5.0,<3.0",
-    "trio~=0.30.0",
-    "trio-websocket~=0.12.2",
+    "trio>=0.30.0,<1.0",
+    "trio-websocket>=0.12.2,<1.0",
     "certifi>=2025.6.15",
-    "typing_extensions~=4.14.0",
-    "websocket-client~=1.8.0",
+    "typing_extensions>=4.14.0,<5.0",
+    "websocket-client>=1.8.0<2.0",
     ]
 
 [project.urls]

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "trio-websocket>=0.12.2,<1.0",
     "certifi>=2025.6.15",
     "typing_extensions>=4.14.0,<5.0",
-    "websocket-client>=1.8.0<2.0",
+    "websocket-client>=1.8.0,<2.0",
     ]
 
 [project.urls]


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR loosens the dependency specifiers used in Python packaging configuration.

Since Selenium is a library used in various projects, we can't force specific versions of our dependencies on users because it might conflict with different versions of the same packages they use with other libraries. However, we want to ensure the selenium package still works with some range of declared dependencies, and not just let it pull in possibly incompatible dependencies on installation. There is no perfect solution for this.

Currently we use the "compatible release" specifier for Python package dependencies, which allows new dependency versions within the same minor version. Based on user feedback, this seems to be too strict.  This PR changes the dependency specifications to use a minimum and maximum version instead, with the maximum being the next major version.

This will allow more installation flexibility, while (hopefully) not pulling in new dependency versions that introduce breaking changes (major version upgrades).

### 💡 Additional Considerations

Going forward, we would raise the minimum version occasionally with new releases. For CI and development, we will continue to pin a specific version via `requirements.txt`.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Packaging


___

### **PR Type**
Other


___

### **Description**
- Changed dependency specifiers from compatible release (~=) to minimum/maximum version ranges

- Updated trio, trio-websocket, typing_extensions, and websocket-client version constraints

- Allows more installation flexibility while preventing major version conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Compatible Release Specifiers"] -- "Replace with" --> B["Min/Max Version Ranges"]
  B --> C["More Installation Flexibility"]
  B --> D["Prevent Major Version Conflicts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update Bazel wheel dependency constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/BUILD.bazel

<ul><li>Updated dependency version specifiers in Bazel wheel configuration<br> <li> Changed from compatible release (~=) to minimum/maximum version ranges<br> <li> Applied to trio, trio-websocket, typing_extensions, and <br>websocket-client</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16262/files#diff-3e8ff3a52e8e6c0b195ea328e17c50ba6d90abca1ce1624110607da20691d7a9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update pyproject dependency constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<ul><li>Updated dependency version specifiers in Python project configuration<br> <li> Changed from compatible release (~=) to minimum/maximum version ranges<br> <li> Applied to trio, trio-websocket, typing_extensions, and <br>websocket-client</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16262/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

