### PR TITLE
[rb] update syntax with rspec linter

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -119,7 +119,7 @@ RSpec/MultipleExpectations:
 
 RSpec/NoExpectationExample:
   Exclude:
-    - 'spec/integration/selenium/webdriver/guard_spec.rb'
+    - 'spec/unit/selenium/webdriver/guards_spec.rb'
     - 'spec/integration/selenium/webdriver/takes_screenshot_spec.rb'
 
 RSpec/MultipleMemoizedHelpers:

--- a/rb/spec/integration/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/ie/service_spec.rb
@@ -22,9 +22,9 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module IE
-      describe Service, {exclusive: [{bidi: false, reason: 'Not yet implemented with BiDi'}, {browser: :ie}],
-               exclude: {driver: :remote}} do
-
+      describe Service,
+               {exclude: {driver: :remote},
+                exclusive: [{bidi: false, reason: 'Not yet implemented with BiDi'}, {browser: :ie}]} do
         let(:service) { described_class.new }
         let(:service_manager) { service.launch }
 

--- a/rb/spec/integration/selenium/webdriver/safari/service_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/safari/service_spec.rb
@@ -22,8 +22,9 @@ require_relative '../spec_helper'
 module Selenium
   module WebDriver
     module Safari
-      describe Service, { exclusive: [{ bidi: false, reason: 'Not yet implemented with BiDi' }, { browser: :safari }],
-                          exclude: {driver: :remote}} do
+      describe Service,
+               {exclude: {driver: :remote},
+                exclusive: [{bidi: false, reason: 'Not yet implemented with BiDi'}, {browser: :safari}]} do
         let(:service) { described_class.new }
         let(:service_manager) { service.launch }
 

--- a/rb/spec/unit/selenium/webdriver/guards_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/guards_spec.rb
@@ -34,79 +34,80 @@ module Selenium
 
         context 'with single guard' do
           describe '#exclude' do
-            it 'ignores an unrecognized guard parameter', invalid: { condition: :guarded } do
+            it 'ignores an unrecognized guard parameter', invalid: {condition: :guarded} do
               # pass
             end
 
-            it 'skips without running', exclude: { condition: :guarded } do
+            it 'skips without running', exclude: {condition: :guarded} do
               raise 'This code will not get executed so it will not fail'
             end
           end
 
           describe '#flaky' do
-            it 'skips without running', flaky: { condition: :guarded } do
+            it 'skips without running', flaky: {condition: :guarded} do
               raise 'This code will not get executed so it will not fail'
             end
           end
 
           describe '#exclusive' do
-            it 'skips without running if it does not match', exclusive: { condition: :not_guarded } do
+            it 'skips without running if it does not match', exclusive: {condition: :not_guarded} do
               raise 'This code will not get executed so it will not fail'
             end
 
-            it 'does not guard if it does match', exclusive: { condition: :guarded } do
+            it 'does not guard if it does match', exclusive: {condition: :guarded} do
               # pass
             end
           end
 
           describe '#only' do
-            it 'guards when value does not match', only: { condition: :not_guarded } do
+            it 'guards when value does not match', only: {condition: :not_guarded} do
               raise 'This code is executed but expected to fail'
             end
 
-            it 'does not guard when value matches', only: { condition: :guarded } do
+            it 'does not guard when value matches', only: {condition: :guarded} do
               # pass
             end
           end
 
           describe '#except' do
-            it 'guards when value matches and test fails', except: { condition: :guarded } do
+            it 'guards when value matches and test fails', except: {condition: :guarded} do
               raise 'This code is executed but expected to fail'
             end
 
-            it 'does not guard when value does not match and test passes', except: { condition: :not_guarded } do
+            it 'does not guard when value does not match and test passes', except: {condition: :not_guarded} do
               # pass
             end
           end
         end
 
         context 'when multiple guards' do
-          it 'guards if neither only nor except match and test fails', except: { condition: :not_guarded },
-             only: { condition: :not_guarded } do
+          it 'guards if neither only nor except match and test fails', except: {condition: :not_guarded},
+                                                                       only: {condition: :not_guarded} do
             raise 'This code is executed but expected to fail'
           end
 
