### PR TITLE
[dotnet] Annotate JavaScript strings within BiDi

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
@@ -17,14 +17,16 @@
 // under the License.
 // </copyright>
 
-using System.Threading.Tasks;
 using OpenQA.Selenium.BiDi.Script;
+using OpenQA.Selenium.Internal;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
 public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptModule scriptModule)
 {
-    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync(string functionDeclaration, BrowsingContextAddPreloadScriptOptions? options = null)
+    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, BrowsingContextAddPreloadScriptOptions? options = null)
     {
         AddPreloadScriptOptions addPreloadScriptOptions = new(options)
         {
@@ -43,7 +45,7 @@ public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptM
         return await scriptModule.GetRealmsAsync(options).ConfigureAwait(false);
     }
 
-    public Task<EvaluateResult> EvaluateAsync(string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public Task<EvaluateResult> EvaluateAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var contextTarget = new ContextTarget(context);
 
@@ -55,14 +57,14 @@ public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptM
         return scriptModule.EvaluateAsync(expression, awaitPromise, contextTarget, options);
     }
 
-    public async Task<TResult?> EvaluateAsync<TResult>(string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public async Task<TResult?> EvaluateAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var result = await EvaluateAsync(expression, awaitPromise, options, targetOptions).ConfigureAwait(false);
 
         return result.AsSuccessResult().ConvertTo<TResult>();
     }
 
-    public Task<EvaluateResult> CallFunctionAsync(string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public Task<EvaluateResult> CallFunctionAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var contextTarget = new ContextTarget(context);
 
@@ -74,7 +76,7 @@ public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptM
         return scriptModule.CallFunctionAsync(functionDeclaration, awaitPromise, contextTarget, options);
     }
 
-    public async Task<TResult?> CallFunctionAsync<TResult>(string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
+    public async Task<TResult?> CallFunctionAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null)
     {
         var result = await CallFunctionAsync(functionDeclaration, awaitPromise, options, targetOptions).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -17,14 +17,16 @@
 // under the License.
 // </copyright>
 
+using OpenQA.Selenium.Internal;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenQA.Selenium.BiDi.Script;
 
 internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params)
     : Command<AddPreloadScriptParameters, AddPreloadScriptResult>(@params, "script.addPreloadScript");
 
-internal sealed record AddPreloadScriptParameters(string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : Parameters;
+internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : Parameters;
 
 public sealed class AddPreloadScriptOptions : CommandOptions
 {

--- a/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
@@ -17,14 +17,16 @@
 // under the License.
 // </copyright>
 
+using OpenQA.Selenium.Internal;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenQA.Selenium.BiDi.Script;
 
 internal sealed class CallFunctionCommand(CallFunctionParameters @params)
     : Command<CallFunctionParameters, EvaluateResult>(@params, "script.callFunction");
 
-internal sealed record CallFunctionParameters(string FunctionDeclaration, bool AwaitPromise, Target Target, IEnumerable<LocalValue>? Arguments, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, LocalValue? This, bool? UserActivation) : Parameters;
+internal sealed record CallFunctionParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, bool AwaitPromise, Target Target, IEnumerable<LocalValue>? Arguments, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, LocalValue? This, bool? UserActivation) : Parameters;
 
 public sealed class CallFunctionOptions : CommandOptions
 {

--- a/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
@@ -18,7 +18,9 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Json.Converters.Polymorphic;
+using OpenQA.Selenium.Internal;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Script;
@@ -26,7 +28,7 @@ namespace OpenQA.Selenium.BiDi.Script;
 internal sealed class EvaluateCommand(EvaluateParameters @params)
     : Command<EvaluateParameters, EvaluateResult>(@params, "script.evaluate");
 
-internal sealed record EvaluateParameters(string Expression, Target Target, bool AwaitPromise, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, bool? UserActivation) : Parameters;
+internal sealed record EvaluateParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string Expression, Target Target, bool AwaitPromise, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, bool? UserActivation) : Parameters;
 
 public sealed class EvaluateOptions : CommandOptions
 {

--- a/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -29,28 +30,28 @@ public sealed class ScriptModule : Module
 {
     private ScriptJsonSerializerContext _jsonContext = null!;
 
-    public async Task<EvaluateResult> EvaluateAsync(string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
+    public async Task<EvaluateResult> EvaluateAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
     {
         var @params = new EvaluateParameters(expression, target, awaitPromise, options?.ResultOwnership, options?.SerializationOptions, options?.UserActivation);
 
         return await Broker.ExecuteCommandAsync(new EvaluateCommand(@params), options, _jsonContext.EvaluateCommand, _jsonContext.EvaluateResult).ConfigureAwait(false);
     }
 
-    public async Task<TResult?> EvaluateAsync<TResult>(string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
+    public async Task<TResult?> EvaluateAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, Target target, EvaluateOptions? options = null)
     {
         var result = await EvaluateAsync(expression, awaitPromise, target, options).ConfigureAwait(false);
 
         return result.AsSuccessResult().ConvertTo<TResult>();
     }
 
-    public async Task<EvaluateResult> CallFunctionAsync(string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
+    public async Task<EvaluateResult> CallFunctionAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
     {
         var @params = new CallFunctionParameters(functionDeclaration, awaitPromise, target, options?.Arguments, options?.ResultOwnership, options?.SerializationOptions, options?.This, options?.UserActivation);
 
         return await Broker.ExecuteCommandAsync(new CallFunctionCommand(@params), options, _jsonContext.CallFunctionCommand, _jsonContext.EvaluateResult).ConfigureAwait(false);
     }
 
-    public async Task<TResult?> CallFunctionAsync<TResult>(string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
+    public async Task<TResult?> CallFunctionAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null)
     {
         var result = await CallFunctionAsync(functionDeclaration, awaitPromise, target, options).ConfigureAwait(false);
 
@@ -71,7 +72,7 @@ public sealed class ScriptModule : Module
         return await Broker.ExecuteCommandAsync(new GetRealmsCommand(@params), options, _jsonContext.GetRealmsCommand, _jsonContext.GetRealmsResult).ConfigureAwait(false);
     }
 
-    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync(string functionDeclaration, AddPreloadScriptOptions? options = null)
+    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, AddPreloadScriptOptions? options = null)
     {
         var @params = new AddPreloadScriptParameters(functionDeclaration, options?.Arguments, options?.Contexts, options?.Sandbox);
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

Missed in https://github.com/SeleniumHQ/selenium/pull/16616

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `[StringSyntax(StringSyntaxConstants.JavaScript)]` annotations to JavaScript string parameters

- Improve IDE support for JavaScript code completion and syntax highlighting

- Organize and add missing using statements across BiDi script files

- Enable better tooling integration for JavaScript expressions in BiDi API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JavaScript String Parameters"] -->|Add StringSyntax Annotation| B["IDE Support Enhanced"]
  B -->|Code Completion| C["Better Developer Experience"]
  B -->|Syntax Highlighting| C
  D["Using Statements"] -->|Organize & Add| E["Code Quality Improved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextScriptModule.cs</strong><dd><code>Annotate JavaScript parameters with StringSyntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs

<ul><li>Added <code>[StringSyntax(StringSyntaxConstants.JavaScript)]</code> annotation to <br>four method parameters: <code>functionDeclaration</code> and <code>expression</code> parameters<br> <li> Added missing using statements: <code>OpenQA.Selenium.Internal</code> and <br><code>System.Diagnostics.CodeAnalysis</code><br> <li> Reorganized using statements in alphabetical order</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16657/files#diff-aa602ac791163e69e232a5c6676709905f92d894a8da7ff46ab6d3450512b61c">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddPreloadScriptCommand.cs</strong><dd><code>Annotate FunctionDeclaration with StringSyntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs

<ul><li>Added <code>[StringSyntax(StringSyntaxConstants.JavaScript)]</code> annotation to <br><code>FunctionDeclaration</code> parameter in <code>AddPreloadScriptParameters</code> record<br> <li> Added missing using statements: <code>OpenQA.Selenium.Internal</code> and <br><code>System.Diagnostics.CodeAnalysis</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16657/files#diff-9b0ba21d638ed69dac4b05032dada1694f6a5a2eaab71e9be255866ea47216bb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CallFunctionCommand.cs</strong><dd><code>Annotate FunctionDeclaration with StringSyntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs

<ul><li>Added <code>[StringSyntax(StringSyntaxConstants.JavaScript)]</code> annotation to <br><code>FunctionDeclaration</code> parameter in <code>CallFunctionParameters</code> record<br> <li> Added missing using statements: <code>OpenQA.Selenium.Internal</code> and <br><code>System.Diagnostics.CodeAnalysis</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16657/files#diff-a78dfad79d1d8f82e58b1c9a85447847d968a2e17c45b5da7097ff984bd6958e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EvaluateCommand.cs</strong><dd><code>Annotate Expression with StringSyntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs

<ul><li>Added <code>[StringSyntax(StringSyntaxConstants.JavaScript)]</code> annotation to <br><code>Expression</code> parameter in <code>EvaluateParameters</code> record<br> <li> Added missing using statements: <code>OpenQA.Selenium.Internal</code> and <br><code>System.Diagnostics.CodeAnalysis</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16657/files#diff-3906c7efa9231e353b0912c4c3e743d1d9c6ac7b92918b9fc1904f45b35fbcc1">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptModule.cs</strong><dd><code>Annotate JavaScript parameters with StringSyntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/ScriptModule.cs

<ul><li>Added <code>[StringSyntax(StringSyntaxConstants.JavaScript)]</code> annotation to <br>four method parameters across multiple overloads: <code>expression</code> and <br><code>functionDeclaration</code><br> <li> Added missing using statement: <code>System.Diagnostics.CodeAnalysis</code><br> <li> Methods annotated: <code>EvaluateAsync</code>, <code>CallFunctionAsync</code>, and <br><code>AddPreloadScriptAsync</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16657/files#diff-da8cf630954e0732aa2b7f257aca8b49117eeceae343e373e2ba5914e639b6d2">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

