### PR TITLE
#16645 switch DevTools connection between tabs/windows

### DIFF
--- a/java/src/org/openqa/selenium/devtools/DevTools.java
+++ b/java/src/org/openqa/selenium/devtools/DevTools.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -31,6 +32,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.devtools.idealized.Domains;
 import org.openqa.selenium.devtools.idealized.target.model.SessionID;
@@ -44,7 +47,8 @@ public class DevTools implements Closeable {
   private final Domains protocol;
   private final Duration timeout = Duration.ofSeconds(30);
   private final Connection connection;
-  private SessionID cdpSession = null;
+  private volatile String windowHandle;
+  private volatile SessionID cdpSession;
 
   public DevTools(Function<DevTools, Domains> protocol, Connection connection) {
     this.connection = Require.nonNull("WebSocket connection", connection);
@@ -73,6 +77,8 @@ public class DevTools implements Closeable {
 
       SessionID id = cdpSession;
       cdpSession = null;
+      windowHandle = null;
+
       try {
         connection.sendAndWait(
             cdpSession,
@@ -132,17 +138,20 @@ public class DevTools implements Closeable {
   }
 
   public void createSessionIfThereIsNotOne() {
-    createSessionIfThereIsNotOne(null);
+    createSessionIfThereIsNotOne(windowHandle);
   }
 
-  public void createSessionIfThereIsNotOne(String windowHandle) {
+  public void createSessionIfThereIsNotOne(@Nullable String windowHandle) {
     if (cdpSession == null) {
       createSession(windowHandle);
+    } else if (!Objects.equals(this.windowHandle, windowHandle)) {
+      disconnectSession();
+      attachToWindow(windowHandle);
     }
   }
 
   public void createSession() {
-    createSession(null);
+    createSession(windowHandle);
   }
 
   /**
@@ -152,12 +161,20 @@ public class DevTools implements Closeable {
    *
    * @param windowHandle result of {@link WebDriver#getWindowHandle()}, optional.
    */
-  public void createSession(String windowHandle) {
+  public void createSession(@Nullable String windowHandle) {
     if (connection.isClosed()) {
       connection.reopen();
     }
-    TargetID targetId = findTarget(windowHandle);
+    attachToWindow(windowHandle);
+  }
 
+  private void attachToWindow(String windowHandle) {
+    TargetID targetId = findTarget(windowHandle);
+    attachToTarget(targetId);
+    this.windowHandle = windowHandle;
+  }
+
+  private void attachToTarget(TargetID targetId) {
     // Starts the session
     // CDP creates a parent browser session when websocket connection is made
     // Create session that is child of parent browser session and not child of already existing
@@ -193,6 +210,7 @@ public class DevTools implements Closeable {
     }
   }
 
+  @NonNull
   private TargetID findTarget(String windowHandle) {
     // Figure out the targets.
     List<TargetInfo> infos =

--- a/java/src/org/openqa/selenium/devtools/DevTools.java
+++ b/java/src/org/openqa/selenium/devtools/DevTools.java
@@ -222,7 +222,7 @@ public class DevTools implements Closeable {
     return infos.stream()
         .filter(info -> "page".equals(info.getType()))
         .map(TargetInfo::getTargetId)
-        .filter(id -> windowHandle == null || windowHandle.contains(id.toString()))
+        .filter(id -> windowHandle == null || windowHandle.endsWith(id.toString()))
         .findAny()
         .orElseThrow(() -> new DevToolsException("Unable to find target id of a page"));
   }


### PR DESCRIPTION
### **User description**
1. When `createSessionIfThereIsNotOne(tab1)` is called, CDP session is opened - and attached to the first tab.
2. When `createSessionIfThereIsNotOne(tab2)` is called, we detach connection from the first tab, and attach to the second tab (a new CDP session ID is created).


### 🔗 Related Issues
Fixes #16645



### 🔧 Implementation Notes
Current implementation holds only one CDP session at a time.
When user wants to switch to other tab, the previous CDP session gets closed.

An alternative solution would be holding map of CDP sessions for all existing tabs.
But ChatGPT suggested that it's worth it: every `attachTarget` and `detachTarget` is very fast (less than 1 ms), so holding multiple sessions would not give any benefit in speed.


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Switch DevTools CDP session between tabs/windows dynamically

- Track current window handle to detect tab switches

- Disconnect from previous tab and attach to new tab

- Refactor session attachment logic into separate methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["createSessionIfThereIsNotOne<br/>with windowHandle"] -->|"cdpSession == null"| B["createSession"]
  A -->|"windowHandle changed"| C["disconnectSession"]
  C --> D["attachToWindow"]
  B --> D
  D --> E["findTarget"]
  E --> F["attachToTarget"]
  F --> G["CDP Session Active<br/>on new tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DevTools.java</strong><dd><code>Implement dynamic DevTools tab switching with session management</code></dd></summary>
<hr>

java/src/org/openqa/selenium/devtools/DevTools.java

<ul><li>Added <code>windowHandle</code> field to track current tab/window connection<br> <li> Enhanced <code>createSessionIfThereIsNotOne()</code> to detect tab switches and <br>reconnect<br> <li> Refactored session attachment logic into separate <code>attachToWindow()</code> and <br><code>attachToTarget()</code> methods<br> <li> Added <code>@Nullable</code> and <code>@NonNull</code> annotations for better null-safety<br> <li> Clear <code>windowHandle</code> when disconnecting session</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16647/files#diff-b48878c5792d2d457709d97741d3538ee53f19e639b38ba148600277ac6a5f66">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