-          it 'guards if both only and except match', except: { condition: :guarded }, only: { condition: :guarded } do
+          it 'guards if both only and except match', except: {condition: :guarded}, only: {condition: :guarded} do
             raise 'This code is executed but expected to fail'
           end
 
-          it 'guards if except matches and only does not', except: { condition: :guarded }, only: { condition: :not_guarded } do
+          it 'guards if except matches and only does not', except: {condition: :guarded},
+                                                           only: {condition: :not_guarded} do
             raise 'This code is executed but expected to fail'
           end
 
-          it 'does not guard if only matches and except does not', except: { condition: :not_guarded },
-             only: { condition: :guarded } do
+          it 'does not guard if only matches and except does not', except: {condition: :not_guarded},
+                                                                   only: {condition: :guarded} do
             # pass
           end
 
-          it 'gives correct reason', except: [{ condition: :guarded, reason: 'bug1' },
-                                              { condition: :not_guarded, reason: 'bug2' }] do
+          it 'gives correct reason', except: [{condition: :guarded, reason: 'bug1'},
+                                              {condition: :not_guarded, reason: 'bug2'}] do
             raise 'This code is executed but expected to fail'
           end
         end
 
         context 'when array of hashes' do
-          it 'guards if any Hash value is satisfied', only: [{ condition: :guarded }, { condition: :not_guarded }] do
+          it 'guards if any Hash value is satisfied', only: [{condition: :guarded}, {condition: :not_guarded}] do
             raise 'This code is executed but expected to fail'
           end
         end


### PR DESCRIPTION
### **User description**
does not look like the rubocop-rspec linter is being run with our current bazel command. Need to track that down.


___

### **PR Type**
Enhancement


___

### **Description**
- Standardize Ruby hash formatting in RSpec tests

- Remove spaces around hash braces per rubocop-rspec linter

- Reorganize hash key ordering for consistency

- Fix incorrect file path in RuboCop configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RSpec Test Files"] -->|"Apply hash formatting rules"| B["Remove spaces in hashes"]
  B -->|"Reorder keys"| C["Standardized syntax"]
  D["RuboCop Config"] -->|"Fix file path"| E["Correct exclusion reference"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_spec.rb</strong><dd><code>Standardize hash formatting in IE service spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/ie/service_spec.rb

<ul><li>Reformatted <code>describe</code> block hash parameters to remove spaces around <br>braces<br> <li> Reordered hash keys with <code>exclude</code> before <code>exclusive</code><br> <li> Split hash across multiple lines for improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16498/files#diff-f37b0b8f7e7746bf129e4afaf3d0b5c6b7c73ea89c76eb3d8da61af7ca95c05b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_spec.rb</strong><dd><code>Standardize hash formatting in Safari service spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/safari/service_spec.rb

<ul><li>Reformatted <code>describe</code> block hash parameters to remove spaces around <br>braces<br> <li> Reordered hash keys with <code>exclude</code> before <code>exclusive</code><br> <li> Split hash across multiple lines for improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16498/files#diff-9eae1334ecad4d4d1b2ff60167f41d5f8d429d401802e19f664b967bf73302e6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>guards_spec.rb</strong><dd><code>Remove spaces in hash formatting throughout guards spec</code>&nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/webdriver/guards_spec.rb

<ul><li>Removed spaces around hash braces throughout test file (e.g., <code>{ </code><br><code>condition: :guarded }</code> to <code>{condition: :guarded}</code>)<br> <li> Reformatted multi-line hash parameters for consistent alignment<br> <li> Applied consistent spacing rules across all guard test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16498/files#diff-76db8b703c34c909e178458d8771564d75b175b5a013a8112ac98bb5ada20f28">+19/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.rubocop.yml</strong><dd><code>Fix incorrect file path in RuboCop configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/.rubocop.yml

<ul><li>Corrected file path in <code>RSpec/NoExpectationExample</code> exclusion<br> <li> Changed from <code>spec/integration/selenium/webdriver/guard_spec.rb</code> to <br><code>spec/unit/selenium/webdriver/guards_spec.rb</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16498/files#diff-010ef45e983d9d8b2649f7c517543a64e66362de0d8ef845df7527c634496e0f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

