### PR TITLE
[rb] simplify how we deal with BiDi urlPatterns

### DIFF
--- a/rb/lib/selenium/webdriver/bidi/network.rb
+++ b/rb/lib/selenium/webdriver/bidi/network.rb
@@ -40,12 +40,11 @@ module Selenium
           @bidi = bidi
         end
 
-        def add_intercept(phases: [], contexts: nil, url_patterns: nil, pattern_type: :string)
-          url_patterns = url_patterns && pattern_type ? UrlPattern.format_pattern(url_patterns, pattern_type) : nil
+        def add_intercept(phases: [], contexts: nil, filters: nil)
           @bidi.send_cmd('network.addIntercept',
                          phases: phases,
                          contexts: contexts,
-                         urlPatterns: url_patterns)
+                         urlPatterns: UrlPattern.format_pattern(filters))
         end
 
         def remove_intercept(intercept)

--- a/rb/lib/selenium/webdriver/bidi/network/url_pattern.rb
+++ b/rb/lib/selenium/webdriver/bidi/network/url_pattern.rb
@@ -25,39 +25,39 @@ module Selenium
       module UrlPattern
         module_function
 
-        def format_pattern(url_patterns, pattern_type)
-          case pattern_type
-          when :string
-            to_url_string_pattern(url_patterns)
-          when :url
-            to_url_pattern(url_patterns)
-          else
-            raise ArgumentError, "Unknown pattern type: #{pattern_type}"
+        ALLOWED_KEYS = %i[protocol hostname port pathname search].freeze
+        WEB = [{ type: 'pattern', protocol: 'https' }.freeze, { type: 'pattern', protocol: 'http' }.freeze].freeze
+
+        def format_pattern(filters)
+          patterns = Array(filters).flatten.compact
+          return WEB.dup if patterns.empty?
+
+          patterns.each_with_object([]) do |pattern, array|
+            case pattern
+            when String, ::URI::Generic
+              array << { type: 'string', pattern: pattern.to_s }
+            when Hash
+              url_pattern = to_url_pattern(pattern)
+              if url_pattern.key?(:protocol)
+                array << url_pattern
+              else
+                array << url_pattern.merge(protocol: 'http')
+                array << url_pattern.merge(protocol: 'https')
+              end
+            else
+              raise TypeError, "pattern must be a String, URI or a Hash of keys: #{ALLOWED_KEYS.join(", ")}"
+            end
           end
+
         end
 
-        def to_url_pattern(*url_patterns)
-          url_patterns.flatten.map do |url_pattern|
-            uri = URI.parse(url_pattern)
+        private
 
-            {
-              type: 'pattern',
-              protocol: uri.scheme || '',
-              hostname: uri.host || '',
-              port: uri.port.to_s,
-              pathname: uri.path || '',
-              search: uri.query || ''
-            }
-          end
-        end
+        def to_url_pattern(pattern)
+          unknown = pattern.keys - ALLOWED_KEYS
+          raise ArgumentError, "Unknown keys in pattern hash: #{unknown.inspect}" unless unknown.empty?
 
-        def to_url_string_pattern(*url_patterns)
-          url_patterns.flatten.map do |url_pattern|
-            {
-              type: 'string',
-              pattern: url_pattern
-            }
-          end
+          pattern.slice(*ALLOWED_KEYS).merge(type: 'pattern')
         end
       end
     end # BiDi

--- a/rb/lib/selenium/webdriver/common/network.rb
+++ b/rb/lib/selenium/webdriver/common/network.rb
@@ -44,7 +44,7 @@ module Selenium
         callbacks.each_key { |id| remove_handler(id) }
       end
 
-      def add_authentication_handler(username = nil, password = nil, *filter, pattern_type: nil, &block)
+      def add_authentication_handler(username = nil, password = nil, *filters, &block)
         selected_block =
           if username && password
             proc { |auth| auth.authenticate(username, password) }
@@ -56,38 +56,35 @@ module Selenium
           :auth_required,
           BiDi::Network::PHASES[:auth_required],
           BiDi::InterceptedAuth,
-          filter,
-          pattern_type: pattern_type,
+          Array(filters).flatten,
           &selected_block
         )
       end
 
-      def add_request_handler(*filter, pattern_type: nil, &block)
+      def add_request_handler(*filters, &block)
         add_handler(
           :before_request,
           BiDi::Network::PHASES[:before_request],
           BiDi::InterceptedRequest,
-          filter,
-          pattern_type: pattern_type,
+          Array(filters).flatten,
           &block
         )
       end
 
