### PR TITLE
[rb][build] disable dev shm for Chrome and Edge on RBE

### DIFF
--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -276,7 +276,9 @@ module Selenium
           opts[:binary] ||= ENV['CHROME_BINARY'] if ENV.key?('CHROME_BINARY')
           args << '--headless' if ENV['HEADLESS']
           args << '--no-sandbox' unless Platform.windows?
-          WebDriver::Options.chrome(args: args, **opts)
+          args << '--disable-dev-shm-usage' if GlobalTestEnv.rbe?
+          opts[:args] = args
+          WebDriver::Options.chrome(**opts)
         end
 
         def edge_options(args: [], **opts)
@@ -285,7 +287,9 @@ module Selenium
           opts[:binary] ||= ENV['EDGE_BINARY'] if ENV.key?('EDGE_BINARY')
           args << '--headless' if ENV['HEADLESS']
           args << '--no-sandbox' unless Platform.windows?
-          WebDriver::Options.edge(args: args, **opts)
+          args << '--disable-dev-shm-usage' if GlobalTestEnv.rbe?
+          opts[:args] = args
+          WebDriver::Options.edge(**opts)
         end
 
         def firefox_options(args: [], **opts)


### PR DESCRIPTION
### **User description**
Getting tab crashed errors with Chrome 142 on RBE 
Copying the fix in Python from #16443


___

### **PR Type**
Bug fix


___

### **Description**
- Disable `/dev/shm` usage for Chrome and Edge on RBE

- Prevents tab crash errors with Chrome 142

- Refactors argument passing to options hash


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chrome/Edge Options"] -->|Add disable-dev-shm flag| B["RBE Environment"]
  B -->|Prevents tab crashes| C["Stable Chrome 142"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Add dev-shm disable flag for Chrome/Edge on RBE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<ul><li>Added <code>--disable-dev-shm-usage</code> flag for Chrome and Edge when running on <br>RBE<br> <li> Refactored argument passing to use <code>opts[:args]</code> instead of direct <code>args:</code> <br>parameter<br> <li> Applied same fix to both <code>chrome_options</code> and <code>edge_options</code> methods<br> <li> Prevents tab crash errors with Chrome 142 on RBE infrastructure</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16497/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

