### PR TITLE
[dotnet] [bidi] Implement browsing context download events

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -167,14 +167,24 @@ public sealed class BrowsingContext
         return BiDi.BrowsingContext.OnLoadAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
-    public Task<Subscription> OnDownloadWillBeginAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)
+    public Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, SubscriptionOptions? options = null)
     {
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
-    public Task<Subscription> OnDownloadWillBeginAsync(Func<NavigationInfo, Task> handler, SubscriptionOptions? options = null)
+    public Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, SubscriptionOptions? options = null)
     {
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
+    }
+
+    public Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, SubscriptionOptions? options = null)
+    {
+        return BiDi.BrowsingContext.OnDownloadEndAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
+    }
+
+    public Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, SubscriptionOptions? options = null)
+    {
+        return BiDi.BrowsingContext.OnDownloadEndAsync(handler, new BrowsingContextsSubscriptionOptions(options) { Contexts = [this] });
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Action<NavigationInfo> handler, SubscriptionOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
@@ -171,6 +171,16 @@ public sealed class BrowsingContextModule(Broker broker) : Module(broker)
         return await Broker.SubscribeAsync("browsingContext.downloadWillBegin", handler, options).ConfigureAwait(false);
     }
 
+    public async Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("browsingContext.downloadEnd", handler, options).ConfigureAwait(false);
+    }
+
+    public async Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, BrowsingContextsSubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("browsingContext.downloadEnd", handler, options).ConfigureAwait(false);
+    }
+
     public async Task<Subscription> OnNavigationAbortedAsync(Func<NavigationInfo, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("browsingContext.navigationAborted", handler, options).ConfigureAwait(false);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
@@ -161,12 +161,12 @@ public sealed class BrowsingContextModule(Broker broker) : Module(broker)
         return await Broker.SubscribeAsync("browsingContext.load", handler, options).ConfigureAwait(false);
     }
 
-    public async Task<Subscription> OnDownloadWillBeginAsync(Func<NavigationInfo, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
+    public async Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, BrowsingContextsSubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("browsingContext.downloadWillBegin", handler, options).ConfigureAwait(false);
     }
 
