### PR TITLE
[py] Cleanup and convert more doctrings to google-style

### DIFF
--- a/py/selenium/webdriver/common/action_chains.py
+++ b/py/selenium/webdriver/common/action_chains.py
@@ -69,9 +69,9 @@ class ActionChains:
     def __init__(self, driver: WebDriver, duration: int = 250, devices: list[AnyDevice] | None = None) -> None:
         """Creates a new ActionChains.
 
-        :Args:
-         - driver: The WebDriver instance which performs user actions.
-         - duration: override the default 250 msecs of DEFAULT_MOVE_DURATION in PointerInput
+        Args:
+            driver: The WebDriver instance which performs user actions.
+            duration: override the default 250 msecs of DEFAULT_MOVE_DURATION in PointerInput
         """
         self._driver = driver
         mouse = None
@@ -101,9 +101,9 @@ class ActionChains:
     def click(self, on_element: WebElement | None = None) -> ActionChains:
         """Clicks an element.
 
-        :Args:
-         - on_element: The element to click.
-           If None, clicks on current mouse position.
+        Args:
+            on_element: The element to click.
+                If None, clicks on current mouse position.
         """
         if on_element:
             self.move_to_element(on_element)
@@ -117,9 +117,9 @@ class ActionChains:
     def click_and_hold(self, on_element: WebElement | None = None) -> ActionChains:
         """Holds down the left mouse button on an element.
 
-        :Args:
-         - on_element: The element to mouse down.
-           If None, clicks on current mouse position.
+        Args:
+            on_element: The element to mouse down.
+                If None, clicks on current mouse position.
         """
         if on_element:
             self.move_to_element(on_element)
@@ -132,9 +132,9 @@ class ActionChains:
     def context_click(self, on_element: WebElement | None = None) -> ActionChains:
         """Performs a context-click (right click) on an element.
 
-        :Args:
-         - on_element: The element to context-click.
-           If None, clicks on current mouse position.
+        Args:
+            on_element: The element to context-click.
+                If None, clicks on current mouse position.
         """
         if on_element:
             self.move_to_element(on_element)
@@ -148,9 +148,9 @@ class ActionChains:
     def double_click(self, on_element: WebElement | None = None) -> ActionChains:
         """Double-clicks an element.
 
-        :Args:
-         - on_element: The element to double-click.
-           If None, clicks on current mouse position.
+        Args:
+            on_element: The element to double-click.
+                If None, clicks on current mouse position.
         """
         if on_element:
             self.move_to_element(on_element)
@@ -165,9 +165,9 @@ class ActionChains:
         """Holds down the left mouse button on the source element, then moves
         to the target element and releases the mouse button.
 
-        :Args:
-         - source: The element to mouse down.
-         - target: The element to mouse up.
+        Args:
+            source: The element to mouse down.
+            target: The element to mouse up.
         """
         self.click_and_hold(source)
         self.release(target)
@@ -177,10 +177,10 @@ class ActionChains:
         """Holds down the left mouse button on the source element, then moves
         to the target offset and releases the mouse button.
 
-        :Args:
-         - source: The element to mouse down.
-         - xoffset: X offset to move to.
-         - yoffset: Y offset to move to.
+        Args:
+            source: The element to mouse down.
+            xoffset: X offset to move to.
+            yoffset: Y offset to move to.
         """
         self.click_and_hold(source)
         self.move_by_offset(xoffset, yoffset)
@@ -191,10 +191,10 @@ class ActionChains:
         """Sends a key press only, without releasing it. Should only be used
         with modifier keys (Control, Alt and Shift).
 
-        :Args:
-         - value: The modifier key to send. Values are defined in `Keys` class.
-         - element: The element to send keys.
-           If None, sends a key to current focused element.
+        Args:
+            value: The modifier key to send. Values are defined in `Keys` class.
+            element: The element to send keys.
+                If None, sends a key to current focused element.
 
         Example, pressing ctrl+c::
 
@@ -211,10 +211,10 @@ class ActionChains:
     def key_up(self, value: str, element: WebElement | None = None) -> ActionChains:
         """Releases a modifier key.
 
-        :Args:
-         - value: The modifier key to send. Values are defined in Keys class.
-         - element: The element to send keys.
-           If None, sends a key to current focused element.
+        Args:
+            value: The modifier key to send. Values are defined in Keys class.
+            element: The element to send keys.
+                If None, sends a key to current focused element.
 
         Example, pressing ctrl+c::
 
@@ -231,9 +231,9 @@ class ActionChains:
     def move_by_offset(self, xoffset: int, yoffset: int) -> ActionChains:
         """Moving the mouse to an offset from current mouse position.
 
-        :Args:
-         - xoffset: X offset to move to, as a positive or negative integer.
-         - yoffset: Y offset to move to, as a positive or negative integer.
+        Args:
+            xoffset: X offset to move to, as a positive or negative integer.
+            yoffset: Y offset to move to, as a positive or negative integer.
         """
 
         self.w3c_actions.pointer_action.move_by(xoffset, yoffset)
@@ -244,8 +244,8 @@ class ActionChains:
     def move_to_element(self, to_element: WebElement) -> ActionChains:
         """Moving the mouse to the middle of an element.
 
-        :Args:
-         - to_element: The WebElement to move to.
+        Args:
+            to_element: The WebElement to move to.
         """
 
         self.w3c_actions.pointer_action.move_to(to_element)
@@ -257,10 +257,10 @@ class ActionChains:
         """Move the mouse by an offset of the specified element. Offsets are
         relative to the in-view center point of the element.
 
-        :Args:
-         - to_element: The WebElement to move to.
-         - xoffset: X offset to move to, as a positive or negative integer.
-         - yoffset: Y offset to move to, as a positive or negative integer.
+        Args:
+            to_element: The WebElement to move to.
+            xoffset: X offset to move to, as a positive or negative integer.
+            yoffset: Y offset to move to, as a positive or negative integer.
         """
 
         self.w3c_actions.pointer_action.move_to(to_element, int(xoffset), int(yoffset))
@@ -279,9 +279,9 @@ class ActionChains:
     def release(self, on_element: WebElement | None = None) -> ActionChains:
         """Releasing a held mouse button on an element.
 
-        :Args:
-         - on_element: The element to mouse up.
-           If None, releases on current mouse position.
+        Args:
+            on_element: The element to mouse up.
+                If None, releases on current mouse position.
         """
         if on_element:
             self.move_to_element(on_element)
@@ -294,9 +294,9 @@ class ActionChains:
     def send_keys(self, *keys_to_send: str) -> ActionChains:
         """Sends keys to current focused element.
 
-        :Args:
-         - keys_to_send: The keys to send.  Modifier keys constants can be found in the
-           'Keys' class.
+        Args:
+            keys_to_send: The keys to send. Modifier keys constants can be found in the
+                'Keys' class.
         """
         typing = keys_to_typing(keys_to_send)
 
@@ -309,10 +309,10 @@ class ActionChains:
     def send_keys_to_element(self, element: WebElement, *keys_to_send: str) -> ActionChains:
         """Sends keys to an element.
 
-        :Args:
-         - element: The element to send keys.
-         - keys_to_send: The keys to send.  Modifier keys constants can be found in the
-           'Keys' class.
+        Args:
+            element: The element to send keys.
+            keys_to_send: The keys to send. Modifier keys constants can be found in the
+                'Keys' class.
         """
         self.click(element)
         self.send_keys(*keys_to_send)
