### PR TITLE
[py]: reuse driver in case of bidi tests

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -343,12 +343,28 @@ def driver(request):
 
         request.addfinalizer(selenium_driver.stop_driver)
 
-    # Close the browser after BiDi tests. Those make event subscriptions
-    # and doesn't seems to be stable enough, causing the flakiness of the
-    # subsequent tests.
-    # Remove this when BiDi implementation and API is stable.
+    # For BiDi tests, only restart driver when explicitly marked as needing fresh driver.
+    # Tests marked with @pytest.mark.needs_fresh_driver get full driver restart for test isolation.
+    # Cleanup after every test is recommended.
     if selenium_driver is not None and selenium_driver.bidi:
-        request.addfinalizer(selenium_driver.stop_driver)
+        if request.node.get_closest_marker("needs_fresh_driver"):
+            request.addfinalizer(selenium_driver.stop_driver)
+        else:
+
+            def ensure_valid_window():
+                try:
+                    driver = selenium_driver._driver
+                    if driver:
+                        try:
+                            # Check if current window is still valid
+                            driver.current_window_handle
+                        except Exception:
+                            # restart driver
+                            selenium_driver.stop_driver()
+                except Exception:
+                    pass
+
+            request.addfinalizer(ensure_valid_window)
 
     yield selenium_driver.driver
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -86,7 +86,8 @@ markers = [
     "xfail_safari: Tests expected to fail in Safari",
     "xfail_webkitgtk: Tests expected to fail in WebKitGTK",
     "xfail_wpewebkit: Tests expected to fail in WPEWebKit",
-    "no_driver_after_test: If there are no drivers after the test it will create a new one."
+    "no_driver_after_test: If there are no drivers after the test it will create a new one.",
+    "needs_fresh_driver: Mark tests that may need a fresh driver instance for proper isolation."
 ]
 python_files = ["test_*.py", "*_test.py", "*_tests.py"]
 testpaths = ["test"]

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -721,6 +721,7 @@ def test_add_event_handler_user_prompt_opened(driver, pages):
     create_alert_page(driver, pages)
     driver.find_element(By.ID, "alert").click()
     WebDriverWait(driver, 5).until(EC.alert_is_present())
+    WebDriverWait(driver, 5).until(lambda d: len(events_received) > 0)
 
     assert len(events_received) == 1
     assert events_received[0].type == "alert"

--- a/py/test/selenium/webdriver/common/bidi_network_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_network_tests.py
@@ -33,6 +33,9 @@ def test_add_intercept(driver, pages):
     result = driver.network._add_intercept()
     assert result is not None, "Intercept not added"
 
+    # Clean up
+    driver.network._remove_intercept(result["intercept"])
+
 
 def test_remove_intercept(driver):
     result = driver.network._add_intercept()
@@ -88,6 +91,8 @@ def test_continue_request(driver, pages):
     assert driver.find_element(By.NAME, "login").is_displayed(), "Request not continued"
     assert len(exceptions) == 0, "Exception raised when continuing request in handler callback"
 
+    driver.network.remove_request_handler("before_request", callback_id)
+
 
 def test_continue_with_auth(driver):
     callback_id = driver.network.add_auth_handler("postman", "password")
@@ -96,6 +101,8 @@ def test_continue_with_auth(driver):
         context=driver.current_window_handle, url="https://postman-echo.com/basic-auth", wait=ReadinessState.COMPLETE
     )
     assert "authenticated" in driver.page_source, "Authorization failed"
+
+    driver.network.remove_auth_handler(callback_id)
 
 
 def test_remove_auth_handler(driver):
@@ -124,6 +131,8 @@ def test_handler_with_classic_navigation(driver, pages):
     pages.load("formPage.html")
     assert len(exceptions) == 0, "Exception raised in handler callback"
 
+    driver.network.remove_request_handler("before_request", callback_id)
+
 
 @pytest.mark.xfail_chrome(reason="Data URLs in Network requests are not implemented in Chrome yet")
 @pytest.mark.xfail_edge(reason="Data URLs in Network requests are not implemented in Edge yet")
@@ -140,10 +149,12 @@ def test_handler_with_data_url_request(driver, pages):
         except WebDriverException as e:
             exceptions.append(e)
 
-    driver.network.add_request_handler("before_request", callback)
+    callback_id = driver.network.add_request_handler("before_request", callback)
     url = pages.url("data_url.html")
     driver.browsing_context.navigate(context=driver.current_window_handle, url=url, wait=ReadinessState.COMPLETE)
     time.sleep(1)  # give callback time to complete
     assert driver.find_element(By.ID, "data-url-image").is_displayed()
     assert len(data_requests) > 0, "BiDi event not captured"
     assert len(exceptions) == 0, "Exception raised when continuing request in handler callback"
+
+    driver.network.remove_request_handler("before_request", callback_id)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Reuses the driver instance while running bidi tests. Currently, we restart the driver between every bidi test, which increase the test execution time. 
This change will reduce the test execution times for all browsers.

Although, we need to make sure all the tests, especially event handler tests are properly cleaned up in the end.
If a test requires a fully isolated driver, then we can use the `needs_fresh_driver` marker added in this PR.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Reuse driver instance across BiDi tests to reduce execution time

- Add `needs_fresh_driver` marker for tests requiring isolation

- Implement window validity check instead of full driver restart

- Clean up event handlers and network callbacks in BiDi tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BiDi Test Execution"] --> B{"needs_fresh_driver marker?"}
  B -->|Yes| C["Restart Driver"]
  B -->|No| D["Check Window Validity"]
  D -->|Invalid| E["Restart Driver"]
  D -->|Valid| F["Reuse Driver"]
  C --> G["Next Test"]
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>BiDi driver reuse with selective restart logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<ul><li>Modified BiDi driver fixture to reuse driver instance across tests <br>instead of always restarting<br> <li> Added <code>needs_fresh_driver</code> marker check to allow selective full driver <br>restart when needed<br> <li> Implemented <code>ensure_valid_window()</code> function to verify window handle <br>validity before reusing driver<br> <li> Replaces unconditional driver stop with conditional cleanup logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16597/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_browsing_context_tests.py</strong><dd><code>Add event handler callback wait condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_browsing_context_tests.py

<ul><li>Added explicit wait for event handler to receive callback before <br>assertion<br> <li> Ensures event is captured before checking <code>events_received</code> list length</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16597/files#diff-cea00ba1c71fd6f4ca93d87f14bcc291e1b87383cd61cd1bf1eec678e8d9efbf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bidi_network_tests.py</strong><dd><code>Add network handler cleanup in BiDi tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_network_tests.py

<ul><li>Added cleanup calls to remove network intercepts after test completion<br> <li> Added cleanup calls to remove request handlers after test completion<br> <li> Added cleanup call to remove auth handler after test completion<br> <li> Ensures proper isolation when driver is reused across tests</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16597/files#diff-97c8d35b88402ef5de934c8fb95da5f7c7c04039a79baf20cc8fd6c91379dac7">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add needs_fresh_driver pytest marker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/pyproject.toml

<ul><li>Added new <code>needs_fresh_driver</code> pytest marker definition<br> <li> Updated marker documentation to describe fresh driver isolation <br>requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16597/files#diff-3adb340b5a499e26b04507d972c31f5cf6fc27a6d81e3f7b547bf50e90c43be3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

