### PR TITLE
[Java] Fix typo in invisibilityOf method documentation

### DIFF
--- a/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -1352,7 +1352,7 @@ public class ExpectedConditions {
    * An expectation for checking the element to be invisible
    *
    * @param element used to check its invisibility
-   * @return Boolean true when elements is not visible anymore
+   * @return Boolean true when element is not visible anymore
    */
   public static ExpectedCondition<Boolean> invisibilityOf(final WebElement element) {
     return new ExpectedCondition<Boolean>() {


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes #16455

### 💥 What does this PR do?

Fixes a grammatical error in Javadocs

### 💡 Additional Considerations

This doesn't affect any runnable code, so no other considerations are necessary

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Documentation


___

### **Description**
- Fixes grammatical error in invisibilityOf method Javadoc

- Changes "elements is" to "element is" for accuracy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["invisibilityOf method<br/>Javadoc"] -- "Fix typo:<br/>elements → element" --> B["Corrected<br/>documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExpectedConditions.java</strong><dd><code>Fix grammar in invisibilityOf Javadoc comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/support/ui/ExpectedConditions.java

<ul><li>Corrects grammatical error in <code>invisibilityOf</code> method Javadoc<br> <li> Changes "@return Boolean true when elements is not visible anymore" to <br>"@return Boolean true when element is not visible anymore"<br> <li> Improves documentation accuracy for singular WebElement parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16456/files#diff-9d144815e7045eabe45652340d3517cf24a5bc09c113f6f441aca18a3c0353a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

