### PR TITLE
[bazel] bump `rules_jvm_external` to 6.9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "rules_cc", version = "0.2.0", dev_dependency = True)
 
 bazel_dep(name = "rules_dotnet", version = "0.17.5")
 bazel_dep(name = "rules_java", version = "8.7.1")
-bazel_dep(name = "rules_jvm_external", version = "6.8")
+bazel_dep(name = "rules_jvm_external", version = "6.9")
 bazel_dep(name = "rules_multitool", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "6.3.2")
 bazel_dep(name = "rules_oci", version = "1.8.0")


### PR DESCRIPTION
### **User description**
Bump `rules_jvm_external` to version 6.9. This picks up a fix needed by the experimental SBOM generation tools in the `supply_chain_tools` 0.0.1 module.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump `rules_jvm_external` dependency from 6.8 to 6.9

- Picks up fix needed for experimental SBOM generation tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rules_jvm_external 6.8"] -- "upgrade" --> B["rules_jvm_external 6.9"]
  B -- "enables" --> C["SBOM generation support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Update rules_jvm_external dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Updated <code>rules_jvm_external</code> bazel dependency version from 6.8 to 6.9<br> <li> Enables compatibility with experimental SBOM generation tools in <br>supply_chain_tools 0.0.1</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16563/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

