### PR TITLE
[dotnet] switch tests back to v141 until v142 is released

### DIFF
--- a/dotnet/test/common/DevTools/DevToolsConsoleTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsConsoleTest.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsConsoleTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsLogTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsLogTest.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsLogTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsNetworkTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsNetworkTest.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsNetworkTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsPerformanceTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsPerformanceTest.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsPerformanceTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsProfilerTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsProfilerTest.cs
@@ -24,7 +24,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsProfilerTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsSecurityTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsSecurityTest.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsSecurityTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsTabsTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsTabsTest.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsTabsTest : DevToolsTestFixture

--- a/dotnet/test/common/DevTools/DevToolsTargetTest.cs
+++ b/dotnet/test/common/DevTools/DevToolsTargetTest.cs
@@ -25,12 +25,12 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.DevTools;
 
-using CurrentCdpVersion = V142;
+using CurrentCdpVersion = V141;
 
 [TestFixture]
 public class DevToolsTargetTest : DevToolsTestFixture
 {
-    private int id = 142;
+    private int id = 141;
 
     [Test]
     [IgnoreBrowser(Selenium.Browser.IE, "IE does not support Chrome DevTools Protocol")]

--- a/scripts/update_cdp.py
+++ b/scripts/update_cdp.py
@@ -14,17 +14,16 @@ from packaging.version import parse
 http = urllib3.PoolManager()
 root_dir = Path(os.path.realpath(__file__)).parent.parent
 
+"""This is the same method from pinned_browser. Use --chrome_channel=Beta if
+using early stable release."""
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--chrome_channel", default="Stable", help="Set the Chrome channel"
+)
+args = parser.parse_args()
+channel = args.chrome_channel
 
 def get_chrome_milestone():
-    """This is the same method from pinned_browser. Use --chrome_channel=Beta if
-    using early stable release."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--chrome_channel", default="Stable", help="Set the Chrome channel"
-    )
-    args = parser.parse_args()
-    channel = args.chrome_channel
-
     r = http.request(
         "GET",
         f"https://chromiumdash.appspot.com/fetch_releases?channel={channel}&num=1&platform=Mac,Linux",
@@ -195,16 +194,12 @@ def update_dotnet(chrome_milestone):
             file, old_chrome(chrome_milestone), new_chrome(chrome_milestone)
         )
 
-    files = [
-        root_dir / "dotnet/test/common/CustomDriverConfigs/StableChannelChromeDriver.cs"
-    ]
-    dir_path = root_dir / "dotnet/test/common/DevTools"
-    files.extend(str(file) for file in dir_path.glob("*") if file.is_file())
-    for file in files:
-        replace_in_file(
-            file, previous_chrome(chrome_milestone), new_chrome(chrome_milestone)
-        )
-
+    if channel == "Stable":
+        dir_path = root_dir / "dotnet/test/common/DevTools"
+        for file in dir_path.glob("*") if file.is_file()
+            replace_in_file(
+                file, previous_chrome(chrome_milestone), new_chrome(chrome_milestone)
+            )
 
 def update_ruby(chrome_milestone):
     file = root_dir / "rb/lib/selenium/devtools/BUILD.bazel"


### PR DESCRIPTION
### **User description**
I tried tricking dotnet and Java to use chrome_beta instead of chrome for driver & browser locations while we are using "early release" (beta version). It worked for .NET but made Java unhappy, and I'm not sure the right thing to do here. Ideally we want to test the new CDP version, but we also don't want failing tests. What do you think @nvborisenko ?

I think this CDP code would work to check the channel and only update the test files if it is the stable channel. @cgoldberg does this python logic look right? I'm not sure we actually want to do it, though.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Revert .NET DevTools tests to CDP v141 from v142

- Add conditional logic to only update test files on stable Chrome channel

- Prevent test failures during beta/early release versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CDP v142 Tests"] -->|Revert| B["CDP v141 Tests"]
  C["update_cdp.py Script"] -->|Add Channel Check| D["Conditional Updates"]
  D -->|Stable Channel| E["Update Test Files"]
  D -->|Beta Channel| F["Skip Test Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>DevToolsConsoleTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-4f3df9c340b299fd04df2f11f9305af47c9913626c3c7023c342d5c020155208">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsLogTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-f4478513da17aaef7dd7713e963a8af55ec59648f24ff29d75974ea5e36e6d6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsNetworkTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-c7dfa1cd84e63d24fd1cae8dc785b1da3019c0772fdc9ab583e5ffec034921e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsPerformanceTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-27457f673004e13c7b46e481e64f836e7caaad0f159ef776d04f168550621a36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsProfilerTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-ba006639f1cf86df74d37deefad1e81caff9147974af82a3ab237f7ffcecbf9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsSecurityTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-cac893563e648ffe38902ea10d2ea4a2e3b47c29c7e5d8de5401dac2b1c19585">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsTabsTest.cs</strong><dd><code>Revert CDP version from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-a328a58b82c2837def4cc21d9eaead2b4c1a471872e9fb7319924dcfa23f183e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DevToolsTargetTest.cs</strong><dd><code>Revert CDP version and id from v142 to v141</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-b3126b2245cc94a39924a7a0b76a2d777497fc5db2664799be5c2f6c0d38dad4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>update_cdp.py</strong><dd><code>Add channel detection and conditional test file updates</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16510/files#diff-4902199f49976366d7ef822e7b11d6eac7f63a409846d9cfa799ed3ded05f925">+14/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

