### PR TITLE
[py][build] Re-add Windows to CI workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -127,7 +127,7 @@ jobs:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
-      cache-key: py-browser-windows-${{ matrix.browser }}
+      cache-key: py-browser-${{ matrix.browser }}
       run: |
         fsutil 8dot3name set 0
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
@@ -146,6 +146,6 @@ jobs:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
-      cache-key: py-browser-macos-${{ matrix.browser }}
+      cache-key: py-browser-${{ matrix.browser }}
       run: |
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -140,8 +140,6 @@ jobs:
             os: windows
           - browser: edge
             os: windows
-          - browser: firefox
-            os: windows
     with:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -73,23 +73,6 @@ jobs:
       run: |
         bazel test //py:unit
 
-  unit-tests-windows:
-    name: Unit Tests
-    needs: build
-    uses: ./.github/workflows/bazel.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows
-    with:
-      name: Unit Tests (${{ matrix.os }})
-      os: ${{ matrix.os }}
-      cache-key: python-unit-test-${{ matrix.os }}
-      run: |
-        fsutil 8dot3name set 0
-        bazel test //py:unit
-
   remote-tests:
     name: Remote Tests
     needs: build

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -127,12 +127,12 @@ jobs:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
-      cache-key: py-browser-${{ matrix.browser }}
+      cache-key: py-browser-windows-${{ matrix.browser }}
       run: |
         fsutil 8dot3name set 0
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
 
-  safari-tests:
+  browser-tests-macos:
     name: Browser Tests
     needs: build
     uses: ./.github/workflows/bazel.yml
@@ -146,6 +146,6 @@ jobs:
       name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
-      cache-key: py-browser-${{ matrix.browser }}
+      cache-key: py-browser-macos-${{ matrix.browser }}
       run: |
         bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -126,9 +126,7 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
-          //py:common-${{ matrix.browser }}-bidi \
-          //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
 
   browser-tests-windows:
     name: Browser Tests
@@ -151,9 +149,7 @@ jobs:
       cache-key: py-browser-${{ matrix.browser }}
       run: |
         fsutil 8dot3name set 0
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
-          //py:common-${{ matrix.browser }}-bidi \
-          //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
 
   safari-tests:
     name: Browser Tests
@@ -171,6 +167,4 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
-          //py:common-${{ matrix.browser }} \
-          //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -11,7 +11,8 @@ jobs:
     with:
       name: Build
       cache-key: py-build
-      run: bazel build //py:selenium-wheel //py:selenium-sdist
+      run: |
+        bazel build //py:selenium-wheel //py:selenium-sdist
 
   docs:
     name: Documentation
@@ -29,7 +30,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox==4.30.2
       - name: Generate docs
-        run: tox -c py/tox.ini
+        run: |
+          tox -c py/tox.ini
         env:
           TOXENV: docs
 
@@ -68,7 +70,25 @@ jobs:
       name: Unit Tests (${{ matrix.os }})
       os: ${{ matrix.os }}
       cache-key: python-unit-test-${{ matrix.os }}
-      run: bazel test //py:unit
+      run: |
+        bazel test //py:unit
+
+  unit-tests-windows:
+    name: Unit Tests
+    needs: build
+    uses: ./.github/workflows/bazel.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows
+    with:
+      name: Unit Tests (${{ matrix.os }})
+      os: ${{ matrix.os }}
+      cache-key: python-unit-test-${{ matrix.os }}
+      run: |
+        fsutil 8dot3name set 0
+        bazel test //py:unit
 
   remote-tests:
     name: Remote Tests
@@ -83,7 +103,8 @@ jobs:
       name: Integration Tests (remote, ${{ matrix.browser }})
       browser: ${{ matrix.browser }}
       cache-key: py-remote-${{ matrix.browser }}
-      run: bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-remote
+      run: |
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-remote
 
   browser-tests:
     name: Browser Tests
@@ -105,7 +126,34 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
+          //py:common-${{ matrix.browser }}-bidi \
+          //py:test-${{ matrix.browser }}
+
+  browser-tests-windows:
+    name: Browser Tests
+    needs: build
+    uses: ./.github/workflows/bazel.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - browser: chrome
+            os: windows
+          - browser: edge
+            os: windows
+          - browser: firefox
+            os: windows
+    with:
+      name: Integration Tests (${{ matrix.browser }}, ${{ matrix.os }})
+      browser: ${{ matrix.browser }}
+      os: ${{ matrix.os }}
+      cache-key: py-browser-${{ matrix.browser }}
+      run: |
+        fsutil 8dot3name set 0
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
+          //py:common-${{ matrix.browser }}-bidi \
+          //py:test-${{ matrix.browser }}
 
   safari-tests:
     name: Browser Tests
@@ -123,4 +171,6 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true \
+          //py:common-${{ matrix.browser }} \
+          //py:test-${{ matrix.browser }}

--- a/py/test/unit/selenium/webdriver/remote/new_session_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/new_session_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 from importlib import import_module
 
 import pytest

--- a/py/test/unit/selenium/webdriver/remote/subtyping_tests.py
+++ b/py/test/unit/selenium/webdriver/remote/subtyping_tests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 from selenium.webdriver.remote.webdriver import WebDriver, WebElement
 
 


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #16390

### 💥 What does this PR do?

This PR adds a new GitHub Actions workflow jobs for Python: `browser-tests-windows`

This runs the Python integration tests on Windows/Chrome and Windows/Edge. The job is identical to the existing `browser-tests` job, but it includes the `fsutil 8dot3name set 0` command to workaround the long path name issue that Bazel has on Windows. 

Note: There's probably a better way to do this using a single matrix job where the command is only run when the runner is using Windows, but I couldn't figure that out.

### 💡 Additional Considerations

- Unit tests on Windows are still not included because some tests randomly timeout on the GHA runners (can't reproduce locally)
- Firefox on Windows is not included because it is insanely slow and would increase the job run time to 2+ hours

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Build/Test


___

### **PR Type**
Tests


___

### **Description**
- Add Windows CI job for browser tests

- Include Windows path workaround with `fsutil 8dot3name set 0`

- Support Chrome and Edge on Windows

- Minor formatting improvements to existing commands


___

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-python.yml</strong><dd><code>Add Windows CI jobs and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-python.yml

<ul><li> Add <code>browser-tests-windows</code> job for Chrome, Edge<br> <li> Include <code>fsutil 8dot3name set 0</code> command for path issues<br>

</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16396/files#diff-a7ec86144013d78c9f1d734aa65a898e66b609638aa7b872491ee3858ebebbeb">+56/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new_session_tests.py</strong><dd><code>Remove extra blank line</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/unit/selenium/webdriver/remote/new_session_tests.py

- Remove extra blank line after license header


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16396/files#diff-796ccf287d5fe4869871971128599eb2c753a904cc8181399272687dea26441e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subtyping_tests.py</strong><dd><code>Remove extra blank line</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/unit/selenium/webdriver/remote/subtyping_tests.py

- Remove extra blank line after license header


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16396/files#diff-3dfa911f886315f3a6e37f89d8a97910a56c2131cdbaa44f151d333c0549c097">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

