### PR TITLE
[grid] Update container label `compose.oneoff` in Dynamic Grid

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -141,9 +141,11 @@ public class DockerSessionFactory implements SessionFactory {
     this.predicate = Require.nonNull("Accepted capabilities predicate", predicate);
     this.hostConfig = Require.nonNull("Container host config", hostConfig);
     this.hostConfigKeys = Require.nonNull("Browser container host config keys", hostConfigKeys);
-    this.composeLabels = Require.nonNull("Docker Compose labels", composeLabels);
     // Merge compose labels with oneoff=False to prevent triggering --exit-code-from dynamic grid
-    this.composeLabels.put("com.docker.compose.oneoff", "False");
+    Map<String, String> allLabels =
+        new HashMap<>(Require.nonNull("Docker Compose labels", composeLabels));
+    allLabels.put("com.docker.compose.oneoff", "False");
+    this.composeLabels = Collections.unmodifiableMap(allLabels);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -142,6 +142,8 @@ public class DockerSessionFactory implements SessionFactory {
     this.hostConfig = Require.nonNull("Container host config", hostConfig);
     this.hostConfigKeys = Require.nonNull("Browser container host config keys", hostConfigKeys);
     this.composeLabels = Require.nonNull("Docker Compose labels", composeLabels);
+    // Merge compose labels with oneoff=False to prevent triggering --exit-code-from dynamic grid
+    this.composeLabels.put("com.docker.compose.oneoff", "False");
   }
 
   @Override


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
In previous PR #16599 - Improve browser container labels and naming in Dynamic Grid.

If Docker Compose starts with `--exit-code-from`, the compose stack will exit when any of the dynamic containers (Grid browser or recorder) terminate.

The `com.docker.compose.oneoff=False` label marks containers as service containers rather than one-off containers. When Docker Compose runs with --exit-code-from, it only monitors containers that are marked as one-off (or the specific container named in the flag). By setting this label to False, these dynamically created browser and video containers will:
- Still be part of the compose stack (grouped by the compose labels)
- Not trigger the compose stack to exit when they terminate
- Allow the main services to continue running independently

This is particularly useful when running Dynamic Grid in Docker Compose, where browser container and test container are in same stack, and only listen to the status of test container for exit code.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `com.docker.compose.oneoff=False` label to dynamic containers

- Prevents compose stack exit when browser containers terminate

- Allows main services to continue running independently

- Ensures proper container lifecycle management in Docker Compose


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Compose Stack"] -->|"--exit-code-from flag"| B["Monitor Container Status"]
  B -->|"oneoff=False label"| C["Browser Containers"]
  C -->|"Continue running"| D["Main Services Unaffected"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DockerSessionFactory.java</strong><dd><code>Add oneoff label to dynamic container configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java

<ul><li>Add <code>com.docker.compose.oneoff=False</code> label to compose labels map<br> <li> Label prevents dynamic containers from triggering stack exit<br> <li> Ensures browser and video containers remain part of compose stack<br> <li> Allows independent lifecycle management of test containers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16613/files#diff-a05d31304c9c75c40d9d11ef388a2c669f1f8c35e943ed8dcbc32e1da7694c5e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

