### PR TITLE
[build] remove more ruby test targets that do not apply and support r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ bazel test //py:all
 Test targets:
 
 | Command                                                                          | Description                                        |
-| -------------------------------------------------------------------------------- | -------------------------------------------------- |
+|----------------------------------------------------------------------------------|----------------------------------------------------|
 | `bazel test //rb/...`                                                            | Run unit, all integration tests and lint           |
 | `bazel test //rb:lint`                                                           | Run RuboCop linter                                 |
 | `bazel test //rb/spec/...`                                                       | Run unit and integration tests for all browsers    |
@@ -406,23 +406,29 @@ Test targets:
 | `bazel test //rb/spec/... --test_size_filters large`                             | Run integration tests for all browsers             |
 | `bazel test //rb/spec/integration/...`                                           | Run integration tests for all browsers             |
 | `bazel test //rb/spec/integration/... --test_tag_filters firefox`                | Run integration tests for local Firefox only       |
-| `bazel test //rb/spec/integration/... --test_tag_filters firefox-remote`         | Run integration tests for remote Firefox only      |
+| `bazel test //rb/spec/integration/... --test_tag_filters bidi`                   | Run integration tests for all bidi tests           |
 | `bazel test //rb/spec/integration/... --test_tag_filters firefox,firefox-remote` | Run integration tests for local and remote Firefox |
 
 Ruby test targets have the same name as the spec file with `_spec.rb` removed, so you can run them individually.
-Integration tests targets also have a browser and remote suffix to control which browser to pick and whether to use Grid.
+Integration tests targets also allow specific suffixes to control specific browsers and settings.
+These targets are dynamically generated in the `rb/spec/tests.bzl` file
+Running in BiDi mode will be increasingly important as we re-implement classic selenium functionality with BiDi protocol.
+Not every test is set to run with BiDi by default, and which spec files are valid is explicitly
+with the `BIDI_BROWSERS` in the `tests.bzl` file and `_BIDI_FILES` in `//rb/spec/integration/selenium/webdriver/BUILD.bazel`
 
-| Test file                                               | Test target                                                      |
-| ------------------------------------------------------- | ---------------------------------------------------------------- |
-| `rb/spec/unit/selenium/webdriver/proxy_spec.rb`         | `//rb/spec/unit/selenium/webdriver:proxy`                        |
-| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome`         |
-| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome-remote`  |
-| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox`        |
-| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox-remote` |
+| Test file                                               | Test target                                                          |
+| ------------------------------------------------------- |----------------------------------------------------------------------|
+| `rb/spec/unit/selenium/webdriver/proxy_spec.rb`         | `//rb/spec/unit/selenium/webdriver:proxy`                            |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome`             |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox-beta`       |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome-remote`      |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-firefox-bidi`       |
+| `rb/spec/integration/selenium/webdriver/driver_spec.rb` | `//rb/spec/integration/selenium/webdriver:driver-chrome-remote-bidi` |
 
 Supported browsers:
 
 * `chrome`
+* `chrome-beta`
 * `edge`
 * `firefox`
 * `firefox-beta`
@@ -441,6 +447,7 @@ Supported environment variables for use with `--test_env`:
 - `WD_REMOTE_URL` - URL of an already running server to use for remote tests
 - `DOWNLOAD_SERVER` - when `WD_REMOTE_URL` not set; whether to download and use most recently released server version for remote tests
 - `DEBUG` - turns on verbose debugging
+- `WEBDRIVER_BIDI` - enables `web_socket_url` in the capabilities
 - `HEADLESS` - for chrome, edge and firefox; runs tests in headless mode
 - `DISABLE_BUILD_CHECK` - for chrome and edge; whether to ignore driver and browser version mismatches (allows testing Canary builds)
 - `CHROME_BINARY` - path to test specific Chrome browser

