### PR TITLE
[java] Rescuing the remote cause for session creation errors

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -572,10 +572,14 @@ public class RemoteWebDriver
         if (e instanceof SessionNotCreatedException) {
           toThrow = (WebDriverException) e;
         } else {
+          // When this exception comes from a remote end, the real cause is usually hidden in the
+          // cause. Let's try to rescue it and display it at the top level.
+          String cause = e.getCause() != null ? e.getCause().getMessage() : "";
           toThrow =
               new SessionNotCreatedException(
                   "Possible causes are invalid address of the remote server or browser start-up"
-                      + " failure.",
+                      + " failure. "
+                      + cause,
                   e);
         }
       } else if (e instanceof WebDriverException) {

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -574,11 +574,11 @@ public class RemoteWebDriver
         } else {
           // When this exception comes from a remote end, the real cause is usually hidden in the
           // cause. Let's try to rescue it and display it at the top level.
-          String cause = e.getCause() != null ? e.getCause().getMessage() : "";
+          String cause = e.getCause() != null ? " " + e.getCause().getMessage() : "";
           toThrow =
               new SessionNotCreatedException(
                   "Possible causes are invalid address of the remote server or browser start-up"
-                      + " failure. "
+                      + " failure."
                       + cause,
                   e);
         }


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #16388

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Every now and then, someone complains because the real reason a remote session creation fails is hidden in the stack trace. This identifies the cause, if it exists, and displays it at the top level.


___

### **PR Type**
Bug fix


___

### **Description**
- Improved error messaging for remote session creation failures

- Extracts and displays the underlying cause message at the top level

- Prevents real error reasons from being hidden in stack traces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Session Creation Error"] --> B["Check for Cause"]
  B --> C["Extract Cause Message"]
  C --> D["Display at Top Level"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Enhanced remote session error message extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<ul><li>Enhanced error handling in <code>execute()</code> method for NEW_SESSION command<br> <li> Extracts cause message from exception chain when available<br> <li> Appends cause message to SessionNotCreatedException for better <br>visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16418/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

