### PR TITLE
[dotnet] [bidi] Avoid BiDi type in EventArgs ctor for unnecessary metadata generation

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInfo.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInfo.cs
@@ -21,5 +21,5 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record BrowsingContextInfo(BiDi BiDi, IReadOnlyList<BrowsingContextInfo>? Children, Browser.ClientWindow ClientWindow, BrowsingContext Context, BrowsingContext? OriginalOpener, string Url, Browser.UserContext UserContext, BrowsingContext? Parent)
-    : BrowsingContextEventArgs(BiDi, Context);
+public sealed record BrowsingContextInfo(IReadOnlyList<BrowsingContextInfo>? Children, Browser.ClientWindow ClientWindow, BrowsingContext Context, BrowsingContext? OriginalOpener, string Url, Browser.UserContext UserContext, BrowsingContext? Parent)
+    : BrowsingContextEventArgs(Context);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadEndEventArgs.cs
@@ -28,11 +28,11 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 //[JsonDerivedType(typeof(DownloadCanceledEventArgs), "canceled")]
 //[JsonDerivedType(typeof(DownloadCompleteEventArgs), "complete")]
 [JsonConverter(typeof(DownloadEndEventArgsConverter))]
-public abstract record DownloadEndEventArgs(BiDi BiDi, BrowsingContext Context)
-    : BrowsingContextEventArgs(BiDi, Context);
+public abstract record DownloadEndEventArgs(BrowsingContext Context)
+    : BrowsingContextEventArgs(Context);
 
