### PR TITLE
[dotnet] Remove obsoleted FtpProxy

### DIFF
--- a/dotnet/src/webdriver/Proxy.cs
+++ b/dotnet/src/webdriver/Proxy.cs
@@ -72,7 +72,6 @@ public class Proxy
 {
     private ProxyKind proxyKind = ProxyKind.Unspecified;
     private bool isAutoDetect;
-    private string? ftpProxyLocation;
     private string? httpProxyLocation;
     private string? proxyAutoConfigUrl;
     private string? sslProxyLocation;
@@ -114,11 +113,6 @@ public class Proxy
                 ProxyKind rawType = (ProxyKind)Enum.Parse(typeof(ProxyKind), proxyType, ignoreCase: true);
                 this.Kind = rawType;
             }
-        }
-
-        if (settings.TryGetValue("ftpProxy", out object? ftpProxyObj) && ftpProxyObj?.ToString() is string ftpProxy)
-        {
-            this.FtpProxy = ftpProxy;
         }
 
         if (settings.TryGetValue("httpProxy", out object? httpProxyObj) && httpProxyObj?.ToString() is string httpProxy)
@@ -233,24 +227,6 @@ public class Proxy
             this.VerifyProxyTypeCompatilibily(ProxyKind.AutoDetect);
             this.proxyKind = ProxyKind.AutoDetect;
             this.isAutoDetect = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the value of the proxy for the FTP protocol.
-    /// </summary>
-    [JsonPropertyName("ftpProxy")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Obsolete("FTP proxy support is deprecated and will be removed in the 4.37 version.")]
-    public string? FtpProxy
-    {
-        get => this.ftpProxyLocation;
-
-        set
-        {
-            this.VerifyProxyTypeCompatilibily(ProxyKind.Manual);
-            this.proxyKind = ProxyKind.Manual;
-            this.ftpProxyLocation = value;
         }
     }
 
@@ -492,11 +468,6 @@ public class Proxy
             if (!string.IsNullOrEmpty(this.sslProxyLocation))
             {
                 serializedDictionary["sslProxy"] = this.sslProxyLocation;
-            }
-
-            if (!string.IsNullOrEmpty(this.ftpProxyLocation))
-            {
-                serializedDictionary["ftpProxy"] = this.ftpProxyLocation;
             }
 
             if (!string.IsNullOrEmpty(this.socksProxyLocation))

--- a/dotnet/test/common/ProxyTest.cs
+++ b/dotnet/test/common/ProxyTest.cs
@@ -31,7 +31,6 @@ public class ProxyTest
         Proxy proxy = new Proxy();
 
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.Unspecified));
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -54,7 +53,6 @@ public class ProxyTest
         Assert.That(() => proxy.SocksUserName = "", Throws.InvalidOperationException);
         Assert.That(() => proxy.SocksProxy = "", Throws.InvalidOperationException);
         Assert.That(() => proxy.SocksVersion = 5, Throws.InvalidOperationException);
-        Assert.That(() => proxy.FtpProxy = "", Throws.InvalidOperationException);
         Assert.That(() => proxy.HttpProxy = "", Throws.InvalidOperationException);
         Assert.That(() => proxy.SslProxy = "", Throws.InvalidOperationException);
         Assert.That(() => proxy.ProxyAutoConfigUrl = "", Throws.InvalidOperationException);
@@ -73,7 +71,6 @@ public class ProxyTest
         Proxy proxy = new Proxy();
 
         proxy.HttpProxy = "http.proxy:1234";
-        proxy.FtpProxy = "ftp.proxy";
         proxy.SslProxy = "ssl.proxy";
         proxy.AddBypassAddresses("localhost", "127.0.0.*");
         proxy.SocksProxy = "socks.proxy:65555";
@@ -82,7 +79,6 @@ public class ProxyTest
         proxy.SocksPassword = "test2";
 
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.Manual));
-        Assert.That(proxy.FtpProxy, Is.EqualTo("ftp.proxy"));
         Assert.That(proxy.HttpProxy, Is.EqualTo("http.proxy:1234"));
         Assert.That(proxy.SslProxy, Is.EqualTo("ssl.proxy"));
         Assert.That(proxy.SocksProxy, Is.EqualTo("socks.proxy:65555"));
