### PR TITLE
[dotnet] [bidi] Remove unnecessary command type info

### DIFF
--- a/dotnet/src/webdriver/BiDi/Communication/Command.cs
+++ b/dotnet/src/webdriver/BiDi/Communication/Command.cs
@@ -24,10 +24,9 @@ namespace OpenQA.Selenium.BiDi.Communication;
 
 public abstract class Command
 {
-    protected Command(string method, Type resultType)
+    protected Command(string method)
     {
         Method = method;
-        ResultType = resultType;
     }
 
     [JsonPropertyOrder(1)]
@@ -35,12 +34,9 @@ public abstract class Command
 
     [JsonPropertyOrder(0)]
     public long Id { get; internal set; }
-
-    [JsonIgnore]
-    public Type ResultType { get; }
 }
 
-internal abstract class Command<TParameters, TResult>(TParameters @params, string method) : Command(method, typeof(TResult))
+internal abstract class Command<TParameters, TResult>(TParameters @params, string method) : Command(method)
     where TParameters : Parameters
     where TResult : EmptyResult
 {


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Clean command type

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unnecessary `ResultType` property from `Command` class

- Simplify constructor by removing `resultType` parameter

- Update generic `Command<TParameters, TResult>` to match new signature

- Reduce code complexity and improve maintainability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command class<br/>with ResultType property"] -- "Remove ResultType<br/>and constructor param" --> B["Simplified Command class<br/>with only Method and Id"]
  C["Command&lt;TParameters, TResult&gt;<br/>passes typeof(TResult)"] -- "Update to match<br/>new signature" --> D["Command&lt;TParameters, TResult&gt;<br/>simplified constructor call"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Command.cs</strong><dd><code>Remove ResultType property and simplify Command class</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Communication/Command.cs

<ul><li>Removed <code>resultType</code> parameter from <code>Command</code> constructor<br> <li> Deleted <code>ResultType</code> property and its <code>[JsonIgnore]</code> attribute<br> <li> Updated <code>Command<TParameters, TResult></code> base class call to remove <br><code>typeof(TResult)</code> argument<br> <li> Streamlined class design by removing unused type information</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16454/files#diff-3c2d7c1c63b4af3a773d68343890cd40c7816d8bc1ba4b1ca794230a2eefcf68">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

