### PR TITLE
[dotnet] [bidi] Support browser SetDownloadBehaviour command

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
@@ -52,4 +52,25 @@ public sealed class BrowserModule(Broker broker) : Module(broker)
     {
         return await Broker.ExecuteCommandAsync<GetClientWindowsCommand, GetClientWindowsResult>(new(), options).ConfigureAwait(false);
     }
+
+    public async Task<EmptyResult> SetDownloadBehaviorAllowedAsync(string destinationFolder, SetDownloadBehaviorOptions? options = null)
+    {
+        var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorAllowed(destinationFolder), options?.UserContexts);
+
+        return await Broker.ExecuteCommandAsync<SetDownloadBehaviorCommand, EmptyResult>(new SetDownloadBehaviorCommand(@params), options).ConfigureAwait(false);
+    }
+
+    public async Task<EmptyResult> SetDownloadBehaviorAllowedAsync(SetDownloadBehaviorOptions? options = null)
+    {
+        var @params = new SetDownloadBehaviorParameters(null, options?.UserContexts);
+
+        return await Broker.ExecuteCommandAsync<SetDownloadBehaviorCommand, EmptyResult>(new SetDownloadBehaviorCommand(@params), options).ConfigureAwait(false);
+    }
+
+    public async Task<EmptyResult> SetDownloadBehaviorDeniedAsync(SetDownloadBehaviorOptions? options = null)
+    {
+        var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorDenied(), options?.UserContexts);
+
+        return await Broker.ExecuteCommandAsync<SetDownloadBehaviorCommand, EmptyResult>(new SetDownloadBehaviorCommand(@params), options).ConfigureAwait(false);
+    }
 }

--- a/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
@@ -1,0 +1,43 @@
+// <copyright file="SetDownloadBehaviorCommand.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using OpenQA.Selenium.BiDi.Communication;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.Browser;
+
+internal sealed class SetDownloadBehaviorCommand(SetDownloadBehaviorParameters @params)
+    : Command<SetDownloadBehaviorParameters, EmptyResult>(@params, "browser.setDownloadBehavior");
+
+internal sealed record SetDownloadBehaviorParameters(DownloadBehavior? DownloadBehavior, IEnumerable<UserContext>? UserContexts) : Parameters;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(DownloadBehaviorAllowed), "allowed")]
+[JsonDerivedType(typeof(DownloadBehaviorDenied), "denied")]
+internal abstract record DownloadBehavior;
+
+internal sealed record DownloadBehaviorAllowed(string DestinationFolder) : DownloadBehavior;
+
+internal sealed record DownloadBehaviorDenied : DownloadBehavior;
+
+public sealed class SetDownloadBehaviorOptions : CommandOptions
+{
+    public IEnumerable<UserContext>? UserContexts { get; set; }
+}

--- a/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
@@ -26,7 +26,7 @@ namespace OpenQA.Selenium.BiDi.Browser;
 internal sealed class SetDownloadBehaviorCommand(SetDownloadBehaviorParameters @params)
     : Command<SetDownloadBehaviorParameters, EmptyResult>(@params, "browser.setDownloadBehavior");
 
-internal sealed record SetDownloadBehaviorParameters(DownloadBehavior? DownloadBehavior, IEnumerable<UserContext>? UserContexts) : Parameters;
+internal sealed record SetDownloadBehaviorParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] DownloadBehavior? DownloadBehavior, IEnumerable<UserContext>? UserContexts) : Parameters;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(DownloadBehaviorAllowed), "allowed")]

--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -86,6 +86,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Browser.RemoveUserContextCommand))]
 [JsonSerializable(typeof(Browser.GetClientWindowsCommand))]
 [JsonSerializable(typeof(Browser.GetClientWindowsResult))]
+[JsonSerializable(typeof(Browser.SetDownloadBehaviorCommand))]
 [JsonSerializable(typeof(Browser.UserContextInfo))]
 [JsonSerializable(typeof(IReadOnlyList<Browser.UserContextInfo>))]
 [JsonSerializable(typeof(IReadOnlyList<Browser.ClientWindowInfo>))]

--- a/dotnet/test/common/BiDi/Browser/BrowserTest.cs
+++ b/dotnet/test/common/BiDi/Browser/BrowserTest.cs
@@ -69,4 +69,37 @@ class BrowserTest : BiDiTestFixture
         Assert.That(clientWindows, Has.Count.GreaterThanOrEqualTo(1));
         Assert.That(clientWindows[0].ClientWindow, Is.Not.Null);
     }
+
+    [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
+    public async Task CanSetDownloadBehaviorAllowed()
+    {
+        var result = await bidi.Browser.SetDownloadBehaviorAllowedAsync("/my/path");
+
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
+    public async Task CanSetDownloadBehaviorAllowedDefault()
+    {
+        var result = await bidi.Browser.SetDownloadBehaviorAllowedAsync();
+
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
+    public async Task CanSetDownloadBehaviorDenied()
+    {
+        var result = await bidi.Browser.SetDownloadBehaviorDeniedAsync();
+
+        Assert.That(result, Is.Not.Null);
+    }
 }


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#command-browser-setDownloadBehavior

### 💥 What does this PR do?
Implements `SetDownloadBehavior` command.

### 💡 Additional Considerations
Not yet supported by browsers, but I verified locally whether we serialize command properly.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement WebDriver BiDi `SetDownloadBehavior` command

- Add support for allowed/denied download behaviors

- Include comprehensive test coverage for all scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BrowserModule"] --> B["SetDownloadBehaviorCommand"]
  B --> C["DownloadBehavior Types"]
  C --> D["DownloadBehaviorAllowed"]
  C --> E["DownloadBehaviorDenied"]
  F["JSON Serialization"] --> B
  G["Tests"] --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserModule.cs</strong><dd><code>Add SetDownloadBehavior methods to BrowserModule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs

<ul><li>Add three async methods for setting download behavior<br> <li> Support allowed behavior with destination folder<br> <li> Support allowed behavior with default settings<br> <li> Support denied behavior configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16383/files#diff-8e4bcc00ef63cf737c6e26397ac40f1e18d960e4ff47589fee1bae1b9fe8cdc7">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SetDownloadBehaviorCommand.cs</strong><dd><code>Create SetDownloadBehavior command infrastructure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs

<ul><li>Create new command class for SetDownloadBehavior<br> <li> Define polymorphic DownloadBehavior base class<br> <li> Implement DownloadBehaviorAllowed and DownloadBehaviorDenied types<br> <li> Add SetDownloadBehaviorOptions configuration class</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16383/files#diff-3b8a97c7277de592d327c59de8b49ab916db6d58702abacaafabc76fa7d71c69">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Register command for JSON serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

- Register SetDownloadBehaviorCommand for JSON serialization


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16383/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserTest.cs</strong><dd><code>Add comprehensive SetDownloadBehavior tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Browser/BrowserTest.cs

<ul><li>Add test for allowed download behavior with path<br> <li> Add test for default allowed download behavior<br> <li> Add test for denied download behavior<br> <li> Include browser ignore attributes for unsupported browsers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16383/files#diff-0628232f831c351032d9d79e558fe9d84032404228a29a40679dd618371b467e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

