### PR TITLE
[py] Add test for Data URL in BiDi Network request handler

### DIFF
--- a/common/src/web/data_url.html
+++ b/common/src/web/data_url.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page containing an image encoded as a Data URL</title>
+</head>
+<body>
+<img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7" alt="star" id="data-url-image">
+</body>
+</html>

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -100,10 +100,17 @@ def test_remove_auth_handler(driver):
 @pytest.mark.xfail_edge(reason="Data URLs in Network requests are not implemented in Edge yet")
 @pytest.mark.xfail_firefox(reason="Data URLs in Network requests are not implemented in Firefox yet")
 def test_handler_with_data_url_request(driver, pages):
+    data_requests = []
     def callback(request: Request):
+        if request.url.startswith("data:"):
+            data_requests.append(request)
         request.continue_request()
 
     driver.network.add_request_handler("before_request", callback)
     url = pages.url("data_url.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
-    driver.find_element(By.ID, "data-url-image").is_displayed(), "Request with Data URL failed"
+
+    # Assert that the BiDi event was captured.
+    assert len(data_requests) > 0
+    # Assert that the image is displayed.
+    assert driver.find_element(By.ID, "data-url-image").is_displayed()

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -17,6 +17,7 @@
 
 import pytest
 
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.bidi.browsing_context import ReadinessState
 from selenium.webdriver.common.bidi.network import Request
 from selenium.webdriver.common.by import By
@@ -101,17 +102,19 @@ def test_remove_auth_handler(driver):
 @pytest.mark.xfail_firefox(reason="Data URLs in Network requests are not implemented in Firefox yet")
 def test_handler_with_data_url_request(driver, pages):
     data_requests = []
+    exceptions = []
 
     def callback(request: Request):
         if request.url.startswith("data:"):
             data_requests.append(request)
-        request.continue_request()
+        try:
+            request.continue_request()
+        except WebDriverException as e:
+            exceptions.append(e)
 
     driver.network.add_request_handler("before_request", callback)
     url = pages.url("data_url.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
-
-    # Assert that the BiDi event was captured.
-    assert len(data_requests) > 0
-    # Assert that the image is displayed.
     assert driver.find_element(By.ID, "data-url-image").is_displayed()
+    assert len(data_requests) > 0, "BiDi event not captured"
+    assert len(exceptions) == 0, "Exception raised when continuing request in callback"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 
 from selenium.webdriver.common.bidi.browsing_context import ReadinessState
 from selenium.webdriver.common.bidi.network import Request
@@ -93,3 +94,16 @@ def test_remove_auth_handler(driver):
     assert callback_id is not None, "Request handler not added"
     driver.network.remove_auth_handler(callback_id)
     assert driver.network.intercepts == [], "Intercept not removed"
+
+
+@pytest.mark.xfail_chrome(reason="Data URLs in Network requests are not implemented in Chrome yet")
+@pytest.mark.xfail_edge(reason="Data URLs in Network requests are not implemented in Edge yet")
+@pytest.mark.xfail_firefox(reason="Data URLs in Network requests are not implemented in Firefox yet")
+def test_handler_with_data_url_request(driver, pages):
+    def callback(request: Request):
+        request.continue_request()
+
+    driver.network.add_request_handler("before_request", callback)
+    url = pages.url("data_url.html")
+    driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
+    driver.find_elements(By.ID, "data-url-image").is_displayed(), "Request with Data URL failed"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import time
+
 import pytest
 
 from selenium.common.exceptions import WebDriverException
@@ -115,6 +117,7 @@ def test_handler_with_data_url_request(driver, pages):
     driver.network.add_request_handler("before_request", callback)
     url = pages.url("data_url.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
+    time.sleep(1)  # give callback time to complete
     assert driver.find_element(By.ID, "data-url-image").is_displayed()
     assert len(data_requests) > 0, "BiDi event not captured"
     assert len(exceptions) == 0, "Exception raised when continuing request in callback"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -101,6 +101,7 @@ def test_remove_auth_handler(driver):
 @pytest.mark.xfail_firefox(reason="Data URLs in Network requests are not implemented in Firefox yet")
 def test_handler_with_data_url_request(driver, pages):
     data_requests = []
+
     def callback(request: Request):
         if request.url.startswith("data:"):
             data_requests.append(request)

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -106,4 +106,4 @@ def test_handler_with_data_url_request(driver, pages):
     driver.network.add_request_handler("before_request", callback)
     url = pages.url("data_url.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
-    driver.find_elements(By.ID, "data-url-image").is_displayed(), "Request with Data URL failed"
+    driver.find_element(By.ID, "data-url-image").is_displayed(), "Request with Data URL failed"


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

#16279

### 💥 What does this PR do?

This PR adds a new web page to the test suite that contains an image embedded as a Data URL, and a Python test that navigates to the page with a BiDi Network request handler enabled. The test is currently marked as an expected failure because it will fail in all browsers. Once browsers can handle this feature we will enable the test.

See: https://github.com/w3c/webdriver-bidi/issues/727

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Test


___

### **PR Type**
Tests


___

### **Description**
- Add test for BiDi Network request handler with Data URLs

- Create HTML test page with embedded Data URL image

- Mark test as expected failure across all browsers

- Test validates Data URL handling in network requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test File"] --> B["Add Data URL Test"]
  C["HTML Page"] --> D["Embed Data URL Image"]
  B --> E["Mark as Expected Failure"]
  D --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_network_tests.py</strong><dd><code>Add Data URL BiDi network test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_network_tests.py

<ul><li>Import <code>pytest</code> module for test markers<br> <li> Add new test function <code>test_handler_with_data_url_request</code><br> <li> Mark test as expected failure for Chrome, Edge, and Firefox<br> <li> Test navigates to data URL page with BiDi network handler</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16281/files#diff-97c8d35b88402ef5de934c8fb95da5f7c7c04039a79baf20cc8fd6c91379dac7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data_url.html</strong><dd><code>Create Data URL test page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/web/data_url.html

<ul><li>Create new HTML test page with Data URL embedded image<br> <li> Include base64-encoded GIF image as data URL<br> <li> Add proper HTML structure with meta tags and title</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16281/files#diff-af08ef77cfa703d93aa330412f9f9904f0a337e77e35ab7cad15f50db03038b8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

