### PR TITLE
[java]: refactor request interception tests and handle CORS

### DIFF
--- a/java/test/org/openqa/selenium/devtools/NetworkInterceptorRestTest.java
+++ b/java/test/org/openqa/selenium/devtools/NetworkInterceptorRestTest.java
@@ -70,7 +70,8 @@ class NetworkInterceptorRestTest extends JupiterTestBase {
                         new HttpResponse()
                             .addHeader(
                                 "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH")
-                            .addHeader("Access-Control-Allow-Origin", "*"));
+                            .addHeader("Access-Control-Allow-Origin", "*")
+                            .addHeader("Access-Control-Allow-Headers", "*"));
 
     appServer = new NettyAppServer(route);
     appServer.start();
@@ -81,188 +82,82 @@ class NetworkInterceptorRestTest extends JupiterTestBase {
     safelyCall(() -> interceptor.close(), () -> driver.quit(), () -> appServer.stop());
   }
 
-  @Test
-  @NoDriverBeforeTest
-  void shouldInterceptPatchRequest() throws MalformedURLException {
+  private void assertRequest(HttpMethod method, boolean withBody) throws MalformedURLException {
     AtomicBoolean seen = new AtomicBoolean(false);
     interceptor =
         new NetworkInterceptor(
             driver,
-            Route.matching(req -> (req.getMethod() == HttpMethod.PATCH))
+            Route.matching(
+                    req -> req.getMethod() == method || req.getMethod() == HttpMethod.OPTIONS)
                 .to(
                     () ->
                         req -> {
+                          if (req.getMethod() == HttpMethod.OPTIONS) {
+                            return new HttpResponse()
+                                .setStatus(200)
+                                .addHeader("Access-Control-Allow-Origin", "*")
+                                .addHeader(
+                                    "Access-Control-Allow-Methods",
+                                    "GET, POST, PUT, DELETE, PATCH");
+                          }
                           seen.set(true);
                           return new HttpResponse()
                               .setStatus(200)
                               .addHeader("Access-Control-Allow-Origin", "*")
-                              .setContent(utf8String("Received response for PATCH"));
+                              .setContent(utf8String("Received response for " + method));
                         }));
 
     JavascriptExecutor js = (JavascriptExecutor) driver;
+    String script =
+        "var url = arguments[0];"
+            + "var callback = arguments[arguments.length - 1];"
+            + "var xhr = new XMLHttpRequest();"
+            + "xhr.open(arguments[1], url, true);"
+            + "xhr.onload = function() {"
+            + "  if (xhr.readyState == 4) {"
+            + "    callback(xhr.responseText);"
+            + "  }"
+            + "};"
+            + "xhr.onerror = function() {"
+            + "  callback('ERROR: ' + xhr.statusText);"
+            + "};"
+            + (withBody ? "xhr.send('Hey');" : "xhr.send();");
+
     Object response =
         js.executeAsyncScript(
-            "var url = arguments[0];"
-                + "var callback = arguments[arguments.length - 1];"
-                + "var xhr = new XMLHttpRequest();"
-                + "xhr.open('PATCH', url, true);"
-                + "xhr.onload = function() {"
-                + "  if (xhr.readyState == 4) {"
-                + "    callback(xhr.responseText);"
-                + "  }"
-                + "};"
-                + "xhr.send('Hey');",
-            new URL(appServer.whereIs("/")).toString());
+            script, new URL(appServer.whereIs("/")).toString(), method.toString());
 
     assertThat(seen.get()).isTrue();
-    assertThat(response.toString()).contains("Received response for PATCH");
+    assertThat(response.toString()).contains("Received response for " + method);
+  }
+
+  @Test
+  @NoDriverBeforeTest
+  void shouldInterceptPatchRequest() throws MalformedURLException {
+    assertRequest(HttpMethod.PATCH, true);
   }
 
   @Test
   @NoDriverBeforeTest
   void shouldInterceptPutRequest() throws MalformedURLException {
-    AtomicBoolean seen = new AtomicBoolean(false);
-    interceptor =
-        new NetworkInterceptor(
-            driver,
-            Route.matching(req -> (req.getMethod() == HttpMethod.PUT))
-                .to(
-                    () ->
-                        req -> {
-                          seen.set(true);
-                          return new HttpResponse()
-                              .setStatus(200)
-                              .addHeader("Access-Control-Allow-Origin", "*")
-                              .setContent(utf8String("Received response for PUT"));
-                        }));
-
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    Object response =
-        js.executeAsyncScript(
-            "var url = arguments[0];"
-                + "var callback = arguments[arguments.length - 1];"
-                + "var xhr = new XMLHttpRequest();"
-                + "xhr.open('PUT', url, true);"
-                + "xhr.onload = function() {"
-                + "  if (xhr.readyState == 4) {"
-                + "    callback(xhr.responseText);"
-                + "  }"
-                + "};"
-                + "xhr.send('Hey');",
-            new URL(appServer.whereIs("/")).toString());
-
-    assertThat(seen.get()).isTrue();
-    assertThat(response.toString()).contains("Received response for PUT");
+    assertRequest(HttpMethod.PUT, true);
   }
 
   @Test
   @NoDriverBeforeTest
   void shouldInterceptPostRequest() throws MalformedURLException {
-    AtomicBoolean seen = new AtomicBoolean(false);
-    interceptor =
-        new NetworkInterceptor(
-            driver,
-            Route.matching(req -> (req.getMethod() == HttpMethod.POST))
-                .to(
-                    () ->
-                        req -> {
-                          seen.set(true);
-                          return new HttpResponse()
-                              .setStatus(200)
-                              .addHeader("Access-Control-Allow-Origin", "*")
-                              .setContent(utf8String("Received response for POST"));
-                        }));
-
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    Object response =
-        js.executeAsyncScript(
-            "var url = arguments[0];"
-                + "var callback = arguments[arguments.length - 1];"
-                + "var xhr = new XMLHttpRequest();"
-                + "xhr.open('POST', url, true);"
-                + "xhr.onload = function() {"
-                + "  if (xhr.readyState == 4) {"
-                + "    callback(xhr.responseText);"
-                + "  }"
-                + "};"
-                + "xhr.send('Hey');",
-            new URL(appServer.whereIs("/")).toString());
-
-    assertThat(seen.get()).isTrue();
-    assertThat(response.toString()).contains("Received response for POST");
+    assertRequest(HttpMethod.POST, true);
   }
 
   @Test
   @NoDriverBeforeTest
   void shouldInterceptDeleteRequest() throws MalformedURLException {
-    AtomicBoolean seen = new AtomicBoolean(false);
-    interceptor =
-        new NetworkInterceptor(
-            driver,
-            Route.matching(req -> (req.getMethod() == HttpMethod.DELETE))
-                .to(
-                    () ->
-                        req -> {
-                          seen.set(true);
-                          return new HttpResponse()
-                              .setStatus(200)
-                              .addHeader("Access-Control-Allow-Origin", "*")
-                              .setContent(utf8String("Received response for DELETE"));
-                        }));
-
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    Object response =
-        js.executeAsyncScript(
-            "var url = arguments[0];"
-                + "var callback = arguments[arguments.length - 1];"
-                + "var xhr = new XMLHttpRequest();"
-                + "xhr.open('DELETE', url, true);"
-                + "xhr.onload = function() {"
-                + "  if (xhr.readyState == 4) {"
-                + "    callback(xhr.responseText);"
-                + "  }"
-                + "};"
-                + "xhr.send('Hey');",
-            new URL(appServer.whereIs("/")).toString());
-
-    assertThat(seen.get()).isTrue();
-    assertThat(response.toString()).contains("Received response for DELETE");
+    assertRequest(HttpMethod.DELETE, true);
   }
 
   @Test
   @NoDriverBeforeTest
   void shouldInterceptGetRequest() throws MalformedURLException {
-    AtomicBoolean seen = new AtomicBoolean(false);
-    interceptor =
-        new NetworkInterceptor(
-            driver,
-            Route.matching(req -> (req.getMethod() == HttpMethod.GET))
-                .to(
-                    () ->
-                        req -> {
-                          seen.set(true);
-                          return new HttpResponse()
-                              .setStatus(200)
-                              .addHeader("Access-Control-Allow-Origin", "*")
-                              .setContent(utf8String("Received response for GET"));
-                        }));
-
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    Object response =
-        js.executeAsyncScript(
-            "var url = arguments[0];"
-                + "var callback = arguments[arguments.length - 1];"
-                + "var xhr = new XMLHttpRequest();"
-                + "xhr.open('GET', url, true);"
-                + "xhr.onload = function() {"
-                + "  if (xhr.readyState == 4) {"
-                + "    callback(xhr.responseText);"
-                + "  }"
-                + "};"
-                + "xhr.send();",
-            new URL(appServer.whereIs("/")).toString());
-
-    assertThat(seen.get()).isTrue();
-    assertThat(response.toString()).contains("Received response for GET");
+    assertRequest(HttpMethod.GET, false);
   }
 }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Resolves test failures in various PRs for `NetworkInterceptorRestTest.java` - https://github.com/SeleniumHQ/selenium/pull/16530, https://github.com/SeleniumHQ/selenium/pull/16558

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Refactors the request interception tests to reuse `assertRequest` for different request types. 
Handles CORS headers so that `PUT`, `PATCH` and `DELETE` tests work as expected.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Refactored request interception tests to eliminate code duplication

