### PR TITLE
[py][bidi] Allow resetting viewport

### DIFF
--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -1002,15 +1002,15 @@ class BrowsingContext:
             ValueError: If both `contexts` and `user_contexts` are used
         """
 
-        if contexts is not None and user_contexts is not None:
-            raise ValueError("Cannot specify both contexts and user_contexts")
+        if context is not None and user_contexts is not None:
+            raise ValueError("Cannot specify both context and user_contexts")
 
-        if contexts is None and user_contexts is None:
-            raise ValueError("Must specify either contexts or user_contexts")
+        if context is None and user_contexts is None:
+            raise ValueError("Must specify either context or user_contexts")
 
         params: dict[str, Any] = {}
-        if contexts is not None:
-            params["contexts"] = contexts
+        if context is not None:
+            params["context"] = context
         elif user_contexts is not None:
             params["userContexts"] = user_contexts
         if viewport is UNDEFINED:

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -992,14 +992,14 @@ class BrowsingContext:
 
         Args:
             context: The browsing context ID.
-            viewport: The viewport parameters (`None` resets to default).
-            device_pixel_ratio: The device pixel ratio (`None` resets default).
+            viewport: The viewport parameters - {"width": <int>, "height": <int>} (`None` resets to default).
+            device_pixel_ratio: The device pixel ratio (`None` resets to default).
             user_contexts: The user context IDs.
 
         Raises:
             Exception: If the browsing context is not a top-level traversable
-            ValueError: If neither `contexts` or `user_contexts` are used
-            ValueError: If both `contexts` and `user_contexts` are used
+            ValueError: If neither `context` nor `user_contexts` is provided
+            ValueError: If both `context` and `user_contexts` are provided
         """
         if context is not None and user_contexts is not None:
             raise ValueError("Cannot specify both context and user_contexts")

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -1012,17 +1012,9 @@ class BrowsingContext:
             params["context"] = context
         elif user_contexts is not None:
             params["userContexts"] = user_contexts
-        if viewport is UNDEFINED:
-            pass
-        elif viewport is None:
-            params["viewport"] = None
-        else:
+        if viewport is not UNDEFINED:
             params["viewport"] = viewport
-        if device_pixel_ratio is UNDEFINED:
-            pass
-        elif device_pixel_ratio is None:
-            params["devicePixelRatio"] = None
-        else:
+        if device_pixel_ratio is not UNDEFINED:
             params["devicePixelRatio"] = device_pixel_ratio
 
         self.conn.execute(command_builder("browsingContext.setViewport", params))

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -20,8 +20,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from typing_extensions import Sentinel
+
 from selenium.webdriver.common.bidi.common import command_builder
 from selenium.webdriver.common.bidi.session import Session
+
+UNDEFINED = Sentinel("UNDEFINED")
 
 
 class ReadinessState:
@@ -980,16 +984,16 @@ class BrowsingContext:
     def set_viewport(
         self,
         context: str | None = None,
-        viewport: dict | None = None,
-        device_pixel_ratio: float | None = None,
+        viewport: dict | None | UNDEFINED = UNDEFINED,
+        device_pixel_ratio: float | UNDEFINED = UNDEFINED,
         user_contexts: list[str] | None = None,
     ) -> None:
         """Modifies specific viewport characteristics on the given top-level traversable.
 
         Args:
             context: The browsing context ID.
-            viewport: The viewport parameters.
-            device_pixel_ratio: The device pixel ratio.
+            viewport: The viewport parameters (`None` resets to default).
+            device_pixel_ratio: The device pixel ratio (`None` resets default).
             user_contexts: The user context IDs.
 
         Raises:
@@ -998,10 +1002,18 @@ class BrowsingContext:
         params: dict[str, Any] = {}
         if context is not None:
             params["context"] = context
-        if viewport is not None:
+        if viewport is UNDEFINED:
+            pass
+        elif viewport is None:
+            params["viewport"] = None
+        else:
             params["viewport"] = viewport
-        if device_pixel_ratio is not None:
-            params["devicePixelRatio"] = device_pixel_ratio
+        if device_pixel_ratio is UNDEFINED:
+            pass
+        elif device_pixel_ratio is None:
+            params["devicePixelRatio"] = None
+        else:
+            params["devicePixelRatio"] = viewport
         if user_contexts is not None:
             params["userContexts"] = user_contexts
 

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -997,11 +997,22 @@ class BrowsingContext:
             user_contexts: The user context IDs.
 
         Raises:
-            Exception: If the browsing context is not a top-level traversable.
+            Exception: If the browsing context is not a top-level traversable
+            ValueError: If neither `contexts` or `user_contexts` are used
+            ValueError: If both `contexts` and `user_contexts` are used
         """
+
+        if contexts is not None and user_contexts is not None:
+            raise ValueError("Cannot specify both contexts and user_contexts")
+
+        if contexts is None and user_contexts is None:
+            raise ValueError("Must specify either contexts or user_contexts")
+
         params: dict[str, Any] = {}
