### PR TITLE
[grid] Fix regression Distributor rejecting requests when nodes have supported caps but no free slots

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/NodeRegistry.java
+++ b/java/src/org/openqa/selenium/grid/distributor/NodeRegistry.java
@@ -85,7 +85,14 @@ public interface NodeRegistry extends HasReadyState, Closeable {
   DistributorStatus getStatus();
 
   /**
-   * Gets all available nodes that are not DOWN or DRAINING.
+   * Get all nodes that are UP.
+   *
+   * @return Set of UP node statuses.
+   */
+  Set<NodeStatus> getUpNodes();
+
+  /**
+   * Gets all available nodes that are not DOWN or DRAINING and has free slots.
    *
    * @return Set of available node statuses.
    */

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -466,7 +466,8 @@ public class LocalDistributor extends Distributor implements Closeable {
   }
 
   private boolean isNotSupported(Capabilities caps) {
-    return getAvailableNodes().stream().noneMatch(node -> node.hasCapability(caps, slotMatcher));
+    return nodeRegistry.getUpNodes().stream()
+        .noneMatch(node -> node.hasCapability(caps, slotMatcher));
   }
 
   private boolean reserve(SlotId id) {
@@ -560,21 +561,28 @@ public class LocalDistributor extends Distributor implements Closeable {
     }
 
     private void checkMatchingSlot(List<SessionRequestCapability> sessionRequests) {
-      for (SessionRequestCapability request : sessionRequests) {
-        long unmatchableCount =
-            request.getDesiredCapabilities().stream()
-                .filter(LocalDistributor.this::isNotSupported)
-                .count();
-
-        if (unmatchableCount == request.getDesiredCapabilities().size()) {
-          LOG.info(
-              "No nodes support the capabilities in the request: "
-                  + request.getDesiredCapabilities());
-          SessionNotCreatedException exception =
-              new SessionNotCreatedException("No nodes support the capabilities in the request");
-          sessionQueue.complete(request.getRequestId(), Either.left(exception));
-        }
-      }
+      // Get UP nodes once to avoid lock & loop over multiple requests
+      Set<NodeStatus> upNodes = nodeRegistry.getUpNodes();
+      // Filter and reject only requests where NO capabilities are supported by ANY UP node
+      // This prevents rejecting requests when nodes support capabilities but are just busy
+      sessionRequests.stream()
+          .filter(
+              request ->
+                  request.getDesiredCapabilities().stream()
+                      .noneMatch(
+                          caps ->
+                              upNodes.stream()
+                                  .anyMatch(node -> node.hasCapability(caps, slotMatcher))))
+          .forEach(
+              request -> {
+                LOG.info(
+                    "No nodes support the capabilities in the request: "
+                        + request.getDesiredCapabilities());
+                SessionNotCreatedException exception =
+                    new SessionNotCreatedException(
+                        "No nodes support the capabilities in the request");
+                sessionQueue.complete(request.getRequestId(), Either.left(exception));
+              });
     }
 
     private void handleNewSessionRequest(SessionRequest sessionRequest) {

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
@@ -357,12 +357,18 @@ public class LocalNodeRegistry implements NodeRegistry {
 
   @Override
   public Set<NodeStatus> getAvailableNodes() {
+    // Filter nodes are UP and have capacity (available slots)
+    return getUpNodes().stream()
+        .filter(NodeStatus::hasCapacity)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  public Set<NodeStatus> getUpNodes() {
     Lock readLock = this.lock.readLock();
     readLock.lock();
     try {
       return model.getSnapshot().stream()
-          // Filter nodes are UP and have capacity (available slots)
-          .filter(node -> UP.equals(node.getAvailability()) && node.hasCapacity())
+          .filter(node -> UP.equals(node.getAvailability()))
           .collect(ImmutableSet.toImmutableSet());
     } finally {
       readLock.unlock();

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
@@ -363,6 +363,7 @@ public class LocalNodeRegistry implements NodeRegistry {
         .collect(ImmutableSet.toImmutableSet());
   }
 
+  @Override
   public Set<NodeStatus> getUpNodes() {
     Lock readLock = this.lock.readLock();
     readLock.lock();

--- a/java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java
@@ -778,6 +778,140 @@ class LocalDistributorTest {
   }
 
   @Test
+  void shouldNotRejectRequestsWhenNodesHaveCapabilityButNoFreeSlots() throws URISyntaxException {
+    // Create a distributor with rejectUnsupportedCaps enabled
+    NewSessionQueue queue =
+        new LocalNewSessionQueue(
+            tracer,
+            new DefaultSlotMatcher(),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(1),
+            registrationSecret,
+            5);
+    LocalDistributor distributor =
+        new LocalDistributor(
+            tracer,
+            bus,
+            new PassthroughHttpClient.Factory(localNode),
+            new LocalSessionMap(tracer, bus),
+            queue,
+            new DefaultSlotSelector(),
+            registrationSecret,
+            Duration.ofMinutes(5),
+            true, // Enable rejectUnsupportedCaps
+            Duration.ofSeconds(5),
+            newSessionThreadPoolSize,
+            new DefaultSlotMatcher(),
+            Duration.ofSeconds(30));
+
+    // Create a node that supports Chrome with single slot
+    URI nodeUri = new URI("http://example:1234");
+    Node node =
+        LocalNode.builder(tracer, bus, nodeUri, nodeUri, registrationSecret)
+            .add(
+                new ImmutableCapabilities("browserName", "chrome"),
+                new TestSessionFactory(
+                    (id, c) ->
+                        new Session(id, nodeUri, new ImmutableCapabilities(), c, Instant.now())))
+            .maximumConcurrentSessions(1)
+            .build();
+    distributor.add(node);
+
+    // Occupy the node's only slot
+    SessionRequest sessionRequest =
+        new SessionRequest(
+            new RequestId(UUID.randomUUID()),
+            Instant.now(),
+            Set.of(W3C),
+            Set.of(new ImmutableCapabilities("browserName", "chrome")),
+            Map.of(),
+            Map.of());
+    Either<SessionNotCreatedException, CreateSessionResponse> result =
+        distributor.newSession(sessionRequest);
+    assertThat(result.isRight()).isTrue(); // Session created successfully
+
+    // Verify node has no available capacity but still supports Chrome
+    assertThat(distributor.getAvailableNodes()).isEmpty(); // No available nodes
+
+    // Test that the distributor status shows the node is still UP and supports Chrome
+    // even though it has no available capacity
+    DistributorStatus status = distributor.getStatus();
+    Set<NodeStatus> allNodes = status.getNodes();
+    assertThat(allNodes).hasSize(1);
+
+    NodeStatus nodeStatus = allNodes.iterator().next();
+    assertThat(nodeStatus.getAvailability()).isEqualTo(UP);
+
+    // Verify the node still supports Chrome capability even with no free slots
+    boolean supportsChrome =
+        nodeStatus.hasCapability(
+            new ImmutableCapabilities("browserName", "chrome"), new DefaultSlotMatcher());
+    assertThat(supportsChrome).isTrue();
+
+    // Verify the node has no capacity (all slots occupied)
+    assertThat(nodeStatus.hasCapacity()).isFalse();
+  }
+
+  @Test
+  void shouldRejectRequestsWhenNoNodesHaveCapability() throws URISyntaxException {
+    // Create a distributor with rejectUnsupportedCaps enabled
+    NewSessionQueue queue =
+        new LocalNewSessionQueue(
+            tracer,
+            new DefaultSlotMatcher(),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(1),
+            registrationSecret,
+            5);
+    LocalDistributor distributor =
+        new LocalDistributor(
+            tracer,
+            bus,
+            new PassthroughHttpClient.Factory(localNode),
+            new LocalSessionMap(tracer, bus),
+            queue,
+            new DefaultSlotSelector(),
+            registrationSecret,
+            Duration.ofMinutes(5),
+            true, // Enable rejectUnsupportedCaps
+            Duration.ofSeconds(5),
+            newSessionThreadPoolSize,
+            new DefaultSlotMatcher(),
+            Duration.ofSeconds(30));
+
+    // Create a node that only supports Chrome
+    URI nodeUri = new URI("http://example:1234");
+    Node node =
+        LocalNode.builder(tracer, bus, nodeUri, nodeUri, registrationSecret)
+            .add(
+                new ImmutableCapabilities("browserName", "chrome"),
+                new TestSessionFactory(
+                    (id, c) ->
+                        new Session(id, nodeUri, new ImmutableCapabilities(), c, Instant.now())))
+            .build();
+    distributor.add(node);
+
+    // Add a Firefox request to the queue (unsupported capability)
+    SessionRequest unsupportedRequest =
+        new SessionRequest(
+            new RequestId(UUID.randomUUID()),
+            Instant.now(),
+            Set.of(W3C),
+            Set.of(new ImmutableCapabilities("browserName", "firefox")),
+            Map.of(),
+            Map.of());
+    queue.addToQueue(unsupportedRequest);
+
+    // Wait for checkMatchingSlot to run and reject the request
+    wait.until(obj -> queue.getQueueContents().isEmpty());
+
+    // The request should be rejected and removed from queue
+    assertThat(queue.getQueueContents()).isEmpty();
+  }
+
+  @Test
   void shouldHandleAllNodesFullyOccupied() throws URISyntaxException {
     // Create a distributor
     NewSessionQueue queue =


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Fix the regression issue from #16155 where adjusting the condition of `getAvailableNodes()` to include a condition that has at least 1 available Slot
It causes even if Node supports caps, but it is busy, the request is immediately dropped in case docker grid standalone mode enables `--reject-unsupported-caps` always.
Expected that when having supported caps and slots are busy, requests will wait in the queue for a while.
```

15:51:38.473 INFO [LocalDistributor$NewSessionRunnable.checkMatchingSlot] - No nodes support the capabilities in the request: [Capabilities {browserName: chrome, goog:chromeOptions: {args: [], extensions: []}, pageLoadStrategy: normal, se:downloadsEnabled: true}]

15:51:38.474 INFO [LocalDistributor$NewSessionRunnable.checkMatchingSlot] - No nodes support the capabilities in the request: [Capabilities {browserName: chrome, goog:chromeOptions: {args: [], extensions: []}, pageLoadStrategy: normal, se:downloadsEnabled: true}]

15:51:40.068 INFO [LocalNode.newSession] - Session created by the Node. Id: 9a1d15628f9147cf8033241b777aefb3, Caps: Capabilities
```

Add a method to `getUpNodes()` only 
Add unit tests


### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix regression where distributor rejects requests when nodes support capabilities but have no free slots

- Add `getUpNodes()` method to distinguish UP nodes from available nodes with capacity

- Update capability checking logic to use UP nodes instead of available nodes

- Add comprehensive unit tests for both supported and unsupported capability scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Session Request"] --> B["Check Capability Support"]
  B --> C{"Any UP Node Supports?"}
  C -->|Yes| D["Queue Request"]
  C -->|No| E["Reject Request"]
  F["getUpNodes()"] --> C
  G["getAvailableNodes()"] --> H["Reserve Slot"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NodeRegistry.java</strong><dd><code>Add getUpNodes interface method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/NodeRegistry.java

<ul><li>Add <code>getUpNodes()</code> method interface declaration<br> <li> Update <code>getAvailableNodes()</code> documentation to clarify it requires free <br>slots</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16327/files#diff-9f3590a1cefb44c4506cd4cea3f2aaab54991efe2bfc85c40beb1be7fd59030f">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalNodeRegistry.java</strong><dd><code>Implement getUpNodes method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java

<ul><li>Implement <code>getUpNodes()</code> method to return nodes with UP availability<br> <li> Refactor <code>getAvailableNodes()</code> to filter UP nodes by capacity</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16327/files#diff-06b3a8bdcef7cba88a17fee41788e719566cc7618aacddb5d055d1b504d3684c">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributor.java</strong><dd><code>Fix capability checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java

<ul><li>Change <code>isNotSupported()</code> to use <code>getUpNodes()</code> instead of <br><code>getAvailableNodes()</code><br> <li> Refactor <code>checkMatchingSlot()</code> to use UP nodes for capability checking<br> <li> Optimize by getting UP nodes once per batch instead of per request</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16327/files#diff-024d7dccb0a4ff87c444dc3549032e7c6b2595f582f4f267cdf48c7f8c2f87c1">+24/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributorTest.java</strong><dd><code>Add regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/distributor/local/LocalDistributorTest.java

<ul><li>Add test for nodes with capability but no free slots scenario<br> <li> Add test for completely unsupported capability rejection<br> <li> Verify proper behavior with rejectUnsupportedCaps enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16327/files#diff-2b9b6b96ab14f541e617736c0d98d1d2904e13ddc2117e05177d580ab2141da2">+134/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

