### PR TITLE
[rust] Log browser path also in offline mode (#16215)

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -254,6 +254,7 @@ fn main() {
         })
         .unwrap_or_else(|err| {
             let log = selenium_manager.get_logger();
+            let browser_path = selenium_manager.get_browser_path_or_latest_from_cache();
             if selenium_manager.is_fallback_driver_from_cache()
                 && let Some(best_driver_from_cache) =
                     selenium_manager.find_best_driver_from_cache().unwrap()
@@ -269,13 +270,14 @@ fn main() {
                 log_driver_and_browser_path(
                     log,
                     &best_driver_from_cache,
-                    &selenium_manager.get_browser_path_or_latest_from_cache(),
+                    &browser_path,
                     selenium_manager.get_receiver(),
                 );
                 flush_and_exit(OK, log, Some(err));
             }
             if selenium_manager.is_offline() {
                 log.warn(&err);
+                log_browser_path(&log, &browser_path);
                 flush_and_exit(OK, log, Some(err));
             } else {
                 let error_msg = if log.is_debug_enabled() {
@@ -304,6 +306,10 @@ fn log_driver_and_browser_path(
         log.error(format!("Driver unavailable: {}", driver_path.display()));
         flush_and_exit(UNAVAILABLE, log, None);
     }
+    log_browser_path(log, browser_path);
+}
+
+fn log_browser_path(log: &Logger, browser_path: &str) {
     if !browser_path.is_empty() {
         log.info(format!("{}{}", BROWSER_PATH, browser_path));
     }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Fixes #16215.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
This PR makes SM to log the browser path even when offline mode is specified:

```
./selenium-manager --browser chrome --debug --offline --output json --clear-cache
{
  "logs": [
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "Offline flag set, but also asked not to avoid browser downloads. Honouring offline flag"
    },
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "Using Selenium Manager in offline mode"
    },
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "Clearing cache at: C:\\Users\\boni\\.cache\\selenium"
    },
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "chromedriver not found in PATH"
    },
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "chrome detected at C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
    },
    {
      "level": "DEBUG",
      "timestamp": 1759397333,
      "message": "Detected browser: chrome 140.0.7339.208"
    },
    {
      "level": "WARN",
      "timestamp": 1759397333,
      "message": "Unable to discover proper chromedriver version in offline mode"
    },
    {
      "level": "INFO",
      "timestamp": 1759397333,
      "message": "Browser path: C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
    }
  ],
  "result": {
    "code": 0,
    "message": "",
    "driver_path": "",
    "browser_path": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
  }
}
```

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Log browser path in offline mode when driver discovery fails

- Extract browser path logging into separate function

- Ensure consistent browser path reporting across all execution paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Offline Mode"] --> B["Driver Discovery Fails"]
  B --> C["Extract Browser Path"]
  C --> D["Log Browser Path"]
  D --> E["Exit with Status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Add browser path logging in offline mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/main.rs

<ul><li>Extract browser path early in error handling flow<br> <li> Create dedicated <code>log_browser_path</code> function for reusability<br> <li> Add browser path logging in offline mode error path<br> <li> Refactor existing logging to use new function</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16370/files#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