-        if context is not None:
-            params["context"] = context
+        if contexts is not None:
+            params["contexts"] = contexts
+        elif user_contexts is not None:
+            params["userContexts"] = user_contexts
         if viewport is UNDEFINED:
             pass
         elif viewport is None:
@@ -1014,8 +1025,6 @@ class BrowsingContext:
             params["devicePixelRatio"] = None
         else:
             params["devicePixelRatio"] = device_pixel_ratio
-        if user_contexts is not None:
-            params["userContexts"] = user_contexts
 
         self.conn.execute(command_builder("browsingContext.setViewport", params))
 

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -985,7 +985,7 @@ class BrowsingContext:
         self,
         context: str | None = None,
         viewport: dict | None | UNDEFINED = UNDEFINED,
-        device_pixel_ratio: float | UNDEFINED = UNDEFINED,
+        device_pixel_ratio: float | None | UNDEFINED = UNDEFINED,
         user_contexts: list[str] | None = None,
     ) -> None:
         """Modifies specific viewport characteristics on the given top-level traversable.

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -1001,7 +1001,6 @@ class BrowsingContext:
             ValueError: If neither `contexts` or `user_contexts` are used
             ValueError: If both `contexts` and `user_contexts` are used
         """
-
         if context is not None and user_contexts is not None:
             raise ValueError("Cannot specify both context and user_contexts")
 

--- a/py/selenium/webdriver/common/bidi/browsing_context.py
+++ b/py/selenium/webdriver/common/bidi/browsing_context.py
@@ -1013,7 +1013,7 @@ class BrowsingContext:
         elif device_pixel_ratio is None:
             params["devicePixelRatio"] = None
         else:
-            params["devicePixelRatio"] = viewport
+            params["devicePixelRatio"] = device_pixel_ratio
         if user_contexts is not None:
             params["userContexts"] = user_contexts
 

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -381,6 +381,31 @@ def test_set_viewport_with_device_pixel_ratio(driver, pages):
         driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
 
 
+def test_set_viewport_with_no_args_doesnt_change_values(driver, pages):
+    """Test setting the viewport with no args doesn't change viewport or device pixel ratio."""
+    context_id = driver.current_window_handle
+    driver.get(pages.url("formPage.html"))
+
+    try:
+        driver.browsing_context.set_viewport(
+            context=context_id, viewport={"width": 253, "height": 303}, device_pixel_ratio=6
+        )
+
+        driver.browsing_context.set_viewport(context=context_id)
+
+        viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
+
+        assert viewport_size[0] == 253
+        assert viewport_size[1] == 303
+
+        device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
+
+        assert device_pixel_ratio == 6
+    finally:
+        driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
+
+
+
 def test_set_viewport_back_to_default(driver, pages):
     """Test resetting the viewport and device pixel ratio to defaults."""
     context_id = driver.current_window_handle
@@ -391,7 +416,7 @@ def test_set_viewport_back_to_default(driver, pages):
 
     try:
         driver.browsing_context.set_viewport(
-            context=context_id, viewport={"width": 253, "height": 303}, device_pixel_ratio=10
+            context=context_id, viewport={"width": 254, "height": 304}, device_pixel_ratio=10
         )
 
         driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -405,7 +405,6 @@ def test_set_viewport_with_no_args_doesnt_change_values(driver, pages):
         driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
 
 
-
 def test_set_viewport_back_to_default(driver, pages):
     """Test resetting the viewport and device pixel ratio to defaults."""
     context_id = driver.current_window_handle

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -348,12 +348,15 @@ def test_set_viewport(driver, pages):
     context_id = driver.current_window_handle
     driver.get(pages.url("formPage.html"))
 
-    driver.browsing_context.set_viewport(context=context_id, viewport={"width": 250, "height": 300})
+    try:
+        driver.browsing_context.set_viewport(context=context_id, viewport={"width": 251, "height": 301})
 
-    viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
+        viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
 
-    assert viewport_size[0] == 250
-    assert viewport_size[1] == 300
+        assert viewport_size[0] == 251
+        assert viewport_size[1] == 301
+    finally:
+        driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
 
 
 def test_set_viewport_with_device_pixel_ratio(driver, pages):
@@ -361,18 +364,46 @@ def test_set_viewport_with_device_pixel_ratio(driver, pages):
     context_id = driver.current_window_handle
     driver.get(pages.url("formPage.html"))
 
-    driver.browsing_context.set_viewport(
-        context=context_id, viewport={"width": 250, "height": 300}, device_pixel_ratio=5
-    )
+    try:
+        driver.browsing_context.set_viewport(
+            context=context_id, viewport={"width": 252, "height": 302}, device_pixel_ratio=5
+        )
 
-    viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
+        viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
 
-    assert viewport_size[0] == 250
-    assert viewport_size[1] == 300
+        assert viewport_size[0] == 252
+        assert viewport_size[1] == 302
 
