### PR TITLE
[rust] Honor full browser version even if major version is installed (#15517)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -490,58 +490,66 @@ pub trait SeleniumManager {
                             discovered_version
                         ));
                     }
-                    let discovered_major_browser_version = self
-                        .get_major_version(&discovered_version)
-                        .unwrap_or_default();
+                    if self.is_browser_version_specific()
+                        && !self.get_browser_version().eq(&discovered_version)
+                    {
+                        download_browser = true;
+                    } else {
+                        let discovered_major_browser_version = self
+                            .get_major_version(&discovered_version)
+                            .unwrap_or_default();
 
-                    if self.is_browser_version_stable() || self.is_browser_version_unstable() {
-                        let online_browser_version = self.request_browser_version()?;
-                        if online_browser_version.is_some() {
-                            let major_online_browser_version =
-                                self.get_major_version(&online_browser_version.unwrap())?;
-                            if discovered_major_browser_version.eq(&major_online_browser_version) {
-                                self.get_logger().debug(format!(
-                                    "Discovered online {} version ({}) is the same as the detected local {} version",
-                                    self.get_browser_name(),
-                                    discovered_major_browser_version,
-                                    self.get_browser_name(),
-                                ));
-                                self.set_browser_version(discovered_version);
+                        if self.is_browser_version_stable() || self.is_browser_version_unstable() {
+                            let online_browser_version = self.request_browser_version()?;
+                            if online_browser_version.is_some() {
+                                let major_online_browser_version =
+                                    self.get_major_version(&online_browser_version.unwrap())?;
+                                if discovered_major_browser_version
+                                    .eq(&major_online_browser_version)
+                                {
+                                    self.get_logger().debug(format!(
+                                        "Discovered online {} version ({}) is the same as the detected local {} version",
+                                        self.get_browser_name(),
+                                        discovered_major_browser_version,
+                                        self.get_browser_name(),
+                                    ));
+                                    self.set_browser_version(discovered_version);
+                                } else {
+                                    self.get_logger().debug(format!(
+                                        "Discovered online {} version ({}) is different to the detected local {} version ({})",
+                                        self.get_browser_name(),
+                                        major_online_browser_version,
+                                        self.get_browser_name(),
+                                        discovered_major_browser_version,
+                                    ));
+                                    download_browser = true;
+                                }
                             } else {
-                                self.get_logger().debug(format!(
-                                    "Discovered online {} version ({}) is different to the detected local {} version ({})",
-                                    self.get_browser_name(),
-                                    major_online_browser_version,
-                                    self.get_browser_name(),
-                                    discovered_major_browser_version,
-                                ));
-                                download_browser = true;
+                                self.set_browser_version(discovered_version);
                             }
+                        } else if !major_browser_version.is_empty()
+                            && !self.is_browser_version_unstable()
+                            && !major_browser_version.eq(&discovered_major_browser_version)
+                        {
+                            self.get_logger().debug(format!(
+                                "Discovered {} version ({}) different to specified browser version ({})",
+                                self.get_browser_name(),
+                                discovered_major_browser_version,
+                                major_browser_version,
+                            ));
+                            download_browser = true;
                         } else {
                             self.set_browser_version(discovered_version);
                         }
-                    } else if !major_browser_version.is_empty()
-                        && !self.is_browser_version_unstable()
-                        && !major_browser_version.eq(&discovered_major_browser_version)
-                    {
-                        self.get_logger().debug(format!(
-                            "Discovered {} version ({}) different to specified browser version ({})",
-                            self.get_browser_name(),
-                            discovered_major_browser_version,
-                            major_browser_version,
-                        ));
-                        download_browser = true;
-                    } else {
-                        self.set_browser_version(discovered_version);
-                    }
-                    if self.is_webview2() && PathBuf::from(self.get_browser_path()).is_dir() {
-                        let browser_path = format!(
-                            r"{}\{}\msedge{}",
-                            self.get_browser_path(),
-                            &self.get_browser_version(),
-                            get_binary_extension(self.get_os())
-                        );
-                        self.set_browser_path(browser_path);
+                        if self.is_webview2() && PathBuf::from(self.get_browser_path()).is_dir() {
+                            let browser_path = format!(
+                                r"{}\{}\msedge{}",
+                                self.get_browser_path(),
+                                &self.get_browser_version(),
+                                get_binary_extension(self.get_os())
+                            );
+                            self.set_browser_path(browser_path);
+                        }
                     }
                 }
                 None => {


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Fixes #15517.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

This PR makes Selenium Manager to honor the full browser version when specified even when a matching major browser version is already installed.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Honor full browser version when specified, even if major version exists

- Restructure browser version comparison logic with conditional checks

- Add specific version validation before fallback to major version matching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser Version Request"] --> B["Check if Specific Version"]
  B --> C["Compare with Discovered Version"]
  C --> D["Download if Mismatch"]
  C --> E["Use Discovered if Match"]
  B --> F["Fallback to Major Version Logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Browser version matching logic enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<ul><li>Add specific browser version check before major version comparison<br> <li> Restructure conditional logic to prioritize exact version matching<br> <li> Move WebView2 path handling inside conditional block</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16346/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+55/-47</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

