### PR TITLE
[rb] allow setting socket timeout and interval from http client

### DIFF
--- a/rb/lib/selenium/webdriver/bidi.rb
+++ b/rb/lib/selenium/webdriver/bidi.rb
@@ -31,8 +31,8 @@ module Selenium
       autoload :InterceptedAuth, 'selenium/webdriver/bidi/network/intercepted_auth'
       autoload :InterceptedItem, 'selenium/webdriver/bidi/network/intercepted_item'
 
-      def initialize(url:)
-        @ws = WebSocketConnection.new(url: url)
+      def initialize(url:, http:)
+        @ws = WebSocketConnection.new(url: url, http: http)
       end
 
       def close

--- a/rb/lib/selenium/webdriver/common/websocket_connection.rb
+++ b/rb/lib/selenium/webdriver/common/websocket_connection.rb
@@ -21,19 +21,23 @@ require 'websocket'
 
 module Selenium
   module WebDriver
+    #
+    # WebSocketConnection manages lifecycle of sockets for Devtools and BiDi implementations.
+    # @api private
+    #
+
     class WebSocketConnection
       CONNECTION_ERRORS = [
         Errno::ECONNRESET, # connection is aborted (browser process was killed)
         Errno::EPIPE # broken pipe (browser process was killed)
       ].freeze
 
-      RESPONSE_WAIT_TIMEOUT = 30
-      RESPONSE_WAIT_INTERVAL = 0.1
-
       MAX_LOG_MESSAGE_SIZE = 9999
 
-      def initialize(url:)
+      def initialize(url:, http: nil)
         @callback_threads = ThreadGroup.new
+        @socket_timeout = http&.socket_timeout || 30
+        @socket_interval = http&.socket_interval || 0.1
 
         @session_id = nil
         @url = url
@@ -147,7 +151,7 @@ module Selenium
       end
 
       def wait
-        @wait ||= Wait.new(timeout: RESPONSE_WAIT_TIMEOUT, interval: RESPONSE_WAIT_INTERVAL)
+        @wait ||= Wait.new(timeout: @socket_timeout, interval: @socket_interval)
       end
 
       def socket

--- a/rb/lib/selenium/webdriver/remote/bidi_bridge.rb
+++ b/rb/lib/selenium/webdriver/remote/bidi_bridge.rb
@@ -26,7 +26,7 @@ module Selenium
         def create_session(capabilities)
           super
           socket_url = @capabilities[:web_socket_url]
-          @bidi = Selenium::WebDriver::BiDi.new(url: socket_url)
+          @bidi = Selenium::WebDriver::BiDi.new(url: socket_url, http: @http)
         end
 
         def get(url)

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -22,20 +22,21 @@ module Selenium
   module WebDriver
     module Remote
       module Http
-        # @api private
         class Default < Common
           attr_writer :proxy
 
-          attr_accessor :open_timeout, :read_timeout
+          attr_accessor :open_timeout, :read_timeout, :socket_timeout, :socket_interval
 
           # Initializes object.
           # Warning: Setting {#open_timeout} to non-nil values will cause a separate thread to spawn.
           # Debuggers that freeze the process will not be able to evaluate any operations if that happens.
           # @param [Numeric] open_timeout - Open timeout to apply to HTTP client.
           # @param [Numeric] read_timeout - Read timeout (seconds) to apply to HTTP client.
-          def initialize(open_timeout: nil, read_timeout: nil)
+          def initialize(open_timeout: nil, read_timeout: nil, socket_timeout: 30, socket_interval: 0.1)
             @open_timeout = open_timeout
             @read_timeout = read_timeout
+            @socket_timeout = socket_timeout
+            @socket_interval = socket_interval
             super()
           end
 

--- a/rb/lib/selenium/webdriver/remote/http/default.rb
+++ b/rb/lib/selenium/webdriver/remote/http/default.rb
@@ -32,11 +32,11 @@ module Selenium
           # Debuggers that freeze the process will not be able to evaluate any operations if that happens.
           # @param [Numeric] open_timeout - Open timeout to apply to HTTP client.
           # @param [Numeric] read_timeout - Read timeout (seconds) to apply to HTTP client.
-          def initialize(open_timeout: nil, read_timeout: nil, socket_timeout: 30, socket_interval: 0.1)
+          def initialize(open_timeout: nil, read_timeout: nil, socket_timeout: nil, socket_interval: nil)
             @open_timeout = open_timeout
             @read_timeout = read_timeout
-            @socket_timeout = socket_timeout
-            @socket_interval = socket_interval
+            @socket_timeout = socket_timeout || 30
+            @socket_interval = socket_interval || 0.1
             super()
           end
 

--- a/rb/sig/lib/selenium/webdriver/common/websocket_connection.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/websocket_connection.rbs
@@ -7,6 +7,10 @@ module Selenium
 
       @session_id: untyped
 
+      @socket_interval: float
+
+      @socket_timeout: int
+
       @url: untyped
 
       @socket_thread: untyped

