### PR TITLE
py: add Ruff docstring lint rules (Google style) (#16432, refs #11442)

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -144,8 +144,33 @@ respect-gitignore = true
 target-version = "py39"
 
 [tool.ruff.lint]
-extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252"]
+extend-select = ["E4", "E7", "E9", "F", "I", "E501", "RUF022", "TID252", "D"]
 fixable = ["ALL"]
+extend-ignore = [
+    "D103", # Missing docstring in public function
+    "D102", # Missing docstring in public method
+    "D100", # Missing docstring in public module
+    "D205", # 1 blank line required between summary line and description
+    "D107", # Missing docstring in `__init__`
+    "D101", # Missing docstring in public class
+    "D104", # Missing docstring in public package
+    "D209", # Multi-line docstring closing quotes should be on a separate line
+    "D202", # No blank lines allowed after function docstring (found 1)
+    "D105", # Missing docstring in magic method
+    "D415", # First line should end with a period, question mark, or exclamation point
+    "D212", # Multi-line docstring summary should start at the first line
+    "D200", # One-line docstring should fit on one line
+    "D411", # Missing blank line before section ("Example")
+    "D301", # Use `r\"\"\"` if any backslashes in a docstring
+    "D412", # No blank lines allowed between a section header and its content ("Example")
+    "D410", # Missing blank line after section ("Example")
+    "D419", # Docstring is empty
+    "D417", # Missing argument descriptions in the docstring for `__init__`
+    "D416", # Section name should end with a colon ("Returns")
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
### **User description**
## Summary

**Goal:** Add Ruff configuration to lint Python docstrings using the **Google** convention.  
**Issues:** #16432, refs #11442  

---

## What’s in this PR

- **Ruff docstrings enabled:** add `D` codes to `extend-select`.  
- **Transitional ignores:** add a focused `extend-ignore` list so existing code won’t fail immediately.  
- **Convention:** set `pydocstyle` convention to `google`.  

---

## Why

- **Consistency:** enforce a clear, automated standard for docstrings across the Python package.  
- **Scalability:** allow gradual enforcement by tightening ignores as we fix legacy docs.  

---

## Scope / Impact

- **Lint-only:** configuration change; no runtime or public API impact.  

---


___

### **PR Type**
Enhancement


___

### **Description**
- Enable Ruff docstring linting with Google convention for Python package

- Add transitional ignore rules for 17 docstring violations to prevent immediate failures

- Configure `pydocstyle` convention to enforce Google-style docstrings

- Extend Ruff lint selection to include all "D" (docstring) rules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml"] --> B["Add 'D' to extend-select"]
  B --> C["Configure pydocstyle convention='google'"]
  C --> D["Add 17 transitional ignore rules"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Configure Ruff for Google-style docstring linting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<ul><li>Enable Ruff docstring linting by adding "D" codes to <code>extend-select</code><br> <li> Add 17 transitional <code>extend-ignore</code> rules for existing docstring <br>violations<br> <li> Configure <code>pydocstyle</code> convention to "google" for Google-style <br>docstrings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16435/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

