### PR TITLE
[py] Fix default rpId in virtual authenticator

### DIFF
--- a/py/selenium/webdriver/common/virtual_authenticator.py
+++ b/py/selenium/webdriver/common/virtual_authenticator.py
@@ -80,7 +80,7 @@ class Credential:
         self,
         credential_id: bytes,
         is_resident_credential: bool,
-        rp_id: str,
+        rp_id: Optional[str],
         user_handle: Optional[bytes],
         private_key: bytes,
         sign_count: int,

--- a/py/selenium/webdriver/common/virtual_authenticator.py
+++ b/py/selenium/webdriver/common/virtual_authenticator.py
@@ -180,7 +180,7 @@ class Credential:
     def from_dict(cls, data: dict[str, Any]) -> "Credential":
         _id = urlsafe_b64decode(f"{data['credentialId']}==")
         is_resident_credential = bool(data["isResidentCredential"])
-        rp_id = data["rpId"]
+        rp_id = data.get("rpId", None)
         private_key = urlsafe_b64decode(f"{data['privateKey']}==")
         sign_count = int(data["signCount"])
         user_handle = urlsafe_b64decode(f"{data['userHandle']}==") if data.get("userHandle", None) else None


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #16424 

### 💥 What does this PR do?

This PR sets `rp_id` to None in the `Credential` created by `Credential.from_dict()` if the `rpId` key is missing. This was inadvertently changed in #16174, causing a breaking change.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `Credential.from_dict()` to handle missing `rpId` key gracefully

- Restore default `rp_id` to `None` when `rpId` is absent from input dictionary

- Resolve regression introduced in previous virtual authenticator changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Credential.from_dict()"] --> B["Check rpId in data"]
  B --> C["Use data.get() with None default"]
  C --> D["Return Credential with rp_id=None if missing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>virtual_authenticator.py</strong><dd><code>Use safe dictionary access for rpId field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/virtual_authenticator.py

<ul><li>Changed <code>rpId</code> extraction from direct dictionary access to <code>.get()</code> method<br> <li> Set default value to <code>None</code> when <code>rpId</code> key is missing<br> <li> Aligns with existing pattern used for <code>userHandle</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16428/files#diff-5da367f7e3363010c619d8097422a270cd228eb9af198d8d4ee7482a0c647b66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

