### PR TITLE
[py] Use f-string in generate.py

### DIFF
--- a/py/generate.py
+++ b/py/generate.py
@@ -233,7 +233,7 @@ class CdpProperty:
                 py_ref = ref_to_python(self.items.ref)
                 ann = f"typing.List[{py_ref}]"
             else:
-                ann = "typing.List[{}]".format(CdpPrimitiveType.get_annotation(self.items.type))
+                ann = f"typing.List[{CdpPrimitiveType.get_annotation(self.items.type)}]"
         else:
             if self.ref:
                 py_ref = ref_to_python(self.ref)


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR updates `generate.py` to use an f-string instead of the older `format()` syntax for string formatting.

With this change, all Python files under `./py/` are upgraded to Python 3.10+ syntax using pyupgrade: https://github.com/asottile/pyupgrade

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Convert string formatting from `.format()` to f-string syntax

- Modernize Python code to use Python 3.10+ conventions

- Improve code readability and consistency across codebase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old format() syntax"] -- "pyupgrade conversion" --> B["Modern f-string syntax"]
  B -- "improves" --> C["Code readability & consistency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate.py</strong><dd><code>Convert format() to f-string in type annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/generate.py

<ul><li>Replaced <code>.format()</code> method call with f-string in <code>py_annotation</code> property<br> <li> Updated line 232 to use f-string for <code>typing.List</code> type annotation <br>formatting<br> <li> Maintains identical functionality while improving code style</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16641/files#diff-197acd5304c91406cc4a12818c1694fe525f0efb718a12996516b082c29345f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

