### PR TITLE
[py] Update docstrings style

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -144,8 +144,37 @@ respect-gitignore = true
 target-version = "py39"
 
 [tool.ruff.lint]
-extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252"]
+extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252", "D"]
 fixable = ["ALL"]
+
+extend-ignore = [
+"D103", # Missing docstring in public function
+"D102", # Missing docstring in public method
+"D100", # Missing docstring in public module
+"D205", # 1 blank line required between summary line and description
+"D107", # Missing docstring in `__init__`
+"D101", # Missing docstring in public class
+"D104", # Missing docstring in public package
+"D209", # Multi-line docstring closing quotes should be on a separate line
+"D202", # No blank lines allowed after function docstring (found 1)
+"D105", # Missing docstring in magic method
+"D415", # First line should end with a period, question mark, or exclamation point
+"D212", # Multi-line docstring summary should start at the first line
+"D200", # One-line docstring should fit on one line
+"D411", # Missing blank line before section ("Example")
+"D301", # Use `r"""` if any backslashes in a docstring
+"D412", # No blank lines allowed between a section header and its content ("Example")
+"D410", # Missing blank line after section ("Example")
+"D419", # Docstring is empty
+"D417", # Missing argument descriptions in the docstring for `__init__`: `duration`, `source`
+"D416" # Section name should end with a colon ("Returns")
+]
+
+[tool.ruff.lint.per-file-ignores]
+"*.py" = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -144,37 +144,8 @@ respect-gitignore = true
 target-version = "py39"
 
 [tool.ruff.lint]
-extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252", "D"]
+extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252"]
 fixable = ["ALL"]
