### PR TITLE
[py][bidi]: add `set_timezone_override` command in emulation

### DIFF
--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -215,3 +215,38 @@ class Emulation:
             params["userContexts"] = user_contexts
 
         self.conn.execute(command_builder("emulation.setGeolocationOverride", params))
+
+    def set_timezone_override(
+        self,
+        timezone: Optional[str] = None,
+        contexts: Optional[list[str]] = None,
+        user_contexts: Optional[list[str]] = None,
+    ) -> None:
+        """Set timezone override for the given contexts or user contexts.
+
+        Parameters:
+        -----------
+            timezone: Timezone identifier (IANA timezone name or offset string like '+01:00'),
+                     or None to clear the override.
+            contexts: List of browsing context IDs to apply the override to.
+            user_contexts: List of user context IDs to apply the override to.
+
+        Raises:
+        ------
+            ValueError: If both contexts and user_contexts are provided, or if neither
+                       contexts nor user_contexts are provided.
+        """
+        if contexts is not None and user_contexts is not None:
+            raise ValueError("Cannot specify both contexts and user_contexts")
+
+        if contexts is None and user_contexts is None:
+            raise ValueError("Must specify either contexts or user_contexts")
+
+        params: dict[str, Any] = {"timezone": timezone}
+
+        if contexts is not None:
+            params["contexts"] = contexts
+        elif user_contexts is not None:
+            params["userContexts"] = user_contexts
+
+        self.conn.execute(command_builder("emulation.setTimezoneOverride", params))

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -21,6 +21,22 @@ from selenium.webdriver.common.bidi.permissions import PermissionState
 from selenium.webdriver.common.window import WindowTypes
 
 
+def get_browser_timezone_string(driver):
+    result = driver.script._evaluate(
+        "Intl.DateTimeFormat().resolvedOptions().timeZone",
+        {"context": driver.current_window_handle},
+        await_promise=False,
+    )
+    return result.result["value"]
+
+
+def get_browser_timezone_offset(driver):
+    result = driver.script._evaluate(
+        "new Date().getTimezoneOffset()", {"context": driver.current_window_handle}, await_promise=False
+    )
+    return result.result["value"]
+
+
 def get_browser_geolocation(driver, user_context=None):
     origin = driver.execute_script("return window.location.origin;")
     driver.permissions.set_permission("geolocation", PermissionState.GRANTED, origin, user_context=user_context)
@@ -214,3 +230,66 @@ def test_set_geolocation_override_with_error(driver, pages):
 
     result = get_browser_geolocation(driver)
     assert "error" in result, f"Expected geolocation error, got: {result}"
