### PR TITLE
[py][bidi]: add `set_screen_orientation_override` command in Emulation

### DIFF
--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -41,7 +41,7 @@ def _convert_to_enum(value, enum_class):
     if isinstance(value, enum_class):
         return value
     try:
-        return enum_class(value)
+        return enum_class(value.lower())
     except ValueError:
         raise ValueError(f"Invalid orientation: {value}")
 

--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -37,6 +37,15 @@ class ScreenOrientationType(Enum):
     LANDSCAPE_SECONDARY = "landscape-secondary"
 
 
+def _convert_to_enum(value, enum_class):
+    if isinstance(value, enum_class):
+        return value
+    try:
+        return enum_class(value)
+    except ValueError:
+        raise ValueError(f"Invalid orientation: {value}")
+
+
 class ScreenOrientation:
     """Represents screen orientation configuration."""
 
@@ -55,22 +64,9 @@ class ScreenOrientation:
         Raises:
             ValueError: If natural or type values are invalid.
         """
-        # Convert strings to enums if needed
-        if isinstance(natural, str):
-            try:
-                self.natural = ScreenOrientationNatural(natural)
-            except ValueError:
-                raise ValueError(f"Invalid natural orientation: {natural}")
-        else:
-            self.natural = natural
-
-        if isinstance(type, str):
-            try:
-                self.type = ScreenOrientationType(type)
-            except ValueError:
-                raise ValueError(f"Invalid orientation type: {type}")
-        else:
-            self.type = type
+        # handle string values
+        self.natural = _convert_to_enum(natural, ScreenOrientationNatural)
+        self.type = _convert_to_enum(type, ScreenOrientationType)
 
     def to_dict(self) -> dict[str, str]:
         return {

--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -15,9 +15,68 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from enum import Enum
 from typing import Any, Optional, Union
 
 from selenium.webdriver.common.bidi.common import command_builder
+
+
+class ScreenOrientationNatural(Enum):
+    """Natural screen orientation."""
+
+    PORTRAIT = "portrait"
+    LANDSCAPE = "landscape"
+
+
+class ScreenOrientationType(Enum):
+    """Screen orientation type."""
+
+    PORTRAIT_PRIMARY = "portrait-primary"
+    PORTRAIT_SECONDARY = "portrait-secondary"
+    LANDSCAPE_PRIMARY = "landscape-primary"
+    LANDSCAPE_SECONDARY = "landscape-secondary"
+
+
+class ScreenOrientation:
+    """Represents screen orientation configuration."""
+
+    def __init__(
+        self,
+        natural: Union[ScreenOrientationNatural, str],
+        type: Union[ScreenOrientationType, str],
+    ):
+        """Initialize ScreenOrientation.
+
+        Args:
+            natural: Natural screen orientation ("portrait" or "landscape").
+            type: Screen orientation type ("portrait-primary", "portrait-secondary",
+                "landscape-primary", or "landscape-secondary").
+
+        Raises:
+            ValueError: If natural or type values are invalid.
+        """
+        # Convert strings to enums if needed
+        if isinstance(natural, str):
+            try:
+                self.natural = ScreenOrientationNatural(natural)
+            except ValueError:
+                raise ValueError(f"Invalid natural orientation: {natural}")
+        else:
+            self.natural = natural
+
+        if isinstance(type, str):
+            try:
+                self.type = ScreenOrientationType(type)
+            except ValueError:
+                raise ValueError(f"Invalid orientation type: {type}")
+        else:
+            self.type = type
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "natural": self.natural.value,
+            "type": self.type.value,
+        }
 
 
 class GeolocationCoordinates:
@@ -312,3 +371,37 @@ class Emulation:
             params["userContexts"] = user_contexts
 
         self.conn.execute(command_builder("emulation.setScriptingEnabled", params))
+
+    def set_screen_orientation_override(
+        self,
+        screen_orientation: Optional[ScreenOrientation] = None,
+        contexts: Optional[list[str]] = None,
+        user_contexts: Optional[list[str]] = None,
+    ) -> None:
+        """Set screen orientation override for the given contexts or user contexts.
+
+        Args:
+            screen_orientation: ScreenOrientation object to emulate, or None to clear the override.
+            contexts: List of browsing context IDs to apply the override to.
+            user_contexts: List of user context IDs to apply the override to.
+
+        Raises:
+            ValueError: If both contexts and user_contexts are provided, or if neither
+                contexts nor user_contexts are provided.
+        """
+        if contexts is not None and user_contexts is not None:
+            raise ValueError("Cannot specify both contexts and userContexts")
+
+        if contexts is None and user_contexts is None:
+            raise ValueError("Must specify either contexts or userContexts")
+
+        params: dict[str, Any] = {
+            "screenOrientation": screen_orientation.to_dict() if screen_orientation is not None else None
+        }
+
+        if contexts is not None:
+            params["contexts"] = contexts
+        elif user_contexts is not None:
+            params["userContexts"] = user_contexts
+
+        self.conn.execute(command_builder("emulation.setScreenOrientationOverride", params))

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -16,7 +16,14 @@
 # under the License.
 import pytest
 
-from selenium.webdriver.common.bidi.emulation import Emulation, GeolocationCoordinates, GeolocationPositionError
+from selenium.webdriver.common.bidi.emulation import (
+    Emulation,
+    GeolocationCoordinates,
+    GeolocationPositionError,
+    ScreenOrientation,
+    ScreenOrientationNatural,
+    ScreenOrientationType,
+)
 from selenium.webdriver.common.bidi.permissions import PermissionState
 from selenium.webdriver.common.window import WindowTypes
 
@@ -71,6 +78,24 @@ def get_browser_locale(driver):
         await_promise=False,
     )
     return result.result["value"]
+
+
+def get_screen_orientation(driver, context_id):
+    result = driver.script._evaluate(
+        "screen.orientation.type",
+        {"context": context_id},
+        await_promise=False,
+    )
+    orientation_type = result.result["value"]
+
+    result = driver.script._evaluate(
+        "screen.orientation.angle",
+        {"context": context_id},
+        await_promise=False,
+    )
+    orientation_angle = result.result["value"]
+
+    return {"type": orientation_type, "angle": orientation_angle}
 
 
 def test_emulation_initialized(driver):
@@ -415,6 +440,78 @@ def test_set_scripting_enabled_with_user_contexts(driver, pages):
                 "document.getElementById('clickField').value", {"context": context_id}, await_promise=False
             )
             assert result_value.result["value"] == "Clicked"
+        finally:
+            driver.browsing_context.close(context_id)
+    finally:
+        driver.browser.remove_user_context(user_context)
+
+
+def test_set_screen_orientation_override_with_contexts(driver, pages):
+    context_id = driver.current_window_handle
+    initial_orientation = get_screen_orientation(driver, context_id)
+
+    # Set landscape-primary orientation
+    orientation = ScreenOrientation(
+        natural=ScreenOrientationNatural.LANDSCAPE,
+        type=ScreenOrientationType.LANDSCAPE_PRIMARY,
+    )
+    driver.emulation.set_screen_orientation_override(screen_orientation=orientation, contexts=[context_id])
+
+    url = pages.url("formPage.html")
+    driver.browsing_context.navigate(context_id, url, wait="complete")
+
+    # Verify the orientation was set
+    current_orientation = get_screen_orientation(driver, context_id)
+    assert current_orientation["type"] == "landscape-primary", f"Expected landscape-primary, got {current_orientation}"
+    assert current_orientation["angle"] == 0, f"Expected angle 0, got {current_orientation['angle']}"
+
+    # Set portrait-secondary orientation
+    orientation = ScreenOrientation(
+        natural=ScreenOrientationNatural.PORTRAIT,
+        type=ScreenOrientationType.PORTRAIT_SECONDARY,
+    )
+    driver.emulation.set_screen_orientation_override(screen_orientation=orientation, contexts=[context_id])
+
+    # Verify the orientation was changed
+    current_orientation = get_screen_orientation(driver, context_id)
+    assert current_orientation["type"] == "portrait-secondary", (
+        f"Expected portrait-secondary, got {current_orientation}"
+    )
+    assert current_orientation["angle"] == 180, f"Expected angle 180, got {current_orientation['angle']}"
+
+    driver.emulation.set_screen_orientation_override(screen_orientation=None, contexts=[context_id])
+
+    # Verify orientation was cleared
+    assert get_screen_orientation(driver, context_id) == initial_orientation
+
+
+def test_set_screen_orientation_override_with_user_contexts(driver, pages):
+    user_context = driver.browser.create_user_context()
+    try:
+        context_id = driver.browsing_context.create(type=WindowTypes.TAB, user_context=user_context)
+        try:
+            driver.switch_to.window(context_id)
+
+            # Set landscape-secondary orientation on portrait natural using string
+            orientation = ScreenOrientation(
+                natural="portrait",
+                type="landscape-secondary",
+            )
+            driver.emulation.set_screen_orientation_override(
+                screen_orientation=orientation, user_contexts=[user_context]
+            )
+
+            url = pages.url("formPage.html")
+            driver.browsing_context.navigate(context_id, url, wait="complete")
+
+            # Verify the orientation was set
+            current_orientation = get_screen_orientation(driver, context_id)
+            assert current_orientation["type"] == "landscape-secondary", (
+                f"Expected landscape-secondary, got {current_orientation}"
+            )
+            assert current_orientation["angle"] == 270, f"Expected angle 270, got {current_orientation['angle']}"
+
+            driver.emulation.set_screen_orientation_override(screen_orientation=None, user_contexts=[user_context])
         finally:
             driver.browsing_context.close(context_id)
     finally:

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -489,12 +489,12 @@ def test_set_screen_orientation_override_with_contexts(driver, pages):
     "natural,orientation_type,expected_angle",
     [
         # Portrait natural orientations
-        ("portrait", "portrait-primary", 0),
+        ("Portrait", "portrait-primary", 0),
         ("portrait", "portrait-secondary", 180),
         ("portrait", "landscape-primary", 90),
         ("portrait", "landscape-secondary", 270),
         # Landscape natural orientations
-        ("landscape", "portrait-primary", 90),
+        ("Landscape", "Portrait-Primary", 90),  # test with different casing
         ("landscape", "portrait-secondary", 270),
         ("landscape", "landscape-primary", 0),
         ("landscape", "landscape-secondary", 180),
@@ -519,7 +519,7 @@ def test_set_screen_orientation_override_with_user_contexts(driver, pages, natur
             # Verify the orientation was set
             current_orientation = get_screen_orientation(driver, context_id)
 
-            assert current_orientation["type"] == orientation_type
+            assert current_orientation["type"] == orientation_type.lower()
             assert current_orientation["angle"] == expected_angle
 
             driver.emulation.set_screen_orientation_override(screen_orientation=None, user_contexts=[user_context])

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -485,18 +485,30 @@ def test_set_screen_orientation_override_with_contexts(driver, pages):
     assert get_screen_orientation(driver, context_id) == initial_orientation
 
 
-def test_set_screen_orientation_override_with_user_contexts(driver, pages):
+@pytest.mark.parametrize(
+    "natural,orientation_type,expected_angle",
+    [
+        # Portrait natural orientations
+        ("portrait", "portrait-primary", 0),
+        ("portrait", "portrait-secondary", 180),
+        ("portrait", "landscape-primary", 90),
+        ("portrait", "landscape-secondary", 270),
+        # Landscape natural orientations
+        ("landscape", "portrait-primary", 90),
+        ("landscape", "portrait-secondary", 270),
+        ("landscape", "landscape-primary", 0),
+        ("landscape", "landscape-secondary", 180),
+    ],
+)
+def test_set_screen_orientation_override_with_user_contexts(driver, pages, natural, orientation_type, expected_angle):
     user_context = driver.browser.create_user_context()
     try:
         context_id = driver.browsing_context.create(type=WindowTypes.TAB, user_context=user_context)
         try:
             driver.switch_to.window(context_id)
 
-            # Set landscape-secondary orientation on portrait natural using string
-            orientation = ScreenOrientation(
-                natural="portrait",
-                type="landscape-secondary",
-            )
+            # Set the specified orientation
+            orientation = ScreenOrientation(natural=natural, type=orientation_type)
             driver.emulation.set_screen_orientation_override(
                 screen_orientation=orientation, user_contexts=[user_context]
             )
@@ -506,10 +518,9 @@ def test_set_screen_orientation_override_with_user_contexts(driver, pages):
 
             # Verify the orientation was set
             current_orientation = get_screen_orientation(driver, context_id)
-            assert current_orientation["type"] == "landscape-secondary", (
-                f"Expected landscape-secondary, got {current_orientation}"
-            )
-            assert current_orientation["angle"] == 270, f"Expected angle 270, got {current_orientation['angle']}"
+
+            assert current_orientation["type"] == orientation_type
+            assert current_orientation["angle"] == expected_angle
 
             driver.emulation.set_screen_orientation_override(screen_orientation=None, user_contexts=[user_context])
         finally:


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds the `set_screen_orientation_override` command to the Emulation module - https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenOrientationOverride.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Usage:

1. Using ENUM:
	```python
	orientation = ScreenOrientation(
	        natural=ScreenOrientationNatural.LANDSCAPE,
	        type=ScreenOrientationType.LANDSCAPE_PRIMARY,
	    )
    driver.emulation.set_screen_orientation_override(screen_orientation=orientation, contexts=[context_id])
	```

2. Using strings:
	```python
	orientation = ScreenOrientation(natural="landscape", type="landscape-secondary")
	driver.emulation.set_screen_orientation_override(screen_orientation=orientation, user_contexts=[user_context])
	```

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Supported by both chromium and Firefox.

We can set the natural orientation and the type via ENUMs or through strings directly. `_convert_to_enum` internally converts str to enum and raises value error if wrong string is passed.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `set_screen_orientation_override` command to Emulation module

- Implements `ScreenOrientation` class with enum support

- Supports both enum and string-based orientation configuration

- Includes comprehensive tests for contexts and user contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ScreenOrientationNatural<br/>ScreenOrientationType<br/>Enums"] -->|"_convert_to_enum"| B["ScreenOrientation<br/>Class"]
  B -->|"to_dict()"| C["set_screen_orientation_override<br/>Command"]
  C -->|"execute"| D["Emulation Module"]
  E["Test Cases<br/>Contexts & UserContexts"] -->|"verify"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emulation.py</strong><dd><code>Implement screen orientation override functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/emulation.py

<ul><li>Added <code>ScreenOrientationNatural</code> and <code>ScreenOrientationType</code> enums for <br>orientation values<br> <li> Implemented <code>_convert_to_enum()</code> helper function to convert strings to <br>enums with validation<br> <li> Created <code>ScreenOrientation</code> class to encapsulate natural and type <br>orientation settings<br> <li> Added <code>set_screen_orientation_override()</code> method to apply orientation <br>overrides to contexts or user contexts<br> <li> Includes validation to ensure either contexts or user_contexts is <br>provided, but not both</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16522/files#diff-18902e3ee516a208783ae0cb490460a1c9608548b8a3a24a15ed8d5a86ca71b1">+89/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_emulation_tests.py</strong><dd><code>Add comprehensive screen orientation override tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_emulation_tests.py

<ul><li>Added imports for <code>ScreenOrientation</code>, <code>ScreenOrientationNatural</code>, and <br><code>ScreenOrientationType</code><br> <li> Implemented <code>get_screen_orientation()</code> helper function to retrieve <br>current screen orientation and angle<br> <li> Added <code>test_set_screen_orientation_override_with_contexts()</code> to test <br>orientation changes with browsing contexts<br> <li> Added parametrized <br><code>test_set_screen_orientation_override_with_user_contexts()</code> covering all <br>orientation combinations<br> <li> Tests verify orientation type, angle values, and clearing overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16522/files#diff-ddf815686b0674b1c74ff3ad30cd4a43a0f3eb1594c8fe0109146bb7ea9b39b0">+109/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