-
-extend-ignore = [
-"D103", # Missing docstring in public function
-"D102", # Missing docstring in public method
-"D100", # Missing docstring in public module
-"D205", # 1 blank line required between summary line and description
-"D107", # Missing docstring in `__init__`
-"D101", # Missing docstring in public class
-"D104", # Missing docstring in public package
-"D209", # Multi-line docstring closing quotes should be on a separate line
-"D202", # No blank lines allowed after function docstring (found 1)
-"D105", # Missing docstring in magic method
-"D415", # First line should end with a period, question mark, or exclamation point
-"D212", # Multi-line docstring summary should start at the first line
-"D200", # One-line docstring should fit on one line
-"D411", # Missing blank line before section ("Example")
-"D301", # Use `r"""` if any backslashes in a docstring
-"D412", # No blank lines allowed between a section header and its content ("Example")
-"D410", # Missing blank line after section ("Example")
-"D419", # Docstring is empty
-"D417", # Missing argument descriptions in the docstring for `__init__`: `duration`, `source`
-"D416" # Section name should end with a colon ("Returns")
-]
-
-[tool.ruff.lint.per-file-ignores]
-"*.py" = ["D"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/py/selenium/webdriver/chrome/service.py
+++ b/py/selenium/webdriver/chrome/service.py
@@ -27,11 +27,17 @@ class Service(service.ChromiumService):
     """A Service class that is responsible for the starting and stopping of
     `chromedriver`.
 
-    :param executable_path: install path of the chromedriver executable, defaults to `chromedriver`.
-    :param port: Port for the service to run on, defaults to 0 where the operating system will decide.
-    :param service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
-    :param log_output: (Optional) int representation of STDOUT/DEVNULL, any IO instance or String path to file.
-    :param env: (Optional) Mapping of environment variables for the new process, defaults to `os.environ`.
+    Args:
+        executable_path: Install path of the chromedriver executable, defaults
+            to `chromedriver`.
+        port: Port for the service to run on, defaults to 0 where the operating
+            system will decide.
+        service_args: (Optional) Sequence of args to be passed to the subprocess
+            when launching the executable.
+        log_output: (Optional) int representation of STDOUT/DEVNULL, any IO
+            instance or String path to file.
+        env: (Optional) Mapping of environment variables for the new process,
+            defaults to `os.environ`.
     """
 
     def __init__(

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -27,12 +27,18 @@ class ChromiumService(service.Service):
     """A Service class that is responsible for the starting and stopping the
     WebDriver instance of the ChromiumDriver.
 
-    :param executable_path: install path of the executable.
-    :param port: Port for the service to run on, defaults to 0 where the operating system will decide.
-    :param service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
-    :param log_output: (Optional) int representation of STDOUT/DEVNULL, any IO instance or String path to file.
-    :param env: (Optional) Mapping of environment variables for the new process, defaults to `os.environ`.
-    :param driver_path_env_key: (Optional) Environment variable to use to get the path to the driver executable.
+    Args:
+        executable_path: Install path of the executable.
+        port: Port for the service to run on, defaults to 0 where the operating
+            system will decide.
+        service_args: (Optional) Sequence of args to be passed to the subprocess
+            when launching the executable.
+        log_output: (Optional) int representation of STDOUT/DEVNULL, any IO
+            instance or String path to file.
+        env: (Optional) Mapping of environment variables for the new process,
+            defaults to `os.environ`.
+        driver_path_env_key: (Optional) Environment variable to use to get the
+            path to the driver executable.
     """
 
     def __init__(

--- a/py/selenium/webdriver/webkitgtk/service.py
+++ b/py/selenium/webdriver/webkitgtk/service.py
@@ -29,13 +29,17 @@ class Service(service.Service):
     """A Service class that is responsible for the starting and stopping of
     `WebKitWebDriver`.
 
-    :param executable_path: install path of the WebKitWebDriver executable, defaults to the first
-        `WebKitWebDriver` in `$PATH`.
-    :param port: Port for the service to run on, defaults to 0 where the operating system will decide.
-    :param service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
-    :param log_output: (Optional) File path for the file to be opened and passed as the subprocess
-        stdout/stderr handler.
-    :param env: (Optional) Mapping of environment variables for the new process, defaults to `os.environ`.
+    Args:
+        executable_path: Install path of the WebKitWebDriver executable,
+            defaults to the first `WebKitWebDriver` in `$PATH`.
+        port: Port for the service to run on, defaults to 0 where the
+            operating system will decide.
+        service_args: (Optional) Sequence of args to be passed to the
+            subprocess when launching the executable.
+        log_output: (Optional) File path for the file to be opened and passed
+            as the subprocess stdout/stderr handler.
+        env: (Optional) Mapping of environment variables for the new process,
+            defaults to `os.environ`.
     """
 
     def __init__(

--- a/py/selenium/webdriver/wpewebkit/service.py
+++ b/py/selenium/webdriver/wpewebkit/service.py
@@ -28,13 +28,17 @@ class Service(service.Service):
     """A Service class that is responsible for the starting and stopping of
     `WPEWebDriver`.
 
-    :param executable_path: install path of the WPEWebDriver executable, defaults to the first
-        `WPEWebDriver` in `$PATH`.
-    :param port: Port for the service to run on, defaults to 0 where the operating system will decide.
-    :param service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
-    :param log_output: (Optional) File path for the file to be opened and passed as the subprocess
-        stdout/stderr handler.
-    :param env: (Optional) Mapping of environment variables for the new process, defaults to `os.environ`.
+    Args:
+        executable_path: Install path of the WPEWebDriver executable, defaults
+            to the first `WPEWebDriver` in `$PATH`.
+        port: Port for the service to run on, defaults to 0 where the
+            operating system will decide.
+        service_args: (Optional) Sequence of args to be passed to the
+            subprocess when launching the executable.
+        log_output: (Optional) File path for the file to be opened and passed
+            as the subprocess stdout/stderr handler.
+        env: (Optional) Mapping of environment variables for the new process,
+            defaults to `os.environ`.
     """
 
     def __init__(


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
related to #11442

### 💥 What does this PR do?
This pull request primarily updates docstring formatting in several service classes to follow the Google style, and adjusts the Python linting configuration to better handle docstring-related checks. The changes improve code consistency and maintainability by standardizing documentation and configuring the linter to align with the new style.

**Docstring formatting updates:**

* Updated the docstrings in `ChromiumService` (`py/selenium/webdriver/chromium/service.py`), `Service` for Chrome (`py/selenium/webdriver/chrome/service.py`), `Service` for WebKitGTK (`py/selenium/webdriver/webkitgtk/service.py`), and `Service` for WPEWebKit (`py/selenium/webdriver/wpewebkit/service.py`) to use Google-style `Args:` sections instead of the previous `:param` format. [[1]](diffhunk://#diff-062c917a35158860c8065910187232dbab480ac982cc48bb293c8e808d29818eL30-R41) [[2]](diffhunk://#diff-94e16ea2a7773a7ba8eeb142111c7956558fc0f90c08394bb1e99dd1fa7290b1L30-R40) [[3]](diffhunk://#diff-2f176dbccc5f64167acc6345e2351cab42ccebdefcc77374c69cb9e23b130806L32-R42) [[4]](diffhunk://#diff-321ce05c1440d20719ef90b39396b3b32b495c7c9da1dcca04b2964596f2ccd0L31-R41)

**Linting configuration changes:**

* Modified `pyproject.toml` to enable docstring checks (`D` codes) in Ruff, but added extensive ignores for specific docstring rules and set the docstring convention to Google style, ensuring the linter matches the new docstring format.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Documentation


___

### **Description**
- Standardized docstrings to Google style across Python service classes

- Configured Ruff linter for Google-style docstring convention

- Added extensive docstring rule ignores in linting configuration

- Reformatted parameter documentation in Chrome, Chromium, WebKitGTK, and WPEWebKit services


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Classes"] -- "Convert to Google style" --> B["ChromiumService"]
  A -- "Convert to Google style" --> C["Chrome Service"]
  A -- "Convert to Google style" --> D["WebKitGTK Service"]
  A -- "Convert to Google style" --> E["WPEWebKit Service"]
  F["pyproject.toml"] -- "Configure linter" --> G["Ruff with Google convention"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Convert Chrome Service docstring to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/chrome/service.py

<ul><li>Converted docstring from <code>:param</code> format to Google-style <code>Args:</code> section<br> <li> Reformatted parameter descriptions with proper line wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16427/files#diff-94e16ea2a7773a7ba8eeb142111c7956558fc0f90c08394bb1e99dd1fa7290b1">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Convert ChromiumService docstring to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/chromium/service.py

<ul><li>Converted docstring from <code>:param</code> format to Google-style <code>Args:</code> section<br> <li> Reformatted six parameter descriptions with proper indentation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16427/files#diff-062c917a35158860c8065910187232dbab480ac982cc48bb293c8e808d29818e">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Convert WebKitGTK Service docstring to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/webkitgtk/service.py

<ul><li>Converted docstring from <code>:param</code> format to Google-style <code>Args:</code> section<br> <li> Reformatted parameter descriptions for WebKitWebDriver service</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16427/files#diff-2f176dbccc5f64167acc6345e2351cab42ccebdefcc77374c69cb9e23b130806">+11/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Convert WPEWebKit Service docstring to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/wpewebkit/service.py

<ul><li>Converted docstring from <code>:param</code> format to Google-style <code>Args:</code> section<br> <li> Reformatted parameter descriptions for WPEWebDriver service</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16427/files#diff-321ce05c1440d20719ef90b39396b3b32b495c7c9da1dcca04b2964596f2ccd0">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Configure Ruff linter for Google-style docstrings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<ul><li>Added <code>D</code> (docstring) checks to Ruff linter configuration<br> <li> Added 17 docstring rule ignores for gradual adoption<br> <li> Set pydocstyle convention to Google style<br> <li> Configured per-file ignores to disable docstring checks by default</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16427/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+30/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

