### PR TITLE
[grid] Dynamic Grid group dynamic containers in compose stack

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java
@@ -116,6 +116,17 @@ public class DockerFlags implements HasRoles {
   private List<String> devices;
 
   @Parameter(
+      names = {"--docker-grouping-labels"},
+      description =
+          "Users to specify custom labels for grouping dynamic containers. This will make the"
+              + " system more flexible for different platforms and use cases")
+  @ConfigValue(
+      section = DockerOptions.DOCKER_SECTION,
+      name = "grouping-labels",
+      example = "[\"azure.container.group\", \"aws.ecs.cluster\"]")
+  private List<String> groupingLabels;
+
+  @Parameter(
       names = {"--docker-video-image"},
       description = "Docker image to be used when video recording is enabled")
   @ConfigValue(

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
@@ -30,9 +30,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
@@ -270,22 +272,14 @@ public class DockerOptions {
     List<String> customLabelKeys =
         config.getAll(DOCKER_SECTION, "grouping-labels").orElseGet(Collections::emptyList);
 
+    Set<String> groupingKeys = new HashSet<>(customLabelKeys);
+    groupingKeys.add("com.docker.compose.project");
+    groupingKeys.add("io.podman.compose.project");
+
     Map<String, String> allLabels = info.get().getLabels();
-    // Filter for project/grouping labels that work across orchestration systems
-    // Keep only project identifiers, exclude service-specific labels to prevent
-    // exit monitoring in Docker Compose, Podman Compose, etc.
+    // Filter for grouping labels that work across orchestration systems
     return allLabels.entrySet().stream()
-        .filter(
-            entry -> {
-              String key = entry.getKey();
-              // Docker Compose project label
-              if (key.equals("com.docker.compose.project")) return true;
-              // Podman Compose project label
-              if (key.equals("io.podman.compose.project")) return true;
-              // Custom user-defined grouping labels
-              if (customLabelKeys.contains(key)) return true;
-              return false;
-            })
+        .filter(entry -> groupingKeys.contains(entry.getKey()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java
@@ -174,7 +174,7 @@ public class DockerOptions {
     DockerAssetsPath assetsPath = getAssetsPath(info);
     String networkName = getDockerNetworkName(info);
     Map<String, Object> hostConfig = getDockerHostConfig(info);
-    Map<String, String> composeLabels = getComposeLabels(info);
+    Map<String, String> groupingLabels = getGroupingLabels(info);
 
     loadImages(docker, kinds.keySet().toArray(new String[0]));
     Image videoImage = getVideoImage(docker);
@@ -211,7 +211,7 @@ public class DockerOptions {
                     capabilities -> options.getSlotMatcher().matches(caps, capabilities),
                     hostConfig,
                     hostConfigKeys,
-                    composeLabels));
+                    groupingLabels));
           }
           LOG.info(
               String.format(
@@ -261,15 +261,31 @@ public class DockerOptions {
   }
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  private Map<String, String> getComposeLabels(Optional<ContainerInfo> info) {
+  private Map<String, String> getGroupingLabels(Optional<ContainerInfo> info) {
     if (info.isEmpty()) {
       return Collections.emptyMap();
     }
 
+    // Get custom grouping labels from configuration
+    List<String> customLabelKeys =
+        config.getAll(DOCKER_SECTION, "grouping-labels").orElseGet(Collections::emptyList);
+
     Map<String, String> allLabels = info.get().getLabels();
-    // Filter for Docker Compose labels (com.docker.compose.*)
+    // Filter for project/grouping labels that work across orchestration systems
+    // Keep only project identifiers, exclude service-specific labels to prevent
+    // exit monitoring in Docker Compose, Podman Compose, etc.
     return allLabels.entrySet().stream()
-        .filter(entry -> entry.getKey().startsWith("com.docker.compose."))
+        .filter(
+            entry -> {
+              String key = entry.getKey();
+              // Docker Compose project label
+              if (key.equals("com.docker.compose.project")) return true;
+              // Podman Compose project label
+              if (key.equals("io.podman.compose.project")) return true;
+              // Custom user-defined grouping labels
+              if (customLabelKeys.contains(key)) return true;
+              return false;
+            })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -105,7 +105,7 @@ public class DockerSessionFactory implements SessionFactory {
   private final Predicate<Capabilities> predicate;
   private final Map<String, Object> hostConfig;
   private final List<String> hostConfigKeys;
-  private final Map<String, String> composeLabels;
+  private final Map<String, String> groupingLabels;
 
   public DockerSessionFactory(
       Tracer tracer,
@@ -124,7 +124,7 @@ public class DockerSessionFactory implements SessionFactory {
       Predicate<Capabilities> predicate,
       Map<String, Object> hostConfig,
       List<String> hostConfigKeys,
-      Map<String, String> composeLabels) {
+      Map<String, String> groupingLabels) {
     this.tracer = Require.nonNull("Tracer", tracer);
     this.clientFactory = Require.nonNull("HTTP client", clientFactory);
     this.sessionTimeout = Require.nonNull("Session timeout", sessionTimeout);
@@ -141,11 +141,7 @@ public class DockerSessionFactory implements SessionFactory {
     this.predicate = Require.nonNull("Accepted capabilities predicate", predicate);
     this.hostConfig = Require.nonNull("Container host config", hostConfig);
     this.hostConfigKeys = Require.nonNull("Browser container host config keys", hostConfigKeys);
-    // Merge compose labels with oneoff=False to prevent triggering --exit-code-from dynamic grid
-    Map<String, String> allLabels =
-        new HashMap<>(Require.nonNull("Docker Compose labels", composeLabels));
-    allLabels.put("com.docker.compose.oneoff", "False");
-    this.composeLabels = Collections.unmodifiableMap(allLabels);
+    this.groupingLabels = Require.nonNull("Container grouping labels", groupingLabels);
   }
 
   @Override
@@ -332,7 +328,7 @@ public class DockerSessionFactory implements SessionFactory {
             .network(networkName)
             .devices(devices)
             .applyHostConfig(hostConfig, hostConfigKeys)
-            .labels(composeLabels)
+            .labels(groupingLabels)
             .name(containerName);
     Optional<DockerAssetsPath> path = ofNullable(this.assetsPath);
     if (path.isPresent() && videoImage == null && recordVideoForSession(sessionCapabilities)) {
@@ -397,7 +393,7 @@ public class DockerSessionFactory implements SessionFactory {
             .env(envVars)
             .bind(volumeBinds)
             .network(networkName)
-            .labels(composeLabels)
+            .labels(groupingLabels)
             .name(containerName);
     if (!runningInDocker) {
       videoPort = PortProber.findFreePort();


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Continue of #16599, #16613 - manage and group dynamic containers in Dynamic Grid under a compose stack (compatible when running with Docker Compose, Podman, or other platforms based on grouping labels defined by the user).

Enhanced filtering to support multiple orchestration systems:
- Docker Compose: `com.docker.compose.project`
- Podman Compose: `io.podman.compose.project`
- User-defined grouping labels via CLI `--docker-grouping-labels` or TOML config key `grouping-labels`

✅ Platform agnostic - Works with any container orchestration system
✅ User configurable - No code changes needed for new platforms
✅ Backward compatible - Existing setups continue to work
✅ Flexible - Supports multiple custom labels simultaneously
✅ Safe - Only project labels are copied, service labels are excluded

Makes the Dynamic Grid Docker integration truly platform-independent and ready for any container orchestration system.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable grouping labels for Docker containers

- Support multiple orchestration systems (Docker Compose, Podman Compose)

- Allow user-defined custom labels via CLI and TOML config

- Filter and apply only project-level labels to containers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DockerFlags"] -->|"adds grouping-labels parameter"| B["DockerOptions"]
  B -->|"reads custom labels from config"| C["getGroupingLabels"]
  C -->|"filters Docker/Podman/custom labels"| D["DockerSessionFactory"]
  D -->|"applies labels to containers"| E["Browser & Video Containers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DockerFlags.java</strong><dd><code>Add CLI parameter for custom grouping labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerFlags.java

<ul><li>Add new <code>--docker-grouping-labels</code> CLI parameter<br> <li> Support TOML config key <code>grouping-labels</code><br> <li> Allow users to specify custom labels for container grouping<br> <li> Example labels: <code>azure.container.group</code>, <code>aws.ecs.cluster</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16620/files#diff-73c455146a4c6b8003174819c76874c0ea3f8d8e03874d447a4612145cdffb5e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DockerOptions.java</strong><dd><code>Enhance label filtering for multiple orchestration systems</code></dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerOptions.java

<ul><li>Rename <code>getComposeLabels()</code> to <code>getGroupingLabels()</code> for clarity<br> <li> Enhance filtering to support Docker Compose, Podman Compose, and <br>custom labels<br> <li> Read custom label keys from configuration<br> <li> Filter labels to include only project identifiers, excluding <br>service-specific labels<br> <li> Update method calls to use new naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16620/files#diff-5a4e578c5c5711a9b26d92a059bfe58b426177f8d2fc68aaaa79cd0fbef456bd">+21/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerSessionFactory.java</strong><dd><code>Refactor to use generic grouping labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java

<ul><li>Rename <code>composeLabels</code> field to <code>groupingLabels</code> throughout class<br> <li> Remove hardcoded <code>com.docker.compose.oneoff=False</code> label logic<br> <li> Simplify label handling to use filtered grouping labels directly<br> <li> Update constructor and container creation methods</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16620/files#diff-a05d31304c9c75c40d9d11ef388a2c669f1f8c35e943ed8dcbc32e1da7694c5e">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

