### PR TITLE
[ci] Revert latest changes related to the mirror workflow

### DIFF
--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -19,8 +19,6 @@ jobs:
         cd common/mirror
         export JQ_FILTER="[.[] | {tag_name: .tag_name, assets: [.assets[] | {browser_download_url: .browser_download_url} ] } ]"
         curl -H "Authorization: ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/SeleniumHQ/selenium/releases | jq "$JQ_FILTER" > selenium
-    - name: Set current date
-      run: echo "DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
     - name: Commit files
       id: git
       run: |
@@ -29,26 +27,12 @@ jobs:
           git config --local user.email "selenium-ci@users.noreply.github.com"
           git config --local user.name "Selenium CI Bot"
           git add common/mirror/selenium
-          git commit -m "Update mirror info (${{ env.DATE }})" -a
+          git commit -m "Update mirror info (`date`)" -a
           echo "::set-output name=commit::true"
         fi
-    - name: Create PR
+    - name: Push changes
       if: steps.git.outputs.commit == 'true'
-      uses: peter-evans/create-pull-request@v6
+      uses: ad-m/github-push-action@master
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Update mirror info (${{ env.DATE }})"
-        title: "[ci] Update mirror info (${{ env.DATE }})"
-        body: |
-          Automated update of `common/mirror/selenium`.
-          - Trigger: ${{ github.event_name }}
-          - Committer: Selenium CI Bot
-        branch: ci/mirror-selenium-releases
-        base: trunk
-        labels: ci, automated
-        delete-branch: true
-        signoff: false
-        reviewers: |
-          bonigarcia
-        add-paths: |
-          common/mirror/selenium
+        github_token: ${{ secrets.SELENIUM_CI_TOKEN }}
+        branch: ${{ github.ref }}

--- a/common/mirror/selenium
+++ b/common/mirror/selenium
@@ -669,5 +669,57 @@
         "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.12.0/selenium-server-4.12.1.zip"
       }
     ]
+  },
+  {
+    "tag_name": "selenium-4.11.0",
+    "assets": [
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/IEDriverServer_Win32_4.11.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/IEDriverServer_x64_4.11.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/selenium-dotnet-4.11.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/selenium-dotnet-strongnamed-4.11.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/selenium-java-4.11.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/selenium-server-4.11.0.jar"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.11.0/selenium-server-4.11.0.zip"
+      }
+    ]
+  },
+  {
+    "tag_name": "selenium-4.10.0",
+    "assets": [
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/IEDriverServer_Win32_4.10.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/IEDriverServer_x64_4.10.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/selenium-dotnet-4.10.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/selenium-dotnet-strongnamed-4.10.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/selenium-java-4.10.0.zip"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/selenium-server-4.10.0.jar"
+      },
+      {
+        "browser_download_url": "https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.10.0/selenium-server-4.10.0.zip"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

It reverts 2b5da89b8f and 0e7508261b.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Reverts PR workflow changes to mirror update process

- Removes PR creation step, restores direct push to trunk

- Simplifies commit message to use dynamic date

- Restores mirror data for selenium-4.11.0 and 4.10.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mirror Workflow"] -->|Remove PR Creation| B["Direct Push to Trunk"]
  A -->|Simplify Date Handling| C["Dynamic Date in Commit"]
  D["Mirror Data"] -->|Restore Versions| E["selenium-4.11.0 & 4.10.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mirror-selenium-releases.yml</strong><dd><code>Revert to direct push workflow without PR creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mirror-selenium-releases.yml

<ul><li>Removes the "Set current date" step that exported DATE environment <br>variable<br> <li> Changes commit message from using <code>${{ env.DATE }}</code> to dynamic <code>date</code> <br>command<br> <li> Replaces "Create PR" step using peter-evans/create-pull-request with <br>direct push using ad-m/github-push-action<br> <li> Removes PR-related configuration (title, body, branch, reviewers, <br>labels)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16580/files#diff-09af8e9f2d0267b1778e969beb999aa35ddec12a5d9a50019440aefddb1c1fed">+5/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium</strong><dd><code>Restore selenium 4.11.0 and 4.10.0 mirror data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/mirror/selenium

<ul><li>Adds mirror data for selenium-4.11.0 release with 7 asset download <br>URLs<br> <li> Adds mirror data for selenium-4.10.0 release with 7 asset download <br>URLs<br> <li> Restores previously removed release information</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16580/files#diff-a95ecb025fa03ae0f2b222a926fd2f2531ee3a933a47851da3556f3d329af06e">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

