### PR TITLE
[dotnet] [bidi] Give only one chance to receive from remote end

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -136,7 +136,7 @@ public sealed class Broker : IAsyncDisposable
         {
             if (_logger.IsEnabled(LogEventLevel.Error))
             {
-                _logger.Error($"Couldn't process received BiDi remote message: {ex}");
+                _logger.Error($"Couldn't receive or process BiDi remote message: {ex}");
             }
 
             throw;

--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -132,9 +132,9 @@ public sealed class Broker : IAsyncDisposable
                 ProcessReceivedMessage(data);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (cancellationToken.IsCancellationRequested is false && _logger.IsEnabled(LogEventLevel.Error))
+            if (_logger.IsEnabled(LogEventLevel.Error))
             {
                 _logger.Error($"Couldn't process received BiDi remote message: {ex}");
             }

--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -129,14 +129,24 @@ public sealed class Broker : IAsyncDisposable
             {
                 var data = await _transport.ReceiveAsync(cancellationToken).ConfigureAwait(false);
 
-                ProcessReceivedMessage(data);
+                try
+                {
+                    ProcessReceivedMessage(data);
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsEnabled(LogEventLevel.Error))
+                    {
+                        _logger.Error($"Unhandled error occured while process remote message: {ex}");
+                    }
+                }
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             if (_logger.IsEnabled(LogEventLevel.Error))
             {
-                _logger.Error($"Couldn't receive or process BiDi remote message: {ex}");
+                _logger.Error($"Unhandled error occured while receiving remote messages: {ex}");
             }
 
             throw;

--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -123,21 +123,23 @@ public sealed class Broker : IAsyncDisposable
 
     private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            try
+            while (!cancellationToken.IsCancellationRequested)
             {
                 var data = await _transport.ReceiveAsync(cancellationToken).ConfigureAwait(false);
 
                 ProcessReceivedMessage(data);
             }
-            catch (Exception ex)
+        }
+        catch (Exception ex)
+        {
+            if (cancellationToken.IsCancellationRequested is false && _logger.IsEnabled(LogEventLevel.Error))
             {
-                if (cancellationToken.IsCancellationRequested is not true && _logger.IsEnabled(LogEventLevel.Error))
-                {
-                    _logger.Error($"Couldn't process received BiDi remote message: {ex}");
-                }
+                _logger.Error($"Couldn't process received BiDi remote message: {ex}");
             }
+
+            throw;
         }
     }
 

--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -137,7 +137,7 @@ public sealed class Broker : IAsyncDisposable
                 {
                     if (_logger.IsEnabled(LogEventLevel.Error))
                     {
-                        _logger.Error($"Unhandled error occured while process remote message: {ex}");
+                        _logger.Error($"Unhandled error occured while processing remote message: {ex}");
                     }
                 }
             }


### PR DESCRIPTION
### **User description**
BiDi Broker listens to incoming WebSocket messages and repeats even if remote end is died.

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/16134

### 💥 What does this PR do?
This PR gives only one chance. As soon as it fails for any reason, we stop to listen (with writing failure to internal logs only once). It is still not resolving more interesting issue when `WebSocketTransport` class should behave more robust, but this is right improvement (and quick win).

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Modify BiDi message receiving to fail fast on errors

- Remove retry loop for failed WebSocket connections

- Improve error handling with single attempt strategy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Receive BiDi Messages"] --> B["Single Attempt"]
  B --> C["Success: Continue"]
  B --> D["Failure: Log & Throw"]
  D --> E["Stop Listening"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Implement fail-fast BiDi message reception</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Broker.cs

<ul><li>Restructured error handling in <code>ReceiveMessagesAsync</code> method<br> <li> Removed infinite retry loop on WebSocket receive failures<br> <li> Added fail-fast behavior with single error logging<br> <li> Improved exception filtering to exclude <code>OperationCanceledException</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16360/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