--- a/rb/sig/lib/selenium/webdriver/remote/http/common.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/http/common.rbs
@@ -17,7 +17,7 @@ module Selenium
 
           def self.user_agent: -> String
 
-          attr_writer server_url: String
+          attr_writer server_url: URI::Generic
 
           def quit_errors: () -> Array[untyped]
 

--- a/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
@@ -18,6 +18,10 @@ module Selenium
 
           attr_accessor read_timeout: untyped
 
+          attr_accessor socket_timeout: int
+
+          attr_accessor socket_interval: float
+
           def initialize: (?open_timeout: untyped?, ?read_timeout: untyped?) -> void
 
           def close: () -> untyped

--- a/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
+++ b/rb/sig/lib/selenium/webdriver/remote/http/default.rbs
@@ -20,9 +20,9 @@ module Selenium
 
           attr_accessor socket_timeout: int
 
-          attr_accessor socket_interval: float
+          attr_accessor socket_interval: Numeric
 
-          def initialize: (?open_timeout: untyped?, ?read_timeout: untyped?) -> void
+          def initialize: (?open_timeout: untyped?, ?read_timeout: untyped?, ?socket_timeout: int?, ?socket_interval: Numeric?) -> void
 
           def close: () -> untyped
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -169,17 +169,14 @@ module Selenium
           @root ||= Pathname.new('../../../../../../../').realpath(__FILE__)
         end
 
-        def create_driver!(listener: nil, **opts, &block)
+        def create_driver!(listener: nil, **, &block)
           check_for_previous_error
-
-          socket_timeout = opts.delete(:socket_timeout)
-          http_client = WebDriver::Remote::Http::Default.new(socket_timeout: socket_timeout) if socket_timeout
 
           method = :"#{driver}_driver"
           instance = if private_methods.include?(method)
-                       send(method, listener: listener, http_client: http_client, options: build_options(**opts))
+                       send(method, listener: listener, options: build_options(**))
                      else
-                       WebDriver::Driver.for(driver, listener: listener, options: build_options(**opts))
+                       WebDriver::Driver.for(driver, listener: listener, options: build_options(**))
                      end
           @create_driver_error_count -= 1 unless @create_driver_error_count.zero?
           if block

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -31,6 +31,7 @@ module Selenium
           WebDriver.logger.ignore(:logger_info)
           SeleniumManager.bin_path = root.join('bazel-bin/rb/bin').to_s if File.exist?(root.join('bazel-bin/rb/bin'))
 
+          ENV['WEBDRIVER_BIDI'] = 'true'
           @driver = ENV.fetch('WD_SPEC_DRIVER', 'chrome').tr('-', '_').to_sym
           @driver_instance = nil
           @remote_server = nil
@@ -168,14 +169,17 @@ module Selenium
           @root ||= Pathname.new('../../../../../../../').realpath(__FILE__)
         end
 
-        def create_driver!(listener: nil, **, &block)
+        def create_driver!(listener: nil, **opts, &block)
           check_for_previous_error
+
+          socket_timeout = opts.delete(:socket_timeout)
+          http_client = WebDriver::Remote::Http::Default.new(socket_timeout: socket_timeout) if socket_timeout
 
           method = :"#{driver}_driver"
           instance = if private_methods.include?(method)
-                       send(method, listener: listener, options: build_options(**))
+                       send(method, listener: listener, http_client: http_client, options: build_options(**opts))
                      else
-                       WebDriver::Driver.for(driver, listener: listener, options: build_options(**))
+                       WebDriver::Driver.for(driver, listener: listener, options: build_options(**opts))
                      end
           @create_driver_error_count -= 1 unless @create_driver_error_count.zero?
           if block

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -31,7 +31,6 @@ module Selenium
           WebDriver.logger.ignore(:logger_info)
           SeleniumManager.bin_path = root.join('bazel-bin/rb/bin').to_s if File.exist?(root.join('bazel-bin/rb/bin'))
 
-          ENV['WEBDRIVER_BIDI'] = 'true'
           @driver = ENV.fetch('WD_SPEC_DRIVER', 'chrome').tr('-', '_').to_sym
           @driver_instance = nil
           @remote_server = nil

--- a/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
@@ -36,8 +36,6 @@ module Selenium
 
             expect(http.open_timeout).to eq 60
             expect(http.read_timeout).to eq 60
-            expect(http.socket_timeout).to eq 30
-            expect(http.socket_interval).to eq 0.1
           end
 
           describe '#initialize' do
@@ -50,7 +48,6 @@ module Selenium
               expect(client.read_timeout).to eq 22
               expect(client.socket_timeout).to eq 4
               expect(client.socket_interval).to eq 0.5
-
             end
           end
 

--- a/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb
@@ -36,17 +36,21 @@ module Selenium
 
             expect(http.open_timeout).to eq 60
             expect(http.read_timeout).to eq 60