@@ -104,7 +100,6 @@ public class ProxyTest
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.ProxyAutoConfigure));
         Assert.That(proxy.ProxyAutoConfigUrl, Is.EqualTo("http://aaa/bbb.pac"));
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -124,7 +119,6 @@ public class ProxyTest
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.AutoDetect));
         Assert.That(proxy.IsAutoDetect, Is.True);
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -153,7 +147,6 @@ public class ProxyTest
         Proxy proxy = new Proxy(proxyData);
 
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.Manual));
-        Assert.That(proxy.FtpProxy, Is.EqualTo("ftp.proxy"));
         Assert.That(proxy.HttpProxy, Is.EqualTo("http.proxy:1234"));
         Assert.That(proxy.SslProxy, Is.EqualTo("ssl.proxy"));
         Assert.That(proxy.SocksProxy, Is.EqualTo("socks.proxy:65555"));
@@ -199,7 +192,6 @@ public class ProxyTest
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.ProxyAutoConfigure));
         Assert.That(proxy.ProxyAutoConfigUrl, Is.EqualTo("http://aaa/bbb.pac"));
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -222,7 +214,6 @@ public class ProxyTest
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.AutoDetect));
         Assert.That(proxy.IsAutoDetect, Is.True);
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -243,7 +234,6 @@ public class ProxyTest
 
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.System));
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -265,7 +255,6 @@ public class ProxyTest
 
         Assert.That(proxy.Kind, Is.EqualTo(ProxyKind.Direct));
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.HttpProxy, Is.Null);
         Assert.That(proxy.SslProxy, Is.Null);
         Assert.That(proxy.SocksProxy, Is.Null);
@@ -281,13 +270,11 @@ public class ProxyTest
     public void ConstructingWithNullKeysWorksAsExpected()
     {
         Dictionary<string, object> rawProxy = new Dictionary<string, object>();
-        rawProxy.Add("ftpProxy", null);
         rawProxy.Add("httpProxy", "http://www.example.com");
         rawProxy.Add("autodetect", null);
 
         Proxy proxy = new Proxy(rawProxy);
 
-        Assert.That(proxy.FtpProxy, Is.Null);
         Assert.That(proxy.IsAutoDetect, Is.False);
         Assert.That(proxy.HttpProxy, Is.EqualTo("http://www.example.com"));
     }


### PR DESCRIPTION
### **User description**
This pull request removes support for FTP proxies from the `Proxy` class and its related tests. The changes simplify the codebase by eliminating the `FtpProxy` property, its serialization, and all associated logic and tests. This aligns with the previous deprecation notice and helps maintain a cleaner, more focused proxy implementation.

### 💥 What does this PR do?
* Removed the `FtpProxy` property, its backing field, and related logic from the `Proxy` class, including JSON serialization and dictionary conversion.
* Removed handling of the `ftpProxy` key in the `Proxy(Dictionary<string, object> settings)` constructor.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Other


___

### **Description**
- Remove deprecated `FtpProxy` property from Proxy class

- Clean up related serialization and constructor logic

- Update all associated unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Proxy Class"] --> B["Remove FtpProxy Property"]
  B --> C["Remove Serialization Logic"]
  B --> D["Remove Constructor Handling"]
  E["Unit Tests"] --> F["Remove FtpProxy Assertions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Proxy.cs</strong><dd><code>Remove FtpProxy property and related logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Proxy.cs

<ul><li>Remove <code>ftpProxyLocation</code> field and <code>FtpProxy</code> property<br> <li> Remove FTP proxy handling from constructor and serialization<br> <li> Clean up JSON attributes and obsolete annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16411/files#diff-1232f487fb55bb2e5ec46d8da9ca7f1821c359d93bea34694f80cb44a332bd19">+0/-29</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProxyTest.cs</strong><dd><code>Remove FtpProxy test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/ProxyTest.cs

<ul><li>Remove all <code>FtpProxy</code> assertions from test methods<br> <li> Remove FTP proxy setup from manual proxy tests<br> <li> Clean up dictionary-based proxy construction tests</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16411/files#diff-08a624bc925e510f8590112a19654b709bc85855fc26201ec77200de1e729dfa">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

