### PR TITLE
[rb] Update `unhandled_prompt_behavior` capability to support hash syntax.

### DIFF
--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -131,7 +131,8 @@ module Selenium
 
       def process_w3c_options(options)
         w3c_options = options.select { |key, val| w3c?(key) && !val.nil? }
-        w3c_options[:unhandled_prompt_behavior] &&= process_unhandled_prompt_behavior_value(w3c_options[:unhandled_prompt_behavior])
+        w3c_options[:unhandled_prompt_behavior] &&= 
+          process_unhandled_prompt_behavior_value(w3c_options[:unhandled_prompt_behavior])
         options.delete_if { |key, _val| w3c?(key) }
         w3c_options
       end

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -131,7 +131,7 @@ module Selenium
 
       def process_w3c_options(options)
         w3c_options = options.select { |key, val| w3c?(key) && !val.nil? }
-        w3c_options[:unhandled_prompt_behavior] &&= 
+        w3c_options[:unhandled_prompt_behavior] &&=
           process_unhandled_prompt_behavior_value(w3c_options[:unhandled_prompt_behavior])
         options.delete_if { |key, _val| w3c?(key) }
         w3c_options

--- a/rb/lib/selenium/webdriver/common/options.rb
+++ b/rb/lib/selenium/webdriver/common/options.rb
@@ -131,9 +131,17 @@ module Selenium
 
       def process_w3c_options(options)
         w3c_options = options.select { |key, val| w3c?(key) && !val.nil? }
-        w3c_options[:unhandled_prompt_behavior] &&= w3c_options[:unhandled_prompt_behavior]&.to_s&.tr('_', ' ')
+        w3c_options[:unhandled_prompt_behavior] &&= process_unhandled_prompt_behavior_value(w3c_options[:unhandled_prompt_behavior])
         options.delete_if { |key, _val| w3c?(key) }
         w3c_options
+      end
+
+      def process_unhandled_prompt_behavior_value(value)
+        if value.is_a?(Hash)
+          value.transform_values { |v| process_unhandled_prompt_behavior_value(v) }
+        else
+          value&.to_s&.tr('_', ' ')
+        end
       end
 
       def process_browser_options(_browser_options)

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -275,7 +275,7 @@ module Selenium
                                          before_unload: 'accept',
                                          default: :dismiss
                                        })
-            
+
             expect(opts.as_json).to eq('browserName' => 'chrome',
                                        'unhandledPromptBehavior' => {
                                          'alert' => 'accept and notify',

--- a/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/options_spec.rb
@@ -267,6 +267,26 @@ module Selenium
                                          {'args' => ["--user-data-dir=#{directory}"]})
           end
 
+          it 'processes unhandled_prompt_behavior hash values' do
+            opts = described_class.new(unhandled_prompt_behavior: {
+                                         alert: :accept_and_notify,
+                                         confirm: 'dismiss_and_notify',
+                                         prompt: :ignore,
+                                         before_unload: 'accept',
+                                         default: :dismiss
+                                       })
+            
+            expect(opts.as_json).to eq('browserName' => 'chrome',
+                                       'unhandledPromptBehavior' => {
+                                         'alert' => 'accept and notify',
+                                         'confirm' => 'dismiss and notify',
+                                         'prompt' => 'ignore',
+                                         'beforeUnload' => 'accept',
+                                         'default' => 'dismiss'
+                                       },
+                                       'goog:chromeOptions' => {})
+          end
+
           it 'returns a JSON hash' do
             allow(File).to receive(:file?).and_return(true)
             allow_any_instance_of(described_class)


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR extends the capability processing method to correctly support the [struct format of UserPromptHandler](https://www.w3.org/TR/webdriver-bidi/#type-session-UserPromptHandler) for unhandledPromptBehaviour in a [CapabilityRequest](https://www.w3.org/TR/webdriver-bidi/#type-session-CapabilityRequest)

The current implementation supports the "string" only values format. For correct BiDi operation the more complex hash format is required due to a recent change in the [Chrome BiDi driver](https://github.com/GoogleChromeLabs/chromium-bidi/pull/3318) code to enforce `beforeUnload` to be `accept` when only strings are used.

The code that worked before the Chrome BiDi update:
```
Selenium::WebDriver::Chrome.new(unhandled_prompt_behavior: :ignore)
```

The code that now does the same after the Chrome BiDi update:
```
Selenium::WebDriver::Chrome.new(unhandled_prompt_behavior: {
  before_unload: :ignore,
  default: :ignore
})
```

### 🔧 Implementation Notes
The implement is backwards compatible with existing code .

### 💡 Additional Considerations
This PR is to resolve an issue I originally raised in the Capybara project https://github.com/teamcapybara/capybara/issues/2824

This PR does not update the web documentation for Selenium

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for hash format in `unhandled_prompt_behavior` capability

- Maintain backward compatibility with existing string format

- Enable proper BiDi operation with Chrome driver updates

- Add comprehensive test coverage for hash value processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String Format"] --> B["process_unhandled_prompt_behavior_value"]
  C["Hash Format"] --> B
  B --> D["Transformed Values"]
  D --> E["W3C Compatible Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options.rb</strong><dd><code>Enhanced capability processing for hash format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/options.rb

<ul><li>Extract <code>unhandled_prompt_behavior</code> processing into dedicated method<br> <li> Add recursive hash value transformation support<br> <li> Maintain backward compatibility with string format</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16289/files#diff-79d21161b23e41cd35d8f6d0153479fe40ce1d037cb37759ddec0559944d0d19">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options_spec.rb</strong><dd><code>Test coverage for hash format capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/chrome/options_spec.rb

<ul><li>Add comprehensive test for hash format <code>unhandled_prompt_behavior</code><br> <li> Verify proper key transformation and value processing<br> <li> Test multiple prompt types with different values</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16289/files#diff-0eda788bc753b36bb5822216d5a044623b00d53ec00f623f23bcf442b77e2260">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

