### PR TITLE
[py] Add test for BiDi request handlers with classic navigation

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -99,6 +99,27 @@ def test_remove_auth_handler(driver):
     assert driver.network.intercepts == [], "Intercept not removed"
 
 
+def test_handler_with_classic_navigation(driver, pages):
+    """Verify request handlers also work with classic navigation."""
+    if driver.caps["browserName"] == "chrome":
+        pytest.skip(reason="Request handlers don't yet work in Chrome when using classic navigation")
+    if driver.caps["browserName"] == "edge":
+        pytest.skip(reason="Request handlers don't yet work in Edge when using classic navigation")
+
+    exceptions = []
+
+    def callback(request: Request):
+        try:
+            request.continue_request()
+        except WebDriverException as e:
+            exceptions.append(e)
+
+    callback_id = driver.network.add_request_handler("before_request", callback)
+    assert callback_id is not None, "Request handler not added"
+    pages.load("formPage.html")
+    assert len(exceptions) == 0, "Exception raised when continuing request in callback"
+
+
 @pytest.mark.xfail_chrome(reason="Data URLs in Network requests are not implemented in Chrome yet")
 @pytest.mark.xfail_edge(reason="Data URLs in Network requests are not implemented in Edge yet")
 @pytest.mark.xfail_firefox(reason="Data URLs in Network requests are not implemented in Firefox yet")

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -109,7 +109,7 @@ def test_handler_with_classic_navigation(driver, pages):
     """Verify request handlers also work with classic navigation."""
     browser_name = driver.caps["browserName"]
     if browser_name.lower() in ("chrome", "microsoftedge"):
-        pytest.skip(reason="Request handlers don't yet work in {browser_name} when using classic navigation")
+        pytest.skip(reason=f"Request handlers don't yet work in {browser_name} using classic navigation")
 
     exceptions = []
 

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -73,14 +73,20 @@ def test_clear_request_handlers(driver, pages):
 
 
 def test_continue_request(driver, pages):
+    exceptions = []
+
     def callback(request: Request):
-        request.continue_request()
+        try:
+            request.continue_request()
+        except WebDriverException as e:
+            exceptions.append(e)
 
     callback_id = driver.network.add_request_handler("before_request", callback)
     assert callback_id is not None, "Request handler not added"
     url = pages.url("formPage.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
+    assert len(exceptions) == 0, "Exception raised when continuing request in handler callback"
 
 
 def test_continue_with_auth(driver):
@@ -101,10 +107,9 @@ def test_remove_auth_handler(driver):
 
 def test_handler_with_classic_navigation(driver, pages):
     """Verify request handlers also work with classic navigation."""
-    if driver.caps["browserName"] == "chrome":
-        pytest.skip(reason="Request handlers don't yet work in Chrome when using classic navigation")
-    if driver.caps["browserName"] == "edge":
-        pytest.skip(reason="Request handlers don't yet work in Edge when using classic navigation")
+    browser_name = driver.caps["browserName"]
+    if browser_name.lower() in ("chrome", "microsoftedge"):
+        pytest.skip(reason="Request handlers don't yet work in {browser_name} when using classic navigation")
 
     exceptions = []
 
@@ -117,7 +122,7 @@ def test_handler_with_classic_navigation(driver, pages):
     callback_id = driver.network.add_request_handler("before_request", callback)
     assert callback_id is not None, "Request handler not added"
     pages.load("formPage.html")
-    assert len(exceptions) == 0, "Exception raised when continuing request in callback"
+    assert len(exceptions) == 0, "Exception raised in handler callback"
 
 
 @pytest.mark.xfail_chrome(reason="Data URLs in Network requests are not implemented in Chrome yet")
@@ -141,4 +146,4 @@ def test_handler_with_data_url_request(driver, pages):
     time.sleep(1)  # give callback time to complete
     assert driver.find_element(By.ID, "data-url-image").is_displayed()
     assert len(data_requests) > 0, "BiDi event not captured"
-    assert len(exceptions) == 0, "Exception raised when continuing request in callback"
+    assert len(exceptions) == 0, "Exception raised when continuing request in handler callback"


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR adds a test for using BiDi request handlers when using classic navigation. This is currently broken in Chrome and Edge, but works in Firefox.

### 🔧 Implementation Notes

I wanted to mark is as `xfail_chrome`/`xfail_edge`, but the test hangs for several minutes when you attempt to run it with those browsers, so I just explicitly skip it inside the test.

### 💡 Additional Considerations

Once Chrome/Edge fixes this, we should stop skipping this test.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Test


___

### **PR Type**
Tests


___

### **Description**
- Add test verifying BiDi request handlers work with classic navigation

- Skip test for Chrome and Edge due to known browser limitations

- Test passes in Firefox, demonstrating expected behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] --> B["Add Request Handler"]
  B --> C["Classic Navigation"]
  C --> D["Verify No Exceptions"]
  D --> E["Skip for Chrome/Edge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_network_tests.py</strong><dd><code>Add BiDi request handler test for classic navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_network_tests.py

<ul><li>Adds new test <code>test_handler_with_classic_navigation</code> to verify BiDi <br>request handlers work with classic navigation<br> <li> Implements browser-specific skip logic for Chrome and Edge where <br>feature is not yet supported<br> <li> Uses callback with exception tracking to validate request continuation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16421/files#diff-97c8d35b88402ef5de934c8fb95da5f7c7c04039a79baf20cc8fd6c91379dac7">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

