### PR TITLE
[py]: guess mimetypes in webserver for content serving

### DIFF
--- a/py/test/selenium/webdriver/common/webserver.py
+++ b/py/test/selenium/webdriver/common/webserver.py
@@ -71,8 +71,20 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
 
     def _serve_file(self, file_path):
         """Serve a file from the HTML root directory."""
-        with open(file_path, encoding="latin-1") as f:
-            return f.read().encode("utf-8")
+        content_type, _ = mimetypes.guess_type(file_path)
+
+        if content_type and (
+            content_type.startswith("image/")
+            or content_type.startswith("application/")
+            or content_type.startswith("video/")
+            or content_type.startswith("audio/")
+        ):
+            with open(file_path, "rb") as f:
+                return f.read()
+        else:
+            # text files
+            with open(file_path, encoding="latin-1") as f:
+                return f.read().encode("utf-8")
 
     def _send_response(self, content_type="text/html"):
         """Send a response."""

--- a/py/test/selenium/webdriver/common/webserver.py
+++ b/py/test/selenium/webdriver/common/webserver.py
@@ -20,6 +20,7 @@ It serves the testing html pages that are needed by the webdriver unit tests."""
 
 import contextlib
 import logging
+import mimetypes
 import os
 import re
 import threading
@@ -89,7 +90,7 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
                 self._send_response("text/html")
                 self.wfile.write(html)
             elif os.path.isfile(file_path):
-                content_type = "application/json" if file_path.endswith(".json") else "text/html"
+                content_type, _ = mimetypes.guess_type(file_path)
                 content = self._serve_file(file_path)
                 self._send_response(content_type)
                 self.wfile.write(content)

--- a/py/test/selenium/webdriver/common/webserver.py
+++ b/py/test/selenium/webdriver/common/webserver.py
@@ -20,10 +20,11 @@ It serves the testing html pages that are needed by the webdriver unit tests."""
 
 import contextlib
 import logging
-import mimetypes
 import os
 import re
 import threading
+
+import filetype
 
 try:
     from urllib import request as urllib_request
@@ -71,20 +72,20 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
 
     def _serve_file(self, file_path):
         """Serve a file from the HTML root directory."""
-        content_type, _ = mimetypes.guess_type(file_path)
+        with open(file_path, "rb") as f:
+            content = f.read()
 
-        if content_type and (
-            content_type.startswith("image/")
-            or content_type.startswith("application/")
-            or content_type.startswith("video/")
-            or content_type.startswith("audio/")
-        ):
-            with open(file_path, "rb") as f:
-                return f.read()
+        kind = filetype.guess(content)
+        if kind is not None:
+            return content, kind.mime
+
+        # fallback for text files that filetype can't detect
+        if file_path.endswith(".txt"):
+            return content, "text/plain"
+        elif file_path.endswith(".json"):
+            return content, "application/json"
         else:
-            # text files
-            with open(file_path, encoding="latin-1") as f:
-                return f.read().encode("utf-8")
+            return content, "text/html"
 
     def _send_response(self, content_type="text/html"):
         """Send a response."""
@@ -102,8 +103,7 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
                 self._send_response("text/html")
                 self.wfile.write(html)
             elif os.path.isfile(file_path):
-                content_type, _ = mimetypes.guess_type(file_path)
-                content = self._serve_file(file_path)
+                content, content_type = self._serve_file(file_path)
                 self._send_response(content_type)
                 self.wfile.write(content)
             else:

--- a/py/test/selenium/webdriver/remote/remote_downloads_tests.py
+++ b/py/test/selenium/webdriver/remote/remote_downloads_tests.py
@@ -28,11 +28,9 @@ from selenium.webdriver.support.wait import WebDriverWait
 def test_get_downloadable_files(driver, pages):
     _browser_downloads(driver, pages)
     file_names = driver.get_downloadable_files()
-    # TODO: why is Chrome downloading files as .html???
-    # assert "file_1.txt" in file_names
-    # assert "file_2.jpg" in file_names
-    assert any(f in file_names for f in ("file_1.txt", "file_1.htm", "file_1.html"))
-    assert any(f in file_names for f in ("file_2.jpg", "file_2.htm", "file_2.html"))
+
+    assert "file_1.txt" in file_names
+    assert "file_2.jpg" in file_names
     assert type(file_names) is list
 
 
