### PR TITLE
[dotnet] [bidi] Immediately start to listen to incoming remote messages

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -61,7 +61,7 @@ public sealed class Broker : IAsyncDisposable
         await _transport.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
         _receiveMessagesCancellationTokenSource = new CancellationTokenSource();
-        _receivingMessageTask = _myTaskFactory.StartNew(async () => await ReceiveMessagesAsync(_receiveMessagesCancellationTokenSource.Token)).Unwrap();
+        _receivingMessageTask = _myTaskFactory.StartNew(async () => await ReceiveMessagesAsync(_receiveMessagesCancellationTokenSource.Token), TaskCreationOptions.LongRunning).Unwrap();
         _eventEmitterTask = _myTaskFactory.StartNew(ProcessEventsAwaiterAsync).Unwrap();
     }
 


### PR DESCRIPTION
### **User description**
Performance optimization.

### 💥 What does this PR do?


### 🔧 Implementation Notes
`Task` for listening to incoming messages as LongRunning, meaning CLR will allocate new thread as fast as possible.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Add TaskCreationOptions.LongRunning to BiDi message receiver

- Enables CLR to allocate thread immediately for incoming messages

- Improves performance of remote message listening


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StartNew without LongRunning"] -->|"Add TaskCreationOptions.LongRunning"| B["StartNew with LongRunning"]
  B -->|"Result"| C["Immediate thread allocation for message receiving"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Add LongRunning option to message receiver task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Broker.cs

<ul><li>Added <code>TaskCreationOptions.LongRunning</code> parameter to <br><code>_myTaskFactory.StartNew()</code> call<br> <li> Signals CLR to allocate a new thread immediately for the message <br>receiving task<br> <li> Improves performance by avoiding thread pool delays for long-running <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16651/files#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

