### PR TITLE
[py][bidi]: add test for `downloadEnd` event

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -807,6 +807,41 @@ def test_add_event_handler_download_will_begin(driver, pages):
     driver.browsing_context.remove_event_handler("download_will_begin", callback_id)
 
 
+@pytest.mark.xfail_firefox
+def test_add_event_handler_download_end(driver, pages):
+    """Test adding event handler for download_end event."""
+    events_received = []
+
+    def on_download_end(info):
+        events_received.append(info)
+
+    callback_id = driver.browsing_context.add_event_handler("download_end", on_download_end)
+    assert callback_id is not None
+
+    context_id = driver.current_window_handle
+    url = pages.url("downloads/download.html")
+    driver.browsing_context.navigate(context=context_id, url=url, wait=ReadinessState.COMPLETE)
+
+    driver.find_element(By.ID, "file-1").click()
+
+    driver.find_element(By.ID, "file-2").click()
+    WebDriverWait(driver, 5).until(lambda d: len(events_received) > 1)
+
+    assert len(events_received) == 2
+
+    download_event = events_received[0]
+    assert download_event.download_params is not None
+    assert download_event.download_params.status == "complete"
+    assert download_event.download_params.context == context_id
+    assert download_event.download_params.timestamp is not None
+    assert "downloads/file_1.txt" in download_event.download_params.url
+    # we assert that atleast the str "file_1" is present in the downloaded file since multiple downloads
+    # will have numbered suffix like file_1 (1)
+    assert "file_1" in download_event.download_params.filepath
+
+    driver.browsing_context.remove_event_handler("download_end", callback_id)
+
+
 def test_add_event_handler_with_specific_contexts(driver):
     """Test adding event handler with specific browsing contexts."""
     events_received = []

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -825,19 +825,27 @@ def test_add_event_handler_download_end(driver, pages):
     driver.find_element(By.ID, "file-1").click()
 
     driver.find_element(By.ID, "file-2").click()
-    WebDriverWait(driver, 5).until(lambda d: len(events_received) > 1)
+    WebDriverWait(driver, 5).until(lambda d: len(events_received) == 2)
 
     assert len(events_received) == 2
 
-    download_event = events_received[0]
-    assert download_event.download_params is not None
-    assert download_event.download_params.status == "complete"
-    assert download_event.download_params.context == context_id
-    assert download_event.download_params.timestamp is not None
-    assert "downloads/file_1.txt" in download_event.download_params.url
-    # we assert that atleast the str "file_1" is present in the downloaded file since multiple downloads
+    for ev in events_received:
+        assert ev.download_params is not None
+        assert ev.download_params.status == "complete"
+        assert ev.download_params.context == context_id
+        assert ev.download_params.timestamp is not None
+
+    # we assert that atleast "file_1" is present in the downloaded file since multiple downloads
     # will have numbered suffix like file_1 (1)
-    assert "file_1" in download_event.download_params.filepath
+    assert any(
+        "downloads/file_1.txt" in ev.download_params.url and "file_1" in ev.download_params.filepath
+        for ev in events_received
+    )
+
+    assert any(
+        "downloads/file_2.jpg" in ev.download_params.url and "file_2" in ev.download_params.filepath
+        for ev in events_received
+    )
 
     driver.browsing_context.remove_event_handler("download_end", callback_id)
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Test for https://github.com/SeleniumHQ/selenium/pull/16209, Chrome 140 supports this event.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds test for the `downloadEnd` browsing context event.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Tests


___

### **PR Type**
Tests


___

### **Description**
- Add test for `downloadEnd` BiDi browsing context event

- Verify download completion event handling and parameters

- Test multiple file downloads with status validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] --> B["Add Event Handler"]
  B --> C["Navigate to Download Page"]
  C --> D["Click Download Links"]
  D --> E["Wait for Events"]
  E --> F["Validate Download Parameters"]
  F --> G["Remove Event Handler"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_browsing_context_tests.py</strong><dd><code>Add downloadEnd event handler test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_browsing_context_tests.py

<ul><li>Add <code>test_add_event_handler_download_end</code> test function<br> <li> Test download completion event with multiple file downloads<br> <li> Validate download parameters including status, context, and filepath<br> <li> Mark test as xfail for Firefox browser</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16325/files#diff-cea00ba1c71fd6f4ca93d87f14bcc291e1b87383cd61cd1bf1eec678e8d9efbf">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

