### PR TITLE
[py] Re-add defaults for Chromium kwargs

### DIFF
--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -31,8 +31,8 @@ class ChromiumDriver(RemoteWebDriver):
 
     def __init__(
         self,
-        browser_name: str,
-        vendor_prefix: str,
+        browser_name: Optional[str] = None,
+        vendor_prefix: Optional[str] = None,
         options: Optional[ChromiumOptions] = None,
         service: Optional[ChromiumService] = None,
         keep_alive: bool = True,


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

#16309

### 💥 What does this PR do?

This PR fixes a breaking change to the Chromium class `__init__` signature inadvertently introduced in #16309. Defaults of `None` are re-added back as keyword argument defaults for `browser_name` and `vendor_prefix`. 

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Re-add `None` defaults for `browser_name` and `vendor_prefix` parameters

- Fix breaking change in ChromiumDriver `__init__` signature

- Restore backwards compatibility for Chromium class initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChromiumDriver.__init__"] --> B["browser_name: Optional[str] = None"]
  A --> C["vendor_prefix: Optional[str] = None"]
  B --> D["Backwards Compatible"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Restore default parameter values in ChromiumDriver constructor</code></dd></summary>
<hr>

py/selenium/webdriver/chromium/webdriver.py

<ul><li>Changed <code>browser_name</code> parameter from required <code>str</code> to optional with <code>None</code> <br>default<br> <li> Changed <code>vendor_prefix</code> parameter from required <code>str</code> to optional with <br><code>None</code> default<br> <li> Added <code>Optional</code> type hints for both parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16372/files#diff-10fa59c3fd96a0c31762373ca8d7373c0ab669a437ae957b1a17ea1377b20608">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