+            expect(http.socket_timeout).to eq 30
+            expect(http.socket_interval).to eq 0.1
           end
 
           describe '#initialize' do
-            let(:client) { described_class.new(read_timeout: 22, open_timeout: 23) }
-
-            it 'accepts read timeout options' do
+            it 'constructs values' do
+              client = described_class.new(read_timeout: 22,
+                                           open_timeout: 23,
+                                           socket_timeout: 4,
+                                           socket_interval: 0.5)
               expect(client.open_timeout).to eq 23
-            end
-
-            it 'accepts open timeout options' do
               expect(client.read_timeout).to eq 22
+              expect(client.socket_timeout).to eq 4
+              expect(client.socket_interval).to eq 0.5
+
             end
           end
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
fixes #15620 

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Allows setting socket timeout and interval values on the default http client.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
This is an alternative to #16053 
I'm not sure "default http config" is the perfect place for this, kind of wish we just had a config file like others, but the superclass gets the http client instance, so easy enough to grab it and send it to the ws socket class.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Allow configuring socket timeout and interval via HTTP client

- Pass HTTP client instance to BiDi and WebSocket connections

- Replace hardcoded timeout constants with configurable values

- Add socket timeout parameter to test environment setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Client"] -->|"socket_timeout, socket_interval"| B["BiDi"]
  B -->|"http parameter"| C["WebSocketConnection"]
  C -->|"uses configured values"| D["Wait timeout/interval"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi.rb</strong><dd><code>Add HTTP client parameter to BiDi initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/bidi.rb

<ul><li>Modified <code>initialize</code> method to accept <code>http</code> parameter<br> <li> Pass <code>http</code> parameter to <code>WebSocketConnection</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-b7660c7b53fec20ce95452b2afdbf306e9c36363e5bf8812863375b7bc96e42e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>websocket_connection.rb</strong><dd><code>Make socket timeout and interval configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/websocket_connection.rb

<ul><li>Added class documentation for WebSocketConnection<br> <li> Modified <code>initialize</code> to accept optional <code>http</code> parameter<br> <li> Extract <code>socket_timeout</code> and <code>socket_interval</code> from HTTP client with <br>defaults<br> <li> Replace hardcoded <code>RESPONSE_WAIT_TIMEOUT</code> and <code>RESPONSE_WAIT_INTERVAL</code> <br>constants with instance variables<br> <li> Updated <code>wait</code> method to use configurable timeout and interval values</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-6675f0e8e985c3acbf5be1124a44431bc20e31f11f7c8054edc572a0e5de66da">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bidi_bridge.rb</strong><dd><code>Pass HTTP client to BiDi initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/remote/bidi_bridge.rb

- Pass `@http` client instance to `BiDi.new` constructor


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-812b66f6ce3688d462c12e405e4808ffc075e0b6b2b9804b236ca977539a46e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default.rb</strong><dd><code>Add socket timeout and interval configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/remote/http/default.rb

<ul><li>Add <code>socket_timeout</code> and <code>socket_interval</code> as accessor attributes<br> <li> Add <code>socket_timeout</code> and <code>socket_interval</code> parameters to <code>initialize</code> method <br>with defaults (30 and 0.1)<br> <li> Store socket timeout and interval values as instance variables<br> <li> Update documentation for new parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-52c65654bea150f9c1c523f1ca349a4bf3f8984cd6fbd17496ed66e39e1d5004">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Enable BiDi and add socket timeout test support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<ul><li>Enable BiDi by default in test environment via <code>ENV['WEBDRIVER_BIDI']</code><br> <li> Refactor <code>create_driver!</code> to accept and handle <code>socket_timeout</code> option<br> <li> Create HTTP client with custom socket timeout when provided<br> <li> Pass <code>http_client</code> parameter to driver creation methods</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default_spec.rb</strong><dd><code>Add socket timeout and interval test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/remote/http/default_spec.rb

<ul><li>Add assertions for default <code>socket_timeout</code> (30) and <code>socket_interval</code> <br>(0.1)<br> <li> Consolidate timeout initialization tests into single test case<br> <li> Add test coverage for socket timeout and interval parameter <br>initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-ed0ec7d55a614ebf5f4ce695e58c10b2d29f3b7f12707d89a97b21e1a5542e67">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>websocket_connection.rbs</strong><dd><code>Add socket timeout and interval type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/common/websocket_connection.rbs

<ul><li>Add type signatures for <code>@socket_interval</code> (float) and <code>@socket_timeout</code> <br>(int) instance variables</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-4b464df89fac1d62be7e226d8f52d82e605d5dba71dbe982e78be4ef1078d270">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default.rbs</strong><dd><code>Add socket timeout and interval type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/remote/http/default.rbs

<ul><li>Add type signatures for <code>socket_timeout</code> (int) and <code>socket_interval</code> <br>(float) accessors</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16472/files#diff-be817817d2ce1b167dc85aa59740e89ddaf4a3325d8854667f95d036fb31f995">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

