### PR TITLE
[py][bidi]: add `set_download_behavior` command

### DIFF
--- a/py/selenium/webdriver/common/bidi/browser.py
+++ b/py/selenium/webdriver/common/bidi/browser.py
@@ -236,3 +236,46 @@ class Browser:
         """
         result = self.conn.execute(command_builder("browser.getClientWindows", {}))
         return [ClientWindowInfo.from_dict(window) for window in result["clientWindows"]]
+
+    def set_download_behavior(
+        self,
+        *,
+        allowed: Optional[bool] = None,
+        destination_folder: Optional[str] = None,
+        user_contexts: Optional[list[str]] = None,
+    ) -> None:
+        """Set the download behavior for the browser or specific user contexts.
+
+        Args:
+            allowed: True to allow downloads, False to deny downloads, or None to
+                clear download behavior (revert to default).
+            destination_folder: Required when allowed is True. Specifies the folder
+                to store downloads in.
+            user_contexts: Optional list of user context IDs to apply this
+                behavior to. If omitted, updates the default behavior.
+
+        Raises:
+            ValueError: If allowed=True and destination_folder is missing, or if
+                allowed=False and destination_folder is provided.
+        """
+        params: dict[str, Any] = {}
+
+        if allowed is None:
+            params["downloadBehavior"] = None
+        else:
+            if allowed:
+                if not destination_folder:
+                    raise ValueError("destination_folder is required when allowed=True.")
+                params["downloadBehavior"] = {
+                    "type": "allowed",
+                    "destinationFolder": destination_folder,
+                }
+            else:
+                if destination_folder:
+                    raise ValueError("destination_folder should not be provided when allowed=False.")
+                params["downloadBehavior"] = {"type": "denied"}
+
+        if user_contexts is not None:
+            params["userContexts"] = user_contexts
+
+        self.conn.execute(command_builder("browser.setDownloadBehavior", params))

--- a/py/selenium/webdriver/common/bidi/browser.py
+++ b/py/selenium/webdriver/common/bidi/browser.py
@@ -14,8 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-
+import os
 from typing import Any, Optional
 
 from selenium.webdriver.common.bidi.common import command_builder
@@ -241,7 +240,7 @@ class Browser:
         self,
         *,
         allowed: Optional[bool] = None,
-        destination_folder: Optional[str] = None,
+        destination_folder: Optional[str | os.PathLike] = None,
         user_contexts: Optional[list[str]] = None,
     ) -> None:
         """Set the download behavior for the browser or specific user contexts.
@@ -268,7 +267,7 @@ class Browser:
                     raise ValueError("destination_folder is required when allowed=True.")
                 params["downloadBehavior"] = {
                     "type": "allowed",
-                    "destinationFolder": destination_folder,
+                    "destinationFolder": os.fspath(destination_folder),
                 }
             else:
                 if destination_folder:

--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -270,6 +270,7 @@ def test_create_user_context_with_unhandled_prompt_behavior(driver, pages):
 
 @pytest.mark.xfail_firefox
 def test_set_download_behavior_allowed(driver, pages, tmp_path):
+    print(f"Driver info: {driver.capabilities}")
     try:
         driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_path)
 

--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -16,17 +16,22 @@
 # under the License.
 
 import http.server
+import os
 import socketserver
+import tempfile
 import threading
+import time
 
 import pytest
 
 from selenium.webdriver.common.bidi.browser import ClientWindowInfo, ClientWindowState
+from selenium.webdriver.common.bidi.browsing_context import ReadinessState
 from selenium.webdriver.common.bidi.session import UserPromptHandler, UserPromptHandlerType
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.proxy import Proxy, ProxyType
 from selenium.webdriver.common.utils import free_port
 from selenium.webdriver.common.window import WindowTypes
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class FakeProxyHandler(http.server.SimpleHTTPRequestHandler):
@@ -262,3 +267,90 @@ def test_create_user_context_with_unhandled_prompt_behavior(driver, pages):
 
     # Clean up
     driver.browser.remove_user_context(user_context)
