### PR TITLE
[py][bidi]: add emulation command `set_user_agent_override`

### DIFF
--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -402,9 +402,9 @@ class Emulation:
 
     def set_user_agent_override(
         self,
-        user_agent: Optional[str] = None,
-        contexts: Optional[list[str]] = None,
-        user_contexts: Optional[list[str]] = None,
+        user_agent: str | None = None,
+        contexts: list[str] | None = None,
+        user_contexts: list[str] | None = None,
     ) -> None:
         """Set user agent override for the given contexts or user contexts.
 
@@ -418,10 +418,10 @@ class Emulation:
                 contexts nor user_contexts are provided.
         """
         if contexts is not None and user_contexts is not None:
-            raise ValueError("Cannot specify both contexts and userContexts")
+            raise ValueError("Cannot specify both contexts and user_contexts")
 
         if contexts is None and user_contexts is None:
-            raise ValueError("Must specify either contexts or userContexts")
+            raise ValueError("Must specify either contexts or user_contexts")
 
         params: dict[str, Any] = {"userAgent": user_agent}
 

--- a/py/selenium/webdriver/common/bidi/emulation.py
+++ b/py/selenium/webdriver/common/bidi/emulation.py
@@ -399,3 +399,35 @@ class Emulation:
             params["userContexts"] = user_contexts
 
         self.conn.execute(command_builder("emulation.setScreenOrientationOverride", params))
+
+    def set_user_agent_override(
+        self,
+        user_agent: Optional[str] = None,
+        contexts: Optional[list[str]] = None,
+        user_contexts: Optional[list[str]] = None,
+    ) -> None:
+        """Set user agent override for the given contexts or user contexts.
+
+        Args:
+            user_agent: User agent string to emulate, or None to clear the override.
+            contexts: List of browsing context IDs to apply the override to.
+            user_contexts: List of user context IDs to apply the override to.
+
+        Raises:
+            ValueError: If both contexts and user_contexts are provided, or if neither
+                contexts nor user_contexts are provided.
+        """
+        if contexts is not None and user_contexts is not None:
+            raise ValueError("Cannot specify both contexts and userContexts")
+
+        if contexts is None and user_contexts is None:
+            raise ValueError("Must specify either contexts or userContexts")
+
+        params: dict[str, Any] = {"userAgent": user_agent}
+
+        if contexts is not None:
+            params["contexts"] = contexts
+        elif user_contexts is not None:
+            params["userContexts"] = user_contexts
+
+        self.conn.execute(command_builder("emulation.setUserAgentOverride", params))

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -98,6 +98,15 @@ def get_screen_orientation(driver, context_id):
     return {"type": orientation_type, "angle": orientation_angle}
 
 
+def get_browser_user_agent(driver):
+    result = driver.script._evaluate(
+        "navigator.userAgent",
+        {"context": driver.current_window_handle},
+        await_promise=False,
+    )
+    return result.result["value"]
+
+
 def test_emulation_initialized(driver):
     assert driver.emulation is not None
     assert isinstance(driver.emulation, Emulation)
@@ -523,6 +532,44 @@ def test_set_screen_orientation_override_with_user_contexts(driver, pages, natur
             assert current_orientation["angle"] == expected_angle
 
             driver.emulation.set_screen_orientation_override(screen_orientation=None, user_contexts=[user_context])
+        finally:
+            driver.browsing_context.close(context_id)
+    finally:
+        driver.browser.remove_user_context(user_context)
+
+
+def test_set_user_agent_override_with_contexts(driver, pages):
+    context_id = driver.current_window_handle
+    url = pages.url("formPage.html")
+    driver.browsing_context.navigate(context_id, url, wait="complete")
+    initial_user_agent = get_browser_user_agent(driver)
+
+    custom_user_agent = "Mozilla/5.0 (Custom Test Agent)"
+    driver.emulation.set_user_agent_override(user_agent=custom_user_agent, contexts=[context_id])
+
+    assert get_browser_user_agent(driver) == custom_user_agent
+
+    driver.emulation.set_user_agent_override(user_agent=None, contexts=[context_id])
+    assert get_browser_user_agent(driver) == initial_user_agent
+
+
+def test_set_user_agent_override_with_user_contexts(driver, pages):
+    user_context = driver.browser.create_user_context()
+    try:
+        context_id = driver.browsing_context.create(type=WindowTypes.TAB, user_context=user_context)
+        try:
+            driver.switch_to.window(context_id)
+            url = pages.url("formPage.html")
+            driver.browsing_context.navigate(context_id, url, wait="complete")
+            initial_user_agent = get_browser_user_agent(driver)
+
+            custom_user_agent = "Mozilla/5.0 (Custom User Context Agent)"
+            driver.emulation.set_user_agent_override(user_agent=custom_user_agent, user_contexts=[user_context])
+
+            assert get_browser_user_agent(driver) == custom_user_agent
+
+            driver.emulation.set_user_agent_override(user_agent=None, user_contexts=[user_context])
+            assert get_browser_user_agent(driver) == initial_user_agent
         finally:
             driver.browsing_context.close(context_id)
     finally:


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Adds support for the `set_user_agent_override` command in the emulation module - https://w3c.github.io/webdriver-bidi/#command-emulation-setUserAgentOverride

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Usage:

1. Overriding a context
	```python
	driver.emulation.set_user_agent_override(user_agent="Mozilla/5.0 (Custom Test Agent)", contexts=[driver.current_window_handle])
	```
2. Overriding a user context
	```python
	driver.emulation.set_user_agent_override(user_agent="Mozilla/5.0 (Custom User Context Agent)", user_contexts=[user_context])
	```

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `set_user_agent_override` command to emulation module

- Supports overriding user agent for contexts or user contexts

- Includes validation to prevent conflicting parameter combinations

- Adds comprehensive test coverage for both context types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Emulation Module"] -->|"adds method"| B["set_user_agent_override"]
  B -->|"accepts"| C["user_agent string"]
  B -->|"accepts"| D["contexts or user_contexts"]
  B -->|"validates"| E["parameter combinations"]
  B -->|"executes"| F["BiDi command"]
  G["Test Suite"] -->|"validates"| H["context override"]
  G -->|"validates"| I["user context override"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emulation.py</strong><dd><code>Add set_user_agent_override emulation command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/emulation.py

<ul><li>Implements <code>set_user_agent_override</code> method following W3C WebDriver BiDi <br>specification<br> <li> Accepts optional <code>user_agent</code> parameter to set or clear override<br> <li> Accepts either <code>contexts</code> or <code>user_contexts</code> parameter (mutually <br>exclusive)<br> <li> Includes validation to ensure exactly one context type is provided<br> <li> Executes BiDi command with properly formatted parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16595/files#diff-18902e3ee516a208783ae0cb490460a1c9608548b8a3a24a15ed8d5a86ca71b1">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_emulation_tests.py</strong><dd><code>Add user agent override tests for contexts and user contexts</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_emulation_tests.py

<ul><li>Adds helper function <code>get_browser_user_agent</code> to retrieve current user <br>agent via script evaluation<br> <li> Adds test <code>test_set_user_agent_override_with_contexts</code> to verify <br>override with browsing contexts<br> <li> Adds test <code>test_set_user_agent_override_with_user_contexts</code> to verify <br>override with user contexts<br> <li> Tests both setting custom user agent and clearing override (resetting <br>to initial value)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16595/files#diff-ddf815686b0674b1c74ff3ad30cd4a43a0f3eb1594c8fe0109146bb7ea9b39b0">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

