### PR TITLE
[rust] Fixe Edge version test

### DIFF
--- a/rust/tests/browser_download_tests.rs
+++ b/rust/tests/browser_download_tests.rs
@@ -54,7 +54,7 @@ fn browser_latest_download_test(#[case] browser: String) {
 #[case("firefox", "121.0.1")]
 #[case("firefox", "beta")]
 #[case("firefox", "esr")]
-#[case("edge", "137.0.3296.93")]
+#[case("edge", "stable")]
 #[case("edge", "beta")]
 fn browser_version_download_test(#[case] browser: String, #[case] browser_version: String) {
     if OS.eq("windows") && browser.eq("edge") {


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

https://github.com/SeleniumHQ/selenium/actions/runs/18769300152/job/53551395345

### 💥 What does this PR do?
This PR fixes a Edge test in SM, broken due to an unavailable Edge version.


### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unavailable Edge version with stable version

- Fixes broken Edge version test in Selenium Manager


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Edge version test"] -- "Replace 137.0.3296.93" --> B["Use stable version"]
  B -- "Ensures test passes" --> C["CI pipeline succeeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browser_download_tests.rs</strong><dd><code>Update Edge version test case to stable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/tests/browser_download_tests.rs

<ul><li>Changed Edge test case from specific version <code>137.0.3296.93</code> to <code>stable</code><br> <li> Resolves test failure caused by unavailable Edge build<br> <li> Maintains test coverage while using available version</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16501/files#diff-359d9c2a125d6fda0f38d3b794fcad796156f1a5786a3ead1ac92759a68a6049">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