-      def add_response_handler(*filter, pattern_type: nil, &block)
+      def add_response_handler(*filters, &block)
         add_handler(
           :response_started,
           BiDi::Network::PHASES[:response_started],
           BiDi::InterceptedResponse,
-          filter,
-          pattern_type: pattern_type,
+          Array(filters).flatten,
           &block
         )
       end
 
       private
 
-      def add_handler(event_type, phase, intercept_type, filter, pattern_type: nil)
-        intercept = network.add_intercept(phases: [phase], url_patterns: [filter].flatten, pattern_type: pattern_type)
+      def add_handler(event_type, phase, intercept_type, filters)
+        intercept = network.add_intercept(phases: [phase], filters: filters)
         callback_id = network.on(event_type) do |event|
           request = event['request']
           intercepted_item = intercept_type.new(network, request)

--- a/rb/sig/lib/selenium/webdriver/bidi/network.rbs
+++ b/rb/sig/lib/selenium/webdriver/bidi/network.rbs
@@ -10,7 +10,7 @@ module Selenium
 
         def initialize: (BiDi bidi) -> void
 
-        def add_intercept: (?phases: Array[String], ?contexts: BrowsingContext?, ?url_patterns: String | Array[String]?) -> Hash[String, String]
+        def add_intercept: (?phases: Array[String], ?contexts: BrowsingContext?, ?filters: Array[String | Hash[Symbol, String]]?) -> Hash[String, String]
 
         def cancel_auth: -> Hash[nil, nil]
 
@@ -22,7 +22,7 @@ module Selenium
 
         def fail_request: -> Hash[nil, nil]
 
-        def remove_intercept: (String intercept) -> Hash[nil, nil]
+        def remove_intercept: (String? intercept) -> Hash[nil, nil]
 
         def continue_with_auth: (Integer request_id, String username, String password) -> Hash[nil, nil]
 

--- a/rb/sig/lib/selenium/webdriver/bidi/network/url_pattern.rbs
+++ b/rb/sig/lib/selenium/webdriver/bidi/network/url_pattern.rbs
@@ -2,11 +2,13 @@ module Selenium
   module WebDriver
     class BiDi
       module UrlPattern
-        def self?.format_pattern: (Array[String] | String url_patterns, Symbol pattern_type) -> Array[Hash[Symbol, String]]
+        ALLOWED_KEYS: Array[Symbol]
 
-        def self?.to_url_pattern: (*String url_patterns) -> Array[Hash[Symbol, String]]
+        WEB: Array[Hash[Symbol, String]]
 
-        def self?.to_url_string_pattern: (*String url_patterns) -> Array[Hash[Symbol, String]]
+        def self?.format_pattern: (nil | Array[String] | Array[URI] | Array[Hash[Symbol, String]]) -> Array[Hash[Symbol, String]]
+
+        def self?.to_url_pattern: (Hash[Symbol, String]) -> Hash[Symbol, String]
       end
     end
   end

--- a/rb/sig/lib/selenium/webdriver/common/network.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/network.rbs
@@ -11,21 +11,21 @@ module Selenium
 
       alias bidi network
 
-      def initialize: (Remote::Bridge bridge) -> void
+      def initialize: (Remote::BiDiBridge bridge) -> void
 
       def remove_handler: (Numeric id) -> untyped
 
       def clear_handlers: () -> untyped
 
-      def add_authentication_handler: (?String? username, ?String? password, *String filter, ?pattern_type: Symbol?) { (?) -> untyped } -> untyped
+      def add_authentication_handler: (?String? username, ?String? password, *(String | Hash[Symbol, String])?) { (BiDi::InterceptedAuth) -> void } -> Hash[String, String]
 
-      def add_request_handler: (*String filter, ?pattern_type: Symbol?) -> Hash[String, String]
+      def add_request_handler: (*(String | Hash[Symbol, String])?)  { (BiDi::InterceptedRequest) -> void } -> Hash[String, String]
 
-      def add_response_handler: (*String filter, ?pattern_type: Symbol?) -> Hash[String, String]
+      def add_response_handler: (*(String | Hash[Symbol, String])?)  { (BiDi::InterceptedResponse) -> void } -> Hash[String, String]
 
       private
 