+
+
+def test_set_timezone_override_with_context(driver, pages):
+    """Test setting timezone override with a browsing context."""
+    context_id = driver.current_window_handle
+    pages.load("blank.html")
+
+    initial_timezone_string = get_browser_timezone_string(driver)
+
+    # Set timezone to Tokyo (UTC+9)
+    driver.emulation.set_timezone_override(timezone="Asia/Tokyo", contexts=[context_id])
+
+    timezone_offset = get_browser_timezone_offset(driver)
+    timezone_string = get_browser_timezone_string(driver)
+
+    # Tokyo is UTC+9, so the offset should be -540 minutes (negative because it's ahead of UTC)
+    assert timezone_offset == -540, f"Expected timezone offset -540, got: {timezone_offset}"
+    assert timezone_string == "Asia/Tokyo", f"Expected timezone 'Asia/Tokyo', got: {timezone_string}"
+
+    # Clear the timezone override
+    driver.emulation.set_timezone_override(timezone=None, contexts=[context_id])
+
+    # verify setting timezone to None clears the timezone override
+    timezone_after_clear_with_none = get_browser_timezone_string(driver)
+    assert timezone_after_clear_with_none == initial_timezone_string
+
+
+def test_set_timezone_override_with_user_context(driver, pages):
+    """Test setting timezone override with a user context."""
+    user_context = driver.browser.create_user_context()
+    context_id = driver.browsing_context.create(type=WindowTypes.TAB, user_context=user_context)
+
+    driver.switch_to.window(context_id)
+    pages.load("blank.html")
+
+    driver.emulation.set_timezone_override(timezone="America/New_York", user_contexts=[user_context])
+
+    timezone_string = get_browser_timezone_string(driver)
+    assert timezone_string == "America/New_York", f"Expected timezone 'America/New_York', got: {timezone_string}"
+
+    driver.emulation.set_timezone_override(timezone=None, user_contexts=[user_context])
+
+    driver.browsing_context.close(context_id)
+    driver.browser.remove_user_context(user_context)
+
+
+@pytest.mark.xfail_firefox(reason="Firefox returns UTC as timezone string in case of offset.")
+def test_set_timezone_override_using_offset(driver, pages):
+    """Test setting timezone override using offset."""
+    context_id = driver.current_window_handle
+    pages.load("blank.html")
+
+    # set timezone to India (UTC+05:30) using offset
+    driver.emulation.set_timezone_override(timezone="+05:30", contexts=[context_id])
+
+    timezone_offset = get_browser_timezone_offset(driver)
+    timezone_string = get_browser_timezone_string(driver)
+
+    # India is UTC+05:30, so the offset should be -330 minutes (negative because it's ahead of UTC)
+    assert timezone_offset == -330, f"Expected timezone offset -540, got: {timezone_offset}"
+    assert timezone_string == "+05:30", f"Expected timezone '+05:30', got: {timezone_string}"
+
+    driver.emulation.set_timezone_override(timezone=None, contexts=[context_id])


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds support for the `set_timezone_override` command from the emulation module - https://w3c.github.io/webdriver-bidi/#command-emulation-setTimezoneOverride

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### Usage:

Using IANA Time Zones {AREA}/{LOCATION}:
1. Contexts
	```python
	driver.emulation.set_timezone_override(timezone="Asia/Tokyo", contexts=[context_id])
	```
2. User contexts
	```python
	driver.emulation.set_timezone_override(timezone="America/New_York", user_contexts=[user_context])
	```

Using Offset:
1. Setting timezone to India:
	```python
	driver.emulation.set_timezone_override(timezone="+05:30", contexts=[context_id])
	```

Use `None` to clear/reset the timezone override:
```python
driver.emulation.set_timezone_override(timezone=None, contexts=[context_id])
```


### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
When setting timezone using offset in Firefox, it returns UTC as timezone instead of the set timezone. So, I have marked the corresponding test as xfail.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `set_timezone_override` command to emulation module

- Supports IANA timezone names and offset strings

- Allows clearing timezone override by setting to None

- Includes comprehensive tests for contexts and user contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Emulation Module"] -->|"set_timezone_override"| B["Timezone Override"]
  B -->|"IANA names or offsets"| C["Apply to Contexts"]
  B -->|"IANA names or offsets"| D["Apply to User Contexts"]
  B -->|"None value"| E["Clear Override"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emulation.py</strong><dd><code>Implement set_timezone_override emulation command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/emulation.py

<ul><li>Adds new <code>set_timezone_override</code> method to Emulation class<br> <li> Accepts timezone identifier (IANA name or offset string) or None<br> <li> Supports applying override to browsing contexts or user contexts<br> <li> Includes validation to ensure either contexts or user_contexts is <br>provided<br> <li> Executes emulation.setTimezoneOverride command via BiDi protocol</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16500/files#diff-18902e3ee516a208783ae0cb490460a1c9608548b8a3a24a15ed8d5a86ca71b1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_emulation_tests.py</strong><dd><code>Add timezone override tests and helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_emulation_tests.py

<ul><li>Adds helper functions to retrieve browser timezone string and offset<br> <li> Adds test for timezone override with browsing context<br> <li> Adds test for timezone override with user context<br> <li> Adds test for timezone override using offset strings with Firefox <br>xfail marker<br> <li> Tests verify timezone changes and clearing with None value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16500/files#diff-ddf815686b0674b1c74ff3ad30cd4a43a0f3eb1594c8fe0109146bb7ea9b39b0">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

