### PR TITLE
Update NoSuchElementException.java

### DIFF
--- a/java/src/org/openqa/selenium/NoSuchElementException.java
+++ b/java/src/org/openqa/selenium/NoSuchElementException.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class NoSuchElementException extends NotFoundException {
 
-  private static final String SUPPORT_URL = BASE_SUPPORT_URL + "#no-such-element-exception";
+  private static final String SUPPORT_URL = BASE_SUPPORT_URL + "#nosuchelementexception"; 
 
   public NoSuchElementException(@Nullable String reason) {
     super(reason);


### PR DESCRIPTION
### **User description**
fix: correct documentation URL path (removed extra '-')

### 💥 What does this PR do?
This PR fixes the documentation URL path in NoSuchElementException.java.
The previous URL contained an extra - (#no-such-element-exception), which caused the link to redirect only to the top of the Understanding Common Errors page instead of directly to the "NoSuchElementException" section.

The corrected path is now #nosuchelementexception, which properly anchors to the relevant section.

### 🔧 Implementation Notes
Updated the SUPPORT_URL string constant in NoSuchElementException.java.
Kept the change minimal.


### 💡 Additional Considerations
-No functional changes to Selenium’s core logic.
-No additional tests needed, since this only affects the generated exception message and documentation link.
-Improves developer experience when troubleshooting.

### 🔄 Types of changes

- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed documentation URL anchor in `NoSuchElementException`

- Removed extra hyphen from URL fragment

- Corrected link to properly navigate to exception section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NoSuchElementException"] -- "URL fix" --> B["Corrected documentation link"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NoSuchElementException.java</strong><dd><code>Fix documentation URL anchor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/NoSuchElementException.java

<ul><li>Updated <code>SUPPORT_URL</code> constant to fix documentation anchor<br> <li> Removed extra hyphen from URL fragment <code>#no-such-element-exception</code> to <br><code>#nosuchelementexception</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16297/files#diff-647977792797c103b3cbc43d566582cd3d4c794990dcd95367a1c9556e85028d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