+
+
+@pytest.mark.xfail_firefox
+def test_set_download_behavior_allowed(driver, pages):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_dir)
+
+        context_id = driver.current_window_handle
+        url = pages.url("downloads/download.html")
+        driver.browsing_context.navigate(context=context_id, url=url, wait=ReadinessState.COMPLETE)
+
+        driver.find_element(By.ID, "file-1").click()
+
+        WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_dir))
+
+        files = os.listdir(tmp_dir)
+        assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_dir}, but found: {files}"
+
+        driver.browser.set_download_behavior(allowed=None)
+
+
+@pytest.mark.xfail_firefox
+def test_set_download_behavior_denied(driver, pages):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        driver.browser.set_download_behavior(allowed=False)
+
+        context_id = driver.current_window_handle
+        url = pages.url("downloads/download.html")
+        driver.browsing_context.navigate(context=context_id, url=url, wait=ReadinessState.COMPLETE)
+
+        driver.find_element(By.ID, "file-1").click()
+
+        time.sleep(1)
+
+        files = os.listdir(tmp_dir)
+        assert len(files) == 0, f"No files should be downloaded when denied, but found: {files}"
+
+        driver.browser.set_download_behavior(allowed=None)
+
+
+@pytest.mark.xfail_firefox
+def test_set_download_behavior_user_context(driver, pages):
+    user_context = driver.browser.create_user_context()
+
+    try:
+        bc = driver.browsing_context.create(type=WindowTypes.WINDOW, user_context=user_context)
+        driver.switch_to.window(bc)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_dir, user_contexts=[user_context])
+
+            url = pages.url("downloads/download.html")
+            driver.browsing_context.navigate(context=bc, url=url, wait=ReadinessState.COMPLETE)
+
+            driver.find_element(By.ID, "file-1").click()
+
+            WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_dir))
+
+            files = os.listdir(tmp_dir)
+            assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_dir}, but found: {files}"
+
+            initial_file_count = len(files)
+
+            driver.browser.set_download_behavior(allowed=False, user_contexts=[user_context])
+
+            driver.find_element(By.ID, "file-2").click()
+
+            time.sleep(1)
+
+            files_after = os.listdir(tmp_dir)
+            assert len(files_after) == initial_file_count, (
+                f"No new files should be downloaded when denied, but found: {files_after}"
+            )
+
+            driver.browser.set_download_behavior(allowed=None, user_contexts=[user_context])
+
+    finally:
+        driver.browser.remove_user_context(user_context)
+
+
+@pytest.mark.xfail_firefox
+def test_set_download_behavior_validation(driver):
+    with pytest.raises(ValueError, match="destination_folder is required when allowed=True"):
+        driver.browser.set_download_behavior(allowed=True)
+
+    with pytest.raises(ValueError, match="destination_folder should not be provided when allowed=False"):
+        driver.browser.set_download_behavior(allowed=False, destination_folder="/tmp")

--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -18,12 +18,11 @@
 import http.server
 import os
 import socketserver
-import tempfile
 import threading
-import time
 
 import pytest
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.bidi.browser import ClientWindowInfo, ClientWindowState
 from selenium.webdriver.common.bidi.browsing_context import ReadinessState
 from selenium.webdriver.common.bidi.session import UserPromptHandler, UserPromptHandlerType
@@ -270,9 +269,9 @@ def test_create_user_context_with_unhandled_prompt_behavior(driver, pages):
 
 
 @pytest.mark.xfail_firefox
-def test_set_download_behavior_allowed(driver, pages):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_dir)
+def test_set_download_behavior_allowed(driver, pages, tmp_path):
+    try:
+        driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_path)
 
         context_id = driver.current_window_handle
         url = pages.url("downloads/download.html")
@@ -280,17 +279,17 @@ def test_set_download_behavior_allowed(driver, pages):
 
         driver.find_element(By.ID, "file-1").click()
 
-        WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_dir))
+        WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_path))
 
-        files = os.listdir(tmp_dir)
-        assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_dir}, but found: {files}"
-
+        files = os.listdir(tmp_path)
+        assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_path}, but found: {files}"
+    finally:
         driver.browser.set_download_behavior(allowed=None)
 
 
 @pytest.mark.xfail_firefox
-def test_set_download_behavior_denied(driver, pages):
-    with tempfile.TemporaryDirectory() as tmp_dir:
+def test_set_download_behavior_denied(driver, pages, tmp_path):
+    try:
         driver.browser.set_download_behavior(allowed=False)
 
         context_id = driver.current_window_handle
@@ -299,34 +298,38 @@ def test_set_download_behavior_denied(driver, pages):
 
         driver.find_element(By.ID, "file-1").click()
 
