### PR TITLE
[py] Bump versions of ruff and mypy for Dev/CI

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -4,41 +4,41 @@
     "binaries": [
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.2/ruff-aarch64-unknown-linux-musl.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.7/ruff-aarch64-unknown-linux-musl.tar.gz",
         "file": "ruff-aarch64-unknown-linux-musl/ruff",
-        "sha256": "e323e9716661c9e18152aefe62e3fada497c10c9b3ef3095359c31b4df4f866a",
+        "sha256": "8d429dbc2c308377c33874dc71d4c2388728f0d01c0a5869d2c878d21a6ced87",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.2/ruff-x86_64-unknown-linux-musl.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.7/ruff-x86_64-unknown-linux-musl.tar.gz",
         "file": "ruff-x86_64-unknown-linux-musl/ruff",
-        "sha256": "e5e177a829b370376abb6a1dc9edc8c59ac519ebe64b1366b65e2952fa524a8d",
+        "sha256": "0f6cd59aa2b266758f1083c73f1b8303e3aedde0d953f0e79777faf174d8104f",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.2/ruff-aarch64-apple-darwin.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.7/ruff-aarch64-apple-darwin.tar.gz",
         "file": "ruff-aarch64-apple-darwin/ruff",
-        "sha256": "33225f67ce61188fce91b801ab50a4028f8b0d66abbf81810841dd7d42371e38",
+        "sha256": "24631da81fe9ce5f4112e8caeb71957e81682e752a563f0a50715735f923e3c4",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.2/ruff-x86_64-apple-darwin.tar.gz",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.7/ruff-x86_64-apple-darwin.tar.gz",
         "file": "ruff-x86_64-apple-darwin/ruff",
-        "sha256": "f119057618599e8983bdeed64e949af54f67d7a62464d11de0ba1237619a9990",
+        "sha256": "c3035811c5354d923f3d7fd6320cfb23de30600f1eb86aa1518bac27c3d7fffd",
         "os": "macos",
         "cpu": "x86_64"
       },
       {
         "kind": "archive",
-        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.2/ruff-x86_64-pc-windows-msvc.zip",
+        "url": "https://github.com/astral-sh/ruff/releases/download/0.14.7/ruff-x86_64-pc-windows-msvc.zip",
         "file": "ruff-x86_64-pc-windows-msvc/ruff.exe",
-        "sha256": "0a1160f45263cc847acd4b42392bf0484c9420806eeb7f776e1384fb557aeade",
+        "sha256": "9a54b82e12574ea068e0914cdb1398993cbf78338c0799b6f9003a783fec779b",
         "os": "windows",
         "cpu": "x86_64"
       }

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -32,7 +32,7 @@ setenv =
 [testenv:mypy]
 skip_install = true
 deps =
-    mypy==1.18.2
+    mypy==1.19.0
     types-urllib3==1.26.25.14
     types-certifi==2021.10.8.3
     trio-typing==0.10.0
@@ -43,7 +43,7 @@ commands =
 [testenv:linting]
 skip_install = true
 deps =
-    ruff==0.14.2
+    ruff==0.14.7
 commands =
     ruff check --fix --show-fixes --exit-non-zero-on-fix .
     ruff format --exit-non-zero-on-format .


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR bumps the versions of ruff (linting/formatting) and mypy (type checking) to the latest versions in `tox.ini`, and updates the version and hashes for ruff in `multitool.lock.json` for use by Bazel.

### 🔄 Types of changes
- Dev/Build/CI


___

### **PR Type**
Enhancement


___

### **Description**
- Bump ruff from 0.14.2 to 0.14.7 for linting/formatting

- Bump mypy from 1.18.2 to 1.19.0 for type checking

- Update ruff binary hashes in multitool.lock.json for all platforms

- Maintain consistency across dev/CI tooling versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tox.ini"] -->|ruff 0.14.2 to 0.14.7| B["Updated versions"]
  A -->|mypy 1.18.2 to 1.19.0| B
  C["multitool.lock.json"] -->|Update ruff binaries & hashes| B
  B -->|All platforms| D["Linux, macOS, Windows"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Bump ruff and mypy tool versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/tox.ini

<ul><li>Upgrade ruff from 0.14.2 to 0.14.7<br> <li> Upgrade mypy from 1.18.2 to 1.19.0<br> <li> Updates dev/CI linting and type-checking tool versions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16660/files#diff-27d219400d7f64afbf3d9bceb197e20b299fdd58fb4e84c9b7c2ee7c4e828177">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multitool.lock.json</strong><dd><code>Update ruff binary versions and checksums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

multitool.lock.json

<ul><li>Update ruff release version from 0.14.2 to 0.14.7 across all platform <br>binaries<br> <li> Update SHA256 hashes for Linux ARM64, Linux x86_64, macOS ARM64, macOS <br>x86_64, and Windows x86_64 binaries<br> <li> Maintain Bazel multitool lockfile consistency with latest ruff release</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16660/files#diff-b0d31fabc955ed7a7168b0b3f4e51773a38a4b7dd6b97a1b49f3a8a2cb5273e4">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