@@ -322,8 +322,8 @@ class ActionChains:
         """If the element is outside the viewport, scrolls the bottom of the
         element to the bottom of the viewport.
 
-        :Args:
-         - element: Which element to scroll into the viewport.
+        Args:
+            element: Which element to scroll into the viewport.
         """
 
         self.w3c_actions.wheel_action.scroll(origin=element)
@@ -333,9 +333,9 @@ class ActionChains:
         """Scrolls by provided amounts with the origin in the top left corner
         of the viewport.
 
-        :Args:
-         - delta_x: Distance along X axis to scroll using the wheel. A negative value scrolls left.
-         - delta_y: Distance along Y axis to scroll using the wheel. A negative value scrolls up.
+        Args:
+            delta_x: Distance along X axis to scroll using the wheel. A negative value scrolls left.
+            delta_y: Distance along Y axis to scroll using the wheel. A negative value scrolls up.
         """
 
         self.w3c_actions.wheel_action.scroll(delta_x=delta_x, delta_y=delta_y)
@@ -348,13 +348,13 @@ class ActionChains:
         is not in the viewport, the bottom of the element will first be
         scrolled to the bottom of the viewport.
 
-        :Args:
-         - origin: Where scroll originates (viewport or element center) plus provided offsets.
-         - delta_x: Distance along X axis to scroll using the wheel. A negative value scrolls left.
-         - delta_y: Distance along Y axis to scroll using the wheel. A negative value scrolls up.
+        Args:
+            scroll_origin: Where scroll originates (viewport or element center) plus provided offsets.
+            delta_x: Distance along X axis to scroll using the wheel. A negative value scrolls left.
+            delta_y: Distance along Y axis to scroll using the wheel. A negative value scrolls up.
 
-         :Raises: If the origin with offset is outside the viewport.
-          - MoveTargetOutOfBoundsException - If the origin with offset is outside the viewport.
+        Raises:
+            MoveTargetOutOfBoundsException: If the origin with offset is outside the viewport.
         """
 
         if not isinstance(scroll_origin, ScrollOrigin):

--- a/py/selenium/webdriver/common/alert.py
+++ b/py/selenium/webdriver/common/alert.py
@@ -47,8 +47,8 @@ class Alert:
     def __init__(self, driver) -> None:
         """Creates a new Alert.
 
-        :Args:
-         - driver: The WebDriver instance which performs user actions.
+        Args:
+            driver: The WebDriver instance which performs user actions.
         """
         self.driver = driver
 
@@ -64,17 +64,15 @@ class Alert:
     def accept(self) -> None:
         """Accepts the alert available.
 
-        :Usage:
-            ::
-
-                Alert(driver).accept()  # Confirm a alert dialog.
+        Example:
+            Alert(driver).accept()  # Confirm a alert dialog.
         """
         self.driver.execute(Command.W3C_ACCEPT_ALERT)
 
     def send_keys(self, keysToSend: str) -> None:
         """Send Keys to the Alert.
 
-        :Args:
-         - keysToSend: The text to be sent to Alert.
+        Args:
+            keysToSend: The text to be sent to Alert.
         """
         self.driver.execute(Command.W3C_SET_ALERT_VALUE, {"value": keys_to_typing(keysToSend), "text": keysToSend})

--- a/py/selenium/webdriver/common/log.py
+++ b/py/selenium/webdriver/common/log.py
@@ -57,9 +57,7 @@ class Log:
     async def mutation_events(self) -> AsyncGenerator[dict[str, Any], None]:
         """Listen for mutation events and emit them as they are found.
 
-        :Usage:
-             ::
-
+        Example:
                async with driver.log.mutation_events() as event:
                     pages.load("dynamic.html")
                     driver.find_element(By.ID, "reveal").click()
@@ -101,9 +99,7 @@ class Log:
         """Listen for JS errors and when the contextmanager exits check if
         there were JS Errors.
 
-        :Usage:
-             ::
-
+        Example:
                 async with driver.log.add_js_error_listener() as error:
                     driver.find_element(By.ID, "throwing-mouseover").click()
                 assert bool(error)
@@ -124,12 +120,10 @@ class Log:
     async def add_listener(self, event_type) -> AsyncGenerator[dict[str, Any], None]:
         """Listen for certain events that are passed in.
 
-        :Args:
-         - event_type: The type of event that we want to look at.
+        Args:
+            event_type: The type of event that we want to look at.
 
-        :Usage:
-             ::
-
+        Example:
                 async with driver.log.add_listener(Console.log) as messages:
                     driver.execute_script("console.log('I like cheese')")
                 assert messages["message"] == "I love cheese"

--- a/py/selenium/webdriver/common/proxy.py
+++ b/py/selenium/webdriver/common/proxy.py
@@ -97,161 +97,41 @@ class Proxy:
 
     # create descriptor type objects
     auto_detect = _ProxyTypeDescriptor("autodetect", ProxyType.AUTODETECT)
-    """Gets and Sets `auto_detect`
-
-    Usage:
-    ------
-    - Get
-        - `self.auto_detect`
-    - Set
-        - `self.auto_detect` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """Proxy autodetection setting (boolean)."""
 
     # TODO: Remove ftpProxy in future version and remove deprecation warning
     ftp_proxy = _ProxyTypeDescriptor("ftpProxy", ProxyType.MANUAL)
-    """Gets and Sets `ftp_proxy`
-
-    Usage:
-    ------
-    - Get
-        - `self.ftp_proxy`
-    - Set
-        - `self.ftp_proxy` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """FTP proxy address (deprecated)."""
 
     http_proxy = _ProxyTypeDescriptor("httpProxy", ProxyType.MANUAL)
-    """Gets and Sets `http_proxy`
-
-    Usage:
-    ------
-    - Get
-        - `self.http_proxy`
-    - Set
-        - `self.http_proxy` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """HTTP proxy address."""
 
     no_proxy = _ProxyTypeDescriptor("noProxy", ProxyType.MANUAL)
-    """Gets and Sets `no_proxy`
-
-    Usage:
-    ------
-    - Get
-        - `self.no_proxy`
-    - Set
-        - `self.no_proxy` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """Addresses to bypass proxy."""
 
     proxy_autoconfig_url = _ProxyTypeDescriptor("proxyAutoconfigUrl", ProxyType.PAC)
-    """Gets and Sets `proxy_autoconfig_url`
-
-    Usage:
-    ------
-    - Get
-        - `self.proxy_autoconfig_url`
-    - Set
-        - `self.proxy_autoconfig_url` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """Proxy autoconfiguration URL."""
 
     ssl_proxy = _ProxyTypeDescriptor("sslProxy", ProxyType.MANUAL)
-    """Gets and Sets `ssl_proxy`
-
-    Usage:
-    ------
-    - Get
-        - `self.ssl_proxy`
-    - Set
-        - `self.ssl_proxy` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """SSL proxy address."""
 
     socks_proxy = _ProxyTypeDescriptor("socksProxy", ProxyType.MANUAL)
-    """Gets and Sets `socks_proxy`
-
-    Usage:
-    ------
-    - Get
-        - `self.sock_proxy`
-    - Set
-        - `self.socks_proxy` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """SOCKS proxy address."""
 
     socks_username = _ProxyTypeDescriptor("socksUsername", ProxyType.MANUAL)
-    """Gets and Sets `socks_password`
-
-    Usage:
-    ------
-    - Get
-        - `self.socks_password`
-    - Set
-        - `self.socks_password` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """SOCKS proxy username."""
 
     socks_password = _ProxyTypeDescriptor("socksPassword", ProxyType.MANUAL)
