### PR TITLE
errors: use non-hyphen anchor for NoSuchElementException

### DIFF
--- a/dotnet/src/webdriver/NoSuchElementException.cs
+++ b/dotnet/src/webdriver/NoSuchElementException.cs
@@ -31,7 +31,7 @@ public class NoSuchElementException : NotFoundException
     /// <summary>
     /// Link to the documentation for this error
     /// </summary>
-    private static string supportUrl = baseSupportUrl + "#no-such-element-exception";
+    private static string supportUrl = baseSupportUrl + "#nosuchelementexception";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NoSuchElementException"/> class.

--- a/dotnet/test/common/RelativeLocatorTest.cs
+++ b/dotnet/test/common/RelativeLocatorTest.cs
@@ -224,7 +224,7 @@ public class RelativeLocatorTest : DriverTestFixture
         {
             var rect2 = driver.FindElement(RelativeBy.WithLocator(By.Id("rect4")).Near(rect));
 
-        }, Throws.TypeOf<NoSuchElementException>().With.Message.EqualTo("Unable to find element; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception"));
+        }, Throws.TypeOf<NoSuchElementException>().With.Message.EqualTo("Unable to find element; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#nosuchelementexception"));
     }
 
     //------------------------------------------------------------------

--- a/java/src/org/openqa/selenium/NoSuchElementException.java
+++ b/java/src/org/openqa/selenium/NoSuchElementException.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class NoSuchElementException extends NotFoundException {
 
-  private static final String SUPPORT_URL = BASE_SUPPORT_URL + "#no-such-element-exception";
+  private static final String SUPPORT_URL = BASE_SUPPORT_URL + "#nosuchelementexception";
 
   public NoSuchElementException(@Nullable String reason) {
     super(reason);

--- a/rb/lib/selenium/webdriver/common/error.rb
+++ b/rb/lib/selenium/webdriver/common/error.rb
@@ -38,7 +38,7 @@ module Selenium
       ERROR_URL = 'https://www.selenium.dev/documentation/webdriver/troubleshooting/errors'
 
       URLS = {
-        NoSuchElementError: "#{ERROR_URL}#no-such-element-exception",
+        NoSuchElementError: "#{ERROR_URL}#nosuchelementexception",
         StaleElementReferenceError: "#{ERROR_URL}#stale-element-reference-exception",
         InvalidSelectorError: "#{ERROR_URL}#invalid-selector-exception",
         NoSuchDriverError: "#{ERROR_URL}/driver_location"

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -149,7 +149,7 @@ module Selenium
           driver.navigate.to url_for('xhtmlTest.html')
           expect {
             driver.find_element(id: 'not-there')
-          }.to raise_error(Error::NoSuchElementError, /errors#no-such-element-exception/)
+          }.to raise_error(Error::NoSuchElementError, /errors#nosuchelementexception/)
         end
 
         it 'raises if invalid locator',

--- a/rb/spec/integration/selenium/webdriver/error_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/error_spec.rb
@@ -27,7 +27,7 @@ module Selenium
 
         expect {
           driver.find_element(id: 'nonexistent')
-        }.to raise_error(WebDriver::Error::NoSuchElementError, /#no-such-element-exception/)
+        }.to raise_error(WebDriver::Error::NoSuchElementError, /#nosuchelementexception/)
       end
 
       it 'has backtrace locations' do


### PR DESCRIPTION
### **User description**
**What**
Update the support URL in NoSuchElementException to use the non-hyphen docs anchor:
- #nosuchelementexception

**Why**
The Selenium docs use lowercase exception names without hyphens for section anchors.
Old link (#no-such-element-exception) doesn’t match and drops users at the top.

**How I tested**
- Triggered NoSuchElementException locally and confirmed the message includes:
  https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#nosuchelementexception

**Scope**
- No changes to other exceptions.

Fixes #16302 16302


___

### **PR Type**
Bug fix


___

### **Description**
- Update NoSuchElementException support URL anchor

- Fix broken documentation links in error messages

- Update test expectations to match new URL format


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old anchor: #no-such-element-exception"] --> B["New anchor: #nosuchelementexception"]
  B --> C["Updated Java exception"]
  B --> D["Updated .NET exception"]
  B --> E["Updated Ruby exception"]
  B --> F["Updated test expectations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NoSuchElementException.java</strong><dd><code>Update Java exception support URL anchor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/NoSuchElementException.java

<ul><li>Changed SUPPORT_URL anchor from "#no-such-element-exception" to <br>"#nosuchelementexception"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-647977792797c103b3cbc43d566582cd3d4c794990dcd95367a1c9556e85028d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NoSuchElementException.cs</strong><dd><code>Update .NET exception support URL anchor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/NoSuchElementException.cs

<ul><li>Changed supportUrl anchor from "#no-such-element-exception" to <br>"#nosuchelementexception"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-7c233d88a4694a199bae8e70a9a1b6d9b530b3571e3e260e814897d92f40bdaf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rb</strong><dd><code>Update Ruby error URL mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/error.rb

<ul><li>Changed NoSuchElementError URL mapping from <br>"#no-such-element-exception" to "#nosuchelementexception"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-942df34e1c3e79a3a6ada80fc46e4ef30a799c7a133efdff252f8b3cce4d7ea1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelativeLocatorTest.cs</strong><dd><code>Update .NET test URL expectation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/RelativeLocatorTest.cs

<ul><li>Updated test assertion to expect new URL format in exception message</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-01b475a5c22cd87cef8166aeed5106ad36264ff6964e888dff4d4228ef0f9c48">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>driver_spec.rb</strong><dd><code>Update Ruby driver test URL expectation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/driver_spec.rb

- Updated test regex to match new URL format in error message


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-f99e2caaa528d675ddc6279b1f1a74dde50ea5870a14dfffcbd45e6a03140693">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error_spec.rb</strong><dd><code>Update Ruby error test URL expectation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/error_spec.rb

- Updated test regex to match new URL format in error message


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16303/files#diff-9a507396bce1fb2360f6852a8022c9df9dcaf6869be5a95feef6571adb2bcd20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

