### PR TITLE
[atoms] fix text node children are always considered as displayed #16284

### DIFF
--- a/javascript/atoms/dom.js
+++ b/javascript/atoms/dom.js
@@ -452,12 +452,12 @@ bot.dom.getCascadedStyle_ = function (elem, styleName) {
  * @param {!Element} elem The element to consider.
  * @param {boolean} ignoreOpacity Whether to ignore the element's opacity
  *     when determining whether it is shown.
- * @param {function(!Element):boolean} parentsDisplayedFn a function that's used
- *     to tell if the chain of ancestors are all shown.
+ * @param {function(!Element):boolean} displayedFn a function that's used
+ *     to tell if the chain of ancestors or descendants are all shown.
  * @return {boolean} Whether or not the element is visible.
  * @private
  */
-bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
+bot.dom.isShown_ = function (elem, ignoreOpacity, displayedFn) {
   if (!bot.dom.isElement(elem)) {
     throw new Error('Argument to isShown must be of type Element');
   }
@@ -476,7 +476,7 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
     var select = /**@type {Element}*/ (goog.dom.getAncestor(elem, function (e) {
       return bot.dom.isElement(e, goog.dom.TagName.SELECT);
     }));
-    return !!select && bot.dom.isShown_(select, true, parentsDisplayedFn);
+    return !!select && bot.dom.isShown_(select, true, displayedFn);
   }
 
   // Image map elements are shown if image that uses it is shown, and
@@ -486,7 +486,7 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
     return !!imageMap.image &&
       imageMap.rect.width > 0 && imageMap.rect.height > 0 &&
       bot.dom.isShown_(
-        imageMap.image, ignoreOpacity, parentsDisplayedFn);
+        imageMap.image, ignoreOpacity, displayedFn);
   }
 
   // Any hidden input is not shown.
@@ -506,7 +506,7 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
     return false;
   }
 
-  if (!parentsDisplayedFn(elem)) {
+  if (!displayedFn(elem)) {
     return false;
   }
 
@@ -526,6 +526,16 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
     if (bot.dom.isElement(e, 'PATH') && (rect.height > 0 || rect.width > 0)) {
       var strokeWidth = bot.dom.getEffectiveStyle(e, 'stroke-width');
       return !!strokeWidth && (parseInt(strokeWidth, 10) > 0);
+    }
+
+    // Any element with hidden/collapsed visibility is not shown.
+    var visibility = bot.dom.getEffectiveStyle(e, 'visibility');
+    if (visibility == 'collapse' || visibility == 'hidden') {
+      return false;
+    }
+
+    if (!displayedFn(e)) {
+      return false;
     }
     // Zero-sized elements should still be considered to have positive size
     // if they have a child element or text node with positive size, unless
@@ -572,7 +582,7 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, parentsDisplayedFn) {
  */
 bot.dom.isShown = function (elem, opt_ignoreOpacity) {
   /**
-   * Determines whether an element or its parents have `display: none` set
+   * Determines whether an element or its parents have `display: none` or similar CSS properties set
    * @param {!Node} e the element
    * @return {!boolean}
    */

--- a/javascript/atoms/test/shown_test.html
+++ b/javascript/atoms/test/shown_test.html
@@ -414,6 +414,11 @@
       assertFalse(isShown(content));
       assertFalse(isShown(findElement({ id: 'b' }, content)));
     }
+
+    function testNestedTextNode() {
+      var content = findElement({ id: 'nestedTextNode' });
+      assertFalse(isShown(content));
+    }
   </script>
 
   <style type="text/css">
@@ -657,6 +662,10 @@
   <div id='contentVisibility' style='content-visibility: hidden'>
     A
     <div id='b'>B</div>
+  </div>
+
+  <div id='nestedTextNode' style='width: 0px; overflow: visible'>
+    <div style="display: none;">text</div>
   </div>
 
 </body>


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Should fix #16284 

### 💥 What does this PR do?
Call the displayed check for children before considering them displayed.

### 🔧 Implementation Notes
I am not to deep into JS, so someone should double check this.

### 💡 Additional Considerations


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix text node children visibility check in DOM atoms

- Add proper displayed check for nested elements

- Rename parameter for clarity in `isShown_` function

- Add test case for nested text node visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["isShown_ function"] --> B["displayedFn parameter"]
  B --> C["Nested element check"]
  C --> D["Text node visibility"]
  D --> E["Test validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dom.js</strong><dd><code>Fix nested element visibility checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/dom.js

<ul><li>Rename <code>parentsDisplayedFn</code> parameter to <code>displayedFn</code> for clarity<br> <li> Add visibility and displayed checks for nested elements<br> <li> Fix logic to properly check children element visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16329/files#diff-53bbf9a76b3e18a714284bd37ffdbcb670cbf537319cdaee94aacca31bcc497d">+17/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shown_test.html</strong><dd><code>Add test for nested text node</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/test/shown_test.html

<ul><li>Add new test case <code>testNestedTextNode</code><br> <li> Create HTML element with hidden nested text content</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16329/files#diff-219f47070e34d2539f1f805d746688422a639046d2bd2ed05095b01af4ab39b9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