-      def add_handler: (Symbol event_type, String phase, BiDi::InterceptedRequest | BiDi::InterceptedAuth | BiDi::InterceptedResponse intercept_type, Array[String] filter, ?pattern_type: Symbol?) { (untyped) -> untyped } -> untyped
+      def add_handler: (Symbol event_type, String phase, Class intercept_type, Array[String | Hash[Symbol, String]] filters) { (untyped) -> untyped } -> untyped
     end
   end
 end

--- a/rb/spec/integration/selenium/webdriver/bidi/network_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/network_spec.rb
@@ -35,16 +35,14 @@ module Selenium
         it 'adds an intercept with a default pattern type' do
           network = described_class.new(driver.bidi)
           pattern = 'http://localhost:4444/formPage.html'
-          intercept = network.add_intercept(phases: [described_class::PHASES[:before_request]], url_patterns: pattern)
+          intercept = network.add_intercept(phases: [described_class::PHASES[:before_request]], filters: [pattern])
           expect(intercept).not_to be_nil
         end
 
         it 'adds an intercept with a url pattern' do
           network = described_class.new(driver.bidi)
           pattern = 'http://localhost:4444/formPage.html'
-          intercept = network.add_intercept(phases: [described_class::PHASES[:before_request]],
-                                            url_patterns: pattern,
-                                            pattern_type: :url)
+          intercept = network.add_intercept(phases: [described_class::PHASES[:before_request]], filters: [pattern])
           expect(intercept).not_to be_nil
         end
 

--- a/rb/spec/integration/selenium/webdriver/network_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/network_spec.rb
@@ -60,7 +60,7 @@ module Selenium
       it 'adds an auth handler with a pattern type' do
         reset_driver!(web_socket_url: true) do |driver|
           network = described_class.new(driver)
-          network.add_authentication_handler(username, password, url_for('basicAuth'), pattern_type: :url)
+          network.add_authentication_handler(username, password, url_for('basicAuth'))
           driver.navigate.to url_for('basicAuth')
           expect(driver.find_element(tag_name: 'h1').text).to eq('authorized')
           expect(network.callbacks.count).to be 1
@@ -135,7 +135,7 @@ module Selenium
       it 'adds a request handler with a pattern type' do
         reset_driver!(web_socket_url: true) do |driver|
           network = described_class.new(driver)
-          network.add_request_handler(url_for('formPage.html'), pattern_type: :url, &:continue)
+          network.add_request_handler(url_for('formPage.html'), &:continue)
           driver.navigate.to url_for('formPage.html')
           expect(driver.current_url).to eq(url_for('formPage.html'))
           expect(network.callbacks.count).to be 1
@@ -230,7 +230,7 @@ module Selenium
       it 'adds a response handler with a pattern type' do
         reset_driver!(web_socket_url: true) do |driver|
           network = described_class.new(driver)
-          network.add_response_handler(url_for('formPage.html'), pattern_type: :url, &:continue)
+          network.add_response_handler(url_for('formPage.html'), &:continue)
           driver.navigate.to url_for('formPage.html')
           expect(driver.current_url).to eq(url_for('formPage.html'))
           expect(network.callbacks.count).to be 1


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Generates complete url pattern from a single filter parameter

### 🔧 Implementation Notes
* Rename parameter to filters as a more human parseable name
* Combine patterns and type into one thing. The spec actually supports sending multiple types at the same time, just add it to the array.
* Adds a WEB constant to set http/https filter by default since it currently hangs on data schemas

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
* What do you think about our throwing a warning when the user doesn't put a filter that it may be non-performant?

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify BiDi URL pattern API by consolidating parameters

- Replace separate `url_patterns` and `pattern_type` with unified `filters` parameter

- Add `WEB` constant for default HTTP/HTTPS protocol filtering

- Support multiple input types: String, URI, and Hash patterns