- Extracted common test logic into reusable `assertRequest` helper method

- Added CORS header handling for preflight OPTIONS requests

- Parameterized tests now support GET, POST, PUT, PATCH, DELETE methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Individual test methods<br/>GET, POST, PUT, PATCH, DELETE"] -->|"Extract common logic"| B["assertRequest helper method"]
  B -->|"Parameterized by HttpMethod"| C["Reusable test implementation"]
  D["CORS setup in setup()"] -->|"Add Access-Control-Allow-Headers"| E["Support preflight requests"]
  B -->|"Handle OPTIONS requests"| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkInterceptorRestTest.java</strong><dd><code>Consolidate HTTP method tests into parameterized helper</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/devtools/NetworkInterceptorRestTest.java

<ul><li>Added <code>Access-Control-Allow-Headers: *</code> header to CORS preflight <br>response in <code>setup()</code> method<br> <li> Extracted common test logic into private <code>assertRequest(HttpMethod </code><br><code>method, boolean withBody)</code> helper method<br> <li> Implemented OPTIONS request handling within the helper to support CORS <br>preflight<br> <li> Refactored all five HTTP method test cases (GET, POST, PUT, PATCH, <br>DELETE) to call <code>assertRequest()</code> with appropriate parameters<br> <li> Reduced code duplication from ~190 lines to ~85 lines while <br>maintaining test coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16585/files#diff-203920a87d101fea61fc05fb58de64944c1f6ba87fee1d20916e58d2d902ca88">+41/-146</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