-    device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
+        device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
 
-    assert device_pixel_ratio == 5
+        assert device_pixel_ratio == 5
+    finally:
+        driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
+
+
+def test_set_viewport_back_to_default(driver, pages):
+    """Test resetting the viewport and device pixel ratio to defaults."""
+    context_id = driver.current_window_handle
+    driver.get(pages.url("formPage.html"))
+
+    default_viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
+    default_device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
+
+    try:
+        driver.browsing_context.set_viewport(
+            context=context_id, viewport={"width": 253, "height": 303}, device_pixel_ratio=10
+        )
+
+        driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
+
+        viewport_size = driver.execute_script("return [window.innerWidth, window.innerHeight];")
+        device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
+
+        assert viewport_size[0] == default_viewport_size[0]
+        assert viewport_size[1] == default_viewport_size[0]
+        assert device_pixel_ratio == default_device_pixel_ratio
+    finally:
+        driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)
 
 
 def test_print_page(driver, pages):

--- a/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py
@@ -400,7 +400,7 @@ def test_set_viewport_back_to_default(driver, pages):
         device_pixel_ratio = driver.execute_script("return window.devicePixelRatio")
 
         assert viewport_size[0] == default_viewport_size[0]
-        assert viewport_size[1] == default_viewport_size[0]
+        assert viewport_size[1] == default_viewport_size[1]
         assert device_pixel_ratio == default_device_pixel_ratio
     finally:
         driver.browsing_context.set_viewport(context=context_id, viewport=None, device_pixel_ratio=None)


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Fixes: #16622
Also see: ##16601 and https://github.com/w3c/webdriver-bidi/issues/1039

### 💥 What does this PR do?

The BiDi spec allows you to reset the viewport size and device pixel ratio by sending `"viewport": null` or `"devicePixelRatio": null`:

https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport

This PR accomplishes that by sending `"viewport": null` or `"devicePixelRatio": null`, when the arguments to `set_viewport()` are explicitly set to `None`.

For example:

```
set_viewport(viewport=None)
set_viewport(device_pixel_ratio=None)
set_viewport(viewport=None, device_pixel_ratio=None)
```

If either argument is not passed, the behavior remains the same as before (`viewport` and/or `devicePixelRatio` is not included in the JSON command payload).

This PR also includes a test for this and updates the other viewport tests to reset the viewport and device pixel ratio to default values in their teardown so they don't affect other tests.

### 🔧 Implementation Notes

To differentiate between being invoked with the arguments set to `None` and not being provided, I used a sentinel value as the default for the keyword args. Python doesn't have a built-in utility for defining sentinel values (it may someday, see PEP661: https://peps.python.org/pep-0661/), so rather than writing my own, I used 
the `Sentinel` class from `typing_extensions` (we already include this as a dependency): https://typing-extensions.readthedocs.io/en/latest/#sentinel-objects

### 🔄 Types of changes
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Allow resetting viewport and device pixel ratio to defaults via `None`

- Use sentinel value to differentiate explicit `None` from unspecified arguments

- Add comprehensive tests for viewport reset functionality

- Update existing tests with teardown to reset viewport state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set_viewport arguments"] -->|UNDEFINED sentinel| B["Skip parameter"]
  A -->|None value| C["Send null to BiDi"]
  A -->|dict/float value| D["Send value to BiDi"]
  C --> E["Reset to defaults"]
  D --> F["Apply custom settings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browsing_context.py</strong><dd><code>Implement viewport reset with sentinel value pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/browsing_context.py

<ul><li>Import <code>Sentinel</code> from <code>typing_extensions</code> and define <code>UNDEFINED</code> sentinel <br>value<br> <li> Update <code>set_viewport()</code> method signature to use sentinel defaults for <br><code>viewport</code> and <code>device_pixel_ratio</code> parameters<br> <li> Implement conditional logic to differentiate between unspecified <br>arguments (UNDEFINED), explicit <code>None</code> (reset), and actual values<br> <li> Update docstrings to clarify that <code>None</code> resets parameters to defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16623/files#diff-a65d02c951aeb477672aa52e5eb0106645ba869aa186c0af6d2672c42cac95c6">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bidi_browsing_context_tests.py</strong><dd><code>Add viewport reset tests and cleanup test teardowns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/common/bidi_browsing_context_tests.py

<ul><li>Add try-finally blocks to existing viewport tests to reset viewport <br>state in teardown<br> <li> Update test values to be unique (251x301, 252x302) to distinguish test <br>cases<br> <li> Add new <code>test_set_viewport_back_to_default()</code> test to verify reset <br>functionality<br> <li> Verify that passing <code>None</code> restores default viewport and device pixel <br>ratio values</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16623/files#diff-cea00ba1c71fd6f4ca93d87f14bcc291e1b87383cd61cd1bf1eec678e8d9efbf">+43/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

