### PR TITLE
[dotnet] Simplify nuget package reference in Bazel

### DIFF
--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -1,11 +1,11 @@
 load("@rules_dotnet//dotnet:defs.bzl", _csharp_binary = "csharp_binary", _csharp_library = "csharp_library", _csharp_test = "csharp_test")
 load("//dotnet:selenium-dotnet-version.bzl", "SUPPORTED_DEVTOOLS_VERSIONS")
 load("//dotnet/private:dotnet_nunit_test_suite.bzl", _dotnet_nunit_test_suite = "dotnet_nunit_test_suite")
-load("//dotnet/private:nuget_package.bzl", _nuget_package = "nuget_package")
 load("//dotnet/private:generate_devtools.bzl", _generate_devtools = "generate_devtools")
 load("//dotnet/private:generate_resources.bzl", _generated_resource_utilities = "generated_resource_utilities")
 load("//dotnet/private:generated_assembly_info.bzl", _generated_assembly_info = "generated_assembly_info")
 load("//dotnet/private:nuget_pack.bzl", _nuget_pack = "nuget_pack")
+load("//dotnet/private:nuget_package.bzl", _nuget_package = "nuget_package")
 load("//dotnet/private:nunit_test.bzl", _nunit_test = "nunit_test")
 
 def devtools_version_targets():
@@ -18,9 +18,9 @@ csharp_binary = _csharp_binary
 csharp_library = _csharp_library
 csharp_test = _csharp_test
 dotnet_nunit_test_suite = _dotnet_nunit_test_suite
-nuget_package = _nuget_package
 generate_devtools = _generate_devtools
 generated_resource_utilities = _generated_resource_utilities
 generated_assembly_info = _generated_assembly_info
 nuget_pack = _nuget_pack
+nuget_package = _nuget_package
 nunit_test = _nunit_test

--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -1,7 +1,7 @@
 load("@rules_dotnet//dotnet:defs.bzl", _csharp_binary = "csharp_binary", _csharp_library = "csharp_library", _csharp_test = "csharp_test")
 load("//dotnet:selenium-dotnet-version.bzl", "SUPPORTED_DEVTOOLS_VERSIONS")
 load("//dotnet/private:dotnet_nunit_test_suite.bzl", _dotnet_nunit_test_suite = "dotnet_nunit_test_suite")
-load("//dotnet/private:framework.bzl", _framework = "framework")
+load("//dotnet/private:nuget_package.bzl", _nuget_package = "nuget_package")
 load("//dotnet/private:generate_devtools.bzl", _generate_devtools = "generate_devtools")
 load("//dotnet/private:generate_resources.bzl", _generated_resource_utilities = "generated_resource_utilities")
 load("//dotnet/private:generated_assembly_info.bzl", _generated_assembly_info = "generated_assembly_info")
@@ -18,7 +18,7 @@ csharp_binary = _csharp_binary
 csharp_library = _csharp_library
 csharp_test = _csharp_test
 dotnet_nunit_test_suite = _dotnet_nunit_test_suite
-framework = _framework
+nuget_package = _nuget_package
 generate_devtools = _generate_devtools
 generated_resource_utilities = _generated_resource_utilities
 generated_assembly_info = _generated_assembly_info

--- a/dotnet/private/framework.bzl
+++ b/dotnet/private/framework.bzl
@@ -1,2 +1,0 @@
-def framework(framework_moniker, name):
-    return "@paket.%s//%s" % (framework_moniker, name.lower())

--- a/dotnet/private/nuget_package.bzl
+++ b/dotnet/private/nuget_package.bzl
@@ -1,0 +1,2 @@
+def nuget_package(nuget_package):
+    return "@paket.nuget//%s" % (nuget_package.lower())

--- a/dotnet/private/nunit_test.bzl
+++ b/dotnet/private/nunit_test.bzl
@@ -1,12 +1,12 @@
 load("@rules_dotnet//dotnet:defs.bzl", "csharp_test")
