### PR TITLE
[rb] Update Chrome/Edge args for test environment

### DIFF
--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -274,9 +274,8 @@ module Selenium
           opts[:browser_version] = 'stable' if WebDriver::Platform.windows?
           opts[:web_socket_url] = true if ENV['WEBDRIVER_BIDI'] && !opts.key?(:web_socket_url)
           opts[:binary] ||= ENV['CHROME_BINARY'] if ENV.key?('CHROME_BINARY')
-          args << '--headless=chrome' if ENV['HEADLESS']
+          args << '--headless' if ENV['HEADLESS']
           args << '--no-sandbox' unless Platform.windows?
-          args << '--disable-gpu'
           WebDriver::Options.chrome(args: args, **opts)
         end
 
@@ -284,9 +283,8 @@ module Selenium
           opts[:browser_version] = 'stable' if WebDriver::Platform.windows?
           opts[:web_socket_url] = true if ENV['WEBDRIVER_BIDI'] && !opts.key?(:web_socket_url)
           opts[:binary] ||= ENV['EDGE_BINARY'] if ENV.key?('EDGE_BINARY')
-          args << '--headless=chrome' if ENV['HEADLESS']
+          args << '--headless' if ENV['HEADLESS']
           args << '--no-sandbox' unless Platform.windows?
-          args << '--disable-gpu'
           WebDriver::Options.edge(args: args, **opts)
         end
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR updates the args used when starting Chrome and Edge for internal Ruby tests

- removes `--disable-gpu` (this used to be necessary for the old headless mode on Windows)
- changes `--headless=chrome` to `--headless` (old headless mode was removed in Chrome 112, and these args now do the same thing)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Tests


___

### **PR Type**
Tests


___

### **Description**
- Update Chrome/Edge headless argument from `--headless=chrome` to `--headless`

- Remove deprecated `--disable-gpu` argument for both browsers

- Modernize browser launch arguments for Ruby test environment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chrome/Edge Options"] --> B["Remove --disable-gpu"]
  A --> C["Update --headless=chrome to --headless"]
  B --> D["Modernized Browser Args"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Modernize Chrome/Edge browser launch arguments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<ul><li>Updated headless argument from <code>--headless=chrome</code> to <code>--headless</code> for <br>Chrome and Edge<br> <li> Removed deprecated <code>--disable-gpu</code> argument from both browser <br>configurations<br> <li> Modernized browser launch arguments for test compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16376/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