-    """Gets and Sets `socks_password`
-
-    Usage:
-    ------
-    - Get
-        - `self.socks_password`
-    - Set
-        - `self.socks_password` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """SOCKS proxy password."""
 
     socks_version = _ProxyTypeDescriptor("socksVersion", ProxyType.MANUAL)
-    """Gets and Sets `socks_version`
-
-    Usage:
-    ------
-    - Get
-        - `self.socks_version`
-    - Set
-        - `self.socks_version` = `value`
-
-    Parameters:
-    -----------
-    `value`: `str`
-    """
+    """SOCKS proxy version."""
 
     def __init__(self, raw=None):
         """Creates a new Proxy.
 
-        :Args:
-         - raw: raw proxy data. If None, default class values are used.
+        Args:
+            raw: Raw proxy data. If None, default class values are used.
         """
         if raw:
             if "proxyType" in raw and raw["proxyType"]:
@@ -293,8 +173,8 @@ class Proxy:
     def proxy_type(self, value) -> None:
         """Sets proxy type.
 
-        :Args:
-         - value: The proxy type.
+        Args:
+            value: The proxy type.
         """
         self._verify_proxy_type_compatibility(value)
         self.proxyType = value
@@ -326,12 +206,11 @@ class Proxy:
                 proxy_caps[proxy] = attr_value
         return proxy_caps
 
-    def to_bidi_dict(self):
+    def to_bidi_dict(self) -> dict:
         """Convert proxy settings to BiDi format.
 
         Returns:
-        -------
-            dict: Proxy configuration in BiDi format.
+            Proxy configuration in BiDi format.
         """
         proxy_type = self.proxyType["string"].lower()
         result = {"proxyType": proxy_type}

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -38,9 +38,11 @@ class SeleniumManager:
     def binary_paths(self, args: list) -> dict:
         """Determines the locations of the requested assets.
 
-        :Args:
-         - args: the commands to send to the selenium manager binary.
-        :Returns: dictionary of assets and their path
+        Args:
+            args: the commands to send to the selenium manager binary.
+
+        Returns:
+            Dictionary of assets and their path.
         """
 
         args = [str(self._get_binary())] + args
@@ -57,9 +59,11 @@ class SeleniumManager:
     def _get_binary() -> Path:
         """Determines the path of the correct Selenium Manager binary.
 
-        :Returns: The Selenium Manager executable location
+        Returns:
+            The Selenium Manager executable location.
 
-        :Raises: WebDriverException if the platform is unsupported
+        Raises:
+            WebDriverException: If the platform is unsupported.
         """
 
         compiled_path = Path(__file__).parent.joinpath("selenium-manager")
@@ -105,9 +109,11 @@ class SeleniumManager:
     def _run(args: list[str]) -> dict:
         """Executes the Selenium Manager Binary.
 
-        :Args:
-         - args: the components of the command being executed.
-        :Returns: The log string containing the driver location.
+        Args:
+            args: the components of the command being executed.
+
+        Returns:
+            The log string containing the driver location.
         """
         command = " ".join(args)
         logger.debug("Executing process: %s", command)

--- a/py/selenium/webdriver/common/timeouts.py
+++ b/py/selenium/webdriver/common/timeouts.py
@@ -54,16 +54,13 @@ class Timeouts:
 
         This implements https://w3c.github.io/webdriver/#timeouts.
 
-        :Args:
-         - implicit_wait - Either an int or a float. Set how many
-            seconds to wait when searching for elements before
-            throwing an error.
-         - page_load - Either an int or a float. Set how many seconds
-            to wait for a page load to complete before throwing
-            an error.
-         - script - Either an int or a float. Set how many seconds to
-            wait for an asynchronous script to finish execution
-            before throwing an error.
+        Args:
+            implicit_wait: Number of seconds to wait when searching for elements
+                before throwing an error.
+            page_load: Number of seconds to wait for a page load to complete
+                before throwing an error.
+            script: Number of seconds to wait for an asynchronous script to
+                finish execution before throwing an error.
         """
 
         self._implicit_wait = self._convert(implicit_wait)
@@ -72,55 +69,21 @@ class Timeouts:
 
     # Creating descriptor objects
     implicit_wait = _TimeoutsDescriptor("_implicit_wait")
-    """Get or set how many seconds to wait when searching for elements.
+    """Number of seconds to wait when searching for elements.
 
-    This does not set the value on the remote end.
-
-    Usage:
-    ------
-    - Get
-        - `self.implicit_wait`
-    - Set
-        - `self.implicit_wait` = `value`
-
-    Parameters:
-    -----------
-    `value`: `float`
+    Note: This does not set the value on the remote end.
     """
 
     page_load = _TimeoutsDescriptor("_page_load")
-    """Get or set how many seconds to wait for the page to load.
+    """Number of seconds to wait for the page to load.
 
-    This does not set the value on the remote end.
-
-    Usage:
-    ------
-    - Get
-        - `self.page_load`
-    - Set
-        - `self.page_load` = `value`
-
-    Parameters:
-    -----------
-    `value`: `float`
+    Note: This does not set the value on the remote end.
     """
 
     script = _TimeoutsDescriptor("_script")
-    """Get or set how many seconds to wait for an asynchronous script to finish
-    execution.
+    """Number of seconds to wait for an asynchronous script to finish execution.
 
-    This does not set the value on the remote end.
-
-    Usage:
-    ------
-    - Get
-        - `self.script`
-    - Set
-        - `self.script` = `value`
-
-    Parameters:
-    -----------
-    `value`: `float`
+    Note: This does not set the value on the remote end.
     """
 
     def _convert(self, timeout: float) -> int:

--- a/py/selenium/webdriver/common/utils.py
+++ b/py/selenium/webdriver/common/utils.py
@@ -68,11 +68,11 @@ def find_connectable_ip(host: Union[str, bytes, bytearray, None], port: Optional
     If the optional port number is provided, only IPs that listen on the given
     port are considered.
 
-    :Args:
-        - host - hostname
-        - port - port number
+    Args:
+        host: hostname
+        port: port number
 
-    :Returns:
+    Returns:
         A single IP address, as a string. If any IPv4 address is found, one is
         returned. Otherwise, if any IPv6 address is found, one is returned. If
         neither, then None is returned.
@@ -101,9 +101,9 @@ def join_host_port(host: str, port: int) -> str:
     This is a minimal implementation intended to cope with IPv6 literals. For
     example, _join_host_port('::1', 80) == '[::1]:80'.
 
-    :Args:
-        - host - hostname or IP
-        - port - port number
+    Args:
+        host: hostname or IP
+        port: port number
     """
     if ":" in host and not host.startswith("["):
         return f"[{host}]:{port}"
@@ -113,9 +113,9 @@ def join_host_port(host: str, port: int) -> str:
 def is_connectable(port: int, host: Optional[str] = "localhost") -> bool:
     """Tries to connect to the server at port to see if it is running.
 
-    :Args:
-        - port - port number
-        - host - hostname or IP
+    Args:
+        port: port number
+        host: hostname or IP
     """
     socket_ = None
     try:
