### PR TITLE
[java] Linux ARM "os.arch" system property is "aarch64"

### DIFF
--- a/java/src/org/openqa/selenium/manager/SeleniumManager.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManager.java
@@ -200,7 +200,8 @@ public class SeleniumManager {
         } else if (current.is(MAC)) {
           folder = "macos";
         } else if (current.is(LINUX)) {
-          if (System.getProperty("os.arch").contains("arm")) {
+          if (System.getProperty("os.arch").contains("arm")
+              || System.getProperty("os.arch").contains("aarch64")) {
             throw new WebDriverException("Linux ARM is not supported by Selenium Manager");
           } else {
             folder = "linux";


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
I am running Linux on a MacBook Pro M1 via https://asahi-alarm.org/.
The architecture of this machine is identified as `aarch64` in Java (and in general).
When selenium tries to start selenium manager it fails because it tries to execute the x86-64 binary, which of course does not work on an aarch64 system.

### 🔧 Implementation Notes
Just also checking for `aarch64`.. Easy.

```
$ uname -a
Linux mkurz-macbook-pro 6.16.4-asahi-2-1-ARCH #1 SMP PREEMPT_DYNAMIC Tue, 02 Sep 2025 08:56:47 +0000 aarch64 GNU/Linux
$ uname -m
aarch64
```
```
$ jshell
|  Welcome to JShell -- Version 17.0.16
|  For an introduction type: /help intro

jshell> System.getProperty("os.arch")
$1 ==> "aarch64"
```
<kbd>
<img width="2816" height="1484" alt="Screenshot_20251004_094212_2" src="https://github.com/user-attachments/assets/1b2b4354-e9ff-4253-a661-1194e659f83f" />
</kbd>


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Add support for detecting `aarch64` architecture on Linux systems

- Fix Selenium Manager binary selection for ARM-based Linux platforms

- Improve error handling for unsupported ARM architectures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["System Architecture Check"] --> B["os.arch Property"]
  B --> C["ARM Detection Logic"]
  C --> D["aarch64 Support Added"]
  D --> E["WebDriverException Thrown"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumManager.java</strong><dd><code>Add aarch64 architecture detection support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/manager/SeleniumManager.java

<ul><li>Extended ARM architecture detection to include <code>aarch64</code><br> <li> Modified conditional check in <code>getBinary()</code> method<br> <li> Maintains existing error handling for unsupported ARM platforms</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16381/files#diff-bc018f8fe13b0ca29c19df281b697583c7ab6ff28e052677871ad22c300464d2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

