### PR TITLE
[py][bidi]: enable download event tests for firefox

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -781,7 +781,6 @@ def test_add_event_handler_history_updated(driver, pages):
     driver.browsing_context.remove_event_handler("history_updated", callback_id)
 
 
-@pytest.mark.xfail_firefox
 def test_add_event_handler_download_will_begin(driver, pages):
     """Test adding event handler for download_will_begin event."""
     events_received = []
@@ -802,12 +801,12 @@ def test_add_event_handler_download_will_begin(driver, pages):
     WebDriverWait(driver, 5).until(lambda d: len(events_received) > 0)
 
     assert len(events_received) == 1
-    assert events_received[0].suggested_filename == "file_1.txt"
+    # filename maybe file_1.txt or file_1(1).txt depending on existing files in download dir
+    assert "file_1" in events_received[0].suggested_filename
 
     driver.browsing_context.remove_event_handler("download_will_begin", callback_id)
 
 
-@pytest.mark.xfail_firefox
 def test_add_event_handler_download_end(driver, pages):
     """Test adding event handler for download_end event."""
     events_received = []


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Enables `test_add_event_handler_download_end` and `test_add_event_handler_download_will_begin` tests for Firefox. 
From Firefox 145, these events are supported.

Also, makes the assertion generalized in case of existing downloads.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Tests


___

### **Description**
- Remove xfail markers for Firefox download event tests

- Generalize filename assertion to handle existing downloads

- Support Firefox 145+ download event functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Firefox 145+ Support"] --> B["Remove xfail Markers"]
  B --> C["test_add_event_handler_download_will_begin"]
  B --> D["test_add_event_handler_download_end"]
  E["Generalize Assertion"] --> F["Handle Filename Variations"]
  F --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_browsing_context_tests.py</strong><dd><code>Enable Firefox download event tests with generalized assertions</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_browsing_context_tests.py

<ul><li>Removed <code>@pytest.mark.xfail_firefox</code> decorator from <br><code>test_add_event_handler_download_will_begin</code> test<br> <li> Removed <code>@pytest.mark.xfail_firefox</code> decorator from <br><code>test_add_event_handler_download_end</code> test<br> <li> Updated filename assertion to use substring matching instead of exact <br>equality<br> <li> Added comment explaining filename variation due to existing downloads</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16587/files#diff-cea00ba1c71fd6f4ca93d87f14bcc291e1b87383cd61cd1bf1eec678e8d9efbf">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