@@ -42,12 +40,8 @@ def test_download_file(driver, pages):
 
     # Get a list of downloadable files and find the txt file
     downloadable_files = driver.get_downloadable_files()
-    # TODO: why is Chrome downloading files as .html???
-    # text_file_name = next((file for file in downloadable_files if file.endswith(".txt")), None)
-    text_file_name = next(
-        (f for f in downloadable_files if all((f.endswith((".txt", ".htm", ".html")), f.startswith("file_1")))), None
-    )
-    assert text_file_name is not None, "Could not find file in downloadable files"
+    text_file_name = next((file for file in downloadable_files if file.endswith(".txt")), None)
+    assert text_file_name is not None, "Could not find a .txt file in downloadable files"
 
     with tempfile.TemporaryDirectory() as target_directory:
         driver.download_file(text_file_name, target_directory)
@@ -69,8 +63,4 @@ def _browser_downloads(driver, pages):
     pages.load("downloads/download.html")
     driver.find_element(By.ID, "file-1").click()
     driver.find_element(By.ID, "file-2").click()
-    # TODO: why is Chrome downloading files as .html???
-    # WebDriverWait(driver, 5).until(lambda d: "file_2.jpg" in d.get_downloadable_files())
-    WebDriverWait(driver, 5).until(
-        lambda d: any(f in d.get_downloadable_files() for f in ("file_2.jpg", "file_2.htm", "file_2.html"))
-    )
+    WebDriverWait(driver, 3).until(lambda d: "file_2.jpg" in d.get_downloadable_files())


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
In here - https://github.com/SeleniumHQ/selenium/pull/16419#issuecomment-3400038998, the txt and image files were getting downloaded as html. The webserver wasn't handling the mimetypes, this PR fixes it.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
I have used `filetype` for mimetype guessing but it isn't very good for text file mime guessing since it works on magic bytes of files. We are already using `filetype` and it was added in this PR - https://github.com/SeleniumHQ/selenium/pull/14771 as per discussion in https://github.com/SeleniumHQ/selenium/issues/14765#issuecomment-2481267685.

We can also use the `mimetypes` library.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Add proper MIME type detection using `mimetypes` library for file serving

- Handle binary files (images, audio, video) separately from text files

- Remove workarounds in download tests that accepted incorrect file extensions

- Simplify test assertions to expect correct file types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Webserver File Handler"] -->|"guess_type()"| B["MIME Type Detection"]
  B -->|"Binary Content"| C["Read as Binary"]
  B -->|"Text Content"| D["Read as Text + Encode"]
  C -->|"Correct Extension"| E["File Downloaded Correctly"]
  D -->|"Correct Extension"| E
  F["Test Assertions"] -->|"Remove Workarounds"| G["Expect Correct File Types"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webserver.py</strong><dd><code>Implement proper MIME type detection for file serving</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/webserver.py

<ul><li>Import <code>mimetypes</code> module for MIME type detection<br> <li> Refactor <code>_serve_file()</code> to handle binary and text files separately <br>based on MIME type<br> <li> Update <code>do_GET()</code> to use <code>mimetypes.guess_type()</code> instead of hardcoded <br><code>.json</code> check<br> <li> Binary files (images, audio, video, applications) are read in binary <br>mode; text files use latin-1 encoding</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16449/files#diff-d95713c8d59a3b97d00ec8a480caaea72c2709ded87c52781ebaed56c488c457">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_downloads_tests.py</strong><dd><code>Remove download test workarounds for correct file types</code>&nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/remote/remote_downloads_tests.py

<ul><li>Remove TODO comments about Chrome downloading files as HTML<br> <li> Simplify <code>test_get_downloadable_files()</code> to assert exact file names <br>instead of accepting multiple extensions<br> <li> Simplify <code>test_download_file()</code> to search for <code>.txt</code> files directly <br>without fallback extensions<br> <li> Update <code>_browser_downloads()</code> wait condition to expect correct <br><code>file_2.jpg</code> instead of multiple extensions<br> <li> Reduce wait timeout from 5 to 3 seconds</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16449/files#diff-076c0af1d631fae433f5422d16b9eccbcac9db99a387833e2662d9bbed250b3a">+6/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

