### PR TITLE
[rb] keep rbenv and RubyMine and bazel in sync with ruby version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -747,9 +747,35 @@ namespace :rb do
 
   desc 'Update generated Ruby files for local development'
   task :local_dev do
+    puts 'installing ruby, this may take a minute'
     Bazel.execute('build', [], '@bundle//:bundle')
     Rake::Task['rb:build'].invoke
     Rake::Task['grid'].invoke
+    Bazel.execute('build', [], '@bundle//bin:rubocop')
+    manage_selenium_ruby!
+  end
+
+  def manage_selenium_ruby!
+    label = 'selenium-ruby'
+
+    rbenv_path = `command -v rbenv`.strip
+    rbenv_root = `#{rbenv_path} root`.strip
+    dest = File.join(rbenv_root, 'versions', label)
+    return if File.symlink?(dest)
+
+    rb_dir = File.join(Dir.pwd, 'rb')
+    bazel_bin  = File.expand_path('../bazel-selenium/external/rules_ruby++ruby+ruby/dist/bin', rb_dir)
+    bazel_dist = File.dirname(bazel_bin)
+    FileUtils.ln_s(bazel_dist, dest)
+    system(rbenv_path, 'rehash')
+
+    Dir.chdir(rb_dir) do
+      system('direnv allow')
+      system('direnv reload')
+      system({ "RBENV_VERSION" => label }, 'bundle', 'install')
+    end
+  rescue StandardError => e
+    puts "Unable to set Bazel Selenium as Default: #{e.message}"
   end
 
   desc 'Push Ruby gems to rubygems'

--- a/rb/.envrc
+++ b/rb/.envrc
@@ -1,0 +1,18 @@
+# Local Ruby environment for Selenium's Bazel-built Ruby
+# Safe to check in — only activates if the symlink already exists.
+
+if command -v rbenv >/dev/null 2>&1; then
+  LABEL=selenium-ruby
+
+  RBENV_ROOT_DEFAULT="$(rbenv root 2>/dev/null || echo "$HOME/.rbenv")"
+  RUBY_SYMLINK="${RBENV_ROOT_DEFAULT}/versions/${LABEL}"
+  RUBY_BIN="${RUBY_SYMLINK}/bin/ruby"
+
+  # Always track the binary, even if missing now
+  watch_file "${RUBY_BIN}"
+
+  # Only set environment variable if active
+  if [ -x "${RUBY_BIN}" ]; then
+    export RBENV_VERSION="${LABEL}"
+  fi
+fi

--- a/rb/.envrc
+++ b/rb/.envrc
@@ -6,13 +6,13 @@ if command -v rbenv >/dev/null 2>&1; then
 
   RBENV_ROOT_DEFAULT="$(rbenv root 2>/dev/null || echo "$HOME/.rbenv")"
   RUBY_SYMLINK="${RBENV_ROOT_DEFAULT}/versions/${LABEL}"
-  RUBY_BIN="${RUBY_SYMLINK}/bin/ruby"
+  BIN_DIR="${RUBY_SYMLINK}/bin"
 
-  # Always track the binary, even if missing now
-  watch_file "${RUBY_BIN}"
+  # Always track the directory, even if missing now
+  watch_file "${BIN_DIR}"
 
-  # Only set environment variable if active
-  if [ -x "${RUBY_BIN}" ]; then
+  # Only set environment variable if directory currently present
+  if [ -d "${BIN_DIR}" ]; then
     export RBENV_VERSION="${LABEL}"
   fi
 fi


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
I got tired of my ruby versions being out of sync, and I kept forgetting where bazel was hiding the ruby binary.

Now, when you run `./go rb:local_dev`, in addition to building the gems and the grid, if you have rbenv installed, it will create a symlink to the bazel installed ruby and call it `selenium-ruby`
If you also have direnv installed, it will execute off of the new `.envrc` to set `$RBENV_VERSION` to `selenium-ruby` to override what is in `.ruby-version` file. There is a conditional in `.envrc` that says not to do anything if the rbenv symlink isn't there, so it shouldn't get in anyone's way.

You still need to select this in Rubymine, but you can go from the rbenv directory symlink instead of bazel nested confusion.

So far this seems to work pretty well for me, but it may be overkill. What do you think?


___

### **PR Type**
Enhancement


___

### **Description**
- Automates Ruby version synchronization between rbenv, RubyMine, and Bazel

- Creates symlink to Bazel-built Ruby in rbenv versions directory

- Adds `.envrc` configuration for direnv integration with RBENV_VERSION

- Simplifies local development setup by eliminating manual version management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rb:local_dev task"] --> B["Build Bazel Ruby"]
  B --> C["manage_selenium_ruby!"]
  C --> D["Create rbenv symlink"]
  D --> E["Configure direnv"]
  E --> F["Install bundles with correct version"]
  G[".envrc file"] --> H["Detect rbenv installation"]
  H --> I["Set RBENV_VERSION if symlink exists"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Add Ruby version management automation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Added <code>manage_selenium_ruby!</code> method to automate Ruby version setup<br> <li> Creates symlink from Bazel-built Ruby to rbenv versions directory<br> <li> Integrates direnv to set <code>RBENV_VERSION</code> environment variable<br> <li> Builds rubocop dependency and handles errors gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16459/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.envrc</strong><dd><code>Add direnv configuration for Ruby environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/.envrc

<ul><li>New direnv configuration file for local Ruby environment<br> <li> Detects rbenv installation and validates symlink existence<br> <li> Sets <code>RBENV_VERSION</code> to <code>selenium-ruby</code> when symlink is available<br> <li> Watches Ruby binary for changes and safely skips if rbenv unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16459/files#diff-ed0e1f0cfb9f87d7d157b075ba2fb5d5dea6e28f858ae9270cb1974f7295404a">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

