### PR TITLE
[dotnet] Fix nullability annotations on `NodeRemoteValue`

### DIFF
--- a/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
@@ -252,7 +252,7 @@ public sealed record HtmlCollectionRemoteValue : RemoteValue
     public IReadOnlyList<RemoteValue>? Value { get; set; }
 }
 
-public sealed record NodeRemoteValue(string? SharedId, NodeProperties? Value) : RemoteValue, ISharedReference
+public sealed record NodeRemoteValue(string SharedId, NodeProperties? Value) : RemoteValue, ISharedReference
 {
     public Handle? Handle { get; set; }
 

--- a/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
+++ b/dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using NUnit.Framework;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.BiDi.Script;
@@ -104,7 +105,10 @@ class CallFunctionParameterTest : BiDiTestFixture
 
         Assert.That(res, Is.Not.Null);
         Assert.That(res.AsSuccessResult(), Is.AssignableFrom<NodeRemoteValue>());
-        Assert.That((res.AsSuccessResult() as NodeRemoteValue).Value, Is.Not.Null);
+
+        var node = (NodeRemoteValue)res.AsSuccessResult();
+        Assert.That(node.Value, Is.Not.Null);
+        Assert.That(node.SharedId, Is.EqualTo(GetElementId(By.Id("consoleLog"))));
     }
 
     [Test]
@@ -218,5 +222,14 @@ class CallFunctionParameterTest : BiDiTestFixture
 
         Assert.That(res1, Is.EqualTo(3));
         Assert.That(res2, Is.EqualTo(5));
+    }
+
+    private string GetElementId(By selector)
+    {
+        var element = (WebElement)driver.FindElement(selector);
+        return ReflectElementId(element);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Id")]
+        static extern string ReflectElementId(WebElement element);
     }
 }


### PR DESCRIPTION
### **User description**
Fix nullability for `NodeRemoteValue.SharedId`.

Also add a test for it.


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `NodeRemoteValue.SharedId` nullability from nullable to non-nullable

- Improve test assertions for `NodeRemoteValue` properties

- Add helper method to retrieve element IDs for validation

- Strengthen test coverage with explicit SharedId verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NodeRemoteValue<br/>SharedId parameter"] -->|"Change from<br/>string? to string"| B["Non-nullable<br/>SharedId"]
  C["CallFunctionParameterTest"] -->|"Add SharedId<br/>verification"| D["Enhanced test<br/>assertions"]
  C -->|"Add GetElementId<br/>helper"| E["Element ID<br/>reflection utility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteValue.cs</strong><dd><code>Fix SharedId nullability to non-nullable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/RemoteValue.cs

<ul><li>Changed <code>NodeRemoteValue</code> constructor parameter <code>SharedId</code> from <code>string?</code> <br>(nullable) to <code>string</code> (non-nullable)<br> <li> Aligns with the fact that <code>NodeRemoteValue</code> implements <code>ISharedReference</code> <br>which requires a valid SharedId</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16661/files#diff-e2bdf9ace0943be5d468ae038f717d9367c80d2207c8a3cdcb9cc1d7421dfed2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CallFunctionParameterTest.cs</strong><dd><code>Enhance test assertions and add element ID helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Script/CallFunctionParameterTest.cs

<ul><li>Added <code>using System.Runtime.CompilerServices;</code> for unsafe accessor <br>support<br> <li> Improved <code>CanCallFunctionToGetElement()</code> test with explicit variable <br>casting and additional assertion for <code>SharedId</code><br> <li> Added new <code>GetElementId()</code> helper method using unsafe accessor to <br>retrieve element IDs for test validation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16661/files#diff-2211a55aa8f7fbbe821213f4f0a771f85a33b7b639fc7bbe2e4bd38a48c85608">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

