### PR TITLE
[dotnet] Help more .NETFramework projects to copy SM binaries to output

### DIFF
--- a/dotnet/src/webdriver/assets/nuget/build/Selenium.WebDriver.targets
+++ b/dotnet/src/webdriver/assets/nuget/build/Selenium.WebDriver.targets
@@ -3,7 +3,7 @@
 
   <!-- Only run if the consumer did NOT set a RID (so NuGet won't select runtimes assets),
        and only for .NET Framework projects where this problem is common. -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win\native\selenium-manager.exe">
       <Link>runtimes\win\native\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/16400

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `RuntimeIdentifiers` condition check in MSBuild targets

- Enable Selenium Manager binary copying for more .NET Framework projects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSBuild Condition"] -- "Remove RuntimeIdentifiers check" --> B["More Projects Supported"]
  B --> C["Selenium Manager Binaries Copied"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.targets</strong><dd><code>Simplify MSBuild condition for binary copying</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/assets/nuget/build/Selenium.WebDriver.targets

<ul><li>Remove <code>RuntimeIdentifiers</code> empty check from MSBuild condition<br> <li> Simplify condition to only check <code>RuntimeIdentifier</code> and target <br>framework</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16406/files#diff-6ebc02b5b46e0df94e0b4db117163a13774b44d9d8c7912710617015350048e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

