### PR TITLE
[dotnet] [bidi] Don't lose scoped events

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -114,7 +114,7 @@ public sealed class Broker : IAsyncDisposable
                             args.BiDi = _bidi;
 
                             // trying to undestand which event handler is intersted in
-                            // https://github.com/w3c/webdriver-bidi/issues/1032 - this isssue is attempt to improve
+                            // https://github.com/w3c/webdriver-bidi/issues/1032 - this BiDi spec proposal is how to improve
 
                             // handle browsing context subscriber
                             if (handler.Contexts is not null && args is BrowsingContextEventArgs browsingContextEventArgs && handler.Contexts.Contains(browsingContextEventArgs.Context))

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -113,6 +113,9 @@ public sealed class Broker : IAsyncDisposable
 
                             args.BiDi = _bidi;
 
+                            // trying to undestand which event handler is intersted in
+                            // https://github.com/w3c/webdriver-bidi/issues/1032 - this isssue is attempt to improve
+
                             // handle browsing context subscriber
                             if (handler.Contexts is not null && args is BrowsingContextEventArgs browsingContextEventArgs && handler.Contexts.Contains(browsingContextEventArgs.Context))
                             {
@@ -120,6 +123,11 @@ public sealed class Broker : IAsyncDisposable
                             }
                             // handle only session subscriber
                             else if (handler.Contexts is null)
+                            {
+                                await handler.InvokeAsync(args).ConfigureAwait(false);
+                            }
+                            // if we didn't determine event scope
+                            else
                             {
                                 await handler.InvokeAsync(args).ConfigureAwait(false);
                             }


### PR DESCRIPTION
### **User description**
This pull request introduces minor improvements to the event processing logic in the `Broker.cs` file, specifically within the `ProcessEventsAwaiterAsync` method. The changes clarify the intent of the event handler scope and add a fallback case to ensure all handlers are invoked appropriately.

Event handler logic improvements:

* Added comments to clarify the purpose of determining which event handler is interested in the event, referencing the related W3C BiDi issue for context.
* Added a fallback branch to invoke the event handler even when the event scope is not explicitly determined, ensuring that no events are missed by handlers.<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Add fallback handler invocation when event scope cannot be determined

- Clarify event handler scope determination logic with comments

- Reference W3C BiDi issue for context on scoped event handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event received"] --> B{"Determine handler scope"}
  B -->|"Browsing context match"| C["Invoke handler"]
  B -->|"Session subscriber"| C
  B -->|"Scope undetermined"| D["Invoke handler<br/>fallback case"]
  C --> E["Handler executed"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Add fallback handler invocation and clarify scope logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Broker.cs

<ul><li>Added clarifying comments explaining event handler scope determination <br>logic<br> <li> Added reference to W3C BiDi issue #1032 for context<br> <li> Introduced fallback <code>else</code> branch to invoke handlers when event scope <br>cannot be explicitly determined<br> <li> Ensures no events are lost due to unhandled scope conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16614/files#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