-        time.sleep(1)
-
-        files = os.listdir(tmp_dir)
-        assert len(files) == 0, f"No files should be downloaded when denied, but found: {files}"
-
+        try:
+            WebDriverWait(driver, 3, poll_frequency=0.2).until(lambda _: len(os.listdir(tmp_path)) > 0)
+            files = os.listdir(tmp_path)
+            pytest.fail(f"A file was downloaded unexpectedly: {files}")
+        except TimeoutException:
+            pass  # Expected, no file downloaded
+    finally:
         driver.browser.set_download_behavior(allowed=None)
 
 
 @pytest.mark.xfail_firefox
-def test_set_download_behavior_user_context(driver, pages):
+def test_set_download_behavior_user_context(driver, pages, tmp_path):
     user_context = driver.browser.create_user_context()
 
     try:
         bc = driver.browsing_context.create(type=WindowTypes.WINDOW, user_context=user_context)
         driver.switch_to.window(bc)
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            driver.browser.set_download_behavior(allowed=True, destination_folder=tmp_dir, user_contexts=[user_context])
+        try:
+            driver.browser.set_download_behavior(
+                allowed=True, destination_folder=tmp_path, user_contexts=[user_context]
+            )
 
             url = pages.url("downloads/download.html")
             driver.browsing_context.navigate(context=bc, url=url, wait=ReadinessState.COMPLETE)
 
             driver.find_element(By.ID, "file-1").click()
 
-            WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_dir))
+            WebDriverWait(driver, 5).until(lambda d: "file_1.txt" in os.listdir(tmp_path))
 
-            files = os.listdir(tmp_dir)
-            assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_dir}, but found: {files}"
+            files = os.listdir(tmp_path)
+            assert "file_1.txt" in files, f"Expected file_1.txt in {tmp_path}, but found: {files}"
 
             initial_file_count = len(files)
 
@@ -334,15 +337,16 @@ def test_set_download_behavior_user_context(driver, pages):
 
             driver.find_element(By.ID, "file-2").click()
 
-            time.sleep(1)
-
-            files_after = os.listdir(tmp_dir)
-            assert len(files_after) == initial_file_count, (
-                f"No new files should be downloaded when denied, but found: {files_after}"
-            )
-
+            try:
+                WebDriverWait(driver, 3, poll_frequency=0.2).until(
+                    lambda _: len(os.listdir(tmp_path)) > initial_file_count
+                )
+                files_after = os.listdir(tmp_path)
+                pytest.fail(f"A file was downloaded unexpectedly: {files_after}")
+            except TimeoutException:
+                pass  # Expected, no file downloaded
+        finally:
             driver.browser.set_download_behavior(allowed=None, user_contexts=[user_context])
-
     finally:
         driver.browser.remove_user_context(user_context)
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds the `set_download_behavior` command to the browser module - https://w3c.github.io/webdriver-bidi/#command-browser-setDownloadBehavior

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
I have used keyword-only params since `destination_folder` is conditional (only needed when `allowed=True`). It will be easier to use and understand instead of guessing order in positional args.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Not supported in Firefox stable yet.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `set_download_behavior` command to browser module

- Supports allowing, denying, or clearing download behavior

- Enables per-user-context download behavior configuration

- Includes comprehensive validation and test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser Module"] -->|"add method"| B["set_download_behavior"]
  B -->|"configure"| C["Download Behavior"]
  C -->|"allowed=True"| D["Store in destination_folder"]
  C -->|"allowed=False"| E["Deny downloads"]
  C -->|"allowed=None"| F["Clear behavior"]
  B -->|"optional"| G["User Contexts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browser.py</strong><dd><code>Implement set_download_behavior command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/browser.py

<ul><li>Implements <code>set_download_behavior</code> method with keyword-only parameters<br> <li> Validates parameter combinations (destination_folder required when <br>allowed=True)<br> <li> Constructs appropriate BiDi command parameters based on allowed state<br> <li> Supports optional user_contexts parameter for context-specific <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16556/files#diff-cd7018a350739e3db649c9e7f186036670f27a06f8df204de5909a03d7a04f5f">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_browser_tests.py</strong><dd><code>Add comprehensive tests for download behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_browser_tests.py

<ul><li>Adds test for allowed downloads with file verification<br> <li> Adds test for denied downloads ensuring no files downloaded<br> <li> Adds test for user context-specific download behavior<br> <li> Adds validation tests for parameter combinations<br> <li> Imports necessary modules (os, tempfile, time, WebDriverWait)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16556/files#diff-e0a8b792e4fc6fa62c5fae3b9c75b56d61e12e4d0929aa991ddb799276b53c3c">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