@@ -141,10 +141,10 @@ def is_url_connectable(
     """Sends a request to the HTTP server at the /status endpoint to see if it
     responds successfully.
 
-    :Args:
-        - port - port number
-        - host - hostname or IP
-        - scheme - URL scheme
+    Args:
+        port: port number
+        host: hostname or IP
+        scheme: URL scheme
     """
     try:
         with urllib.request.urlopen(f"{scheme}://{host}:{port}/status") as res:

--- a/py/selenium/webdriver/common/virtual_authenticator.py
+++ b/py/selenium/webdriver/common/virtual_authenticator.py
@@ -88,13 +88,13 @@ class Credential:
         """Constructor. A credential stored in a virtual authenticator.
         https://w3c.github.io/webauthn/#credential-parameters.
 
-        :Args:
-            - credential_id (bytes): Unique base64 encoded string.
-            - is_resident_credential (bool): Whether the credential is client-side discoverable.
-            - rp_id (str): Relying party identifier.
-            - user_handle (bytes): userHandle associated to the credential. Must be Base64 encoded string. Can be None.
-            - private_key (bytes): Base64 encoded PKCS#8 private key.
-            - sign_count (int): initial value for a signature counter.
+        Args:
+            credential_id (bytes): Unique base64 encoded string.
+            is_resident_credential (bool): Whether the credential is client-side discoverable.
+            rp_id (str): Relying party identifier.
+            user_handle (bytes): userHandle associated to the credential. Must be Base64 encoded string. Can be None.
+            private_key (bytes): Base64 encoded PKCS#8 private key.
+            sign_count (int): initial value for a signature counter.
         """
         self._id = credential_id
         self._is_resident_credential = is_resident_credential
@@ -133,14 +133,14 @@ class Credential:
     def create_non_resident_credential(cls, id: bytes, rp_id: str, private_key: bytes, sign_count: int) -> "Credential":
         """Creates a non-resident (i.e. stateless) credential.
 
-        :Args:
-          - id (bytes): Unique base64 encoded string.
-          - rp_id (str): Relying party identifier.
-          - private_key (bytes): Base64 encoded PKCS
-          - sign_count (int): initial value for a signature counter.
+        Args:
+            id (bytes): Unique base64 encoded string.
+            rp_id (str): Relying party identifier.
+            private_key (bytes): Base64 encoded PKCS
+            sign_count (int): initial value for a signature counter.
 
-        :Returns:
-          - Credential: A non-resident credential.
+        Returns:
+            Credential: A non-resident credential.
         """
         return cls(id, False, rp_id, None, private_key, sign_count)
 
@@ -150,15 +150,15 @@ class Credential:
     ) -> "Credential":
         """Creates a resident (i.e. stateful) credential.
 
-        :Args:
-          - id (bytes): Unique base64 encoded string.
-          - rp_id (str): Relying party identifier.
-          - user_handle (bytes): userHandle associated to the credential. Must be Base64 encoded string.
-          - private_key (bytes): Base64 encoded PKCS
-          - sign_count (int): initial value for a signature counter.
+        Args:
+            id (bytes): Unique base64 encoded string.
+            rp_id (str): Relying party identifier.
+            user_handle (bytes): userHandle associated to the credential. Must be Base64 encoded string.
+            private_key (bytes): Base64 encoded PKCS
+            sign_count (int): initial value for a signature counter.
 
-        :returns:
-          - Credential: A resident credential.
+        Returns:
+            Credential: A resident credential.
         """
         return cls(id, True, rp_id, user_handle, private_key, sign_count)
 

--- a/py/selenium/webdriver/edge/webdriver.py
+++ b/py/selenium/webdriver/edge/webdriver.py
@@ -32,13 +32,16 @@ class WebDriver(ChromiumDriver):
         service: Optional[Service] = None,
         keep_alive: bool = True,
     ) -> None:
-        """Creates a new instance of the edge driver. Starts the service and
-        then creates new instance of edge driver.
+        """Creates a new instance of the edge driver.
 
-        :Args:
-         - options - this takes an instance of EdgeOptions
-         - service - Service object for handling the browser driver if you need to pass extra details
-         - keep_alive - Whether to configure EdgeRemoteConnection to use HTTP keep-alive.
+        Starts the service and then creates new instance of edge driver.
+
+        Args:
+            options: An instance of EdgeOptions.
+            service: Service object for handling the browser driver if you need
+                to pass extra details.
+            keep_alive: Whether to configure EdgeRemoteConnection to use HTTP
+                keep-alive.
         """
         service = service if service else Service()
         options = options if options else Options()

--- a/py/selenium/webdriver/ie/options.py
+++ b/py/selenium/webdriver/ie/options.py
@@ -27,9 +27,9 @@ class ElementScrollBehavior(Enum):
 
 
 class _IeOptionsDescriptor:
-    """_IeOptionsDescriptor is an implementation of Descriptor Protocol:
+    """_IeOptionsDescriptor is an implementation of Descriptor Protocol.
 
-    : Any look-up or assignment to the below attributes in `Options` class will be intercepted
+    Any look-up or assignment to the below attributes in `Options` class will be intercepted
     by `__get__` and `__set__` method respectively.
 
     - `browser_attach_timeout`
@@ -50,13 +50,15 @@ class _IeOptionsDescriptor:
     - `attach_to_edge_chrome`
     - `edge_executable_path`
 
+    When an attribute lookup happens:
 
-    : When an attribute lookup happens,
     Example:
         `self. browser_attach_timeout`
         `__get__` method does a dictionary look up in the dictionary `_options` in `Options` class
         and returns the value of key `browserAttachTimeout`
-    : When an attribute assignment happens,
+
+    When an attribute assignment happens:
+
     Example:
         `self.browser_attach_timeout` = 30
         `__set__` method sets/updates the value of the key `browserAttachTimeout` in `_options`
@@ -368,20 +370,26 @@ class Options(ArgOptions):
 
     @property
     def options(self) -> dict:
-        """:Returns: A dictionary of browser options."""
+        """
+        Returns:
+            A dictionary of browser options.
+        """
         return self._options
 
     @property
     def additional_options(self) -> dict:
-        """:Returns: The additional options."""
+        """
+        Returns:
+            The additional options.
+        """
         return self._additional
 
     def add_additional_option(self, name: str, value) -> None:
         """Adds an additional option not yet added as a safe option for IE.
 
-        :Args:
-         - name: name of the option to add
-         - value: value of the option to add
+        Args:
+            name: name of the option to add
+            value: value of the option to add
         """
         self._additional[name] = value
 

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -38,16 +38,16 @@ class Service(service.Service):
     ) -> None:
         """Creates a new instance of the Service.
 
