### PR TITLE
Python: Switch Remote tests to Chrome; update CI; align markers (#16417)

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - browser: firefox
+          - browser: chrome
     with:
       name: Integration Tests (remote, ${{ matrix.browser }})
       browser: ${{ matrix.browser }}

--- a/Rakefile
+++ b/Rakefile
@@ -685,7 +685,7 @@ namespace :py do
       end
     end
 
-    desc 'Python Remote tests with Firefox'
+    desc 'Python Remote tests with Chrome'
     task :remote do
       Rake::Task['py:clean'].invoke
       Bazel.execute('test', [], '//py:test-remote')

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -131,7 +131,7 @@ class SupportedOptions(ContainerProtocol):
     edge: str = "EdgeOptions"
     safari: str = "SafariOptions"
     ie: str = "IeOptions"
-    remote: str = "FirefoxOptions"
+    remote: str = "ChromeOptions"
     webkitgtk: str = "WebKitGTKOptions"
     wpewebkit: str = "WPEWebKitOptions"
 
@@ -327,7 +327,18 @@ def driver(request):
             pytest.skip(f"{driver_class} does not support BiDi")
 
     # conditionally mark tests as expected to fail based on driver
-    marker = request.node.get_closest_marker(f"xfail_{driver_class.lower()}")
+    # For Remote, respect both Chrome and Remote specific markers
+    if driver_class == "remote":
+        marker_names = ["xfail_chrome", "xfail_remote"]
+    else:
+        marker_names = [f"xfail_{driver_class.lower()}"]
+
+    marker = None
+    for name in marker_names:
+        found = request.node.get_closest_marker(name)
+        if found is not None:
+            marker = found
+            break
     if marker is not None:
         if "run" in marker.kwargs:
             if marker.kwargs["run"] is False:


### PR DESCRIPTION
### **User description**
**Summary**
This switches the Python Remote tests from Firefox to Chrome and updates CI to match. It also makes the Remote tests honor both Chrome- and Remote-specific xfail markers. Fixes #16417.

**What changed**
_py/conftest.py_

- Remote now uses Chrome options (with managed downloads).
- Remote respects both xfail_chrome and xfail_remote.
- The Grid server is started via the bundled Server helper, and we don’t try to start a new one if it’s already running.

_.github/workflows/ci-python.yml_
Remote test job runs with browser: chrome.

_Rakefile_
Description updated to “Python Remote tests with Chrome”.

**Why**
We want Python Remote tests to run on Chrome by default and ensure CI does the same.


**How I tested**
_On macOS with Bazel:_

- Ran: bazel test --cache_test_results=no --local_test_jobs 1 --flaky_test_attempts 1 --test_output=errors //py:test-remote
- Got: 52/52 passing.
- Selenium Grid used Selenium Manager and matched Chrome/ChromeDriver 141.0.7390.78.

**Impact**
Only affects Python Remote tests and the Python CI workflow. No changes to other bindings or local driver tests.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Switch Python Remote tests from Firefox to Chrome

- Update CI workflow to run Remote tests with Chrome browser

- Add support for dual xfail markers (Chrome and Remote) in Remote test configuration

- Configure Remote driver with Chrome options and managed downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remote Tests"] --> B["Chrome Options"]
  A --> C["CI Workflow"]
  A --> D["xfail Markers"]
  B --> E["Managed Downloads"]
  D --> F["xfail_chrome"]
  D --> G["xfail_remote"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Switch Remote driver to Chrome with dual marker support</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<ul><li>Changed Remote driver from <code>FirefoxOptions</code> to <code>ChromeOptions</code><br> <li> Added dual xfail marker support for Remote tests (both <code>xfail_chrome</code> <br>and <code>xfail_remote</code>)<br> <li> Updated marker detection logic to check multiple marker names for <br>Remote driver</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16434/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-python.yml</strong><dd><code>Update CI workflow to use Chrome for Remote tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-python.yml

- Updated Remote tests matrix browser from `firefox` to `chrome`


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16434/files#diff-a7ec86144013d78c9f1d734aa65a898e66b609638aa7b872491ee3858ebebbeb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Update Rake task description for Chrome</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Updated task description from "Python Remote tests with Firefox" to <br>"Python Remote tests with Chrome"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16434/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