--- a/rb/spec/integration/selenium/webdriver/bidi/BUILD.bazel
+++ b/rb/spec/integration/selenium/webdriver/bidi/BUILD.bazel
@@ -1,9 +1,10 @@
-load("//rb/spec:tests.bzl", "rb_integration_test")
+load("//rb/spec:tests.bzl", "BIDI_BROWSERS", "rb_integration_test")
 
 [
     rb_integration_test(
         name = file[:-8],
         srcs = [file],
+        browsers = BIDI_BROWSERS,
         tags = [
             "bidi",
             "exclusive-if-local",

--- a/rb/spec/tests.bzl
+++ b/rb/spec/tests.bzl
@@ -9,6 +9,14 @@ load(
     "firefox_data",
 )
 
+BIDI_BROWSERS = [
+    "chrome",
+    "chrome-beta",
+    "edge",
+    "firefox",
+    "firefox-beta",
+]
+
 BROWSERS = {
     "chrome": {
         "data": chrome_data,
@@ -215,7 +223,7 @@ def rb_integration_test(name, srcs, deps = [], data = [], browsers = BROWSERS.ke
         )
 
         # Generate a test target for bidi browser execution if there is a matching tag
-        if "bidi" in tags:
+        if "bidi" in tags and browser in BIDI_BROWSERS:
             rb_test(
                 name = "{}-{}-bidi".format(name, browser),
                 size = "large",
@@ -225,6 +233,32 @@ def rb_integration_test(name, srcs, deps = [], data = [], browsers = BROWSERS.ke
                 env = BROWSERS[browser]["env"] | {"WEBDRIVER_BIDI": "true"},
                 main = "@bundle//bin:rspec",
                 tags = COMMON_TAGS + BROWSERS[browser]["tags"] + tags + ["{}-bidi".format(browser)],
+                deps = depset(
+                    ["//rb/spec/integration/selenium/webdriver:spec_helper", "//rb/lib/selenium/webdriver:bidi"] +
+                    BROWSERS[browser]["deps"] +
+                    deps,
+                ),
+                visibility = ["//rb:__subpackages__"],
+                target_compatible_with = BROWSERS[browser]["target_compatible_with"],
+            )
+            rb_test(
+                name = "{}-{}-remote-bidi".format(name, browser),
+                size = "large",
+                srcs = srcs,
+                args = ["rb/spec/"],
+                data = BROWSERS[browser]["data"] + data + [
+                    "//common/src/web",
+                    "//java/src/org/openqa/selenium/grid:selenium_server_deploy.jar",
+                    "//rb/spec:java-location",
+                    "@bazel_tools//tools/jdk:current_java_runtime",
+                ],
+                env = BROWSERS[browser]["env"] | {
+                    "WD_BAZEL_JAVA_LOCATION": "$(rootpath //rb/spec:java-location)",
+                    "WD_SPEC_DRIVER": "remote",
+                    "WEBDRIVER_BIDI": "true",
+                },
+                main = "@bundle//bin:rspec",
+                tags = COMMON_TAGS + BROWSERS[browser]["tags"] + tags + ["{}-remote-bidi".format(browser)],
                 deps = depset(
                     ["//rb/spec/integration/selenium/webdriver:spec_helper", "//rb/lib/selenium/webdriver:bidi"] +
                     BROWSERS[browser]["deps"] +


### PR DESCRIPTION
### **User description**
* Adds -bidi-remote option for each test target
* Limits tests in bidi directory to just bidi supported browsers
* Document these things in the README

I did not figure out how to prevent the bidi specific targets in the main webdriver directory from being added to non-supported browsers, but Ruby blocks that from running right now, so it is more housekeeping than performance speedup.
As in, these targets don't matter but will still be generated:
```
//rb/spec/integration/selenium/webdriver:network-ie
//rb/spec/integration/selenium/webdriver:network-ie-remote
//rb/spec/integration/selenium/webdriver:network-safari
//rb/spec/integration/selenium/webdriver:network-safari-preview
```


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds remote-bidi test targets for BiDi-supported browsers

- Restricts bidi tests to explicitly supported browsers via `BIDI_BROWSERS`

- Expands bidi test coverage with remote execution capability

- Updates documentation with bidi testing guidance and examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BIDI_BROWSERS<br/>defined"] -->|filters| B["bidi test<br/>generation"]
  B -->|creates| C["local-bidi<br/>targets"]
  B -->|creates| D["remote-bidi<br/>targets"]
  E["rb_integration_test<br/>function"] -->|checks| A
  E -->|generates| C
  E -->|generates| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.bzl</strong><dd><code>Add bidi browser filtering and remote-bidi test targets</code>&nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/tests.bzl

<ul><li>Defines <code>BIDI_BROWSERS</code> constant listing supported browsers for bidi <br>testing<br> <li> Adds condition to restrict bidi test generation to browsers in <br><code>BIDI_BROWSERS</code><br> <li> Generates new <code>remote-bidi</code> test targets alongside existing <code>bidi</code> targets<br> <li> Configures remote-bidi targets with proper environment variables and <br>dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16484/files#diff-0b035bed60fc62ad1db7c3548fa4df1aa1cd0ebe7b3c50cf5643a34929d8cb68">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Restrict bidi tests to supported browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/bidi/BUILD.bazel

<ul><li>Imports <code>BIDI_BROWSERS</code> constant from tests.bzl<br> <li> Restricts bidi integration tests to only supported browsers via <br><code>browsers</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16484/files#diff-b6db8a683a924c3b3916ea3d33c546a5642424d873fdb0426a979fa4094bc128">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document bidi testing and remote-bidi test targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds documentation for running bidi-specific tests with <br><code>--test_tag_filters bidi</code><br> <li> Explains dynamic test target generation and BiDi protocol importance<br> <li> Updates test target examples to include bidi and remote-bidi variants<br> <li> Documents <code>WEBDRIVER_BIDI</code> environment variable for enabling web socket <br>URLs<br> <li> Adds <code>chrome-beta</code> to supported browsers list</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16484/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+18/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