-        :Args:
-         - executable_path : Path to the IEDriver
-         - port : Port the service is running on
-         - host : (Optional) IP address the service port is bound
-         - service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
-         - log_level : (Optional) Level of logging of service, may be "FATAL", "ERROR", "WARN", "INFO", "DEBUG",
-           "TRACE". Default is "FATAL".
-         - log_output: (Optional) int representation of STDOUT/DEVNULL, any IO instance or String path to file.
-           Default is "stdout".
-         - driver_path_env_key: (Optional) Environment variable to use to get the path to the driver executable.
+        Args:
+            executable_path: Path to the IEDriver
+            port: Port the service is running on
+            host: (Optional) IP address the service port is bound
+            service_args: (Optional) Sequence of args to be passed to the subprocess when launching the executable.
+            log_level: (Optional) Level of logging of service, may be "FATAL", "ERROR", "WARN", "INFO", "DEBUG",
+                "TRACE". Default is "FATAL".
+            log_output: (Optional) int representation of STDOUT/DEVNULL, any IO instance or String path to file.
+                Default is "stdout".
+            driver_path_env_key: (Optional) Environment variable to use to get the path to the driver executable.
         """
         self._service_args = list(service_args or [])
         driver_path_env_key = driver_path_env_key or "SE_IEDRIVER"

--- a/py/selenium/webdriver/ie/webdriver.py
+++ b/py/selenium/webdriver/ie/webdriver.py
@@ -39,10 +39,10 @@ class WebDriver(RemoteWebDriver):
 
         Starts the service and then creates new instance of Ie driver.
 
-        :Args:
-         - options - IE Options instance, providing additional IE options
-         - service - (Optional) service instance for managing the starting and stopping of the driver.
-         - keep_alive - Whether to configure RemoteConnection to use HTTP keep-alive.
+        Args:
+            options: IE Options instance, providing additional IE options
+            service: (Optional) service instance for managing the starting and stopping of the driver.
+            keep_alive: Whether to configure RemoteConnection to use HTTP keep-alive.
         """
 
         self.service = service if service else Service()

