### PR TITLE
[py] Fix Selenium Manager tests on Windows

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -127,7 +127,7 @@ jobs:
           bazelisk-cache: true
           bazelrc: common --color=yes
           # Workaround for long path issues: https://github.com/bazelbuild/bazel/pull/22532
-          output-base: ${{ inputs.os == 'windows' && 'D://b || '' }}
+          output-base: ${{ inputs.os == 'windows' && 'D://b' || '' }}
           cache-version: 2
           disk-cache: ${{ inputs.cache-key }}
           external-cache: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -126,6 +126,8 @@ jobs:
         with:
           bazelisk-cache: true
           bazelrc: common --color=yes
+          # Workaround for long path issues: https://github.com/bazelbuild/bazel/pull/22532
+          output-base: ${{ inputs.os == 'windows' && 'D://b || '' }}
           cache-version: 2
           disk-cache: ${{ inputs.cache-key }}
           external-cache: |

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -64,6 +64,7 @@ jobs:
         include:
           - os: ubuntu
           - os: macos
+          - os: windows
     with:
       name: Unit Tests (${{ matrix.os }})
       os: ${{ matrix.os }}
@@ -99,6 +100,10 @@ jobs:
             os: ubuntu
           - browser: firefox
             os: ubuntu
+          - browser: chrome
+            os: windows
+          - browser: edge
+            os: windows
     with:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -64,7 +64,6 @@ jobs:
         include:
           - os: ubuntu
           - os: macos
-          - os: windows
     with:
       name: Unit Tests (${{ matrix.os }})
       os: ${{ matrix.os }}
@@ -100,19 +99,13 @@ jobs:
             os: ubuntu
           - browser: firefox
             os: ubuntu
-          - browser: chrome
-            os: windows
-          - browser: edge
-            os: windows
     with:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:test-${{ matrix.browser }}
-
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
   safari-tests:
     name: Browser Tests
     needs: build
@@ -129,5 +122,4 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -106,6 +106,7 @@ jobs:
       cache-key: py-browser-${{ matrix.browser }}
       run: |
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
+
   safari-tests:
     name: Browser Tests
     needs: build

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -99,10 +99,6 @@ jobs:
             os: ubuntu
           - browser: firefox
             os: ubuntu
-          - browser: chrome
-            os: windows
-          - browser: edge
-            os: windows
     with:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}

--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import json
 import platform
 import sys
@@ -43,12 +44,13 @@ def test_gets_results(monkeypatch):
 
 
 def test_uses_environment_variable(monkeypatch):
-    monkeypatch.setenv("SE_MANAGER_PATH", "/path/to/manager")
+    sm_path =  r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
+    monkeypatch.setenv("SE_MANAGER_PATH", sm_path)
     monkeypatch.setattr(Path, "is_file", lambda _: True)
 
     binary = SeleniumManager()._get_binary()
 
-    assert str(binary) == "/path/to/manager"
+    assert str(binary) == sm_path
 
 
 def test_uses_windows(monkeypatch):
@@ -59,16 +61,22 @@ def test_uses_windows(monkeypatch):
     assert binary == project_root.joinpath("selenium/webdriver/common/windows/selenium-manager.exe")
 
 
+
 def test_uses_linux(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
 
-    if platform.machine() == "arm64":
-        with pytest.raises(WebDriverException, match="Unsupported platform/architecture combination: linux/arm64"):
-            SeleniumManager()._get_binary()
-    else:
-        binary = SeleniumManager()._get_binary()
-        project_root = Path(selenium.__file__).parent.parent
-        assert binary == project_root.joinpath("selenium/webdriver/common/linux/selenium-manager")
+    binary = SeleniumManager()._get_binary()
+    project_root = Path(selenium.__file__).parent.parent
+    assert binary == project_root.joinpath("selenium/webdriver/common/linux/selenium-manager")
+
+
+def test_uses_linux_arm64(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+
+    with pytest.raises(WebDriverException, match="Unsupported platform/architecture combination: linux/arm64"):
+        SeleniumManager()._get_binary()
 
 
 def test_uses_mac(monkeypatch):
@@ -97,11 +105,12 @@ def test_errors_if_invalid_os(monkeypatch):
 
 
 def test_error_if_invalid_env_path(monkeypatch):
-    monkeypatch.setenv("SE_MANAGER_PATH", "/path/to/manager")
+    sm_path =  r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
+    monkeypatch.setenv("SE_MANAGER_PATH", sm_path)
 
     with pytest.raises(WebDriverException) as excinfo:
         SeleniumManager()._get_binary()
-    assert "Unable to obtain working Selenium Manager binary; /path/to/manager" in str(excinfo.value)
+    assert f"Unable to obtain working Selenium Manager binary; {sm_path}" in str(excinfo.value)
 
 
 def test_run_successful():

--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import json
-import platform
 import sys
 from pathlib import Path
 from unittest import mock
@@ -44,7 +43,7 @@ def test_gets_results(monkeypatch):
 
 
 def test_uses_environment_variable(monkeypatch):
-    sm_path =  r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
+    sm_path = r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
     monkeypatch.setenv("SE_MANAGER_PATH", sm_path)
     monkeypatch.setattr(Path, "is_file", lambda _: True)
 
@@ -59,7 +58,6 @@ def test_uses_windows(monkeypatch):
 
     project_root = Path(selenium.__file__).parent.parent
     assert binary == project_root.joinpath("selenium/webdriver/common/windows/selenium-manager.exe")
-
 
 
 def test_uses_linux(monkeypatch):
@@ -105,7 +103,7 @@ def test_errors_if_invalid_os(monkeypatch):
 
 
 def test_error_if_invalid_env_path(monkeypatch):
-    sm_path =  r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
+    sm_path = r"\path\to\manager" if sys.platform.startswith("win") else "path/to/manager"
     monkeypatch.setenv("SE_MANAGER_PATH", sm_path)
 
     with pytest.raises(WebDriverException) as excinfo:


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

- Fixes Selenium Manager tests for Python that were failing on Windows.
- Removes Windows tests from the workflow matrix until #16390 is solved.
- Combines Bazel commands into a single invocation. Previously, we were getting false positive test runs (the job would pass if the 2nd bazel command passed, even if the previous test command failed)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Test

___

### **PR Type**
Tests


___

### **Description**
- Fix Windows path handling in Selenium Manager tests

- Split Linux test into separate x86_64 and arm64 cases

- Workaround for Bazel issues on Windows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows Path Issues"] --> B["Fix Path Separators"]
  C["Linux Test Issues"] --> D["Split Architecture Tests"]
  B --> G["Tests Pass on Windows"]
  D --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager_tests.py</strong><dd><code>Fix Windows paths and split Linux tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/selenium_manager_tests.py

<ul><li>Fix Windows path separators using raw strings and platform detection<br> <li> Split Linux test into separate x86_64 and arm64 test functions<br> <li> Mock platform.machine() for consistent test behavior<br> <li> Update assertion messages to use dynamic path variables</ul>


</details>


