### PR TITLE
[bazel] Move `rules_rust` to `bzlmod`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,21 +1,21 @@
 module(name = "selenium")
 
 bazel_dep(name = "apple_rules_lint", version = "0.4.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.21.0")
 bazel_dep(name = "aspect_rules_js", version = "2.3.7")
 bazel_dep(name = "aspect_rules_ts", version = "3.6.0")
-bazel_dep(name = "bazel_features", version = "1.23.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
+bazel_dep(name = "bazel_features", version = "1.32.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "contrib_rules_jvm", version = "0.27.0")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 
 # Required for the closure rules
 bazel_dep(name = "protobuf", version = "29.2", dev_dependency = True, repo_name = "com_google_protobuf")
 
 # Required for rules_rust to import the crates properly
-bazel_dep(name = "rules_cc", version = "0.2.0", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.2.8", dev_dependency = True)
 
 bazel_dep(name = "rules_dotnet", version = "0.17.5")
 bazel_dep(name = "rules_java", version = "8.7.1")
@@ -27,6 +27,7 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_python", version = "1.6.3")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "rules_ruby", version = "0.19.0")
+bazel_dep(name = "rules_rust", version = "0.67.0")
 
 # Until `rules_jvm_external` 6.8 ships
 single_version_override(
@@ -366,6 +367,18 @@ ruby.bundle_fetch(
 use_repo(ruby, "bundle", "ruby", "ruby_toolchains")
 
 register_toolchains("@ruby_toolchains//:all")
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(versions = ["1.89.0"])
+
+crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
+crate.from_cargo(
+    name = "crates",
+    cargo_lockfile = "//rust:Cargo.lock",
+    lockfile = "//rust:Cargo.Bazel.lock",
+    manifests = ["//rust:Cargo.toml"],
+)
+use_repo(crate, "crates")
 
 selenium_manager_artifacts = use_extension("//common:selenium_manager.bzl", "selenium_manager_artifacts")
 use_repo(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,4 +20,3 @@ rules_closure_dependencies(
 )
 
 rules_closure_toolchains()
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,34 +21,3 @@ rules_closure_dependencies(
 
 rules_closure_toolchains()
 
-# rules_rust fails to compile zstd on Windows when used with Bzlmod
-# so we keep it in WORKSPACE for now
-
-http_archive(
-    name = "rules_rust",
-    integrity = "sha256-YrnH/f8jCpEqGAU+keNqauc+QSde9egtcFXqPtJuee4=",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
-)
-
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
-
-rules_rust_dependencies()
-
-rust_register_toolchains(versions = ["1.89.0"])
-
-load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
-
-crates_repository(
-    name = "crates",
-    cargo_lockfile = "//rust:Cargo.lock",
-    lockfile = "//rust:Cargo.Bazel.lock",
-    manifests = ["//rust:Cargo.toml"],
-)
-
-load("@crates//:defs.bzl", "crate_repositories")
-
-crate_repositories()
-
-load("@rules_rust//cargo:deps.bzl", "cargo_dependencies")
-
-cargo_dependencies()

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "369365c5089394be8f6fd5d834b8acd8fe568305faff5cca5d29342d01697bd7",
+  "checksum": "c2f6ce33acb9a60d2a50182bd219781cb613c02f03cb33e317ad0f9341fc4606",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",


### PR DESCRIPTION
### **User description**
Bazel 9 is coming out soon, and that drops support for workspace-based builds. Preempt this by moving `rules_rust` into the module file.


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate `rules_rust` from WORKSPACE to MODULE.bazel for Bazel 9 compatibility

- Update multiple Bazel dependency versions to latest stable releases

- Configure Rust toolchain and crate universe extensions via bzlmod

- Remove legacy workspace-based Rust configuration and dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WORKSPACE<br/>rules_rust config"] -->|"Remove legacy<br/>workspace setup"| B["MODULE.bazel<br/>bzlmod extensions"]
  C["Old Rust<br/>dependencies"] -->|"Update versions"| D["New dependency<br/>versions"]
  B -->|"Configure"| E["Rust toolchain<br/>v1.89.0"]
  B -->|"Configure"| F["Crate universe<br/>extensions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Add rules_rust and configure Rust extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Add <code>rules_rust</code> v0.67.0 as a bazel_dep<br> <li> Update multiple dependency versions (aspect_bazel_lib, bazel_features, <br>bazel_skylib, buildifier_prebuilt, platforms, rules_cc)<br> <li> Configure Rust toolchain extension with version 1.89.0<br> <li> Configure crate universe extension to load Cargo.lock and manifests</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16566/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+19/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WORKSPACE</strong><dd><code>Remove legacy workspace-based Rust configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

WORKSPACE

<ul><li>Remove entire <code>rules_rust</code> http_archive definition<br> <li> Remove <code>rules_rust_dependencies()</code> and <code>rust_register_toolchains()</code> calls<br> <li> Remove <code>crates_repository()</code> configuration<br> <li> Remove <code>crate_repositories()</code> and <code>cargo_dependencies()</code> loading</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16566/files#diff-5493ff8e9397811510e780de47c57abb70137f1afe85d1519130dc3679d60ce5">+0/-31</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