-load("//dotnet/private:framework.bzl", "framework")
+load("//dotnet/private:nuget_package.bzl", "nuget_package")
 
 def nunit_test(name, srcs = [], deps = [], **kwargs):
     csharp_test(
         name = name,
         srcs = srcs + ["@rules_dotnet//dotnet/private/rules/common/nunit:shim.cs"],
         deps = deps + [
-            framework("nuget", "NUnitLite"),
+            nuget_package("NUnitLite"),
         ],
         **kwargs
     )

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//common:defs.bzl", "copy_file")
-load("//dotnet:defs.bzl", "csharp_library", "devtools_version_targets", "nuget_package", "generated_assembly_info", "generated_resource_utilities", "nuget_pack")
+load("//dotnet:defs.bzl", "csharp_library", "devtools_version_targets", "generated_assembly_info", "generated_resource_utilities", "nuget_pack", "nuget_package")
 load(
     "//dotnet:selenium-dotnet-version.bzl",
     "ASSEMBLY_COMPANY",

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//common:defs.bzl", "copy_file")
-load("//dotnet:defs.bzl", "csharp_library", "devtools_version_targets", "framework", "generated_assembly_info", "generated_resource_utilities", "nuget_pack")
+load("//dotnet:defs.bzl", "csharp_library", "devtools_version_targets", "nuget_package", "generated_assembly_info", "generated_resource_utilities", "nuget_pack")
 load(
     "//dotnet:selenium-dotnet-version.bzl",
     "ASSEMBLY_COMPANY",
@@ -61,13 +61,13 @@ csharp_library(
         "//dotnet:__subpackages__",
     ],
     deps = [
-        framework("nuget", "NETStandard.Library"),
-        framework("nuget", "Microsoft.Bcl.AsyncInterfaces"),
-        framework("nuget", "System.Threading.Tasks.Extensions"),
-        framework("nuget", "System.Memory"),
-        framework("nuget", "System.Runtime.CompilerServices.Unsafe"),
-        framework("nuget", "System.Text.Encodings.Web"),
-        framework("nuget", "System.Text.Json"),
+        nuget_package("NETStandard.Library"),
+        nuget_package("Microsoft.Bcl.AsyncInterfaces"),
+        nuget_package("System.Threading.Tasks.Extensions"),
+        nuget_package("System.Memory"),
+        nuget_package("System.Runtime.CompilerServices.Unsafe"),
+        nuget_package("System.Text.Encodings.Web"),
+        nuget_package("System.Text.Json"),
     ],
 )
 
@@ -119,13 +119,13 @@ csharp_library(
         "//dotnet:__subpackages__",
     ],
     deps = [
-        framework("nuget", "NETStandard.Library"),
-        framework("nuget", "Microsoft.Bcl.AsyncInterfaces"),
-        framework("nuget", "System.Threading.Tasks.Extensions"),
-        framework("nuget", "System.Memory"),
-        framework("nuget", "System.Runtime.CompilerServices.Unsafe"),
-        framework("nuget", "System.Text.Encodings.Web"),
-        framework("nuget", "System.Text.Json"),
+        nuget_package("NETStandard.Library"),
+        nuget_package("Microsoft.Bcl.AsyncInterfaces"),
+        nuget_package("System.Threading.Tasks.Extensions"),
+        nuget_package("System.Memory"),
+        nuget_package("System.Runtime.CompilerServices.Unsafe"),
+        nuget_package("System.Text.Encodings.Web"),
+        nuget_package("System.Text.Json"),
     ],
 )
 

--- a/dotnet/test/common/BUILD.bazel
+++ b/dotnet/test/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "csharp_library", "dotnet_nunit_test_suite", "framework")
+load("//dotnet:defs.bzl", "csharp_library", "dotnet_nunit_test_suite", "nuget_package")
 
 filegroup(
     name = "assembly-fixtures",
@@ -52,9 +52,9 @@ csharp_library(
     ],
     deps = [
         "//dotnet/src/webdriver:webdriver-net8.0",
-        framework("nuget", "Newtonsoft.Json"),
-        framework("nuget", "NUnit"),
-        framework("nuget", "Runfiles"),
+        nuget_package("Newtonsoft.Json"),
+        nuget_package("NUnit"),
+        nuget_package("Runfiles"),
     ],
 )
 
@@ -90,9 +90,9 @@ dotnet_nunit_test_suite(
     deps = [
         ":fixtures",
         "//dotnet/src/webdriver:webdriver-net8.0",
-        framework("nuget", "BenderProxy"),
-        framework("nuget", "Newtonsoft.Json"),
-        framework("nuget", "NUnit"),
-        framework("nuget", "Runfiles"),
+        nuget_package("BenderProxy"),
+        nuget_package("Newtonsoft.Json"),
+        nuget_package("NUnit"),
+        nuget_package("Runfiles"),
     ],
 )

--- a/dotnet/test/firefox/BUILD.bazel
+++ b/dotnet/test/firefox/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "framework")
+load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 
 dotnet_nunit_test_suite(
     name = "LargeTests",
@@ -22,6 +22,6 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "NUnit"),
+        nuget_package("NUnit"),
     ],
 )

--- a/dotnet/test/support/Events/BUILD.bazel
+++ b/dotnet/test/support/Events/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "framework")
+load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 
 SMALL_TESTS = [
     "EventFiringWebDriverTest.cs",
@@ -13,8 +13,8 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "NUnit"),
-        framework("nuget", "Moq"),
+        nuget_package("NUnit"),
+        nuget_package("Moq"),
     ],
 )
 
