### PR TITLE
[dotnet] Conditionally enable driver service process output redirection

### DIFF
--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -173,7 +173,7 @@ public abstract class DriverService : ICommandServer
     /// <summary>
     /// Gets a value indicating whether process redirection is enforced regardless of other settings.
     /// </summary>
-    /// <remarks>Set this property to <see langword="true"/> to force all process output and input streams to
+    /// <remarks>Set this property to <see langword="true"/> to force all process output and error streams to
     /// be redirected, even if redirection is not required by default behavior. This can be useful in scenarios where
     /// capturing process output is necessary for logging or analysis.</remarks>
     protected virtual internal bool EnableProcessRedirection { get; } = false;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -171,6 +171,14 @@ public abstract class DriverService : ICommandServer
     protected virtual bool HasShutdown => true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether process redirection is enforced regardless of other settings.
+    /// </summary>
+    /// <remarks>Set this property to <see langword="true"/> to force all process output and input streams to
+    /// be redirected, even if redirection is not required by default behavior. This can be useful in scenarios where
+    /// capturing process output is necessary for logging or analysis.</remarks>
+    protected virtual internal bool EnableProcessRedirection { get; } = false;
+
+    /// <summary>
     /// Gets a value indicating whether the service is responding to HTTP requests.
     /// </summary>
     protected virtual bool IsInitialized
@@ -249,16 +257,23 @@ public abstract class DriverService : ICommandServer
         this.driverServiceProcess.StartInfo.RedirectStandardOutput = true;
         this.driverServiceProcess.StartInfo.RedirectStandardError = true;
 
-        this.driverServiceProcess.OutputDataReceived += this.OnDriverProcessDataReceived;
-        this.driverServiceProcess.ErrorDataReceived += this.OnDriverProcessDataReceived;
+        if (this.EnableProcessRedirection)
+        {
+            this.driverServiceProcess.OutputDataReceived += this.OnDriverProcessDataReceived;
+            this.driverServiceProcess.ErrorDataReceived += this.OnDriverProcessDataReceived;
+        }
 
         DriverProcessStartingEventArgs eventArgs = new DriverProcessStartingEventArgs(this.driverServiceProcess.StartInfo);
         this.OnDriverProcessStarting(eventArgs);
 
-        // Important: Start the process and immediately begin reading the output and error streams to avoid IO deadlocks.
         this.driverServiceProcess.Start();
-        this.driverServiceProcess.BeginOutputReadLine();
-        this.driverServiceProcess.BeginErrorReadLine();
+
+        if (this.EnableProcessRedirection)
+        {
+            // Important: Start the process and immediately begin reading the output and error streams to avoid IO deadlocks.
+            this.driverServiceProcess.BeginOutputReadLine();
+            this.driverServiceProcess.BeginErrorReadLine();
+        }
 
         bool serviceAvailable = this.WaitForServiceInitialization();
 
@@ -289,7 +304,7 @@ public abstract class DriverService : ICommandServer
             {
                 this.Stop();
 
-                if (this.driverServiceProcess is not null)
+                if (EnableProcessRedirection && this.driverServiceProcess is not null)
                 {
                     this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
                     this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
@@ -335,13 +350,7 @@ public abstract class DriverService : ICommandServer
     /// <param name="args">The data received event arguments.</param>
     protected virtual void OnDriverProcessDataReceived(object sender, DataReceivedEventArgs args)
     {
-        if (string.IsNullOrEmpty(args.Data))
-            return;
 
-        if (_logger.IsEnabled(LogEventLevel.Trace))
-        {
-            _logger.Trace(args.Data);
-        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -171,7 +171,7 @@ public abstract class DriverService : ICommandServer
     protected virtual bool HasShutdown => true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether process redirection is enforced regardless of other settings.
+    /// Gets a value indicating whether process redirection is enforced regardless of other settings.
     /// </summary>
     /// <remarks>Set this property to <see langword="true"/> to force all process output and input streams to
     /// be redirected, even if redirection is not required by default behavior. This can be useful in scenarios where

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -223,6 +223,11 @@ public sealed class FirefoxDriverService : DriverService
     }
 
     /// <summary>
+    /// Gets a value indicating whether process output redirection is required.
+    /// </summary>
+    protected internal override bool EnableProcessRedirection => LogPath is not null;
+
+    /// <summary>
     /// Called when the driver process is starting. This method sets up log file writing if a log path is specified.
     /// </summary>
     /// <param name="eventArgs">The event arguments containing information about the driver service process.</param>


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Related to https://github.com/SeleniumHQ/selenium/issues/16245

### 💥 What does this PR do?
Introduces new hidden flag whether process output should be listened to. By default we just redirect but not listen it. In case of Firefox driver, if `LogPath` property is set, then we start process redirection with listening to output.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Conditionally enable driver service process output redirection

- Add `EnableProcessRedirection` property to control output listening

- Firefox driver enables redirection only when `LogPath` is set

- Remove default logging behavior from base class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DriverService"] --> B["EnableProcessRedirection property"]
  B --> C["Conditional output listening"]
  C --> D["FirefoxDriverService"]
  D --> E["LogPath-based redirection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DriverService.cs</strong><dd><code>Add conditional process output redirection control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/DriverService.cs

<ul><li>Add <code>EnableProcessRedirection</code> virtual property with default false value<br> <li> Conditionally attach/detach output event handlers based on property<br> <li> Remove default trace logging from <code>OnDriverProcessDataReceived</code> method<br> <li> Guard disposal cleanup with redirection check</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16353/files#diff-c38089621d41671b4719164b262303e275d4a4a442125fd9d4ea61eeca855c2b">+21/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverService.cs</strong><dd><code>Enable redirection when LogPath configured</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxDriverService.cs

<ul><li>Override <code>EnableProcessRedirection</code> to return true when <code>LogPath</code> is set<br> <li> Enable output redirection only when logging is configured</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16353/files#diff-8a02c4932a0154eb11aafcbf7e736968b70fe5d69dac3df52ac67fa8c8a7c965">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

