### PR TITLE
[build] Upgrade rules_dotnet to 0.20.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "protobuf", version = "29.2", dev_dependency = True, repo_name 
 # Required for rules_rust to import the crates properly
 bazel_dep(name = "rules_cc", version = "0.2.8", dev_dependency = True)
 
-bazel_dep(name = "rules_dotnet", version = "0.17.5")
+bazel_dep(name = "rules_dotnet", version = "0.20.5")
 bazel_dep(name = "rules_java", version = "8.7.1")
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 bazel_dep(name = "rules_multitool", version = "1.3.0")

--- a/dotnet/src/webdriver/Firefox/FirefoxExtension.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxExtension.cs
@@ -22,6 +22,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 using System.Text.Json.Nodes;
 using System.Xml;
 
@@ -88,7 +89,7 @@ public class FirefoxExtension
 
         // First, expand the .xpi archive into a temporary location.
         Directory.CreateDirectory(tempFileName);
-        Stream zipFileStream = ResourceUtilities.GetResourceStream(this.extensionFileName, this.extensionResourceId);
+        Stream zipFileStream = ResourceUtilities.GetResourceStream(this.extensionFileName, $"{Assembly.GetExecutingAssembly().GetName().Name}.{this.extensionResourceId}");
         using (ZipArchive extensionZipArchive = new ZipArchive(zipFileStream, ZipArchiveMode.Read))
         {
             extensionZipArchive.ExtractToDirectory(tempFileName);

--- a/dotnet/src/webdriver/Firefox/FirefoxProfile.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxProfile.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 using System.Text.Json;
 
 namespace OpenQA.Selenium.Firefox;
@@ -297,7 +298,7 @@ public class FirefoxProfile
 
     private Preferences ReadDefaultPreferences()
     {
-        using (Stream defaultPrefsStream = ResourceUtilities.GetResourceStream("webdriver_prefs.json", "webdriver_prefs.json"))
+        using (Stream defaultPrefsStream = ResourceUtilities.GetResourceStream("webdriver_prefs.json", $"{Assembly.GetExecutingAssembly().GetName().Name}.webdriver_prefs.json"))
         {
             using JsonDocument defaultPreferences = JsonDocument.Parse(defaultPrefsStream);
 

--- a/dotnet/src/webdriver/Internal/ResourceUtilities.cs
+++ b/dotnet/src/webdriver/Internal/ResourceUtilities.cs
@@ -101,6 +101,7 @@ internal static class ResourceUtilities
             }
 
             Assembly executingAssembly = Assembly.GetExecutingAssembly();
+            resourceId = $"{executingAssembly.GetName().Name}.{resourceId}";
             resourceStream = executingAssembly.GetManifestResourceStream(resourceId);
         }
 

--- a/dotnet/src/webdriver/Internal/ResourceUtilities.cs
+++ b/dotnet/src/webdriver/Internal/ResourceUtilities.cs
@@ -101,7 +101,6 @@ internal static class ResourceUtilities
             }
 
             Assembly executingAssembly = Assembly.GetExecutingAssembly();
-            resourceId = $"{executingAssembly.GetName().Name}.{resourceId}";
             resourceStream = executingAssembly.GetManifestResourceStream(resourceId);
         }
 

--- a/dotnet/src/webdriver/JavaScriptEngine.cs
+++ b/dotnet/src/webdriver/JavaScriptEngine.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -411,7 +412,7 @@ public class JavaScriptEngine : IJavaScriptEngine
     private static string GetMutationListenerScript()
     {
         string listenerScript = string.Empty;
-        using (Stream resourceStream = ResourceUtilities.GetResourceStream("mutation-listener.js", "mutation-listener.js"))
+        using (Stream resourceStream = ResourceUtilities.GetResourceStream("mutation-listener.js", $"{Assembly.GetExecutingAssembly().GetName().Name}.mutation-listener.js"))
         {
             using (StreamReader resourceReader = new StreamReader(resourceStream))
             {

--- a/dotnet/src/webdriver/RelativeBy.cs
+++ b/dotnet/src/webdriver/RelativeBy.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 
 namespace OpenQA.Selenium;
 
@@ -38,7 +39,7 @@ public sealed class RelativeBy : By
     private static string GetWrappedAtom()
     {
         string atom;
-        using (Stream atomStream = ResourceUtilities.GetResourceStream("find-elements.js", "find-elements.js"))
+        using (Stream atomStream = ResourceUtilities.GetResourceStream("find-elements.js", $"{Assembly.GetExecutingAssembly().GetName().Name}.find-elements.js"))
         {
             using (StreamReader atomReader = new StreamReader(atomStream))
             {

--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -85,23 +85,23 @@
     <ItemGroup>
       <EmbeddedResource Include="$(ProjectDir)..\..\..\third_party\js\selenium\webdriver.json">
         <Visible>False</Visible>
-        <LogicalName>webdriver_prefs.json</LogicalName>
+        <LogicalName>$(AssemblyName).webdriver_prefs.json</LogicalName>
       </EmbeddedResource>
       <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\webdriver\atoms\get-attribute.js">
         <Visible>False</Visible>
-        <LogicalName>get-attribute.js</LogicalName>
+        <LogicalName>$(AssemblyName).get-attribute.js</LogicalName>
       </EmbeddedResource>
       <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\atoms\fragments\is-displayed.js">
         <Visible>False</Visible>
-        <LogicalName>is-displayed.js</LogicalName>
+        <LogicalName>$(AssemblyName).is-displayed.js</LogicalName>
       </EmbeddedResource>
       <EmbeddedResource Include="$(ProjectDir)..\..\..\bazel-bin\javascript\atoms\fragments\find-elements.js">
         <Visible>False</Visible>
-        <LogicalName>find-elements.js</LogicalName>
+        <LogicalName>$(AssemblyName).find-elements.js</LogicalName>
       </EmbeddedResource>
       <EmbeddedResource Include="$(ProjectDir)..\..\..\javascript\cdp-support\mutation-listener.js">
         <Visible>False</Visible>
-        <LogicalName>mutation-listener.js</LogicalName>
+        <LogicalName>$(AssemblyName).mutation-listener.js</LogicalName>
       </EmbeddedResource>
     </ItemGroup>
   </Target>

--- a/dotnet/src/webdriver/WebElement.cs
+++ b/dotnet/src/webdriver/WebElement.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenQA.Selenium;
 
@@ -709,7 +710,7 @@ public class WebElement : IWebElement, IFindsElement, IWrapsDriver, ILocatable, 
     private static string GetAtom(string atomResourceName)
     {
         string atom;
-        using (Stream atomStream = ResourceUtilities.GetResourceStream(atomResourceName, atomResourceName))
+        using (Stream atomStream = ResourceUtilities.GetResourceStream(atomResourceName, $"{Assembly.GetExecutingAssembly().GetName().Name}.{atomResourceName}"))
         {
             using (StreamReader atomReader = new StreamReader(atomStream))
             {


### PR DESCRIPTION
### **User description**
Upgrade rules_dotnet to 0.20.5

### 🔗 Related Issues
Enabler for https://github.com/SeleniumHQ/selenium/pull/16564


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade rules_dotnet dependency from 0.17.5 to 0.20.5

- Enables compatibility with newer .NET tooling features


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rules_dotnet 0.17.5"] -- "upgrade" --> B["rules_dotnet 0.20.5"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Update rules_dotnet dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Updated <code>rules_dotnet</code> bazel dependency version from 0.17.5 to 0.20.5<br> <li> Single line change in the MODULE.bazel configuration file</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16592/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