@@ -38,6 +38,6 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "NUnit"),
+        nuget_package("NUnit"),
     ],
 )

--- a/dotnet/test/support/Extensions/BUILD.bazel
+++ b/dotnet/test/support/Extensions/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "framework")
+load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 
 dotnet_nunit_test_suite(
     name = "SmallTests",
@@ -9,7 +9,7 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "Moq"),
-        framework("nuget", "NUnit"),
+        nuget_package("Moq"),
+        nuget_package("NUnit"),
     ],
 )

--- a/dotnet/test/support/UI/BUILD.bazel
+++ b/dotnet/test/support/UI/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "framework")
+load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 
 SMALL_TESTS = [
     "DefaultWaitTest.cs",
@@ -18,8 +18,8 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "NUnit"),
-        framework("nuget", "Moq"),
+        nuget_package("NUnit"),
+        nuget_package("Moq"),
     ],
 )
 
@@ -46,6 +46,6 @@ dotnet_nunit_test_suite(
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
-        framework("nuget", "NUnit"),
+        nuget_package("NUnit"),
     ],
 )

--- a/third_party/dotnet/devtools/src/generator/BUILD.bazel
+++ b/third_party/dotnet/devtools/src/generator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//dotnet:defs.bzl", "csharp_binary", "framework")
+load("//dotnet:defs.bzl", "csharp_binary", "nuget_package")
 
 csharp_binary(
     name = "generator",
@@ -10,10 +10,10 @@ csharp_binary(
         "//dotnet:__subpackages__",
     ],
     deps = [
-        framework("nuget", "CommandLineParser"),
-        framework("nuget", "Handlebars.Net"),
-        framework("nuget", "Humanizer.Core"),
-        framework("nuget", "Microsoft.Extensions.DependencyInjection"),
-        framework("nuget", "Microsoft.Extensions.DependencyInjection.Abstractions"),
+        nuget_package("CommandLineParser"),
+        nuget_package("Handlebars.Net"),
+        nuget_package("Humanizer.Core"),
+        nuget_package("Microsoft.Extensions.DependencyInjection"),
+        nuget_package("Microsoft.Extensions.DependencyInjection.Abstractions"),
     ],
 )


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

All references to `framework` pass in `"nuget"` as its first argument. We can simplify and self-document what the method means.

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Rename `framework()` function to `nuget_package()` for clarity

- Remove hardcoded "nuget" parameter from function signature

- Update all call sites across dotnet build files

- Delete old `framework.bzl` file and create new `nuget_package.bzl`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["framework.bzl<br/>framework(framework_moniker, name)"] -->|Refactor| B["nuget_package.bzl<br/>nuget_package(nuget_package)"]
  B -->|Update imports| C["defs.bzl"]
  C -->|Propagate changes| D["Multiple BUILD.bazel files"]
  D -->|Replace calls| E["nuget_package() calls"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>defs.bzl</strong><dd><code>Update imports from framework to nuget_package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-0846f178a64aa8555e4c6ce6fe66d46f5eb388fd67747724e590fdafdf199b80">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nunit_test.bzl</strong><dd><code>Replace framework calls with nuget_package calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-d45723608650fc38a5e69f1a3efa99ecfedd90d82dc1a67391073751b2ed2ca5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Update all NuGet package references to use nuget_package</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Replace framework function with nuget_package throughout</code>&nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-42c4bbda3788fb91b43ddd7ed9dce8876478e3d5dac2eb88274d6bdc184ff625">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Update NuGet package references in firefox tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-cb9faadb9b4293cdb8a46ef9727345f74ebf9c150317ebbbafc7d04770cdd418">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Replace framework calls with nuget_package in events tests</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-a5affd36ee0eda1f349800ba3a1571f4e811250f3d178a288684596edf7644cd">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Update NuGet references in extensions test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-ae83b5ba573ae081b9fb064a706b35e93d3745f94b05c67f45ab874361abcca7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Replace framework function with nuget_package in UI tests</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-66f883a033ce4cc34758f1e323b40da21349c346d6fd6ed81f126b7f0ac276a8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Update devtools generator NuGet package references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-0495076ce05d4136fe6e50f99d579100367509c07e27a02deb5f8a1ce0b735c5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Cleanup</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>framework.bzl</strong><dd><code>Delete deprecated framework function definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-4316c9b74fb76c0a09f285c270d37ffb6daeee358b12a914fe2925eefd5660b6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>nuget_package.bzl</strong><dd><code>Create new nuget_package function with simplified signature</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16630/files#diff-241d5b8f1adc56e8617baf4a3fcd5f0e83d3279e005cb89836282be8a1c3bdc9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

