### PR TITLE
[dotnet] [bidi] Add Request data type in Network module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -43,6 +43,7 @@ public sealed record AddDataCollectorResult(Collector Collector) : EmptyResult;
 [JsonConverter(typeof(CamelCaseEnumConverter<DataType>))]
 public enum DataType
 {
+    Request,
     Response
 }
 


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#type-network-dataType

### 💥 What does this PR do?
Support new `Request` data type according specification.

### 🔧 Implementation Notes
No internal tests yet, no stable browsers support it. But changes are simple, letting users to experiment with beta browsers.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Request` data type to Network module enum

- Enables BiDi protocol support for request data collection

- Aligns with W3C WebDriver BiDi specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DataType["DataType enum"]
  Request["Request variant"]
  Response["Response variant"]
  DataType --> Request
  DataType --> Response
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddDataCollectorCommand.cs</strong><dd><code>Add Request enum value to DataType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs

<ul><li>Added <code>Request</code> enum value to <code>DataType</code> enum<br> <li> Positioned before existing <code>Response</code> value<br> <li> Enables request data collection in BiDi Network module</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16453/files#diff-01a09e20bf279de7afbb5833ae2a4371db79c96f85e036c2b976ea460ae993ad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

