### PR TITLE
#16573 unwrap double-wrapped webdriver

### DIFF
--- a/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
+++ b/java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java
@@ -195,7 +195,7 @@ public class WebDriverDecorator<T extends WebDriver> {
 
     public Definition(Decorated<?> decorated) {
       this.decoratedClass = decorated.getClass();
-      this.originalClass = decorated.getOriginal().getClass();
+      this.originalClass = unwrapOriginal(decorated).getClass();
     }
 
     @Override
@@ -215,6 +215,17 @@ public class WebDriverDecorator<T extends WebDriver> {
             System.identityHashCode(decoratedClass), System.identityHashCode(originalClass)
           });
     }
+  }
+
+  private static Object unwrapOriginal(Decorated<?> decorated) {
+    return unwrapWebdriver(decorated.getOriginal());
+  }
+
+  private static Object unwrapWebdriver(Object webDriver) {
+    if (webDriver instanceof WebDriver && webDriver instanceof WrapsDriver) {
+      return unwrapWebdriver(((WrapsDriver) webDriver).getWrappedDriver());
+    }
+    return webDriver;
   }
 
   public interface HasTarget<Z> {
@@ -480,12 +491,15 @@ public class WebDriverDecorator<T extends WebDriver> {
   private <Z> Map<Class<?>, Function<Z, InvocationHandler>> deriveAdditionalInterfaces(Z sample) {
     Map<Class<?>, Function<Z, InvocationHandler>> handlers = new HashMap<>();
 
-    if (sample instanceof WebDriver && !(sample instanceof WrapsDriver)) {
+    if (sample instanceof WebDriver) {
       handlers.put(
           WrapsDriver.class,
           (instance) ->
               (proxy, method, args) -> {
                 if ("getWrappedDriver".equals(method.getName())) {
+                  return unwrapWebdriver(instance);
+                }
+                if (sample instanceof WrapsDriver) {
                   return instance;
                 }
                 throw new UnsupportedOperationException(method.getName());

--- a/java/test/org/openqa/selenium/support/decorators/DecoratedRemoteWebDriverTest.java
+++ b/java/test/org/openqa/selenium/support/decorators/DecoratedRemoteWebDriverTest.java
@@ -55,6 +55,28 @@ class DecoratedRemoteWebDriverTest {
     RemoteWebDriver underlying =
         (RemoteWebDriver) ((WrapsDriver) decoratedDriver).getWrappedDriver();
     assertThat(underlying.getSessionId()).isEqualTo(sessionId);
+    assertThat(underlying).isSameAs(originalDriver);
+  }
+
+  @Test
+  void canWrapDriverMultipleTimes() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    RemoteWebDriver originalDriver = mock(RemoteWebDriver.class);
+    when(originalDriver.getSessionId()).thenReturn(sessionId);
+
+    RemoteWebDriver decorated1 =
+        new WebDriverDecorator<>(RemoteWebDriver.class).decorate(originalDriver);
+    RemoteWebDriver decorated2 =
+        new WebDriverDecorator<>(RemoteWebDriver.class).decorate(decorated1);
+    RemoteWebDriver decoratedDriver =
+        new WebDriverDecorator<>(RemoteWebDriver.class).decorate(decorated2);
+
+    assertThat(decoratedDriver.getSessionId()).isEqualTo(sessionId);
+
+    RemoteWebDriver underlying =
+        (RemoteWebDriver) ((WrapsDriver) decoratedDriver).getWrappedDriver();
+    assertThat(underlying.getSessionId()).isEqualTo(sessionId);
+    assertThat(underlying).isSameAs(originalDriver);
   }
 
   @Test


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #16573 

### 💥 What does this PR do?
Fix `WebDriverDecorator` to properly decorate WebDriver instance that is already decorated.

### 🔄 Types of changes
- Bug fix (backwards compatible)

### Test

I have a test, but not sure where to put it in Selenium project codebase:


```java
final class UnwrapWebdriverTest {
  private final WebDriver original = new ChromeDriver();

  @Test
  void webdriverDecorator() {
    WebDriver decorated1 = new WebDriverDecorator<>().decorate(original);
    WebDriver decorated2 = new WebDriverDecorator<>().decorate(decorated1);

    assertThat(((WrapsDriver) decorated1).getWrappedDriver()).isSameAs(original);
    assertThat(((WrapsDriver) decorated2).getWrappedDriver()).isSameAs(decorated1); // This failed

    new WebDriverWait(decorated2, Duration.ofSeconds(2))
      .until((d) -> "zopa".equalsIgnoreCase(d.getTitle())); // This hanged forever
  }

  @AfterEach
  void tearDown() {
    original.quit();
  }
}
```


___

### **PR Type**
Bug fix


___

### **Description**
- Fix WebDriverDecorator to properly unwrap double-wrapped WebDriver instances

- Add recursive unwrapping logic to handle nested WrapsDriver decorators

- Ensure getWrappedDriver returns the original unwrapped driver

- Add test coverage for multiple decorator wrapping scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Double-wrapped WebDriver"] -->|unwrapWebdriver| B["Recursive unwrapping"]
  B -->|Check WrapsDriver| C["Extract wrapped driver"]
  C -->|Repeat until base| D["Original WebDriver"]
  D -->|Return| E["Properly unwrapped driver"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebDriverDecorator.java</strong><dd><code>Add recursive unwrapping for nested WebDriver decorators</code>&nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/support/decorators/WebDriverDecorator.java

<ul><li>Added <code>unwrapOriginal()</code> method to recursively unwrap decorated <br>WebDriver instances<br> <li> Added <code>unwrapWebdriver()</code> method that recursively extracts the base <br>driver from nested WrapsDriver wrappers<br> <li> Modified <code>Definition</code> constructor to use <code>unwrapOriginal()</code> instead of <br>direct <code>getOriginal()</code> call<br> <li> Updated <code>deriveAdditionalInterfaces()</code> to return unwrapped driver for <br>all WebDriver instances and handle WrapsDriver case properly</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16575/files#diff-c1eeb9788c8a7d5f29ee083e2e9fb8fd77b9fb22b0d1b7efbbdea54abeb9a650">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DecoratedRemoteWebDriverTest.java</strong><dd><code>Add test coverage for multiple decorator wrapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/support/decorators/DecoratedRemoteWebDriverTest.java

<ul><li>Added assertion to verify wrapped driver is the original driver <br>instance<br> <li> Added new test <code>canWrapDriverMultipleTimes()</code> to verify multiple <br>decorator wrapping works correctly<br> <li> Test validates that deeply nested decorators properly unwrap to the <br>original driver<br> <li> Ensures getWrappedDriver returns the same original driver instance <br>regardless of wrapping depth</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16575/files#diff-933586eb2851bd99ad895de3dd46c9622409b76e7fd976d69a9ea65f41483c2d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

