### PR TITLE
[dotnet] Move internal compiler services to Properties

### DIFF
--- a/dotnet/BUILD.bazel
+++ b/dotnet/BUILD.bazel
@@ -30,8 +30,8 @@ pkg_zip(
 filegroup(
     name = "source_files_support_needs_from_core",
     srcs = [
-        "//dotnet/src/webdriver:Internal/StringSyntaxAttribute.cs",
-        "//dotnet/src/webdriver:Internal/StringSyntaxConstants.cs",
+        "//dotnet/src/webdriver:Properties/StringSyntaxAttribute.cs",
+        "//dotnet/src/webdriver:Properties/StringSyntaxConstants.cs",
     ],
     visibility = ["__subpackages__"],
 )

--- a/dotnet/src/support/Selenium.WebDriver.Support.csproj
+++ b/dotnet/src/support/Selenium.WebDriver.Support.csproj
@@ -42,8 +42,8 @@
 
   <ItemGroup>
     <!--Workaround for being unable to have two different types of the same name in WebDriver and in Support, despite both being internal-->
-    <Compile Include="$(CsprojIncludePath)\Internal\StringSyntaxAttribute.cs" />
-    <Compile Include="$(CsprojIncludePath)\Internal\StringSyntaxConstants.cs" />
+    <Compile Include="$(CsprojIncludePath)\Properties\StringSyntaxAttribute.cs" />
+    <Compile Include="$(CsprojIncludePath)\Properties\StringSyntaxConstants.cs" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -12,8 +12,8 @@ load(
 
 exports_files([
     "WebDriver.csproj",
-    "Internal/StringSyntaxAttribute.cs",
-    "Internal/StringSyntaxConstants.cs",
+    "Properties/StringSyntaxAttribute.cs",
+    "Properties/StringSyntaxConstants.cs",
 ])
 
 generated_assembly_info(

--- a/dotnet/src/webdriver/Properties/IsExternalInit.cs
+++ b/dotnet/src/webdriver/Properties/IsExternalInit.cs
@@ -1,4 +1,4 @@
-// <copyright file="StringSyntaxConstants.cs" company="Selenium Committers">
+// <copyright file="IsExternalInit.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -17,9 +17,12 @@
 // under the License.
 // </copyright>
 
-namespace OpenQA.Selenium.Internal;
+#if !NET8_0_OR_GREATER
 
-internal static class StringSyntaxConstants
-{
-    public const string JavaScript = "javascript";
-}
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+internal static class IsExternalInit;
+
+#endif

--- a/dotnet/src/webdriver/Properties/NullableAttributes.cs
+++ b/dotnet/src/webdriver/Properties/NullableAttributes.cs
@@ -17,13 +17,14 @@
 // under the License.
 // </copyright>
 
-
 #if !NET8_0_OR_GREATER
 
 // Following polyfill guidance explained here https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/#targetframeworks
 // Original code in https://github.com/dotnet/runtime/blob/419e949d258ecee4c40a460fb09c66d974229623/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace System.Diagnostics.CodeAnalysis;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]

--- a/dotnet/src/webdriver/Properties/StringSyntaxAttribute.cs
+++ b/dotnet/src/webdriver/Properties/StringSyntaxAttribute.cs
@@ -19,7 +19,9 @@
 
 #if !NET8_0_OR_GREATER
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace System.Diagnostics.CodeAnalysis;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>Specifies the syntax used in a string.</summary>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
@@ -86,4 +88,3 @@ internal sealed class StringSyntaxAttribute : Attribute
 }
 
 #endif
-

--- a/dotnet/src/webdriver/Properties/StringSyntaxConstants.cs
+++ b/dotnet/src/webdriver/Properties/StringSyntaxConstants.cs
@@ -1,4 +1,4 @@
-// <copyright file="IsExternalInit.cs" company="Selenium Committers">
+// <copyright file="StringSyntaxConstants.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -17,6 +17,11 @@
 // under the License.
 // </copyright>
 
-namespace System.Runtime.CompilerServices;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace OpenQA.Selenium;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
-internal static class IsExternalInit;
+internal static class StringSyntaxConstants
+{
+    public const string JavaScript = "javascript";
+}

--- a/dotnet/src/webdriver/Properties/TrimmingAttributes.cs
+++ b/dotnet/src/webdriver/Properties/TrimmingAttributes.cs
@@ -21,7 +21,9 @@
 
 #if !NET8_0_OR_GREATER
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace System.Diagnostics.CodeAnalysis;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>
 /// Indicates that the specified method requires the ability to generate new code at runtime,


### PR DESCRIPTION
### **User description**
Collecting internal helpers for compiler services in one place.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Move internal compiler services to Properties folder

- Add pragma directives to suppress IDE0130 namespace warnings

- Update namespace for StringSyntaxConstants from Internal to Properties

- Update build configuration and project references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Internal Folder<br/>Compiler Services"] -->|"Move & Reorganize"| B["Properties Folder<br/>Compiler Services"]
  B -->|"Add Pragma<br/>Directives"| C["IDE0130 Warnings<br/>Suppressed"]
  D["Build Config<br/>References"] -->|"Update Paths"| E["Properties Folder<br/>References"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IsExternalInit.cs</strong><dd><code>Add pragma directives and conditional compilation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Properties/IsExternalInit.cs

<ul><li>Added conditional compilation directive <code>#if !NET8_0_OR_GREATER</code><br> <li> Added pragma directives to suppress IDE0130 namespace mismatch <br>warnings<br> <li> Wrapped namespace declaration with warning disable/restore pragmas</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-e48ca051fcdad059a7af3ab1809c6e8ed37b7e3666eb797cd51de6198c425f73">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NullableAttributes.cs</strong><dd><code>Add pragma directives for namespace warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Properties/NullableAttributes.cs

<ul><li>Removed extra blank line before conditional compilation<br> <li> Added pragma directives to suppress IDE0130 namespace warnings<br> <li> Wrapped namespace declaration with warning disable/restore pragmas</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-5bfd7d689b56512abc946a6aeeb709ecb1200c84ef7fccaf10c65c153d721e8e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StringSyntaxAttribute.cs</strong><dd><code>Add pragma directives and cleanup formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Properties/StringSyntaxAttribute.cs

<ul><li>Added pragma directives to suppress IDE0130 namespace warnings<br> <li> Wrapped namespace declaration with warning disable/restore pragmas<br> <li> Removed trailing blank line at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-3060805698bcb461cab838ec15564b0727a0f264c5efb10267884eb9b63845d6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StringSyntaxConstants.cs</strong><dd><code>Update namespace and add pragma directives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Properties/StringSyntaxConstants.cs

<ul><li>Changed namespace from <code>OpenQA.Selenium.Internal</code> to <code>OpenQA.Selenium</code><br> <li> Added pragma directives to suppress IDE0130 namespace warnings<br> <li> Wrapped namespace declaration with warning disable/restore pragmas</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-9858948d872eff09beee42d3e97da0c99e0221ad3ff39a974978b4c01e17257b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TrimmingAttributes.cs</strong><dd><code>Add pragma directives for namespace warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Properties/TrimmingAttributes.cs

<ul><li>Added pragma directives to suppress IDE0130 namespace warnings<br> <li> Wrapped namespace declaration with warning disable/restore pragmas</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-cee5ea73e7a55edfa78c2c28cf7481408541e25e98072d5836b82b28df9433ba">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update build configuration file paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/BUILD.bazel

<ul><li>Updated file references from <code>Internal/StringSyntaxAttribute.cs</code> to <br><code>Properties/StringSyntaxAttribute.cs</code><br> <li> Updated file references from <code>Internal/StringSyntaxConstants.cs</code> to <br><code>Properties/StringSyntaxConstants.cs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-8e75219e968f5da47dee9789ba5f72083b23b96495163c10dac06ecb93464115">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.Support.csproj</strong><dd><code>Update project file paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/support/Selenium.WebDriver.Support.csproj

<ul><li>Updated compile include paths from <code>Internal\StringSyntaxAttribute.cs</code> <br>to <code>Properties\StringSyntaxAttribute.cs</code><br> <li> Updated compile include paths from <code>Internal\StringSyntaxConstants.cs</code> <br>to <code>Properties\StringSyntaxConstants.cs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-c47914c668153e4cc2132950844b3345537bed59aedd69a713add9f617a7c5c6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Update build exports file paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BUILD.bazel

<ul><li>Updated exports_files references from <br><code>Internal/StringSyntaxAttribute.cs</code> to <br><code>Properties/StringSyntaxAttribute.cs</code><br> <li> Updated exports_files references from <br><code>Internal/StringSyntaxConstants.cs</code> to <br><code>Properties/StringSyntaxConstants.cs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16653/files#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