- Update type signatures and test cases for new API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old API<br/>url_patterns + pattern_type"] -->|Consolidate| B["New API<br/>filters parameter"]
  B -->|Supports| C["String patterns"]
  B -->|Supports| D["URI objects"]
  B -->|Supports| E["Hash patterns"]
  B -->|Default| F["WEB constant<br/>HTTP/HTTPS"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.rb</strong><dd><code>Simplify add_intercept method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/bidi/network.rb

<ul><li>Simplified <code>add_intercept</code> method signature by removing <code>url_patterns</code> and <br><code>pattern_type</code> parameters<br> <li> Replaced with single <code>filters</code> parameter for cleaner API<br> <li> Updated method call to use new <code>UrlPattern.format_pattern</code> signature</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-caed96b819b484a7727db49b5712d0caa86ddf86807a544fc8bd0a94756e301c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>url_pattern.rb</strong><dd><code>Consolidate URL pattern generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/bidi/network/url_pattern.rb

<ul><li>Removed separate <code>format_pattern</code>, <code>to_url_pattern</code>, and <br><code>to_url_string_pattern</code> methods<br> <li> Added <code>ALLOWED_KEYS</code> constant for pattern hash validation<br> <li> Added <code>WEB</code> constant with default HTTP/HTTPS protocol patterns<br> <li> Implemented unified <code>format_pattern</code> method supporting String, URI, and <br>Hash inputs<br> <li> Added private <code>to_url_pattern</code> method with validation for hash patterns<br> <li> Returns <code>WEB</code> patterns by default when filters are empty</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-a813664614324d8d8b8248f147aa9a10bcc8d4986a4d48f982cba5e37fb39906">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network.rb</strong><dd><code>Remove pattern_type parameter from handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/network.rb

<ul><li>Removed <code>pattern_type</code> keyword argument from <code>add_authentication_handler</code>, <br><code>add_request_handler</code>, and <code>add_response_handler</code><br> <li> Renamed <code>filter</code> parameter to <code>filters</code> for consistency<br> <li> Simplified <code>add_handler</code> private method to remove <code>pattern_type</code> parameter<br> <li> Updated filter handling to use <code>Array(filters).flatten</code> for <br>normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-36bbaec2382eeda5ec71df015b4ed38c64e80feb08f44ba368349b07c434f044">+8/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_spec.rb</strong><dd><code>Update BiDi network tests for new API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/bidi/network_spec.rb

<ul><li>Updated test cases to use new <code>filters</code> parameter instead of <br><code>url_patterns</code><br> <li> Removed <code>pattern_type: :url</code> arguments from test calls<br> <li> Wrapped pattern strings in arrays to match new API expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-e7c666a99d84b05ace437427175d9e64176f5628789114d383ed245836d3dd0d">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network_spec.rb</strong><dd><code>Update network handler tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/network_spec.rb

<ul><li>Removed <code>pattern_type: :url</code> arguments from <code>add_authentication_handler</code>, <br><code>add_request_handler</code>, and <code>add_response_handler</code> test calls<br> <li> Tests now use simplified API without explicit pattern type <br>specification</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-1a5e512bf311a90fe92d313bab7fdf226fe29998c5b4bd92b78e354fa6948e36">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.rbs</strong><dd><code>Update BiDi network type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/bidi/network.rbs

<ul><li>Updated <code>add_intercept</code> signature to use <code>filters</code> parameter accepting <br><code>Array[String | Hash[Symbol, String]]</code><br> <li> Changed <code>remove_intercept</code> parameter type from <code>String</code> to <code>String?</code> for <br>optional intercept</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-ed9292ed35d71b668200e1c25116ba4a1933ec8df1aadd76ea9a14f7cc9a1763">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>url_pattern.rbs</strong><dd><code>Update URL pattern type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/bidi/network/url_pattern.rbs

<ul><li>Added <code>ALLOWED_KEYS</code> and <code>WEB</code> constant type declarations<br> <li> Updated <code>format_pattern</code> signature to accept <code>nil | Array[String] | </code><br><code>Array[URI] | Array[Hash[Symbol, String]]</code><br> <li> Simplified <code>to_url_pattern</code> to accept single <code>Hash[Symbol, String]</code> <br>parameter<br> <li> Removed <code>to_url_string_pattern</code> method signature</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-46d5b9d239f05a10c8027acad358458ebb0db7d8f0b373954646b90a8f66db65">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network.rbs</strong><dd><code>Update network handler type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/webdriver/common/network.rbs

<ul><li>Updated <code>initialize</code> parameter type from <code>Remote::Bridge</code> to <br><code>Remote::BiDiBridge</code><br> <li> Removed <code>pattern_type</code> keyword argument from handler method signatures<br> <li> Updated filter parameters to accept <code>String | Hash[Symbol, String]</code> <br>types<br> <li> Improved type annotations for block parameters and return types<br> <li> Updated <code>add_handler</code> private method signature with new parameter types</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16519/files#diff-9e106b0b1db8e86ec1c738074989c75c8a3a0c60080d22d2d687eb0c5d42e89f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

