### PR TITLE
[grid] Improve browser container labels and naming in Dynamic Grid

### DIFF
--- a/java/src/org/openqa/selenium/docker/ContainerConfig.java
+++ b/java/src/org/openqa/selenium/docker/ContainerConfig.java
@@ -44,6 +44,8 @@ public class ContainerConfig {
   private final boolean autoRemove;
   private final long shmSize;
   private final Map<String, Object> hostConfig;
+  private final Map<String, String> labels;
+  private final String name;
 
   public ContainerConfig(
       Image image,
@@ -61,6 +63,7 @@ public class ContainerConfig {
         devices,
         networkName,
         shmSize,
+        ImmutableMap.of(),
         ImmutableMap.of());
   }
 
@@ -73,6 +76,52 @@ public class ContainerConfig {
       String networkName,
       long shmSize,
       Map<String, Object> hostConfig) {
+    this(
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        ImmutableMap.of());
+  }
+
+  public ContainerConfig(
+      Image image,
+      Multimap<String, Map<String, Object>> portBindings,
+      Map<String, String> envVars,
+      Map<String, String> volumeBinds,
+      List<Device> devices,
+      String networkName,
+      long shmSize,
+      Map<String, Object> hostConfig,
+      Map<String, String> labels) {
+    this(
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        null);
+  }
+
+  public ContainerConfig(
+      Image image,
+      Multimap<String, Map<String, Object>> portBindings,
+      Map<String, String> envVars,
+      Map<String, String> volumeBinds,
+      List<Device> devices,
+      String networkName,
+      long shmSize,
+      Map<String, Object> hostConfig,
+      Map<String, String> labels,
+      String name) {
     this.image = image;
     this.portBindings = portBindings;
     this.envVars = envVars;
@@ -82,6 +131,12 @@ public class ContainerConfig {
     this.autoRemove = true;
     this.shmSize = shmSize;
     this.hostConfig = hostConfig;
+    this.labels = labels;
+    this.name = name;
+  }
+
+  public String getName() {
+    return this.name;
   }
 
   public Image getImage() {
@@ -114,40 +169,94 @@ public class ContainerConfig {
         ImmutableMap.of("HostPort", String.valueOf(hostPort.getPort()), "HostIp", ""));
 
     return new ContainerConfig(
-        image, updatedBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        updatedBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig env(Map<String, String> envVars) {
     Require.nonNull("Container env vars", envVars);
 
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig bind(Map<String, String> volumeBinds) {
     Require.nonNull("Container volume binds", volumeBinds);
 
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig network(String networkName) {
     Require.nonNull("Container network name", networkName);
 
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig shmMemorySize(long shmSize) {
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig devices(List<Device> devices) {
     Require.nonNull("Container device files", devices);
 
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   public ContainerConfig applyHostConfig(Map<String, Object> hostConfig, List<String> configKeys) {
@@ -158,7 +267,46 @@ public class ContainerConfig {
             .collect(Collectors.toMap(key -> key, hostConfig::get));
 
     return new ContainerConfig(
-        image, portBindings, envVars, volumeBinds, devices, networkName, shmSize, setHostConfig);
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        setHostConfig,
+        labels,
+        name);
+  }
+
+  public ContainerConfig labels(Map<String, String> labels) {
+    Require.nonNull("Container labels", labels);
+
+    return new ContainerConfig(
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
+  }
+
+  public ContainerConfig name(String name) {
+    return new ContainerConfig(
+        image,
+        portBindings,
+        envVars,
+        volumeBinds,
+        devices,
+        networkName,
+        shmSize,
+        hostConfig,
+        labels,
+        name);
   }
 
   @Override
@@ -221,9 +369,13 @@ public class ContainerConfig {
       hostConfig = ImmutableMap.copyOf(copyMap);
     }
 
-    return ImmutableMap.of(
-        "Image", image.getId(),
-        "Env", envVars,
-        "HostConfig", hostConfig);
+    Map<String, Object> config = new HashMap<>();
+    config.put("Image", image.getId());
+    config.put("Env", envVars);
+    config.put("HostConfig", hostConfig);
+    if (!labels.isEmpty()) {
+      config.put("Labels", labels);
+    }
+    return config;
   }
 }

--- a/java/src/org/openqa/selenium/docker/ContainerInfo.java
+++ b/java/src/org/openqa/selenium/docker/ContainerInfo.java
@@ -30,6 +30,7 @@ public class ContainerInfo {
   private final List<Map<String, Object>> mountedVolumes;
   private final String networkName;
   private Map<String, Object> hostConfig;
+  private Map<String, String> labels;
 
   public ContainerInfo(
       ContainerId id,
@@ -37,11 +38,22 @@ public class ContainerInfo {
       List<Map<String, Object>> mountedVolumes,
       String networkName,
       Map<String, Object> hostConfig) {
+    this(id, ip, mountedVolumes, networkName, hostConfig, Map.of());
+  }
+
+  public ContainerInfo(
+      ContainerId id,
+      String ip,
+      List<Map<String, Object>> mountedVolumes,
+      String networkName,
+      Map<String, Object> hostConfig,
+      Map<String, String> labels) {
     this.ip = Require.nonNull("Container ip address", ip);
     this.id = Require.nonNull("Container id", id);
     this.mountedVolumes = Require.nonNull("Mounted volumes", mountedVolumes);
     this.networkName = Require.nonNull("Network name", networkName);
     this.hostConfig = Require.nonNull("Host config", hostConfig);
+    this.labels = Require.nonNull("Labels", labels);
   }
 
   public String getIp() {
@@ -62,6 +74,10 @@ public class ContainerInfo {
 
   public Map<String, Object> getHostConfig() {
     return this.hostConfig;
+  }
+
+  public Map<String, String> getLabels() {
+    return this.labels;
   }
 
   @Override

--- a/java/src/org/openqa/selenium/docker/client/CreateContainer.java
+++ b/java/src/org/openqa/selenium/docker/client/CreateContainer.java
@@ -22,6 +22,9 @@ import static org.openqa.selenium.json.Json.MAP_TYPE;
 import static org.openqa.selenium.remote.http.Contents.asJson;
 import static org.openqa.selenium.remote.http.HttpMethod.POST;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -64,8 +67,14 @@ class CreateContainer {
 
     // Build the URL with optional name parameter
     String url = String.format("/v%s/containers/create", apiVersion);
-    if (info.getName() != null && !info.getName().isEmpty()) {
-      url += "?name=" + info.getName();
+    if (info.getName() != null && !info.getName().trim().isEmpty()) {
+      String containerName = info.getName().trim();
+      try {
+        String encodedName = URLEncoder.encode(containerName, StandardCharsets.UTF_8.toString());
+        url += "?name=" + encodedName;
+      } catch (UnsupportedEncodingException e) {
+        throw new DockerException("Failed to encode container name: " + containerName, e);
+      }
     }
 
     HttpResponse res =

--- a/java/src/org/openqa/selenium/docker/client/CreateContainer.java
+++ b/java/src/org/openqa/selenium/docker/client/CreateContainer.java
@@ -62,10 +62,16 @@ class CreateContainer {
     Map<String, Object> requestJson = JSON.toType(JSON.toJson(info), MAP_TYPE);
     Map<String, Object> adaptedRequest = adapter.adaptContainerCreateRequest(requestJson);
 
+    // Build the URL with optional name parameter
+    String url = String.format("/v%s/containers/create", apiVersion);
+    if (info.getName() != null && !info.getName().isEmpty()) {
+      url += "?name=" + info.getName();
+    }
+
     HttpResponse res =
         DockerMessages.throwIfNecessary(
             client.execute(
-                new HttpRequest(POST, String.format("/v%s/containers/create", apiVersion))
+                new HttpRequest(POST, url)
                     .addHeader("Content-Type", JSON_UTF_8)
                     .setContent(asJson(adaptedRequest))),
             "Unable to create container: ",

--- a/java/src/org/openqa/selenium/docker/client/InspectContainer.java
+++ b/java/src/org/openqa/selenium/docker/client/InspectContainer.java
@@ -80,7 +80,11 @@ class InspectContainer {
         mounts.stream().map(mount -> (Map<String, Object>) mount).collect(Collectors.toList());
     Map<String, Object> hostConfig =
         (Map<String, Object>) rawInspectInfo.getOrDefault("HostConfig", Collections.emptyMap());
+    Map<String, Object> config =
+        (Map<String, Object>) rawInspectInfo.getOrDefault("Config", Collections.emptyMap());
+    Map<String, String> labels =
+        (Map<String, String>) config.getOrDefault("Labels", Collections.emptyMap());
 
-    return new ContainerInfo(id, ip, mountedVolumes, networkName, hostConfig);
+    return new ContainerInfo(id, ip, mountedVolumes, networkName, hostConfig, labels);
   }
 }

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.docker.ContainerId;
@@ -173,6 +174,7 @@ public class DockerOptions {
     DockerAssetsPath assetsPath = getAssetsPath(info);
     String networkName = getDockerNetworkName(info);
     Map<String, Object> hostConfig = getDockerHostConfig(info);
+    Map<String, String> composeLabels = getComposeLabels(info);
 
     loadImages(docker, kinds.keySet().toArray(new String[0]));
     Image videoImage = getVideoImage(docker);
@@ -208,7 +210,8 @@ public class DockerOptions {
                     info.isPresent(),
                     capabilities -> options.getSlotMatcher().matches(caps, capabilities),
                     hostConfig,
-                    hostConfigKeys));
+                    hostConfigKeys,
+                    composeLabels));
           }
           LOG.info(
               String.format(
@@ -255,6 +258,19 @@ public class DockerOptions {
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private Map<String, Object> getDockerHostConfig(Optional<ContainerInfo> info) {
     return info.map(ContainerInfo::getHostConfig).orElse(Collections.emptyMap());
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private Map<String, String> getComposeLabels(Optional<ContainerInfo> info) {
+    if (info.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> allLabels = info.get().getLabels();
+    // Filter for Docker Compose labels (com.docker.compose.*)
+    return allLabels.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith("com.docker.compose."))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -104,6 +105,7 @@ public class DockerSessionFactory implements SessionFactory {
   private final Predicate<Capabilities> predicate;
   private final Map<String, Object> hostConfig;
   private final List<String> hostConfigKeys;
+  private final Map<String, String> composeLabels;
 
   public DockerSessionFactory(
       Tracer tracer,
@@ -121,7 +123,8 @@ public class DockerSessionFactory implements SessionFactory {
       boolean runningInDocker,
       Predicate<Capabilities> predicate,
       Map<String, Object> hostConfig,
-      List<String> hostConfigKeys) {
+      List<String> hostConfigKeys,
+      Map<String, String> composeLabels) {
     this.tracer = Require.nonNull("Tracer", tracer);
     this.clientFactory = Require.nonNull("HTTP client", clientFactory);
     this.sessionTimeout = Require.nonNull("Session timeout", sessionTimeout);
@@ -138,6 +141,7 @@ public class DockerSessionFactory implements SessionFactory {
     this.predicate = Require.nonNull("Accepted capabilities predicate", predicate);
     this.hostConfig = Require.nonNull("Container host config", hostConfig);
     this.hostConfigKeys = Require.nonNull("Browser container host config keys", hostConfigKeys);
+    this.composeLabels = Require.nonNull("Docker Compose labels", composeLabels);
   }
 
   @Override
@@ -155,6 +159,10 @@ public class DockerSessionFactory implements SessionFactory {
     LOG.info("Starting session for " + sessionRequest.getDesiredCapabilities());
 
     int port = runningInDocker ? 4444 : PortProber.findFreePort();
+    // Using timestamp + short UUID to avoid conflicts in concurrent session creation
+    long timestamp = System.currentTimeMillis();
+    String uniqueId = UUID.randomUUID().toString().substring(0, 6);
+    String sessionIdentifier = timestamp + "-" + uniqueId;
     try (Span span = tracer.getCurrentContext().createSpan("docker_session_factory.apply")) {
       AttributeMap attributeMap = tracer.createAttributeMap();
       attributeMap.put(AttributeKey.LOGGER_CLASS.getKey(), this.getClass().getName());
@@ -163,7 +171,8 @@ public class DockerSessionFactory implements SessionFactory {
               ? "Creating container..."
               : "Creating container, mapping container port 4444 to " + port;
       LOG.info(logMessage);
-      Container container = createBrowserContainer(port, sessionRequest.getDesiredCapabilities());
+      Container container =
+          createBrowserContainer(port, sessionRequest.getDesiredCapabilities(), sessionIdentifier);
       container.start();
       ContainerInfo containerInfo = container.inspect();
 
@@ -243,7 +252,8 @@ public class DockerSessionFactory implements SessionFactory {
         String containerPath = path.get().getContainerPath(id);
         saveSessionCapabilities(mergedCapabilities, containerPath);
         String hostPath = path.get().getHostPath(id);
-        videoContainer = startVideoContainer(mergedCapabilities, containerIp, hostPath);
+        videoContainer =
+            startVideoContainer(mergedCapabilities, containerIp, hostPath, sessionIdentifier);
       }
 
       Dialect downstream =
@@ -288,7 +298,8 @@ public class DockerSessionFactory implements SessionFactory {
         .setCapability("se:forwardCdp", forwardCdpPath);
   }
 
-  private Container createBrowserContainer(int port, Capabilities sessionCapabilities) {
+  private Container createBrowserContainer(
+      int port, Capabilities sessionCapabilities, String sessionIdentifier) {
     Map<String, String> browserContainerEnvVars = new HashMap<>();
     // Enable env var to trigger video recording if session capabilities request and external video
     // container is disabled
@@ -299,16 +310,24 @@ public class DockerSessionFactory implements SessionFactory {
     }
     browserContainerEnvVars.putAll(getBrowserContainerEnvVars(sessionCapabilities));
     long browserContainerShmMemorySize = 2147483648L; // 2GB
+
+    // Generate container name: browser-<browserName>-<timestamp>-<uuid>
+    String browserName = stereotype.getBrowserName().toLowerCase();
+    String containerName = String.format("browser-%s-%s", browserName, sessionIdentifier);
+
     ContainerConfig containerConfig =
         image(browserImage)
             .env(browserContainerEnvVars)
             .shmMemorySize(browserContainerShmMemorySize)
             .network(networkName)
             .devices(devices)
-            .applyHostConfig(hostConfig, hostConfigKeys);
+            .applyHostConfig(hostConfig, hostConfigKeys)
+            .labels(composeLabels)
+            .name(containerName);
     Optional<DockerAssetsPath> path = ofNullable(this.assetsPath);
     if (path.isPresent() && videoImage == null && recordVideoForSession(sessionCapabilities)) {
-      containerConfig.bind(Collections.singletonMap(this.assetsPath.getHostPath(), "/videos"));
+      containerConfig =
+          containerConfig.bind(Collections.singletonMap(this.assetsPath.getHostPath(), "/videos"));
     }
     if (!runningInDocker) {
       containerConfig = containerConfig.map(Port.tcp(4444), Port.tcp(port));
@@ -349,15 +368,28 @@ public class DockerSessionFactory implements SessionFactory {
   }
 
   private Container startVideoContainer(
-      Capabilities sessionCapabilities, String browserContainerIp, String hostPath) {
+      Capabilities sessionCapabilities,
+      String browserContainerIp,
+      String hostPath,
+      String sessionIdentifier) {
     if (videoImage == null || !recordVideoForSession(sessionCapabilities)) {
       return null;
     }
     int videoPort = 9000;
     Map<String, String> envVars = getVideoContainerEnvVars(sessionCapabilities, browserContainerIp);
     Map<String, String> volumeBinds = Collections.singletonMap(hostPath, "/videos");
+
+    // Generate container name: recorder-<browserName>-<timestamp>-<uuid>
+    String browserName = stereotype.getBrowserName().toLowerCase();
+    String containerName = String.format("recorder-%s-%s", browserName, sessionIdentifier);
+
     ContainerConfig containerConfig =
-        image(videoImage).env(envVars).bind(volumeBinds).network(networkName);
+        image(videoImage)
+            .env(envVars)
+            .bind(volumeBinds)
+            .network(networkName)
+            .labels(composeLabels)
+            .name(containerName);
     if (!runningInDocker) {
       videoPort = PortProber.findFreePort();
       containerConfig = containerConfig.map(Port.tcp(9000), Port.tcp(videoPort));

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -159,10 +159,17 @@ public class DockerSessionFactory implements SessionFactory {
     LOG.info("Starting session for " + sessionRequest.getDesiredCapabilities());
 
     int port = runningInDocker ? 4444 : PortProber.findFreePort();
-    // Using timestamp + short UUID to avoid conflicts in concurrent session creation
+    // Generate unique identifier for consistent naming between browser and recorder containers
+    // Using browserName-timestamp-UUID to avoid conflicts in concurrent session creation
+    String browserName = sessionRequest.getDesiredCapabilities().getBrowserName();
+    if (browserName != null && !browserName.isEmpty()) {
+      browserName = browserName.toLowerCase();
+    } else {
+      browserName = "unknown";
+    }
     long timestamp = System.currentTimeMillis();
-    String uniqueId = UUID.randomUUID().toString().substring(0, 6);
-    String sessionIdentifier = timestamp + "-" + uniqueId;
+    String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+    String sessionIdentifier = String.format("%s-%d-%s", browserName, timestamp, uniqueId);
     try (Span span = tracer.getCurrentContext().createSpan("docker_session_factory.apply")) {
       AttributeMap attributeMap = tracer.createAttributeMap();
       attributeMap.put(AttributeKey.LOGGER_CLASS.getKey(), this.getClass().getName());
@@ -312,8 +319,7 @@ public class DockerSessionFactory implements SessionFactory {
     long browserContainerShmMemorySize = 2147483648L; // 2GB
 
     // Generate container name: browser-<browserName>-<timestamp>-<uuid>
-    String browserName = stereotype.getBrowserName().toLowerCase();
-    String containerName = String.format("browser-%s-%s", browserName, sessionIdentifier);
+    String containerName = String.format("browser-%s", sessionIdentifier);
 
     ContainerConfig containerConfig =
         image(browserImage)
@@ -380,8 +386,7 @@ public class DockerSessionFactory implements SessionFactory {
     Map<String, String> volumeBinds = Collections.singletonMap(hostPath, "/videos");
 
     // Generate container name: recorder-<browserName>-<timestamp>-<uuid>
-    String browserName = stereotype.getBrowserName().toLowerCase();
-    String containerName = String.format("recorder-%s-%s", browserName, sessionIdentifier);
+    String containerName = String.format("recorder-%s", sessionIdentifier);
 
     ContainerConfig containerConfig =
         image(videoImage)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
**Dynamic Grid Container Naming Implementation**
- Pattern: `browser-<browserName>-<timestamp>-<uuid> and recorder-<browserName>-<timestamp>-<uuid>`
- Example: `browser-chrome-1731625200000-a3f2b8c9, recorder-chrome-1731625200000-a3f2b8c9`
- Benefits:
  + Easy identification of container purpose and browser type
  + Timestamp allows chronological sorting
  + 8-character UUID prevents naming conflicts in concurrent session creation
  + Browser and recorder containers share the same identifier for easy correlation

**Docker Compose Label Inheritance**
- Extracted Labels: `com.docker.compose.*` labels from parent node container
- Applied To: Both browser and video recorder containers
- Benefits:
  + Containers recognized as part of the same Compose project
  + Proper lifecycle management by Docker Compose
  + Network inheritance and isolation
  + Cleanup handled by `docker-compose down*`

**Before**
<img width="772" height="422" alt="Screenshot at Nov 15 10-17-29" src="https://github.com/user-attachments/assets/9e38dbc6-6bec-4885-b4d3-42527b1be54e" />

**After**
<img width="768" height="414" alt="Screenshot at Nov 15 10-46-07" src="https://github.com/user-attachments/assets/9b995426-d791-45b1-af17-53b64f6764a3" />

### 🔧 Implementation Notes
**Backward Compatibility**
All changes are backward compatible
Container name is optional; existing code without names continues to work
Labels are optional; nodes not running in Docker Compose will have empty label maps

**Related Issues**
Improves debugging and monitoring of Docker-based Grid sessions
Addresses container lifecycle management in Docker Compose environments
Prevents naming conflicts in high-concurrency scenarios

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement container naming pattern for browser and recorder containers

- Extract and apply Docker Compose labels to containers for lifecycle management

- Add labels and name fields to ContainerConfig and ContainerInfo classes

- Generate unique container identifiers using timestamp and UUID


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DockerSessionFactory"] -->|generates sessionIdentifier| B["timestamp + UUID"]
  B -->|creates browserContainer| C["browser-browserName-timestamp-uuid"]
  B -->|creates videoContainer| D["recorder-browserName-timestamp-uuid"]
  E["Parent Node Container"] -->|extracts com.docker.compose labels| F["composeLabels"]
  F -->|applies to| C
  F -->|applies to| D
  C -->|stored in| G["ContainerConfig"]
  D -->|stored in| G
  G -->|passed to| H["CreateContainer API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContainerConfig.java</strong><dd><code>Add labels and name support to ContainerConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/docker/ContainerConfig.java

<ul><li>Added <code>labels</code> and <code>name</code> fields to store container metadata<br> <li> Added multiple constructor overloads to support labels and name <br>parameters<br> <li> Added <code>getName()</code>, <code>labels()</code>, and <code>name()</code> methods for fluent API<br> <li> Updated all builder methods (<code>map()</code>, <code>env()</code>, <code>bind()</code>, etc.) to preserve <br>labels and name<br> <li> Modified <code>toJson()</code> to include labels in container creation request when <br>non-empty</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-ef3399f1ef34da7c97a287ae43ca7feda14f6d23189602a4a1cf70acb8709040">+163/-11</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContainerInfo.java</strong><dd><code>Add labels field to ContainerInfo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/docker/ContainerInfo.java

<ul><li>Added <code>labels</code> field to store container labels from Docker inspect <br>response<br> <li> Added constructor overload accepting labels parameter<br> <li> Added <code>getLabels()</code> getter method to retrieve container labels</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-121b8a2a0142c3abe8c3549cd7a4da52a1e88f422157efb0bbefe64b1cf75cb7">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateContainer.java</strong><dd><code>Support container naming in Docker API request</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/docker/client/CreateContainer.java

<ul><li>Modified container creation URL to include optional <code>name</code> query <br>parameter<br> <li> Dynamically builds URL with container name when provided in <br>ContainerConfig</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-c06fd1d90252380a8c3da33a9c6a691ea94156c2e658ebd0ff547eca897d3371">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InspectContainer.java</strong><dd><code>Extract labels from Docker inspect response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/docker/client/InspectContainer.java

<ul><li>Extract labels from container Config section in Docker inspect <br>response<br> <li> Pass extracted labels to ContainerInfo constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-d3e486e72b93effe93effb9dc6fcd9a91333be40c2a711a069b92396d23c2c89">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerOptions.java</strong><dd><code>Extract and pass Docker Compose labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java

<ul><li>Added <code>getComposeLabels()</code> method to filter Docker Compose labels from <br>parent node container<br> <li> Filters labels starting with <code>com.docker.compose.</code> prefix<br> <li> Pass compose labels to DockerSessionFactory constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-5a4e578c5c5711a9b26d92a059bfe58b426177f8d2fc68aaaa79cd0fbef456bd">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerSessionFactory.java</strong><dd><code>Implement container naming and label application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java

<ul><li>Added <code>composeLabels</code> field to store Docker Compose labels from parent <br>node<br> <li> Generate unique session identifier using timestamp and 6-character <br>UUID<br> <li> Create browser container with name pattern <code>browser-<browserName>-<timestamp>-<uuid></code><br> <li> Create video recorder container with name pattern <code>recorder-<browserName>-<timestamp>-<uuid></code><br> <li> Apply compose labels to both browser and video containers<br> <li> Updated <code>createBrowserContainer()</code> and <code>startVideoContainer()</code> methods to <br>accept and use sessionIdentifier</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16599/files#diff-a05d31304c9c75c40d9d11ef388a2c669f1f8c35e943ed8dcbc32e1da7694c5e">+40/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

