### PR TITLE
[dotnet] [bidi] Enable WebExtension tests at least for Firefox

### DIFF
--- a/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
+++ b/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
@@ -18,21 +18,23 @@
 // </copyright>
 
 using NUnit.Framework;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.BiDi.WebExtension;
 
-[Ignore("""
-    The following test suite wants to set driver arguments via Options, but it breaks CDP/DevTools tests.
-    The desired arguments (for Chromium only?):
-    --enable-unsafe-extension-debugging
-    --remote-debugging-pipe
-    Ignoring these tests for now. Hopefully https://github.com/SeleniumHQ/selenium/issues/15536 will be resolved soon.
-    """)]
+[IgnoreBrowser(Selenium.Browser.Chrome, ChromiumIgnoreReason)]
+[IgnoreBrowser(Selenium.Browser.Edge, ChromiumIgnoreReason)]
 class WebExtensionTest : BiDiTestFixture
 {
+    public const string ChromiumIgnoreReason = """
+        The following test suite wants to set driver arguments via Options, but it breaks CDP/DevTools tests.
+        The desired arguments (for Chromium only?):
+        --enable-unsafe-extension-debugging
+        --remote-debugging-pipe
+        Ignoring these tests for now. Hopefully https://github.com/SeleniumHQ/selenium/issues/15536 will be resolved soon.
+        """;
+
     [Test]
     public async Task CanInstallPathWebExtension()
     {

--- a/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
+++ b/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
@@ -27,7 +27,7 @@ namespace OpenQA.Selenium.BiDi.WebExtension;
 [IgnoreBrowser(Selenium.Browser.Edge, ChromiumIgnoreReason)]
 class WebExtensionTest : BiDiTestFixture
 {
-    public const string ChromiumIgnoreReason = """
+    const string ChromiumIgnoreReason = """
         The following test suite wants to set driver arguments via Options, but it breaks CDP/DevTools tests.
         The desired arguments (for Chromium only?):
         --enable-unsafe-extension-debugging


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Instead of ignoring some tests for all browsers, we can run them at least on Firefox. So ignoring for Chromium only.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Tests


___

### **Description**
- Enable WebExtension tests for Firefox browser

- Replace global test ignore with browser-specific ignores

- Keep Chromium browsers (Chrome/Edge) ignored due to CDP conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global Ignore"] --> B["Browser-Specific Ignores"]
  B --> C["Firefox Tests Enabled"]
  B --> D["Chrome/Edge Still Ignored"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebExtensionTest.cs</strong><dd><code>Replace global ignore with browser-specific ignores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs

<ul><li>Removed global <code>[Ignore]</code> attribute from test class<br> <li> Added browser-specific <code>[IgnoreBrowser]</code> attributes for Chrome and Edge<br> <li> Extracted ignore reason into a constant for reusability<br> <li> Removed unused <code>System</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16333/files#diff-fd6bd42f706660eae4316fd107cd6a0d72b36b16c91e19dd8b03a89d16bb6bf7">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

