### PR TITLE
[py] Update docstrings (remove reST leftovers and resolve D200)

### DIFF
--- a/py/selenium/webdriver/common/bidi/browser.py
+++ b/py/selenium/webdriver/common/bidi/browser.py
@@ -169,9 +169,7 @@ class ClientWindowInfo:
 
 
 class Browser:
-    """
-    BiDi implementation of the browser module.
-    """
+    """BiDi implementation of the browser module."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/py/selenium/webdriver/common/bidi/input.py
+++ b/py/selenium/webdriver/common/bidi/input.py
@@ -378,9 +378,7 @@ class FileDialogOpened:
 
 
 class Input:
-    """
-    BiDi implementation of the input module.
-    """
+    """BiDi implementation of the input module."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/py/selenium/webdriver/common/bidi/permissions.py
+++ b/py/selenium/webdriver/common/bidi/permissions.py
@@ -39,9 +39,7 @@ class PermissionDescriptor:
 
 
 class Permissions:
-    """
-    BiDi implementation of the permissions module.
-    """
+    """BiDi implementation of the permissions module."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/py/selenium/webdriver/common/bidi/script.py
+++ b/py/selenium/webdriver/common/bidi/script.py
@@ -312,9 +312,7 @@ class Script:
             raise WebDriverException(error_message)
 
     def __convert_to_local_value(self, value) -> dict:
-        """
-        Converts a Python value to BiDi LocalValue format.
-        """
+        """Converts a Python value to BiDi LocalValue format."""
         if value is None:
             return {"type": "null"}
         elif isinstance(value, bool):

--- a/py/selenium/webdriver/common/bidi/webextension.py
+++ b/py/selenium/webdriver/common/bidi/webextension.py
@@ -22,9 +22,7 @@ from selenium.webdriver.common.bidi.common import command_builder
 
 
 class WebExtension:
-    """
-    BiDi implementation of the webExtension module.
-    """
+    """BiDi implementation of the webExtension module."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/py/selenium/webdriver/common/print_page_options.py
+++ b/py/selenium/webdriver/common/print_page_options.py
@@ -335,7 +335,10 @@ class PrintOptions:
         self._margin: _MarginOpts = {}
 
     def to_dict(self) -> _PrintOpts:
-        """:Returns: A hash of print options configured."""
+        """
+        Returns:
+            A hash of print options configured.
+        """
         return self._print_options
 
     def set_page_size(self, page_size: dict) -> None:

--- a/py/selenium/webdriver/firefox/options.py
+++ b/py/selenium/webdriver/firefox/options.py
@@ -64,7 +64,10 @@ class Options(ArgOptions):
 
     @property
     def binary_location(self) -> str:
-        """:Returns: The location of the binary."""
+        """
+        Returns:
+            The location of the binary.
+        """
         return self._binary_location
 
     @binary_location.setter  # noqa
@@ -76,7 +79,10 @@ class Options(ArgOptions):
 
     @property
     def preferences(self) -> dict:
-        """:Returns: A dict of preferences."""
+        """
+        Returns:
+            A dict of preferences.
+        """
         return self._preferences
 
     def set_preference(self, name: str, value: Union[str, int, bool]):
@@ -85,7 +91,10 @@ class Options(ArgOptions):
 
     @property
     def profile(self) -> Optional[FirefoxProfile]:
-        """:Returns: The Firefox profile to use."""
+        """
+        Returns:
+            The Firefox profile to use.
+        """
         return self._profile
 
     @profile.setter


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
relates to #16432 

### 💥 What does this PR do?
This pull request makes minor improvements to code documentation throughout several modules. The main change is the standardization of docstring formatting for class and method documentation, improving readability and consistency.

Documentation standardization:

* Reformatted class-level docstrings in the BiDi modules (`browser.py`, `input.py`, `permissions.py`, `webextension.py`) to single-line style for better clarity and consistency. [[1]](diffhunk://#diff-cd7018a350739e3db649c9e7f186036670f27a06f8df204de5909a03d7a04f5fL172-R172) [[2]](diffhunk://#diff-599fc5050a2cc2e3c6bbe8e7528a949f985f51f55bb1183b73303b82aad877dfL381-R381) [[3]](diffhunk://#diff-a560a59bfacd843976f6f153b8f615bbfc453f175364592e8a766ac8208192c8L42-R42) [[4]](diffhunk://#diff-f6467ecd5e2e38f1ba13183bb5fae9f304b5edba8c9acb8855e5572ac5a6e71aL25-R25)
* Updated method docstrings in `firefox/options.py` to use multi-line format with explicit return value descriptions, making documentation more readable. [[1]](diffhunk://#diff-9285f54f92e113fb1115905290d8c5a0d9b514f319480586cdde6beb62eaf45bL67-R70) [[2]](diffhunk://#diff-9285f54f92e113fb1115905290d8c5a0d9b514f319480586cdde6beb62eaf45bL79-R85) [[3]](diffhunk://#diff-9285f54f92e113fb1115905290d8c5a0d9b514f319480586cdde6beb62eaf45bL88-R97)
* Changed method docstrings in `print_page_options.py` and `script.py` to improve formatting and clarity. [[1]](diffhunk://#diff-e4d8ba77fed4f860ac57fd385ea1fc83b9db67e299fee693baa83a7dc515c3ecL338-R341) [[2]](diffhunk://#diff-c4d141b056a48aff05840758a7591f2d2b86d6c2f6b8f79c7362ddc8b41c7fccL315-R315)

### 🔧 Implementation Notes
i've added D200 rule locally and fixed all warns with no changes in rules in the main repo

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Documentation


___

### **Description**
- Standardize docstring formatting to single-line style

- Convert multi-line docstrings to PEP 257 compliant format

- Resolve D200 ruff linting warnings across BiDi modules

- Improve docstring consistency in Firefox and print options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multi-line docstrings"] -->|Convert to single-line| B["BiDi modules"]
  C["Malformed return docs"] -->|Reformat to PEP 257| D["Firefox & Print options"]
  B --> E["D200 compliance"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browser.py</strong><dd><code>Standardize Browser class docstring format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/browser.py

<ul><li>Converted multi-line class docstring to single-line format<br> <li> Improved readability of Browser class documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-cd7018a350739e3db649c9e7f186036670f27a06f8df204de5909a03d7a04f5f">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>input.py</strong><dd><code>Standardize Input class docstring format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/input.py

<ul><li>Converted multi-line class docstring to single-line format<br> <li> Enhanced Input class documentation consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-599fc5050a2cc2e3c6bbe8e7528a949f985f51f55bb1183b73303b82aad877df">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>permissions.py</strong><dd><code>Standardize Permissions class docstring format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/permissions.py

<ul><li>Converted multi-line class docstring to single-line format<br> <li> Improved Permissions class documentation clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-a560a59bfacd843976f6f153b8f615bbfc453f175364592e8a766ac8208192c8">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>script.py</strong><dd><code>Standardize script conversion method docstring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/script.py

<ul><li>Converted multi-line method docstring to single-line format<br> <li> Standardized __convert_to_local_value method documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-c4d141b056a48aff05840758a7591f2d2b86d6c2f6b8f79c7362ddc8b41c7fcc">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webextension.py</strong><dd><code>Standardize WebExtension class docstring format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/webextension.py

<ul><li>Converted multi-line class docstring to single-line format<br> <li> Enhanced WebExtension class documentation consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-f6467ecd5e2e38f1ba13183bb5fae9f304b5edba8c9acb8855e5572ac5a6e71a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>print_page_options.py</strong><dd><code>Reformat print options docstring to PEP 257</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/print_page_options.py

<ul><li>Reformatted to_dict method docstring from inline to multi-line format<br> <li> Added explicit Returns section for better PEP 257 compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-e4d8ba77fed4f860ac57fd385ea1fc83b9db67e299fee693baa83a7dc515c3ec">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>options.py</strong><dd><code>Reformat Firefox options docstrings to PEP 257</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/firefox/options.py

<ul><li>Reformatted binary_location property docstring to multi-line format<br> <li> Reformatted preferences property docstring to multi-line format<br> <li> Reformatted profile property docstring to multi-line format<br> <li> Added explicit Returns sections for all three properties</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16525/files#diff-9285f54f92e113fb1115905290d8c5a0d9b514f319480586cdde6beb62eaf45b">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

