### PR TITLE
[dotnet] Replace lazy caching mechanism in BiDi's constructor with simple initialization

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -17,14 +17,14 @@
 // under the License.
 // </copyright>
 
-using OpenQA.Selenium.BiDi.Communication;
-using OpenQA.Selenium.BiDi.Communication.Json;
-using OpenQA.Selenium.BiDi.Communication.Json.Converters;
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenQA.Selenium.BiDi.Communication;
+using OpenQA.Selenium.BiDi.Communication.Json;
+using OpenQA.Selenium.BiDi.Communication.Json.Converters;
 
 namespace OpenQA.Selenium.BiDi;
 

--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -17,15 +17,14 @@
 // under the License.
 // </copyright>
 
+using OpenQA.Selenium.BiDi.Communication;
+using OpenQA.Selenium.BiDi.Communication.Json;
+using OpenQA.Selenium.BiDi.Communication.Json.Converters;
 using System;
-using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenQA.Selenium.BiDi.Communication;
-using OpenQA.Selenium.BiDi.Communication.Json;
-using OpenQA.Selenium.BiDi.Communication.Json.Converters;
 
 namespace OpenQA.Selenium.BiDi;
 
@@ -34,8 +33,6 @@ public sealed class BiDi : IAsyncDisposable
     private readonly Broker _broker;
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly BiDiJsonSerializerContext _jsonContext;
-
-    private readonly ConcurrentDictionary<Type, Module> _modules = [];
 
     private BiDi(string url)
     {
@@ -68,32 +65,37 @@ public sealed class BiDi : IAsyncDisposable
         _jsonContext = new BiDiJsonSerializerContext(_jsonOptions);
 
         _broker = new Broker(this, uri, _jsonOptions);
+        SessionModule = Module.Create<Session.SessionModule>(this, _broker, _jsonOptions, _jsonContext);
+        BrowsingContext = Module.Create<BrowsingContext.BrowsingContextModule>(this, _broker, _jsonOptions, _jsonContext);
+        Browser = Module.Create<Browser.BrowserModule>(this, _broker, _jsonOptions, _jsonContext);
+        Network = Module.Create<Network.NetworkModule>(this, _broker, _jsonOptions, _jsonContext);
+        InputModule = Module.Create<Input.InputModule>(this, _broker, _jsonOptions, _jsonContext);
+        Script = Module.Create<Script.ScriptModule>(this, _broker, _jsonOptions, _jsonContext);
+        Log = Module.Create<Log.LogModule>(this, _broker, _jsonOptions, _jsonContext);
+        Storage = Module.Create<Storage.StorageModule>(this, _broker, _jsonOptions, _jsonContext);
+        WebExtension = Module.Create<WebExtension.WebExtensionModule>(this, _broker, _jsonOptions, _jsonContext);
+        Emulation = Module.Create<Emulation.EmulationModule>(this, _broker, _jsonOptions, _jsonContext);
     }
 
-    internal Session.SessionModule SessionModule => AsModule<Session.SessionModule>();
+    internal Session.SessionModule SessionModule { get; }
 
-    public BrowsingContext.BrowsingContextModule BrowsingContext => AsModule<BrowsingContext.BrowsingContextModule>();
+    public BrowsingContext.BrowsingContextModule BrowsingContext { get; }
 
-    public Browser.BrowserModule Browser => AsModule<Browser.BrowserModule>();
+    public Browser.BrowserModule Browser { get; }
 
-    public Network.NetworkModule Network => AsModule<Network.NetworkModule>();
+    public Network.NetworkModule Network { get; }
 
-    internal Input.InputModule InputModule => AsModule<Input.InputModule>();
+    internal Input.InputModule InputModule { get; }
 
-    public Script.ScriptModule Script => AsModule<Script.ScriptModule>();
+    public Script.ScriptModule Script { get; }
 
-    public Log.LogModule Log => AsModule<Log.LogModule>();
+    public Log.LogModule Log { get; }
 
-    public Storage.StorageModule Storage => AsModule<Storage.StorageModule>();
+    public Storage.StorageModule Storage { get; }
 
-    public WebExtension.WebExtensionModule WebExtension => AsModule<WebExtension.WebExtensionModule>();
+    public WebExtension.WebExtensionModule WebExtension { get; }
 
-    public Emulation.EmulationModule Emulation => AsModule<Emulation.EmulationModule>();
-
-    public TModule AsModule<TModule>() where TModule : Module, new()
-    {
-        return (TModule)_modules.GetOrAdd(typeof(TModule), _ => Module.Create<TModule>(this, _broker, _jsonOptions, _jsonContext));
-    }
+    public Emulation.EmulationModule Emulation { get; }
 
     public Task<Session.StatusResult> StatusAsync()
     {


### PR DESCRIPTION
### **User description**
### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Replace lazy caching mechanism with direct initialization

- Remove ConcurrentDictionary and AsModule method

- Convert module properties to auto-properties

- Reorganize using statements for better readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lazy Loading"] --> B["Direct Initialization"]
  C["ConcurrentDictionary"] --> D["Auto-Properties"]
  E["AsModule Method"] --> F["Constructor Assignment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDi.cs</strong><dd><code>Simplify module initialization pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BiDi.cs

<ul><li>Removed ConcurrentDictionary-based lazy loading mechanism<br> <li> Replaced AsModule method with direct module initialization in <br>constructor<br> <li> Converted module properties from methods to auto-properties<br> <li> Reorganized using statements alphabetically</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16399/files#diff-3f77d71f94e2a47ea90b74f6d37b5a5b94dc83b2f558b30ab070588b9028c2f6">+23/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

