### PR TITLE
[ci] Make a PR for updating mirror file instead of pushing directly to trunk

### DIFF
--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -19,6 +19,8 @@ jobs:
         cd common/mirror
         export JQ_FILTER="[.[] | {tag_name: .tag_name, assets: [.assets[] | {browser_download_url: .browser_download_url} ] } ]"
         curl -H "Authorization: ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/SeleniumHQ/selenium/releases | jq "$JQ_FILTER" > selenium
+    - name: Set current date
+      run: echo "DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
     - name: Commit files
       id: git
       run: |
@@ -27,12 +29,26 @@ jobs:
           git config --local user.email "selenium-ci@users.noreply.github.com"
           git config --local user.name "Selenium CI Bot"
           git add common/mirror/selenium
-          git commit -m "Update mirror info (`date`)" -a
+          git commit -m "Update mirror info (${{ env.DATE }})" -a
           echo "::set-output name=commit::true"
         fi
-    - name: Push changes
+    - name: Create PR
       if: steps.git.outputs.commit == 'true'
-      uses: ad-m/github-push-action@master
+      uses: peter-evans/create-pull-request@v6
       with:
-        github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
-        branch: ${{ github.ref }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Update mirror info (${{ env.DATE }})"
+        title: "[ci] Update mirror info (${{ env.DATE }})"
+        body: |
+          Automated update of `common/mirror/selenium`.
+          - Trigger: ${{ github.event_name }}
+          - Committer: Selenium CI Bot
+        branch: ci/mirror-selenium-releases
+        base: trunk
+        labels: ci, automated
+        delete-branch: true
+        signoff: false
+        reviewers: |
+          bonigarcia
+        add-paths: |
+          common/mirror/selenium


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
After protecting the trunk branch for security reasons, the workflow for updating the [mirror](https://github.com/SeleniumHQ/selenium/blob/trunk/common/mirror/selenium) file (used by SM) has started to fail:

https://github.com/SeleniumHQ/selenium/actions/workflows/mirror-selenium-releases.yml

### 💥 What does this PR do?
This PR makes to create automatically a new PR (to be manually merged) instead of pushing directly to trunk, which is not possible anymore.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- CI


___

### **PR Type**
Enhancement


___

### **Description**
- Replace direct trunk push with automated PR creation

- Add timestamped commit messages for better traceability

- Configure PR with labels, reviewers, and auto-cleanup

- Adapt workflow to trunk branch protection requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch Selenium Releases"] --> B["Generate Timestamp"]
  B --> C["Commit Mirror Changes"]
  C --> D["Create PR to Trunk"]
  D --> E["Auto-assign Reviewers"]
  E --> F["Delete Feature Branch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mirror-selenium-releases.yml</strong><dd><code>Convert mirror workflow from push to PR creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mirror-selenium-releases.yml

<ul><li>Added timestamp generation step for consistent commit dating<br> <li> Changed commit message to use environment variable for date<br> <li> Replaced direct push action with create-pull-request action<br> <li> Configured PR with title, body, labels, reviewers, and auto-cleanup<br> <li> Set PR base to trunk and feature branch to ci/mirror-selenium-releases</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16579/files#diff-09af8e9f2d0267b1778e969beb999aa35ddec12a5d9a50019440aefddb1c1fed">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

