### PR TITLE
[ci] Use pagination in mirror workflow to get all Selenium releases

### DIFF
--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -16,9 +16,26 @@ jobs:
         fetch-depth: 0
     - name: Read api.github.com and filter response
       run: |
+        set -euo pipefail
         cd common/mirror
-        export JQ_FILTER="[.[] | {tag_name: .tag_name, assets: [.assets[] | {browser_download_url: .browser_download_url} ] } ]"
-        curl -H "Authorization: ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/SeleniumHQ/selenium/releases | jq "$JQ_FILTER" > selenium
+        TOKEN="${{ secrets.GITHUB_TOKEN }}"
+        JQ_FILTER='[.[] | {tag_name: .tag_name, assets: [.assets[] | {browser_download_url: .browser_download_url} ] } ]'
+        page=1
+        tmpfile="$(mktemp)"
+        : > "$tmpfile"
+        while :; do
+          echo "Fetching SeleniumHQ/selenium releases page $page..."
+          resp=$(curl -fsSL \
+            -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/SeleniumHQ/selenium/releases?per_page=100&page=${page}")
+          if [ "$(echo "$resp" | jq 'length')" -eq 0 ]; then
+            break
+          fi
+          echo "$resp" | jq "$JQ_FILTER" >> "$tmpfile"
+          page=$((page+1))
+        done
+        jq -s 'add' "$tmpfile" > selenium
+        rm "$tmpfile"
     - name: Commit files
       id: git
       run: |


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

The latest IEDriverServer was done a long time ago (Selenium 4.14), and so, it is currently excluded from the default GitHub API response used for the mirror workflow (due to result pagination). As a result, the support of IEDriverServer in Selenium Manager was started to fail:

```
> selenium-manager.exe --browser iexplorer --debug
[2025-11-17T09:04:19.669Z DEBUG] IEDriverServer not found in PATH
[2025-11-17T09:04:19.670Z DEBUG] iexplorer detected at C:\Program Files\Internet Explorer\iexplore.exe
[2025-11-17T09:04:19.671Z DEBUG] Detected browser: iexplorer 11.00.26100.1
[2025-11-17T09:04:19.723Z ERROR] IEDriverServer release not available
```

It is currently failing in CI:

https://github.com/SeleniumHQ/selenium/actions/runs/19414639574/job/55541217140

<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
This PR changes the mirror workflow to get all pages in the GitHub API responses. This way, even old releases (e.g., Selenium 4.14) are kept in the mirror file, and Selenium Manager should be able to find IEDriverServer, as usual.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Implements pagination in mirror workflow to fetch all GitHub releases

- Fixes IEDriverServer availability by retrieving old Selenium releases

- Adds error handling and improved shell script robustness

- Processes paginated API responses into consolidated mirror file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub API<br/>Releases Endpoint"] -->|"Paginated<br/>per_page=100"| B["Fetch Loop<br/>All Pages"]
  B -->|"Filter & Transform"| C["JQ Processing"]
  C -->|"Aggregate"| D["selenium<br/>Mirror File"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mirror-selenium-releases.yml</strong><dd><code>Add pagination logic to GitHub releases API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mirror-selenium-releases.yml

<ul><li>Replaces single API call with paginated loop to fetch all releases <br>(100 per page)<br> <li> Adds error handling with <code>set -euo pipefail</code> for shell script robustness<br> <li> Implements temporary file accumulation and final aggregation with <code>jq </code><br><code>-s 'add'</code><br> <li> Improves authorization header format and adds debug logging for <br>pagination progress</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16605/files#diff-09af8e9f2d0267b1778e969beb999aa35ddec12a5d9a50019440aefddb1c1fed">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