-public sealed record DownloadCanceledEventArgs(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
-    : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;
+public sealed record DownloadCanceledEventArgs(BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : DownloadEndEventArgs(Context), IBaseNavigationInfo;
 
-public sealed record DownloadCompleteEventArgs(BiDi BiDi, string? Filepath, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
-    : DownloadEndEventArgs(BiDi, Context), IBaseNavigationInfo;
+public sealed record DownloadCompleteEventArgs(string? Filepath, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : DownloadEndEventArgs(Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadWillBeginEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/DownloadWillBeginEventArgs.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record DownloadWillBeginEventArgs(BiDi BiDi, string SuggestedFilename, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
-    : BrowsingContextEventArgs(BiDi, Context), IBaseNavigationInfo;
+public sealed record DownloadWillBeginEventArgs(string SuggestedFilename, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : BrowsingContextEventArgs(Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/HistoryUpdatedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/HistoryUpdatedEventArgs.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record HistoryUpdatedEventArgs(BiDi BiDi, BrowsingContext Context, DateTimeOffset Timestamp, string Url)
-    : BrowsingContextEventArgs(BiDi, Context);
+public sealed record HistoryUpdatedEventArgs(BrowsingContext Context, DateTimeOffset Timestamp, string Url)
+    : BrowsingContextEventArgs(Context);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/NavigationInfo.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/NavigationInfo.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record NavigationInfo(BiDi BiDi, BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
-    : BrowsingContextEventArgs(BiDi, Context), IBaseNavigationInfo;
+public sealed record NavigationInfo(BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+    : BrowsingContextEventArgs(Context), IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptClosedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptClosedEventArgs.cs
@@ -19,5 +19,5 @@
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record UserPromptClosedEventArgs(BiDi BiDi, BrowsingContext Context, bool Accepted, string? UserText)
-    : BrowsingContextEventArgs(BiDi, Context);
+public sealed record UserPromptClosedEventArgs(BrowsingContext Context, bool Accepted, string? UserText)
+    : BrowsingContextEventArgs(Context);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptOpenedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptOpenedEventArgs.cs
@@ -22,8 +22,8 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record UserPromptOpenedEventArgs(BiDi BiDi, BrowsingContext Context, Session.UserPromptHandlerType Handler, UserPromptType Type, string Message, string? DefaultValue)
-    : BrowsingContextEventArgs(BiDi, Context);
+public sealed record UserPromptOpenedEventArgs(BrowsingContext Context, Session.UserPromptHandlerType Handler, UserPromptType Type, string Message, string? DefaultValue)
+    : BrowsingContextEventArgs(Context);
 
 [JsonConverter(typeof(CamelCaseEnumConverter<UserPromptType>))]
 public enum UserPromptType

--- a/dotnet/src/webdriver/BiDi/EventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/EventArgs.cs
@@ -21,11 +21,11 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi;
 
-public abstract record EventArgs(BiDi BiDi)
+public abstract record EventArgs
 {
     [JsonIgnore]
-    public BiDi BiDi { get; internal set; } = BiDi;
+    public BiDi BiDi { get; internal set; }
 }
 
-public abstract record BrowsingContextEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext Context)
-    : EventArgs(BiDi);
+public abstract record BrowsingContextEventArgs(BrowsingContext.BrowsingContext Context)
+    : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Log/LogEntry.cs
@@ -31,20 +31,20 @@ namespace OpenQA.Selenium.BiDi.Log;
 //[JsonDerivedType(typeof(ConsoleLogEntry), "console")]
 //[JsonDerivedType(typeof(JavascriptLogEntry), "javascript")]
 [JsonConverter(typeof(LogEntryConverter))]
-public abstract record LogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
-    : EventArgs(BiDi)
+public abstract record LogEntry(Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
+    : EventArgs
 {
     public Script.StackTrace? StackTrace { get; set; }
 }
 
-public sealed record GenericLogEntry(BiDi BiDi, string Type, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
-    : LogEntry(BiDi, Level, Source, Text, Timestamp);
+public sealed record GenericLogEntry(string Type, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
+    : LogEntry(Level, Source, Text, Timestamp);
 
-public sealed record ConsoleLogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
-    : LogEntry(BiDi, Level, Source, Text, Timestamp);
+public sealed record ConsoleLogEntry(Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp, string Method, IReadOnlyList<Script.RemoteValue> Args)
+    : LogEntry(Level, Source, Text, Timestamp);
 
-public sealed record JavascriptLogEntry(BiDi BiDi, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
-    : LogEntry(BiDi, Level, Source, Text, Timestamp);
+public sealed record JavascriptLogEntry(Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
+    : LogEntry(Level, Source, Text, Timestamp);
 
 [JsonConverter(typeof(CamelCaseEnumConverter<Level>))]
 public enum Level

--- a/dotnet/src/webdriver/BiDi/Network/AuthRequiredEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AuthRequiredEventArgs.cs
@@ -22,5 +22,5 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public record AuthRequiredEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response, IReadOnlyList<Intercept>? Intercepts) :
-    BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);
+public record AuthRequiredEventArgs(BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response, IReadOnlyList<Intercept>? Intercepts) :
+    BaseParametersEventArgs(Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);

--- a/dotnet/src/webdriver/BiDi/Network/BaseParametersEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/BaseParametersEventArgs.cs
@@ -17,10 +17,10 @@
 // under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public abstract record BaseParametersEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, IReadOnlyList<Intercept>? Intercepts)
-    : BrowsingContextEventArgs(BiDi, Context);
+public abstract record BaseParametersEventArgs(BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, IReadOnlyList<Intercept>? Intercepts)
+    : BrowsingContextEventArgs(Context);

--- a/dotnet/src/webdriver/BiDi/Network/BeforeRequestSentEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/BeforeRequestSentEventArgs.cs
@@ -23,5 +23,5 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public record BeforeRequestSentEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator, IReadOnlyList<Intercept>? Intercepts)
-    : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);
+public record BeforeRequestSentEventArgs(BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator, IReadOnlyList<Intercept>? Intercepts)
+    : BaseParametersEventArgs(Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);

--- a/dotnet/src/webdriver/BiDi/Network/FetchErrorEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/FetchErrorEventArgs.cs
@@ -23,5 +23,5 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public sealed record FetchErrorEventArgs(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, string ErrorText, IReadOnlyList<Intercept>? Intercepts)
-    : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);
+public sealed record FetchErrorEventArgs(BrowsingContext.BrowsingContext? Context, bool IsBlocked, Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, string ErrorText, IReadOnlyList<Intercept>? Intercepts)
+    : BaseParametersEventArgs(Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
@@ -59,9 +59,14 @@ public sealed class InterceptResponseOptions : AddInterceptOptions;
 
 public sealed class InterceptAuthOptions : AddInterceptOptions;
 
-public sealed record InterceptedRequest(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, Initiator Initiator, IReadOnlyList<Intercept>? Intercepts)
-    : BeforeRequestSentEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Initiator, Intercepts)
+public sealed record InterceptedRequest : BeforeRequestSentEventArgs
 {
+    internal InterceptedRequest(BiDi biDi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, Initiator initiator, IReadOnlyList<Intercept>? intercepts)
+        : base(context, isBlocked, navigation, redirectCount, request, timestamp, initiator, intercepts)
+    {
+        BiDi = biDi;
+    }
+
     public Task ContinueAsync(ContinueRequestOptions? options = null)
     {
         return BiDi.Network.ContinueRequestAsync(Request.Request, options);
@@ -78,18 +83,28 @@ public sealed record InterceptedRequest(BiDi BiDi, BrowsingContext.BrowsingConte
     }
 }
 
-public sealed record InterceptedResponse(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response, IReadOnlyList<Intercept>? Intercepts)
-    : ResponseStartedEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Response, Intercepts)
+public sealed record InterceptedResponse : ResponseStartedEventArgs
 {
+    internal InterceptedResponse(BiDi biDi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
+        : base(context, isBlocked, navigation, redirectCount, request, timestamp, response, intercepts)
+    {
+        BiDi = biDi;
+    }
+
     public Task ContinueAsync(ContinueResponseOptions? options = null)
     {
         return BiDi.Network.ContinueResponseAsync(Request.Request, options);
     }
 }
 
-public sealed record InterceptedAuth(BiDi BiDi, BrowsingContext.BrowsingContext? Context, bool IsBlocked, BrowsingContext.Navigation? Navigation, long RedirectCount, RequestData Request, DateTimeOffset Timestamp, ResponseData Response, IReadOnlyList<Intercept>? Intercepts)
-    : AuthRequiredEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Response, Intercepts)
+public sealed record InterceptedAuth : AuthRequiredEventArgs
 {
+    internal InterceptedAuth(BiDi biDi, BrowsingContext.BrowsingContext? context, bool IsBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
+        : base(context, IsBlocked, navigation, redirectCount, request, timestamp, response, intercepts)
+    {
+        BiDi = biDi;
+    }
+
     public Task ContinueAsync(AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null)
     {
         return BiDi.Network.ContinueWithAuthAsync(Request.Request, credentials, options);

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
@@ -61,10 +61,10 @@ public sealed class InterceptAuthOptions : AddInterceptOptions;
 
 public sealed record InterceptedRequest : BeforeRequestSentEventArgs
 {
-    internal InterceptedRequest(BiDi biDi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, Initiator initiator, IReadOnlyList<Intercept>? intercepts)
+    internal InterceptedRequest(BiDi bidi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, Initiator initiator, IReadOnlyList<Intercept>? intercepts)
         : base(context, isBlocked, navigation, redirectCount, request, timestamp, initiator, intercepts)
     {
-        BiDi = biDi;
+        BiDi = bidi;
     }
 
     public Task ContinueAsync(ContinueRequestOptions? options = null)
@@ -85,10 +85,10 @@ public sealed record InterceptedRequest : BeforeRequestSentEventArgs
 
 public sealed record InterceptedResponse : ResponseStartedEventArgs
 {
-    internal InterceptedResponse(BiDi biDi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
+    internal InterceptedResponse(BiDi bidi, BrowsingContext.BrowsingContext? context, bool isBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
         : base(context, isBlocked, navigation, redirectCount, request, timestamp, response, intercepts)
     {
-        BiDi = biDi;
+        BiDi = bidi;
     }
 
     public Task ContinueAsync(ContinueResponseOptions? options = null)
@@ -99,10 +99,10 @@ public sealed record InterceptedResponse : ResponseStartedEventArgs
 
 public sealed record InterceptedAuth : AuthRequiredEventArgs
 {
-    internal InterceptedAuth(BiDi biDi, BrowsingContext.BrowsingContext? context, bool IsBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
+    internal InterceptedAuth(BiDi bidi, BrowsingContext.BrowsingContext? context, bool IsBlocked, BrowsingContext.Navigation? navigation, long redirectCount, RequestData request, DateTimeOffset timestamp, ResponseData response, IReadOnlyList<Intercept>? intercepts)
         : base(context, IsBlocked, navigation, redirectCount, request, timestamp, response, intercepts)
     {
-        BiDi = biDi;
+        BiDi = bidi;
     }
 
     public Task ContinueAsync(AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/Network/ResponseCompletedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ResponseCompletedEventArgs.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public sealed record ResponseCompletedEventArgs(BiDi BiDi,
+public sealed record ResponseCompletedEventArgs(
     BrowsingContext.BrowsingContext? Context,
     bool IsBlocked,
     Navigation? Navigation,
@@ -32,4 +32,4 @@ public sealed record ResponseCompletedEventArgs(BiDi BiDi,
     DateTimeOffset Timestamp,
     ResponseData Response,
     IReadOnlyList<Intercept>? Intercepts)
-    : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);
+    : BaseParametersEventArgs(Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);

--- a/dotnet/src/webdriver/BiDi/Network/ResponseStartedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ResponseStartedEventArgs.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 
 namespace OpenQA.Selenium.BiDi.Network;
 
-public record ResponseStartedEventArgs(BiDi BiDi,
+public record ResponseStartedEventArgs(
     BrowsingContext.BrowsingContext? Context,
     bool IsBlocked,
     Navigation? Navigation,
@@ -32,4 +32,4 @@ public record ResponseStartedEventArgs(BiDi BiDi,
     DateTimeOffset Timestamp,
     ResponseData Response,
     IReadOnlyList<Intercept>? Intercepts)
-    : BaseParametersEventArgs(BiDi, Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);
+    : BaseParametersEventArgs(Context, IsBlocked, Navigation, RedirectCount, Request, Timestamp, Intercepts);

--- a/dotnet/src/webdriver/BiDi/Script/MessageEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Script/MessageEventArgs.cs
@@ -19,4 +19,4 @@
 
 namespace OpenQA.Selenium.BiDi.Script;
 
-public sealed record MessageEventArgs(BiDi BiDi, Channel Channel, RemoteValue Data, Source Source) : EventArgs(BiDi);
+public sealed record MessageEventArgs(Channel Channel, RemoteValue Data, Source Source) : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Script/RealmDestroyedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmDestroyedEventArgs.cs
@@ -19,4 +19,4 @@
 
 namespace OpenQA.Selenium.BiDi.Script;
 
-public sealed record RealmDestroyedEventArgs(BiDi BiDi, Realm Realm) : EventArgs(BiDi);
+public sealed record RealmDestroyedEventArgs(Realm Realm) : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
@@ -34,23 +34,23 @@ namespace OpenQA.Selenium.BiDi.Script;
 //[JsonDerivedType(typeof(AudioWorkletRealmInfo), "audio-worklet")]
 //[JsonDerivedType(typeof(WorkletRealmInfo), "worklet")]
 [JsonConverter(typeof(RealmInfoConverter))]
-public abstract record RealmInfo(BiDi BiDi, Realm Realm, string Origin) : EventArgs(BiDi);
+public abstract record RealmInfo(Realm Realm, string Origin) : EventArgs;
 
-public sealed record WindowRealmInfo(BiDi BiDi, Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(BiDi, Realm, Origin)
+public sealed record WindowRealmInfo(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(Realm, Origin)
 {
     public string? Sandbox { get; set; }
 }
 
-public sealed record DedicatedWorkerRealmInfo(BiDi BiDi, Realm Realm, string Origin, IReadOnlyList<Realm> Owners) : RealmInfo(BiDi, Realm, Origin);
+public sealed record DedicatedWorkerRealmInfo(Realm Realm, string Origin, IReadOnlyList<Realm> Owners) : RealmInfo(Realm, Origin);
 
-public sealed record SharedWorkerRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record SharedWorkerRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);
 
-public sealed record ServiceWorkerRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record ServiceWorkerRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);
 
-public sealed record WorkerRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record WorkerRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);
 
-public sealed record PaintWorkletRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record PaintWorkletRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);
 
-public sealed record AudioWorkletRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record AudioWorkletRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);
 
-public sealed record WorkletRealmInfo(BiDi BiDi, Realm Realm, string Origin) : RealmInfo(BiDi, Realm, Origin);
+public sealed record WorkletRealmInfo(Realm Realm, string Origin) : RealmInfo(Realm, Origin);


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Now STJ doesn't generate metadata for `BiDi` type.

### 💡 Additional Considerations
It still doesn't resolve AOT trimming, but good step forward.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `BiDi` parameter from EventArgs constructors to reduce metadata generation

- Update all BiDi event classes to avoid unnecessary type references

- Refactor `InterceptedRequest`, `InterceptedResponse`, and `InterceptedAuth` to use internal constructors

- Improve AOT compatibility by eliminating BiDi type from serialization metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EventArgs Base Classes"] -->|Remove BiDi param| B["BrowsingContextEventArgs"]
  A -->|Remove BiDi param| C["LogEntry"]
  B -->|Remove BiDi param| D["BrowsingContext Events"]
  B -->|Remove BiDi param| E["Network Events"]
  C -->|Remove BiDi param| F["Log Events"]
  G["Intercepted Classes"] -->|Refactor to internal ctor| H["InterceptedRequest/Response/Auth"]
  H -->|Set BiDi property| I["Improved AOT Compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>EventArgs.cs</strong><dd><code>Remove BiDi parameter from base EventArgs classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-bf9330ad2350fb5f889f164c482ebab483846b1a13296e687c7ff24514b781cc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BrowsingContextInfo.cs</strong><dd><code>Remove BiDi parameter from BrowsingContextInfo record</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-b15289bc02094475e29d1649e2e7bdd91e4003e3238e7e69ab5f740890972201">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DownloadEndEventArgs.cs</strong><dd><code>Remove BiDi parameter from download event records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-96895fa9bca1263cae645a394e4b4d91ad86dcd07bc93d9f395df57c14660c7e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DownloadWillBeginEventArgs.cs</strong><dd><code>Remove BiDi parameter from download begin event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-9c33fa43b6693134d15cda1553724fff58375721b8dcef138be1b73be9ee2db5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HistoryUpdatedEventArgs.cs</strong><dd><code>Remove BiDi parameter from history event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-75525afce550b84ecd5c091b78fa78d0950ee938b1e26ac12956a0d6c5b4f88d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavigationInfo.cs</strong><dd><code>Remove BiDi parameter from navigation event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-baa784a412471e395219d311f19e46d6bd032d453a0abd6e56fb0c28e2a98dab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserPromptClosedEventArgs.cs</strong><dd><code>Remove BiDi parameter from user prompt event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-0de3cc94785ef6c4de0745d5ae189e39084d4882c8b28d7917921e055c56b578">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserPromptOpenedEventArgs.cs</strong><dd><code>Remove BiDi parameter from user prompt opened event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-b7d3659669b095332376600613a0861eb413703ca5c1f2f3e6ffd986af76a7a7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogEntry.cs</strong><dd><code>Remove BiDi parameter from log entry records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-623bd3229f2a30029d54ea9512a3ac05d828ba1635cdfc1f76454f645c13b5ee">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AuthRequiredEventArgs.cs</strong><dd><code>Remove BiDi parameter from auth required event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-4ed7a1656a4419d375815b4cf6d660647b17518aed9d929fe68ea6accc9059c2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BaseParametersEventArgs.cs</strong><dd><code>Remove BiDi parameter from base network event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-8bb7422dbce86dcf5ad9ac5c73f381f0c946e72bf0f8f1bb0d13a79df66be3bf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BeforeRequestSentEventArgs.cs</strong><dd><code>Remove BiDi parameter from request event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-cf7522813818fb138fd5f5c623381c981861f20f73e5007f99983f8bdb49fd41">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FetchErrorEventArgs.cs</strong><dd><code>Remove BiDi parameter from fetch error event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-75624f214009e8ee09cd31f0c1fdbab5c096fc9ee907daec6844e86b287e23f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NetworkModule.HighLevel.cs</strong><dd><code>Refactor intercepted classes to use internal constructors</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-d992a3918d1495c1ed4c6acbe816427ad173b8ad928f1592b6ca94811bca5cf2">+21/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseCompletedEventArgs.cs</strong><dd><code>Remove BiDi parameter from response completed event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-d471fdd6df701cfd5872f454bfacea2eed74ea7961e8a4dd15d76f1578e56e66">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseStartedEventArgs.cs</strong><dd><code>Remove BiDi parameter from response started event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-8da97866cfea6183acf8cece80a003e6c854a601d993796ea2b9e211a8f28b48">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MessageEventArgs.cs</strong><dd><code>Remove BiDi parameter from message event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-4e422c4c1f412eece3e138b687c495234f7fdd04f2b645574abb16025da72449">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RealmDestroyedEventArgs.cs</strong><dd><code>Remove BiDi parameter from realm destroyed event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-5dcffa99f9d2fa14e438e1c4d33eb67f06106fc516020d7b58a55bb571669f10">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RealmInfo.cs</strong><dd><code>Remove BiDi parameter from realm info records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16667/files#diff-97e68a6a9b2385ec0cf1f245934cff6093318f4286707373c28773342086a8bc">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

