### PR TITLE
[dotnet] [bidi] Support network SetExtraHeaders command

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs
@@ -131,6 +131,7 @@ namespace OpenQA.Selenium.BiDi.Communication.Json;
 [JsonSerializable(typeof(Network.RemoveDataCollectorCommand))]
 [JsonSerializable(typeof(Network.RemoveInterceptCommand))]
 [JsonSerializable(typeof(Network.SetCacheBehaviorCommand))]
+[JsonSerializable(typeof(Network.SetExtraHeadersCommand))]
 
 [JsonSerializable(typeof(Network.BeforeRequestSentEventArgs))]
 [JsonSerializable(typeof(Network.ResponseStartedEventArgs))]

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
@@ -65,6 +65,13 @@ public sealed partial class NetworkModule(Broker broker) : Module(broker)
         return await Broker.ExecuteCommandAsync<SetCacheBehaviorCommand, EmptyResult>(new SetCacheBehaviorCommand(@params), options).ConfigureAwait(false);
     }
 
+    public async Task<EmptyResult> SetExtraHeadersAsync(IEnumerable<Header> headers, SetExtraHeadersOptions? options = null)
+    {
+        var @params = new SetExtraHeadersParameters(headers, options?.Contexts, options?.UserContexts);
+
+        return await Broker.ExecuteCommandAsync<SetExtraHeadersCommand, EmptyResult>(new SetExtraHeadersCommand(@params), options).ConfigureAwait(false);
+    }
+
     public async Task<EmptyResult> ContinueRequestAsync(Request request, ContinueRequestOptions? options = null)
     {
         var @params = new ContinueRequestParameters(request, options?.Body, options?.Cookies, options?.Headers, options?.Method, options?.Url);

--- a/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
@@ -1,0 +1,35 @@
+// <copyright file="SetExtraHeadersCommand.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using OpenQA.Selenium.BiDi.Communication;
+
+namespace OpenQA.Selenium.BiDi.Network;
+
+internal sealed class SetExtraHeadersCommand(SetExtraHeadersParameters @params)
+    : Command<SetExtraHeadersParameters, EmptyResult>(@params, "network.setExtraHeaders");
+
+internal sealed record SetExtraHeadersParameters(IEnumerable<Header> Headers, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
+
+public sealed class SetExtraHeadersOptions : CommandOptions
+{
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+}

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -251,4 +251,12 @@ class NetworkTest : BiDiTestFixture
         Assert.That(async () => await bidi.Network.SetCacheBehaviorAsync(CacheBehavior.Default), Throws.Nothing);
         Assert.That(async () => await context.Network.SetCacheBehaviorAsync(CacheBehavior.Default), Throws.Nothing);
     }
+
+    [Test]
+    public async Task CanSetExtraHeaders()
+    {
+        var result = await bidi.Network.SetExtraHeadersAsync([new Header("x-test-header", "test-value")]);
+
+        Assert.That(result, Is.Not.Null);
+    }
 }

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -253,6 +253,9 @@ class NetworkTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanSetExtraHeaders()
     {
         var result = await bidi.Network.SetExtraHeadersAsync([new Header("x-test-header", "test-value")]);


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#command-network-setExtraHeaders

### 💥 What does this PR do?
Implements `SetExtraHeaders` command in Network module.

### 💡 Additional Considerations
Test is ignored, but I verified locally for Chrome Dev channel.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `SetExtraHeaders` command to Network module

- Implement BiDi network header manipulation functionality

- Include command parameters and options classes

- Add test coverage with browser compatibility notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NetworkModule"] --> B["SetExtraHeadersAsync method"]
  B --> C["SetExtraHeadersCommand"]
  C --> D["SetExtraHeadersParameters"]
  E["BiDiJsonSerializerContext"] --> C
  F["NetworkTest"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDiJsonSerializerContext.cs</strong><dd><code>Register SetExtraHeadersCommand for JSON serialization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Json/BiDiJsonSerializerContext.cs

- Add JSON serialization support for `SetExtraHeadersCommand`


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16384/files#diff-940ec174f427c0fe37ed4a09cd37840b888f4a379f42a49d8877b75460cd4048">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkModule.cs</strong><dd><code>Implement SetExtraHeadersAsync method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/NetworkModule.cs

<ul><li>Add <code>SetExtraHeadersAsync</code> method to NetworkModule<br> <li> Accept headers collection and optional contexts/user contexts</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16384/files#diff-ddd0c9f9565ffffc6a3ce489431b76319cc38c727006605f7dc6345b2c0f7c81">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SetExtraHeadersCommand.cs</strong><dd><code>Create SetExtraHeaders command infrastructure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs

<ul><li>Create new command class for setting extra headers<br> <li> Define parameters record with headers and context options<br> <li> Add options class for command configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16384/files#diff-8d86405135b93e41a15aab5a174de7a9175c8f109df358c3bb17ce21458dd5ee">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkTest.cs</strong><dd><code>Add SetExtraHeaders test with browser ignores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkTest.cs

<ul><li>Add test for <code>SetExtraHeaders</code> functionality<br> <li> Include browser compatibility annotations (all ignored)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16384/files#diff-6e4fab225f6b53775948caadd4c88fda1f84c06dc51cc76412ca2a93e07dceb7">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

