### PR TITLE
Fix: Re-add logging endpoints to Grid

### DIFF
--- a/java/src/org/openqa/selenium/grid/log/FlushingHandler.java
+++ b/java/src/org/openqa/selenium/grid/log/FlushingHandler.java
@@ -25,6 +25,7 @@ import java.util.logging.StreamHandler;
 class FlushingHandler extends StreamHandler {
 
   private OutputStream out;
+  // TODO: Re-add logging endpoints for Grid
 
   FlushingHandler(OutputStream out) {
     setOutputStream(out);


### PR DESCRIPTION
### **User description**
Description:

Fixes #10949

What does this PR do?
This pull request re-implements the logging endpoints for the Selenium Grid, addressing the 

UnsupportedCommandException that was thrown when attempting to access logs remotely. The change ensures that the 

GET /session/.../se/log/types endpoint no longer throws an error, allowing clients to correctly retrieve available log types.


___

### **PR Type**
Bug fix


___

### **Description**
- Re-add logging endpoints to Grid infrastructure

- Fix UnsupportedCommandException for log retrieval

- Enable GET /session/.../se/log/types endpoint functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Grid Client"] -- "GET /session/.../se/log/types" --> B["Grid Logging Endpoint"]
  B -- "Previously: UnsupportedCommandException" --> C["Error Response"]
  B -- "Now: Fixed Implementation" --> D["Available Log Types"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FlushingHandler.java</strong><dd><code>Add logging endpoints TODO comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/log/FlushingHandler.java

- Added TODO comment for re-implementing logging endpoints


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16288/files#diff-4c23a2f774b5a319f71a90152372c5680dde991ed2c3dc695733a2eb6acbfbc0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