-    public async Task<Subscription> OnDownloadWillBeginAsync(Action<NavigationInfo> handler, BrowsingContextsSubscriptionOptions? options = null)
+    public async Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, BrowsingContextsSubscriptionOptions? options = null)
     {
         return await Broker.SubscribeAsync("browsingContext.downloadWillBegin", handler, options).ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
@@ -1,0 +1,35 @@
+// <copyright file="DownloadEndEventArgs.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.BrowsingContext;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "status")]
+[JsonDerivedType(typeof(DownloadCanceledEventArgs), "canceled")]
+[JsonDerivedType(typeof(DownloadCompleteEventArgs), "complete")]
+public abstract record DownloadEndEventArgs(BiDi BiDi, BrowsingContext Context)
+    : BrowsingContextEventArgs(BiDi, Context);
+
+public abstract record DownloadCanceledEventArgs(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;
+
+public abstract record DownloadCompleteEventArgs(BiDi BiDi, string? Filepath, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
@@ -18,18 +18,18 @@
 // </copyright>
 
 using System;
-using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-[JsonPolymorphic(TypeDiscriminatorPropertyName = "status")]
-[JsonDerivedType(typeof(DownloadCanceledEventArgs), "canceled")]
-[JsonDerivedType(typeof(DownloadCompleteEventArgs), "complete")]
+// https://github.com/dotnet/runtime/issues/72604
+//[JsonPolymorphic(TypeDiscriminatorPropertyName = "status")]
+//[JsonDerivedType(typeof(DownloadCanceledEventArgs), "canceled")]
+//[JsonDerivedType(typeof(DownloadCompleteEventArgs), "complete")]
 public abstract record DownloadEndEventArgs(BiDi BiDi, BrowsingContext Context)
     : BrowsingContextEventArgs(BiDi, Context);
 
-public abstract record DownloadCanceledEventArgs(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+public sealed record DownloadCanceledEventArgs(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
     : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;
 
-public abstract record DownloadCompleteEventArgs(BiDi BiDi, string? Filepath, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+public sealed record DownloadCompleteEventArgs(BiDi BiDi, string? Filepath, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
     : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadWillBeginEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadWillBeginEventArgs.cs
@@ -1,0 +1,25 @@
+// <copyright file="DownloadWillBeginEventArgs.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+
+namespace OpenQA.Selenium.BiDi.BrowsingContext;
+
+public sealed record DownloadWillBeginEventArgs(BiDi BiDi, string SuggestedFilename, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : BrowsingContextEventArgs(BiDi, Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/Communication/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Broker.cs
@@ -97,6 +97,7 @@ public sealed class Broker : IAsyncDisposable
                 new Json.Converters.Polymorphic.RemoteValueConverter(),
                 new Json.Converters.Polymorphic.RealmInfoConverter(),
                 new Json.Converters.Polymorphic.LogEntryConverter(),
+                new Json.Converters.Polymorphic.DownloadEndEventArgsConverter(),
                 //
 
                 // Enumerable

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -113,6 +113,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 
 [JsonSerializable(typeof(BrowsingContext.BrowsingContextInfo))]
 [JsonSerializable(typeof(BrowsingContext.DownloadWillBeginEventArgs))]
+[JsonSerializable(typeof(BrowsingContext.DownloadEndEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.HistoryUpdatedEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.NavigationInfo))]
 [JsonSerializable(typeof(BrowsingContext.UserPromptOpenedEventArgs))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -114,6 +114,8 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(BrowsingContext.BrowsingContextInfo))]
 [JsonSerializable(typeof(BrowsingContext.DownloadWillBeginEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.DownloadEndEventArgs))]
+[JsonSerializable(typeof(BrowsingContext.DownloadCanceledEventArgs))]
+[JsonSerializable(typeof(BrowsingContext.DownloadCompleteEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.HistoryUpdatedEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.NavigationInfo))]
 [JsonSerializable(typeof(BrowsingContext.UserPromptOpenedEventArgs))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -112,6 +112,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(BrowsingContext.TraverseHistoryResult))]
 
 [JsonSerializable(typeof(BrowsingContext.BrowsingContextInfo))]
+[JsonSerializable(typeof(BrowsingContext.DownloadWillBeginEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.HistoryUpdatedEventArgs))]
 [JsonSerializable(typeof(BrowsingContext.NavigationInfo))]
 [JsonSerializable(typeof(BrowsingContext.UserPromptOpenedEventArgs))]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/DownloadEndEventArgsConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/DownloadEndEventArgsConverter.cs
@@ -1,0 +1,45 @@
+// <copyright file="DownloadEndEventArgsConverter.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using OpenQA.Selenium.BiDi.BrowsingContext;
+using OpenQA.Selenium.BiDi.Communication.Json.Internal;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.Communication.Json.Converters.Polymorphic;
+
+// https://github.com/dotnet/runtime/issues/72604
+internal class DownloadEndEventArgsConverter : JsonConverter<DownloadEndEventArgs>
+{
+    public override DownloadEndEventArgs? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetDiscriminator("status") switch
+        {
+            "canceled" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<DownloadCanceledEventArgs>()),
+            "complete" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<DownloadCompleteEventArgs>()),
+            _ => null,
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, DownloadEndEventArgs value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
@@ -1,0 +1,65 @@
+// <copyright file="BrowsingContextEventsTest.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenQA.Selenium.BiDi.BrowsingContext;
+
+class BrowsingContextEventsTest : BiDiTestFixture
+{
+    [Test]
+    public async Task CanListenDownloadWillBeginEvent()
+    {
+        await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });
+
+        TaskCompletionSource<DownloadWillBeginEventArgs> tcs = new();
+
+        await using var subscription = await context.OnDownloadWillBeginAsync(tcs.SetResult);
+
+        driver.FindElement(By.Id("file-1")).Click();
+
+        var eventArgs = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(eventArgs, Is.Not.Null);
+        Assert.That(eventArgs.Context, Is.EqualTo(context));
+        Assert.That(eventArgs.Url, Does.EndWith("downloads/file_1.txt"));
+        Assert.That(eventArgs.SuggestedFilename, Is.EqualTo("file_1.txt"));
+    }
+
+    [Test]
+    public async Task CanListenDownloadEndEvent()
+    {
+        await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });
+
+        TaskCompletionSource<DownloadEndEventArgs> tcs = new();
+
+        await using var subscription = await context.OnDownloadEndAsync(tcs.SetResult);
+
+        driver.FindElement(By.Id("file-1")).Click();
+
+        var eventArgs = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(eventArgs, Is.Not.Null);
+        Assert.That(eventArgs.Context, Is.EqualTo(context));
+        Assert.That(eventArgs, Is.TypeOf<DownloadCompleteEventArgs>());
+        Assert.That(((DownloadCompleteEventArgs)eventArgs).Filepath, Is.Not.Empty);
+    }
+}

--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
@@ -26,6 +26,7 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 class BrowsingContextEventsTest : BiDiTestFixture
 {
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanListenDownloadWillBeginEvent()
     {
         await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });
@@ -45,6 +46,7 @@ class BrowsingContextEventsTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanListenDownloadEndEvent()
     {
         await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadWillBegin
https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadEnd

### 💥 What does this PR do?
Fix `downloadWillBegin` event signature, implement `downloadEnd` event. Adding tests.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Fix `downloadWillBegin` event signature to use proper event args

- Implement new `downloadEnd` event with polymorphic event args

- Add comprehensive tests for both download events

- Create JSON converters for proper serialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BrowsingContext"] --> B["OnDownloadWillBeginAsync"]
  A --> C["OnDownloadEndAsync"]
  B --> D["DownloadWillBeginEventArgs"]
  C --> E["DownloadEndEventArgs"]
  E --> F["DownloadCanceledEventArgs"]
  E --> G["DownloadCompleteEventArgs"]
  H["JSON Converter"] --> E
  I["Tests"] --> B
  I --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Update download event method signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Fix <code>OnDownloadWillBeginAsync</code> method signatures to use <br><code>DownloadWillBeginEventArgs</code><br> <li> Add new <code>OnDownloadEndAsync</code> methods for both sync and async handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextModule.cs</strong><dd><code>Update module download event subscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs

<ul><li>Fix <code>OnDownloadWillBeginAsync</code> method signatures to use proper event <br>args<br> <li> Add new <code>OnDownloadEndAsync</code> methods subscribing to <br><code>browsingContext.downloadEnd</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-1f04192c50706a21f9dfdc1b79916855ccf2aba6c2c895811f158eeac915680c">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DownloadEndEventArgs.cs</strong><dd><code>Create download end event args classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs

<ul><li>Create abstract base class <code>DownloadEndEventArgs</code><br> <li> Implement <code>DownloadCanceledEventArgs</code> and <code>DownloadCompleteEventArgs</code> <br>derived types<br> <li> Include navigation info and timestamp properties</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-96895fa9bca1263cae645a394e4b4d91ad86dcd07bc93d9f395df57c14660c7e">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DownloadWillBeginEventArgs.cs</strong><dd><code>Create download will begin event args</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/DownloadWillBeginEventArgs.cs

<ul><li>Create <code>DownloadWillBeginEventArgs</code> record with suggested filename<br> <li> Implement <code>IBaseNavigationInfo</code> interface for navigation context</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-9c33fa43b6693134d15cda1553724fff58375721b8dcef138be1b73be9ee2db5">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DownloadEndEventArgsConverter.cs</strong><dd><code>Create polymorphic download end converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/Converters/Polymorphic/DownloadEndEventArgsConverter.cs

<ul><li>Implement custom JSON converter for polymorphic <code>DownloadEndEventArgs</code><br> <li> Handle <code>canceled</code> and <code>complete</code> status discriminators<br> <li> Support deserialization to appropriate derived types</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-0aafac82a87441644bf304bc0f9359e4a0c63a03a2b5304907ce3cbd4beeede8">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Register download end event converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Broker.cs

<ul><li>Register <code>DownloadEndEventArgsConverter</code> for polymorphic JSON <br>serialization</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-5f7fc0e0b816bad29734139ccd27ebb0ff8809c8f49de7827eab7c6c7e8f9669">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Register download event types for serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

<ul><li>Add JSON serializable attributes for all download event args types<br> <li> Include both base and derived download event classes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextEventsTest.cs</strong><dd><code>Add download events integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs

<ul><li>Add test for <code>downloadWillBegin</code> event with file download simulation<br> <li> Add test for <code>downloadEnd</code> event verifying completion and filepath<br> <li> Validate event args properties and types</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16382/files#diff-b3cb443c2ac9387e7845183a2e112c73e864707e2656d2029269970c4f0714a3">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