--- a/py/selenium/webdriver/remote/errorhandler.py
+++ b/py/selenium/webdriver/remote/errorhandler.py
@@ -53,9 +53,9 @@ from selenium.common.exceptions import (
 
 
 class ExceptionMapping:
-    """
-    :Maps each errorcode in ErrorCode object to corresponding exception
-    Please refer to https://www.w3.org/TR/webdriver2/#errors for w3c specification
+    """Maps each errorcode in ErrorCode object to corresponding exception.
+
+    Please refer to https://www.w3.org/TR/webdriver2/#errors for w3c specification.
     """
 
     NO_SUCH_ELEMENT = NoSuchElementException
@@ -146,11 +146,12 @@ class ErrorHandler:
         """Checks that a JSON response from the WebDriver does not have an
         error.
 
-        :Args:
-         - response - The JSON response from the WebDriver server as a dictionary
-           object.
+        Args:
+            response: The JSON response from the WebDriver server as a dictionary
+                object.
 
-        :Raises: If the response contains an error message.
+        Raises:
+            WebDriverException: If the response contains an error message.
         """
         status = response.get("status", None)
         if not status or status == ErrorCode.SUCCESS:

--- a/py/selenium/webdriver/remote/switch_to.py
+++ b/py/selenium/webdriver/remote/switch_to.py
@@ -34,10 +34,8 @@ class SwitchTo:
     def active_element(self) -> WebElement:
         """Returns the element with focus, or BODY if nothing has focus.
 
-        :Usage:
-            ::
-
-                element = driver.switch_to.active_element
+        Example:
+            element = driver.switch_to.active_element
         """
         return self._driver.execute(Command.W3C_GET_ACTIVE_ELEMENT)["value"]
 
@@ -45,10 +43,8 @@ class SwitchTo:
     def alert(self) -> Alert:
         """Switches focus to an alert on the page.
 
-        :Usage:
-            ::
-
-                alert = driver.switch_to.alert
+        Example:
+            alert = driver.switch_to.alert
         """
         alert = Alert(self._driver)
         _ = alert.text
@@ -57,10 +53,8 @@ class SwitchTo:
     def default_content(self) -> None:
         """Switch focus to the default frame.
 
-        :Usage:
-            ::
-
-                driver.switch_to.default_content()
+        Example:
+            driver.switch_to.default_content()
         """
         self._driver.execute(Command.SWITCH_TO_FRAME, {"id": None})
 
@@ -68,13 +62,11 @@ class SwitchTo:
         """Switches focus to the specified frame, by index, name, or
         webelement.
 
-        :Args:
-         - frame_reference: The name of the window to switch to, an integer representing the index,
-                            or a webelement that is an (i)frame to switch to.
+        Args:
+            frame_reference: The name of the window to switch to, an integer representing the index,
+                or a webelement that is an (i)frame to switch to.
 
-        :Usage:
-            ::
-
+        Example:
                 driver.switch_to.frame("frame_name")
                 driver.switch_to.frame(1)
                 driver.switch_to.frame(driver.find_elements(By.TAG_NAME, "iframe")[0])
@@ -96,9 +88,7 @@ class SwitchTo:
         The type hint can be one of "tab" or "window". If not specified the
         browser will automatically select it.
 
-        :Usage:
-            ::
-
+        Example:
                 driver.switch_to.new_window("tab")
         """
         value = self._driver.execute(Command.NEW_WINDOW, {"type": type_hint})["value"]
@@ -108,9 +98,7 @@ class SwitchTo:
         """Switches focus to the parent context. If the current context is the
         top level browsing context, the context remains unchanged.
 
-        :Usage:
-            ::
-
+        Example:
                 driver.switch_to.parent_frame()
         """
         self._driver.execute(Command.SWITCH_TO_PARENT_FRAME)
@@ -118,13 +106,11 @@ class SwitchTo:
     def window(self, window_name: str) -> None:
         """Switches focus to the specified window.
 
-        :Args:
-         - window_name: The name or window handle of the window to switch to.
+        Args:
+            window_name: The name or window handle of the window to switch to.
 
-        :Usage:
-            ::
-
-                driver.switch_to.window("main")
+        Example:
+            driver.switch_to.window("main")
         """
         self._w3c_window(window_name)
 

--- a/py/selenium/webdriver/safari/webdriver.py
+++ b/py/selenium/webdriver/safari/webdriver.py
@@ -37,11 +37,11 @@ class WebDriver(RemoteWebDriver):
         """Creates a new Safari driver instance and launches or finds a running
         safaridriver service.
 
-        :Args:
-         - keep_alive - Whether to configure SafariRemoteConnection to use
-             HTTP keep-alive. Defaults to True.
-         - options - Instance of ``options.Options``.
-         - service - Service object for handling the browser driver if you need to pass extra details
+        Args:
+            keep_alive: Whether to configure SafariRemoteConnection to use
+                HTTP keep-alive. Defaults to True.
+            options: Instance of ``options.Options``.
+            service: Service object for handling the browser driver if you need to pass extra details
         """
         self.service = service if service else Service()
         options = options if options else Options()

--- a/py/selenium/webdriver/support/event_firing_webdriver.py
+++ b/py/selenium/webdriver/support/event_firing_webdriver.py
@@ -42,15 +42,12 @@ class EventFiringWebDriver:
     def __init__(self, driver: WebDriver, event_listener: AbstractEventListener) -> None:
         """Creates a new instance of the EventFiringWebDriver.
 
-        :Args:
-         - driver : A WebDriver instance
-         - event_listener : Instance of a class that subclasses AbstractEventListener and implements it fully
-                            or partially
+        Args:
+            driver: A WebDriver instance
+            event_listener: Instance of a class that subclasses AbstractEventListener and implements it fully
+                           or partially
 
         Example:
-
-        ::
-
             from selenium.webdriver import Firefox
             from selenium.webdriver.support.events import EventFiringWebDriver, AbstractEventListener
 
@@ -77,8 +74,10 @@ class EventFiringWebDriver:
 
     @property
     def wrapped_driver(self) -> WebDriver:
-        """Returns the WebDriver instance wrapped by this
-        EventsFiringWebDriver."""
+        """
+        Returns:
+            The WebDriver instance wrapped by this EventsFiringWebDriver.
+        """
         return self._driver
 
     def get(self, url: str) -> None:
@@ -173,8 +172,10 @@ class EventFiringWebElement:
 
     @property
     def wrapped_element(self) -> WebElement:
-        """Returns the WebElement wrapped by this EventFiringWebElement
-        instance."""
+        """
+        Returns:
+            The WebElement wrapped by this EventFiringWebElement instance.
+        """
         return self._webelement
 
     def click(self) -> None:

--- a/py/selenium/webdriver/support/relative_locator.py
+++ b/py/selenium/webdriver/support/relative_locator.py
@@ -25,25 +25,18 @@ from selenium.webdriver.remote.webelement import WebElement
 def with_tag_name(tag_name: str) -> "RelativeBy":
     """Start searching for relative objects using a tag name.
 
-    Parameters:
-    -----------
-    tag_name : str
-        The DOM tag of element to start searching.
+    Args:
+        tag_name: The DOM tag of element to start searching.
 
     Returns:
-    --------
-    RelativeBy
-        Use this object to create filters within a `find_elements` call.
+        RelativeBy: Use this object to create filters within a `find_elements` call.
 
     Raises:
-    -------
-    WebDriverException
-        If `tag_name` is None.
+        WebDriverException: If `tag_name` is None.
 
-    Notes:
-    ------
-    - This method is deprecated and may be removed in future versions.
-    - Please use `locate_with` instead.
+    Note:
+        This method is deprecated and may be removed in future versions.
+        Please use `locate_with` instead.
     """
     warnings.warn("This method is deprecated and may be removed in future versions. Please use `locate_with` instead.")
     if not tag_name:
@@ -54,23 +47,16 @@ def with_tag_name(tag_name: str) -> "RelativeBy":
 def locate_with(by: ByType, using: str) -> "RelativeBy":
     """Start searching for relative objects your search criteria with By.
 
-    Parameters:
-    -----------
-    by : ByType
-        The method to find the element.
-
-    using : str
-        The value from `By` passed in.
+    Args:
+        by: The method to find the element.
+        using: The value from `By` passed in.
 
     Returns:
-    --------
-    RelativeBy
-        Use this object to create filters within a `find_elements` call.
+        RelativeBy: Use this object to create filters within a `find_elements` call.
 
     Example:
-    --------
-    >>> lowest = driver.find_element(By.ID, "below")
-    >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").above(lowest))
+        >>> lowest = driver.find_element(By.ID, "below")
+        >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").above(lowest))
     """
     assert by is not None, "Please pass in a by argument"
     assert using is not None, "Please pass in a using argument"
@@ -97,13 +83,9 @@ class RelativeBy:
         """Creates a new RelativeBy object. It is preferred if you use the
         `locate_with` method as this signature could change.
 
-        Attributes:
-        -----------
-        root : Dict[By, str]
-            - A dict with `By` enum as the key and the search query as the value
-
-        filters : List
-            - A list of the filters that will be searched. If none are passed
+        Args:
+            root: A dict with `By` enum as the key and the search query as the value
+            filters: A list of the filters that will be searched. If none are passed
                 in please use the fluent API on the object to create the filters
         """
         self.root = root
@@ -118,19 +100,14 @@ class RelativeBy:
     def above(self, element_or_locator: Union[WebElement, LocatorType, None] = None) -> "RelativeBy":
         """Add a filter to look for elements above.
 
-        Parameters:
-        -----------
-        element_or_locator : Union[WebElement, Dict, None]
-            Element to look above
+        Args:
+            element_or_locator: Element to look above
 
         Returns:
-        --------
-        RelativeBy
+            RelativeBy
 
         Raises:
-        -------
-        WebDriverException
-            If `element_or_locator` is None.
+            WebDriverException: If `element_or_locator` is None.
 
         Example:
         --------
@@ -152,24 +129,18 @@ class RelativeBy:
     def below(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements below.
 
-        Parameters:
-        -----------
-        element_or_locator : Union[WebElement, Dict, None]
-            Element to look below
+        Args:
+            element_or_locator: Element to look below
 
         Returns:
-        --------
-        RelativeBy
+            RelativeBy
 
         Raises:
-        -------
-        WebDriverException
-            If `element_or_locator` is None.
+            WebDriverException: If `element_or_locator` is None.
 
         Example:
-        --------
-        >>> highest = driver.find_element(By.ID, "high")
-        >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").below(highest))
+            >>> highest = driver.find_element(By.ID, "high")
+            >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").below(highest))
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling below method")
@@ -186,24 +157,18 @@ class RelativeBy:
     def to_left_of(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements to the left of.
 
-        Parameters:
-        -----------
-        element_or_locator : Union[WebElement, Dict, None]
-            Element to look to the left of
+        Args:
+            element_or_locator: Element to look to the left of
 
         Returns:
-        --------
-        RelativeBy
+            RelativeBy
 
         Raises:
-        -------
-        WebDriverException
-            If `element_or_locator` is None.
+            WebDriverException: If `element_or_locator` is None.
 
         Example:
-        --------
-        >>> right = driver.find_element(By.ID, "right")
-        >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").to_left_of(right))
+            >>> right = driver.find_element(By.ID, "right")
+            >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").to_left_of(right))
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling to_left_of method")
@@ -220,24 +185,18 @@ class RelativeBy:
     def to_right_of(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements right of.
 
-        Parameters:
-        -----------
-        element_or_locator : Union[WebElement, Dict, None]
-            Element to look right of
+        Args:
+            element_or_locator: Element to look right of
 
         Returns:
-        --------
-        RelativeBy
+            RelativeBy
 
         Raises:
-        -------
-        WebDriverException
-            If `element_or_locator` is None.
+            WebDriverException: If `element_or_locator` is None.
 
         Example:
-        --------
-        >>> left = driver.find_element(By.ID, "left")
-        >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").to_right_of(left))
+            >>> left = driver.find_element(By.ID, "left")
+            >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").to_right_of(left))
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling to_right_of method")
@@ -254,8 +213,8 @@ class RelativeBy:
     def straight_above(self, element_or_locator: Union[WebElement, LocatorType, None] = None) -> "RelativeBy":
         """Add a filter to look for elements above.
 
-        :Args:
-            - element_or_locator: Element to look above
+        Args:
+            element_or_locator: Element to look above
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling above method")
@@ -272,8 +231,8 @@ class RelativeBy:
     def straight_below(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements below.
 
-        :Args:
-            - element_or_locator: Element to look below
+        Args:
+            element_or_locator: Element to look below
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling below method")
@@ -290,8 +249,8 @@ class RelativeBy:
     def straight_left_of(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements to the left of.
 
-        :Args:
-            - element_or_locator: Element to look to the left of
+        Args:
+            element_or_locator: Element to look to the left of
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling to_left_of method")
@@ -308,8 +267,8 @@ class RelativeBy:
     def straight_right_of(self, element_or_locator: Union[WebElement, dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements right of.
 
-        :Args:
-            - element_or_locator: Element to look right of
+        Args:
+            element_or_locator: Element to look right of
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling to_right_of method")
@@ -326,28 +285,20 @@ class RelativeBy:
     def near(self, element_or_locator: Union[WebElement, LocatorType, None] = None, distance: int = 50) -> "RelativeBy":
         """Add a filter to look for elements near.
 
-        Parameters:
-        -----------
-        element_or_locator : Union[WebElement, Dict, None]
-            Element to look near by the element or within a distance
-
-        distance : int
-            Distance in pixel
+        Args:
+            element_or_locator: Element to look near by the element or within a distance
+            distance: Distance in pixel
 
         Returns:
-        --------
-        RelativeBy
+            RelativeBy
 
         Raises:
-        -------
-        WebDriverException
-            - If `element_or_locator` is None
-            - If `distance` is less than or equal to 0.
+            WebDriverException: If `element_or_locator` is None
+            WebDriverException: If `distance` is less than or equal to 0.
 
         Example:
-        --------
-        >>> near = driver.find_element(By.ID, "near")
-        >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").near(near, 50))
+            >>> near = driver.find_element(By.ID, "near")
+            >>> elements = driver.find_elements(locate_with(By.CSS_SELECTOR, "p").near(near, 50))
         """
         if not element_or_locator:
             raise WebDriverException("Element or locator must be given when calling near method")

--- a/py/selenium/webdriver/support/select.py
+++ b/py/selenium/webdriver/support/select.py
@@ -26,8 +26,8 @@ class Select:
         """Constructor. A check is made that the given element is, indeed, a
         SELECT tag. If it is not, then an UnexpectedTagNameException is thrown.
 
-        :Args:
-         - webelement - SELECT element to wrap
+        Args:
+            webelement: SELECT element to wrap
 
         Example:
             from selenium.webdriver.support.ui import Select \n
@@ -65,10 +65,11 @@ class Select:
 
         <option value="foo">Bar</option>
 
-        :Args:
-         - value - The value to match against
+        Args:
+            value: The value to match against
 
-        throws NoSuchElementException If there is no option with specified value in SELECT
+        Raises:
+            NoSuchElementException: If there is no option with specified value in SELECT
         """
         css = f"option[value ={self._escape_string(value)}]"
         opts = self._el.find_elements(By.CSS_SELECTOR, css)
@@ -85,10 +86,11 @@ class Select:
         """Select the option at the given index. This is done by examining the
         "index" attribute of an element, and not merely by counting.
 
-        :Args:
-         - index - The option at this index will be selected
+        Args:
+            index: The option at this index will be selected
 
-        throws NoSuchElementException If there is no option with specified index in SELECT
+        Raises:
+            NoSuchElementException: If there is no option with specified index in SELECT
         """
         match = str(index)
         for opt in self.options:
@@ -103,10 +105,11 @@ class Select:
 
          <option value="foo">Bar</option>
 
-        :Args:
-         - text - The visible text to match against
+        Args:
+            text: The visible text to match against
 
-         throws NoSuchElementException If there is no option with specified text in SELECT
+        Raises:
+            NoSuchElementException: If there is no option with specified text in SELECT
         """
         xpath = f".//option[normalize-space(.) = {self._escape_string(text)}]"
         opts = self._el.find_elements(By.XPATH, xpath)
@@ -156,10 +159,11 @@ class Select:
 
          <option value="foo">Bar</option>
 
-        :Args:
-         - value - The value to match against
+        Args:
+            value: The value to match against
 
-         throws NoSuchElementException If there is no option with specified value in SELECT
+        Raises:
+            NoSuchElementException: If there is no option with specified value in SELECT
         """
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
@@ -176,10 +180,11 @@ class Select:
         """Deselect the option at the given index. This is done by examining
         the "index" attribute of an element, and not merely by counting.
 
-        :Args:
-         - index - The option at this index will be deselected
+        Args:
+            index: The option at this index will be deselected
 
-         throws NoSuchElementException If there is no option with specified index in SELECT
+        Raises:
+            NoSuchElementException: If there is no option with specified index in SELECT
         """
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
@@ -195,8 +200,8 @@ class Select:
 
         <option value="foo">Bar</option>
 
-        :Args:
-         - text - The visible text to match against
+        Args:
+            text: The visible text to match against
         """
         if not self.is_multiple:
             raise NotImplementedError("You may only deselect options of a multi-select")
@@ -250,8 +255,8 @@ class Select:
         css_value_candidates = ["hidden", "none", "0", "0.0"]
         css_property_candidates = ["visibility", "display", "opacity"]
 
-        for property in css_property_candidates:
-            css_value = option.value_of_css_property(property)
+        for css_property in css_property_candidates:
+            css_value = option.value_of_css_property(css_property)
             if css_value in css_value_candidates:
                 return False
         return True

--- a/py/selenium/webdriver/webkitgtk/options.py
+++ b/py/selenium/webdriver/webkitgtk/options.py
@@ -29,30 +29,35 @@ class Options(ArgOptions):
 
     @property
     def binary_location(self) -> str:
-        """:Returns: The location of the browser binary otherwise an empty
-        string."""
+        """
+        Returns:
+            The location of the browser binary, otherwise an empty string.
+        """
         return self._binary_location
 
     @binary_location.setter
     def binary_location(self, value: str) -> None:
         """Allows you to set the browser binary to launch.
 
-        :Args:
-         - value : path to the browser binary
+        Args:
+            value: path to the browser binary
         """
         self._binary_location = value
 
     @property
     def overlay_scrollbars_enabled(self):
-        """:Returns: Whether overlay scrollbars should be enabled."""
+        """
+        Returns:
+            Whether overlay scrollbars should be enabled.
+        """
         return self._overlay_scrollbars_enabled
 
     @overlay_scrollbars_enabled.setter
     def overlay_scrollbars_enabled(self, value) -> None:
         """Allows you to enable or disable overlay scrollbars.
 
-        :Args:
-         - value : True or False
+        Args:
+            value: True or False
         """
         self._overlay_scrollbars_enabled = value
 

--- a/py/selenium/webdriver/webkitgtk/webdriver.py
+++ b/py/selenium/webdriver/webkitgtk/webdriver.py
@@ -36,9 +36,9 @@ class WebDriver(RemoteWebDriver):
 
         Starts the service and then creates new instance of WebKitGTK Driver.
 
-        :Args:
-         - options : an instance of WebKitGTKOptions
-         - service : Service object for handling the browser driver if you need to pass extra details
+        Args:
+            options: an instance of WebKitGTKOptions
+            service: Service object for handling the browser driver if you need to pass extra details
         """
 
         options = options if options else Options()

--- a/py/selenium/webdriver/wpewebkit/options.py
+++ b/py/selenium/webdriver/wpewebkit/options.py
@@ -37,8 +37,8 @@ class Options(ArgOptions):
     def binary_location(self, value: str) -> None:
         """Allows you to set the browser binary to launch.
 
-        :Args:
-         - value : path to the browser binary
+        Args:
+            value: path to the browser binary
         """
         if not isinstance(value, str):
             raise TypeError(self.BINARY_LOCATION_ERROR)

--- a/py/selenium/webdriver/wpewebkit/webdriver.py
+++ b/py/selenium/webdriver/wpewebkit/webdriver.py
@@ -36,9 +36,9 @@ class WebDriver(RemoteWebDriver):
 
         Starts the service and then creates new instance of WPEWebKit Driver.
 
-        :Args:
-         - options : an instance of ``WPEWebKitOptions``
-         - service : Service object for handling the browser driver if you need to pass extra details
+        Args:
+            options: an instance of ``WPEWebKitOptions``
+            service: Service object for handling the browser driver if you need to pass extra details
         """
 
         options = options if options else Options()


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
relates to #11442

### 💥 What does this PR do?
This pull request focuses on improving the clarity and consistency of docstrings and documentation throughout several core Selenium Python modules. The changes modernize docstring formatting, replace legacy usage examples with standardized sections, and simplify property documentation for maintainability and readability.

Key changes include:

**Docstring Standardization and Improvements:**

* Updated all method and class docstrings in `action_chains.py`, `alert.py`, `log.py`, and `proxy.py` to use the standard `Args:` and `Example:` (where appropriate) sections, replacing the older `:Args:` and `:Usage:` formats for better readability and consistency. [[1]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L72-R74) [[2]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L104-R105) [[3]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L120-R121) [[4]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L135-R136) [[5]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L151-R152) [[6]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L168-R170) [[7]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L180-R183) [[8]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L194-R196) [[9]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L214-R216) [[10]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L234-R236) [[11]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L247-R248) [[12]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L260-R263) [[13]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L282-R283) [[14]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L297-R298) [[15]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L312-R314) [[16]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L325-R326) [[17]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L336-R338) [[18]](diffhunk://#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390L351-R357) [[19]](diffhunk://#diff-b07f66cf40ea6ebb05e47671e2d982c35184cf92f5182e15f5c30712d24a4384L50-R51) [[20]](diffhunk://#diff-b07f66cf40ea6ebb05e47671e2d982c35184cf92f5182e15f5c30712d24a4384L67-R76) [[21]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL60-R60) [[22]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL104-R102) [[23]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL127-R126) [[24]](diffhunk://#diff-e02f00439774be6b2f8ba90ae285fd16924cfb54ec81ecb501932c09477227bfL100-R134)

**Property and Attribute Documentation Simplification:**

* Replaced verbose, repetitive property docstrings in the `Proxy` class (`proxy.py`) with concise one-line descriptions for each proxy attribute, making the code easier to maintain and understand.

**Example Section Modernization:**

* Updated usage examples in `alert.py` and `log.py` to use an `Example:` section instead of the previous `:Usage:` format, aligning with modern Python documentation standards. [[1]](diffhunk://#diff-b07f66cf40ea6ebb05e47671e2d982c35184cf92f5182e15f5c30712d24a4384L67-R76) [[2]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL60-R60) [[3]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL104-R102) [[4]](diffhunk://#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caaL127-R126)

Overall, these changes bring the codebase's documentation up to date with best practices, making it more accessible for both new and experienced contributors.
### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Documentation


___

### **Description**
- Standardized docstring format from `:Args:` to `Args:` across Python modules

- Replaced `:Usage:` sections with `Example:` for consistency

- Simplified property docstrings in proxy and timeouts classes

- Updated method documentation in action chains, alert, and other core classes

- Improved docstring formatting to follow Google style guide conventions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy Format<br/>:Args: :Usage:"] -->|Refactor| B["Google Style<br/>Args: Example:"]
  B -->|Applied to| C["Action Chains<br/>Alert Log Proxy"]
  B -->|Applied to| D["WebDriver Classes<br/>Options Services"]
  B -->|Applied to| E["Support Classes<br/>Select RelativeBy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>22 files</summary><table>
<tr>
  <td><strong>action_chains.py</strong><dd><code>Converted docstrings to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-2252da278d5aef6ec4ad66a1f179282ce0b1aea21d6fb07995e4122a0b198390">+60/-60</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>alert.py</strong><dd><code>Updated Args and Usage to Example format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-b07f66cf40ea6ebb05e47671e2d982c35184cf92f5182e15f5c30712d24a4384">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>log.py</strong><dd><code>Replaced Usage sections with Example format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-b8d3822bbce3ebf65d2a1ae9f9db32fcbdb6c43877bf8dafd98a61b763150caa">+5/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proxy.py</strong><dd><code>Simplified property docstrings significantly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-e02f00439774be6b2f8ba90ae285fd16924cfb54ec81ecb501932c09477227bf">+16/-137</a></td>

</tr>

<tr>
  <td><strong>selenium_manager.py</strong><dd><code>Standardized Args and Returns documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-5bb7b1c0cf9c81600e07ba0a6e3b612cd005cb9755ced8c3afe7a7c8e28f5ee2">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timeouts.py</strong><dd><code>Simplified property docstrings and Args format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-2c4ed12f85d0450d5b3584a40e84e99a920051789ad1a860f580390fa5404707">+13/-50</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>utils.py</strong><dd><code>Updated Args and Returns to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-b1516e150256fb4a5ef5144d5d8314fc45e92872415ba8900d4cd8d2cc9b9841">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>virtual_authenticator.py</strong><dd><code>Converted Args and Returns to Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-5da367f7e3363010c619d8097422a270cd228eb9af198d8d4ee7482a0c647b66">+22/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>webdriver.py</strong><dd><code>Updated docstring to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-7efa39061cd6f52f01b1996583fad8b66b0ddf7e8d41f5a03c910ac598dfe6dc">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>options.py</strong><dd><code>Standardized docstring format and improved clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-fd8de7ae1e18f97790d402218410985f694af943026216b97683021c438bee91">+17/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service.py</strong><dd><code>Converted Args to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-a13e626edcc84bf396cd60c854a31afd904cdeac659b8ab0b04ff98d9def7b02">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>webdriver.py</strong><dd><code>Updated docstring to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-1059a231eb1b126e550d45f1ebd61fbfba2784149c2a59ae0685ee553b25f017">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errorhandler.py</strong><dd><code>Improved docstring clarity and Args format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-3a2cce6f647dc882c5111a63c86a273646543e70b1ba3538181aee04a9385d78">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>switch_to.py</strong><dd><code>Replaced Usage with Example and standardized Args</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-40598107af3a5db8240684f70ea9fbdb9a682d1e462db1f25bf6279da624cc6d">+16/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>webdriver.py</strong><dd><code>Updated docstring to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-17f0ef4ff7107dea65c60c41cb73096d541f95727842abe9b58a47eb87d6470f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event_firing_webdriver.py</strong><dd><code>Standardized Args and improved docstring formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-d085deada2ae12d284ce6ad0b6836345a52d4e102cbbcefb6c429ef76825febc">+12/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>relative_locator.py</strong><dd><code>Converted Parameters to Args and standardized format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-f73abfa854ae95f9c23519655ed128023a74addb5460531a2e6476f0d3f4fb0d">+55/-104</a></td>

</tr>

<tr>
  <td><strong>select.py</strong><dd><code>Updated Args and Raises to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-48418bfd0178cef4e4f71bf60506204d33e152281f0bb5a670b9295689b6e01e">+26/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>options.py</strong><dd><code>Standardized Args and Returns documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-c2cfb661a575d652121ca4eae33166ffdf21d1b4323c212ee6300c57c853dc39">+12/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>webdriver.py</strong><dd><code>Updated docstring to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-0d84f899f993a1342a3a2e75a3ef749fb36e08dd022b607a7ab81beda9cfcbfc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>options.py</strong><dd><code>Converted Args to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-328aa76538eefc1145f9a680697666ac3e36ed0c11cad17b5a22ca91ed00fa95">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>webdriver.py</strong><dd><code>Updated docstring to Google style format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16503/files#diff-7bd7efef1d46539f7de57369255c776c0d0fd67c0c6174daa77001d302462af3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

