### PR TITLE
[java] Fix concurrency issue in Selenium Manager

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -16,6 +16,9 @@
 // under the License.
 package org.openqa.selenium.manager;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static org.openqa.selenium.Platform.LINUX;
 import static org.openqa.selenium.Platform.MAC;
 import static org.openqa.selenium.Platform.UNIX;
@@ -213,11 +216,10 @@ public class SeleniumManager {
         }
 
         binary = getBinaryInCache(SELENIUM_MANAGER + extension);
-        if (!binary.toFile().exists()) {
-          String binaryPathInJar = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
-          try (InputStream inputStream = this.getClass().getResourceAsStream(binaryPathInJar)) {
+        if (!Files.exists(binary)) {
+          try (InputStream inputStream = findBinaryInClasspath(folder, extension)) {
             Files.createDirectories(binary.getParent());
-            Files.copy(inputStream, binary);
+            saveToFileSafely(inputStream, binary);
           }
         }
       } catch (Exception e) {
@@ -231,6 +233,29 @@ public class SeleniumManager {
 
     LOG.fine(String.format("Selenium Manager binary found at: %s", binary));
     return binary;
+  }
+
+  /**
+   * Protect from concurrency issue when executed by 2+ processes simultaneously. Every process sees
+   * the file created by another process only when the file is fully completed.
+   */
+  private void saveToFileSafely(InputStream inputStream, Path target) throws IOException {
+    Path temporaryFile = target.resolveSibling(target.getFileName() + "." + randomUUID() + ".tmp");
+    Files.copy(inputStream, temporaryFile);
+    try {
+      if (!Files.exists(target)) {
+        Files.move(temporaryFile, target, REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporaryFile);
+    }
+  }
+
+  private InputStream findBinaryInClasspath(String folder, String extension) {
+    String binaryPathInJar = String.format("%s/%s%s", folder, SELENIUM_MANAGER, extension);
+    return requireNonNull(
+        getClass().getResourceAsStream(binaryPathInJar),
+        () -> "Resource not found in classpath: " + binaryPathInJar);
   }
 
   /**


### PR DESCRIPTION
### **User description**
... when executed by 2+ processes simultaneously on a machine with empty Selenium cache.

Every process sees the file created by another process only when the file is fully completed.

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/16314 and https://github.com/SeleniumHQ/selenium/issues/13145

### 💥 What does this PR do?
Fixes https://github.com/SeleniumHQ/selenium/issues/16314 and https://github.com/SeleniumHQ/selenium/issues/13145


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix concurrency issue in Selenium Manager binary extraction

- Implement atomic file operations to prevent race conditions

- Add temporary file creation with UUID for safe concurrent access

- Refactor binary extraction logic for improved reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple Processes"] --> B["Selenium Manager Binary"]
  B --> C["Temporary File + UUID"]
  C --> D["Atomic Move Operation"]
  D --> E["Safe Binary Access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumManager.java</strong><dd><code>Implement atomic file operations for concurrent safety</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/manager/SeleniumManager.java

<ul><li>Add atomic file operations with temporary files and UUID generation<br> <li> Implement <code>saveToFileSafely()</code> method to prevent race conditions<br> <li> Refactor binary extraction logic with <code>findBinaryInClasspath()</code> helper<br> <li> Replace direct file copy with safe concurrent file handling</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16315/files#diff-bc018f8fe13b0ca29c19df281b697583c7ab6ff28e052677871ad22c300464d2">+28/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

