### PR TITLE
[py] Remove old test xfail markers from Travis CI

### DIFF
--- a/py/test/selenium/webdriver/common/alerts_tests.py
+++ b/py/test/selenium/webdriver/common/alerts_tests.py
@@ -157,6 +157,8 @@ def test_alert_should_not_allow_additional_commands_if_dimissed(driver, pages):
         alert.text
 
 
+@pytest.mark.xfail_firefox
+@pytest.mark.xfail_remote
 @pytest.mark.xfail_safari
 def test_should_allow_users_to_accept_an_alert_in_aframe(driver, pages):
     pages.load("alerts.html")
@@ -169,6 +171,8 @@ def test_should_allow_users_to_accept_an_alert_in_aframe(driver, pages):
     assert "Testing Alerts" == driver.title
 
 
+@pytest.mark.xfail_firefox
+@pytest.mark.xfail_remote
 @pytest.mark.xfail_safari
 def test_should_allow_users_to_accept_an_alert_in_anested_frame(driver, pages):
     pages.load("alerts.html")

--- a/py/test/selenium/webdriver/common/alerts_tests.py
+++ b/py/test/selenium/webdriver/common/alerts_tests.py
@@ -157,8 +157,6 @@ def test_alert_should_not_allow_additional_commands_if_dimissed(driver, pages):
         alert.text
 
 
-@pytest.mark.xfail_firefox(reason="Fails on travis")
-@pytest.mark.xfail_remote(reason="Fails on travis")
 @pytest.mark.xfail_safari
 def test_should_allow_users_to_accept_an_alert_in_aframe(driver, pages):
     pages.load("alerts.html")
@@ -171,8 +169,6 @@ def test_should_allow_users_to_accept_an_alert_in_aframe(driver, pages):
     assert "Testing Alerts" == driver.title
 
 
-@pytest.mark.xfail_firefox(reason="Fails on travis")
-@pytest.mark.xfail_remote(reason="Fails on travis")
 @pytest.mark.xfail_safari
 def test_should_allow_users_to_accept_an_alert_in_anested_frame(driver, pages):
     pages.load("alerts.html")

--- a/py/test/selenium/webdriver/common/w3c_interaction_tests.py
+++ b/py/test/selenium/webdriver/common/w3c_interaction_tests.py
@@ -146,8 +146,6 @@ def test_context_click(driver, pages):
 
 @pytest.mark.xfail_firefox
 @pytest.mark.xfail_safari
-@pytest.mark.xfail_remote(reason="Fails on Travis")
-@pytest.mark.xfail_chrome(reason="Fails on Travis")
 def test_double_click(driver, pages):
     """Copied from org.openqa.selenium.interactions.TestBasicMouseInterface."""
     pages.load("javascriptPage.html")

--- a/py/test/selenium/webdriver/common/window_tests.py
+++ b/py/test/selenium/webdriver/common/window_tests.py
@@ -21,9 +21,6 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support.wait import WebDriverWait
 
 # @pytest.mark.xfail_ie
-# @pytest.mark.xfail_edge(reason="Fails on Travis")
-# @pytest.mark.xfail_firefox(reason="Fails on Travis")
-# @pytest.mark.xfail_remote(reason="Fails on Travis")
 # def test_should_maximize_the_window(driver):
 #     resize_timeout = 5
 #     wait = WebDriverWait(driver, resize_timeout)
@@ -138,8 +135,6 @@ def test_set_window_rect_throws_when_height_and_width_are_0(driver):
 
 # @pytest.mark.xfail_safari(raises=WebDriverException,
 #                           reason='Fullscreen command not implemented')
-# @pytest.mark.skipif(os.environ.get('TRAVIS') == 'true',
-#                     reason='Fullscreen command causes Travis to hang')
 # @pytest.mark.no_driver_after_test
 # def test_should_fullscreen_the_current_window(driver):
 #     start_width = driver.execute_script('return window.innerWidth;')
@@ -161,8 +156,6 @@ def test_set_window_rect_throws_when_height_and_width_are_0(driver):
 
 # @pytest.mark.xfail_safari(raises=WebDriverException,
 #                           reason='Minimize command not implemented')
-# @pytest.mark.skipif(os.environ.get('TRAVIS') == 'true',
-#                     reason='Minimize command causes Travis to hang')
 # @pytest.mark.no_driver_after_test
 # def test_should_minimize_the_current_window(driver):
 #     driver.minimize_window()


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR removes some old xfail test markers related to see if they pass on GHA.


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Test


___

### **PR Type**
Tests


___

### **Description**
- Remove outdated Travis CI xfail markers from Python tests

- Clean up test markers for Firefox, Chrome, and remote drivers

- Update alert and interaction test configurations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Travis CI xfail markers"] -- "remove" --> B["Clean test files"]
  B --> C["Updated test configurations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts_tests.py</strong><dd><code>Remove Travis CI alert test markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/alerts_tests.py

<ul><li>Remove <code>@pytest.mark.xfail_firefox</code> and <code>@pytest.mark.xfail_remote</code> <br>markers with "Fails on travis" reason<br> <li> Keep Safari xfail markers intact<br> <li> Clean up two alert test functions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16377/files#diff-6f4115e4d284597d5cd6787d0fac6bfec428b14daafad0cabd87b036f6555ac3">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>w3c_interaction_tests.py</strong><dd><code>Remove Travis CI interaction test markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/w3c_interaction_tests.py

<ul><li>Remove <code>@pytest.mark.xfail_remote</code> and <code>@pytest.mark.xfail_chrome</code> markers <br>with "Fails on Travis" reason<br> <li> Keep Firefox and Safari xfail markers<br> <li> Update double click test configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16377/files#diff-97fe49abaeea5394b8661f6ffea91c54028f32f201df5d1896e590f6e52aed9c">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>window_tests.py</strong><dd><code>Remove Travis CI window test markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/window_tests.py

<ul><li>Remove commented Travis CI related xfail markers and skipif conditions<br> <li> Clean up window maximize, fullscreen, and minimize test comments<br> <li> Remove environment-based test skipping logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16377/files#diff-353dbb22282fdb450da3dbf635018696f756b7c0351d5199c2777cf4a14e9c32">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

