### PR TITLE
[grid] Tracking SessionRemovalInfo when removing session from SessionMap

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/SessionClosedData.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionClosedData.java
@@ -1,0 +1,70 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+import java.util.Map;
+import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.json.JsonException;
+import org.openqa.selenium.remote.SessionId;
+
+/**
+ * Data structure that carries both SessionId and closure reason for SessionClosedEvent. Keeps
+ * closure state separate from the core SessionId class to avoid breaking changes.
+ */
+public class SessionClosedData {
+  private final SessionId sessionId;
+  private final SessionClosedReason reason;
+
+  public SessionClosedData(SessionId sessionId, SessionClosedReason reason) {
+    this.sessionId = Require.nonNull("Session ID", sessionId);
+    this.reason = Require.nonNull("Reason", reason);
+  }
+
+  public SessionId getSessionId() {
+    return sessionId;
+  }
+
+  public SessionClosedReason getReason() {
+    return reason;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("SessionClosedData{sessionId=%s, reason=%s}", sessionId, reason);
+  }
+
+  private Object toJson() {
+    return Map.of("sessionId", sessionId, "reason", reason);
+  }
+
+  private static SessionClosedData fromJson(Object raw) {
+    if (raw instanceof Map) {
+      Map<?, ?> map = (Map<?, ?>) raw;
+      Object sessionIdObj = map.get("sessionId");
+      Object reasonObj = map.get("reason");
+
+      if (sessionIdObj instanceof String) {
+        SessionId sessionId = new SessionId((String) sessionIdObj);
+        SessionClosedReason reason = SessionClosedReason.valueOf((String) reasonObj);
+        return new SessionClosedData(sessionId, reason);
+      }
+    }
+
+    throw new JsonException("Unable to coerce session closed data from " + raw);
+  }
+}

--- a/java/src/org/openqa/selenium/grid/data/SessionClosedEvent.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionClosedEvent.java
@@ -34,21 +34,23 @@ public class SessionClosedEvent extends Event {
   }
 
   public SessionClosedEvent(SessionId id, SessionClosedReason reason) {
-    super(SESSION_CLOSED, markSessionId(id, reason));
+    super(SESSION_CLOSED, new SessionClosedData(id, reason));
     Require.nonNull("Session ID", id);
     Require.nonNull("Reason", reason);
   }
 
-  // Helper method to mark the SessionId before passing to Event constructor
-  private static SessionId markSessionId(SessionId id, SessionClosedReason reason) {
-    id.setCloseReason(reason.getReasonText());
-    return id;
-  }
-
-  // Standard listener method following the Event pattern
-  public static EventListener<SessionId> listener(Consumer<SessionId> handler) {
+  // Standard listener method that provides access to both SessionId and reason
+  public static EventListener<SessionClosedData> listener(Consumer<SessionClosedData> handler) {
     Require.nonNull("Handler", handler);
 
-    return new EventListener<>(SESSION_CLOSED, SessionId.class, handler);
+    return new EventListener<>(SESSION_CLOSED, SessionClosedData.class, handler);
+  }
+
+  // Convenience method for listeners that only care about the SessionId
+  public static EventListener<SessionClosedData> sessionListener(Consumer<SessionId> handler) {
+    Require.nonNull("Handler", handler);
+
+    return new EventListener<>(
+        SESSION_CLOSED, SessionClosedData.class, data -> handler.accept(data.getSessionId()));
   }
 }

--- a/java/src/org/openqa/selenium/grid/data/SessionClosedEvent.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionClosedEvent.java
@@ -28,10 +28,24 @@ public class SessionClosedEvent extends Event {
 
   private static final EventName SESSION_CLOSED = new EventName("session-closed");
 
+  // Backward compatible constructor
   public SessionClosedEvent(SessionId id) {
-    super(SESSION_CLOSED, id);
+    this(id, SessionClosedReason.QUIT_COMMAND);
   }
 
+  public SessionClosedEvent(SessionId id, SessionClosedReason reason) {
+    super(SESSION_CLOSED, markSessionId(id, reason));
+    Require.nonNull("Session ID", id);
+    Require.nonNull("Reason", reason);
+  }
+
+  // Helper method to mark the SessionId before passing to Event constructor
+  private static SessionId markSessionId(SessionId id, SessionClosedReason reason) {
+    id.setCloseReason(reason.getReasonText());
+    return id;
+  }
+
+  // Standard listener method following the Event pattern
   public static EventListener<SessionId> listener(Consumer<SessionId> handler) {
     Require.nonNull("Handler", handler);
 

--- a/java/src/org/openqa/selenium/grid/data/SessionClosedReason.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionClosedReason.java
@@ -1,0 +1,39 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+public enum SessionClosedReason {
+  /** Session was closed normally via QUIT command from client */
+  QUIT_COMMAND("session closed normally (QUIT command)"),
+  /** Session timed out due to inactivity */
+  TIMEOUT("session timed out due to inactivity"),
+  /** Node was removed from the grid */
+  NODE_REMOVED("node was removed from the grid"),
+  /** Node was restarted */
+  NODE_RESTARTED("node was restarted");
+
+  private final String reasonText;
+
+  SessionClosedReason(String reasonText) {
+    this.reasonText = reasonText;
+  }
+
+  public String getReasonText() {
+    return reasonText;
+  }
+}

--- a/java/src/org/openqa/selenium/grid/data/SessionRemovalInfo.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionRemovalInfo.java
@@ -1,0 +1,45 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+
+public class SessionRemovalInfo {
+  private final Instant removedAt;
+  private final String reason;
+  private final URI nodeUri;
+
+  public SessionRemovalInfo(String reason, URI nodeUri) {
+    this.removedAt = Instant.now();
+    this.reason = reason;
+    this.nodeUri = nodeUri;
+  }
+
+  @Override
+  public String toString() {
+    Duration elapsed = Duration.between(removedAt, Instant.now());
+    long seconds = Math.max(elapsed.toSeconds(), 0);
+    String timeAgo = seconds == 1 ? "1 second ago" : seconds + " seconds ago";
+
+    return String.format(
+        "removed at %s (%s), reason: %s, node: %s",
+        removedAt, timeAgo, reason, nodeUri != null ? nodeUri : "unknown");
+  }
+}

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalGridModel.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalGridModel.java
@@ -71,7 +71,7 @@ public class LocalGridModel extends GridModel {
     this.events = Require.nonNull("Event bus", events);
 
     this.events.addListener(NodeDrainStarted.listener(nodeId -> setAvailability(nodeId, DRAINING)));
-    this.events.addListener(SessionClosedEvent.listener(this::release));
+    this.events.addListener(SessionClosedEvent.sessionListener(this::release));
   }
 
   public static LocalGridModel create(Config config) {

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -95,6 +95,7 @@ import org.openqa.selenium.grid.data.NodeHeartBeatEvent;
 import org.openqa.selenium.grid.data.NodeId;
 import org.openqa.selenium.grid.data.NodeStatus;
 import org.openqa.selenium.grid.data.Session;
+import org.openqa.selenium.grid.data.SessionClosedReason;
 import org.openqa.selenium.grid.data.Slot;
 import org.openqa.selenium.grid.data.SlotId;
 import org.openqa.selenium.grid.jmx.JMXHelper;
@@ -334,12 +335,17 @@ public class LocalNode extends Node implements Closeable {
         attributeMap.put("session.id", id.toString());
         attributeMap.put("session.timeout_in_seconds", getSessionTimeout().toSeconds());
         attributeMap.put("session.remove.cause", cause.name());
+
+        // Determine the SessionClosedReason based on RemovalCause
+        SessionClosedReason closeReason;
         if (cause == RemovalCause.EXPIRED) {
+          closeReason = SessionClosedReason.TIMEOUT;
           // Session is timing out, stopping it by sending a DELETE
           LOG.log(Level.INFO, () -> String.format("Session id %s timed out, stopping...", id));
           span.setStatus(Status.CANCELLED);
           span.addEvent(String.format("Stopping the the timed session %s", id), attributeMap);
         } else {
+          closeReason = SessionClosedReason.QUIT_COMMAND;
           LOG.log(Level.INFO, () -> String.format("Session id %s is stopping on demand...", id));
           span.addEvent(String.format("Stopping the session %s on demand", id), attributeMap);
         }
@@ -354,8 +360,8 @@ public class LocalNode extends Node implements Closeable {
                 String.format("Exception while trying to stop session %s", id), attributeMap);
           }
         }
-        // Attempt to stop the session
-        slot.stop();
+        // Attempt to stop the session with the appropriate reason
+        slot.stop(closeReason);
         // Decrement pending sessions if Node is draining
         if (this.isDraining()) {
           int done = pendingSessions.decrementAndGet();

--- a/java/src/org/openqa/selenium/grid/node/local/SessionSlot.java
+++ b/java/src/org/openqa/selenium/grid/node/local/SessionSlot.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.WebDriverInfo;
 import org.openqa.selenium.events.EventBus;
 import org.openqa.selenium.grid.data.CreateSessionRequest;
 import org.openqa.selenium.grid.data.SessionClosedEvent;
+import org.openqa.selenium.grid.data.SessionClosedReason;
 import org.openqa.selenium.grid.node.ActiveSession;
 import org.openqa.selenium.grid.node.SessionFactory;
 import org.openqa.selenium.grid.node.relay.RelaySessionFactory;
@@ -104,6 +105,10 @@ public class SessionSlot
   }
 
   public void stop() {
+    stop(SessionClosedReason.QUIT_COMMAND);
+  }
+
+  public void stop(SessionClosedReason reason) {
     if (isAvailable()) {
       return;
     }
@@ -117,8 +122,8 @@ public class SessionSlot
     currentSession = null;
     connectionCounter.set(0);
     release();
-    bus.fire(new SessionClosedEvent(id));
-    LOG.info(String.format("Stopping session %s", id));
+    bus.fire(new SessionClosedEvent(id, reason));
+    LOG.info(String.format("Stopping session %s (reason: %s)", id, reason));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/sessionmap/jdbc/JdbcBackedSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/jdbc/JdbcBackedSessionMap.java
@@ -81,7 +81,8 @@ public class JdbcBackedSessionMap extends SessionMap implements Closeable {
     this.bus = Require.nonNull("Event bus", bus);
 
     this.connection = jdbcConnection;
-    this.bus.addListener(SessionClosedEvent.listener(this::remove));
+    // Listen to SessionClosedEvent and extract the sessionId
+    this.bus.addListener(SessionClosedEvent.sessionListener(this::remove));
 
     this.bus.addListener(
         NodeRemovedEvent.listener(

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//java:defs.bzl", "java_library")
 
 java_library(
@@ -16,5 +17,6 @@ java_library(
         "//java/src/org/openqa/selenium/grid/server",
         "//java/src/org/openqa/selenium/grid/sessionmap",
         "//java/src/org/openqa/selenium/remote",
+        artifact("com.github.ben-manes.caffeine:caffeine"),
     ],
 )

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
@@ -20,7 +20,10 @@ package org.openqa.selenium.grid.sessionmap.local;
 import static org.openqa.selenium.remote.RemoteTags.SESSION_ID;
 import static org.openqa.selenium.remote.RemoteTags.SESSION_ID_EVENT;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,13 +34,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 import org.openqa.selenium.NoSuchSessionException;
-import org.openqa.selenium.events.Event;
 import org.openqa.selenium.events.EventBus;
 import org.openqa.selenium.grid.config.Config;
 import org.openqa.selenium.grid.data.NodeRemovedEvent;
 import org.openqa.selenium.grid.data.NodeRestartedEvent;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.grid.data.SessionClosedEvent;
+import org.openqa.selenium.grid.data.SessionClosedReason;
+import org.openqa.selenium.grid.data.SessionRemovalInfo;
 import org.openqa.selenium.grid.log.LoggingOptions;
 import org.openqa.selenium.grid.server.EventBusOptions;
 import org.openqa.selenium.grid.sessionmap.SessionMap;
@@ -55,6 +59,13 @@ public class LocalSessionMap extends SessionMap {
   private final EventBus bus;
   private final IndexedSessionMap knownSessions = new IndexedSessionMap();
 
+  /**
+   * Tracks removed sessions with their removal reason and timestamp for 60 minutes to provide
+   * better diagnostics when a NoSuchSessionException occurs.
+   */
+  private final Cache<SessionId, SessionRemovalInfo> recentlyRemovedSessions =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(60)).build();
+
   public LocalSessionMap(Tracer tracer, EventBus bus) {
     super(tracer);
 
@@ -65,13 +76,14 @@ public class LocalSessionMap extends SessionMap {
     bus.addListener(
         NodeRemovedEvent.listener(
             nodeStatus -> {
-              batchRemoveByUri(nodeStatus.getExternalUri(), NodeRemovedEvent.class);
+              batchRemoveByUri(nodeStatus.getExternalUri(), SessionClosedReason.NODE_REMOVED);
             }));
 
     bus.addListener(
         NodeRestartedEvent.listener(
             previousNodeStatus -> {
-              batchRemoveByUri(previousNodeStatus.getExternalUri(), NodeRestartedEvent.class);
+              batchRemoveByUri(
+                  previousNodeStatus.getExternalUri(), SessionClosedReason.NODE_RESTARTED);
             }));
   }
 
@@ -116,6 +128,20 @@ public class LocalSessionMap extends SessionMap {
 
     Session session = knownSessions.get(id);
     if (session == null) {
+      // Check if this session was recently removed and provide detailed information
+      SessionRemovalInfo removalInfo = recentlyRemovedSessions.getIfPresent(id);
+      if (removalInfo != null) {
+        throw new NoSuchSessionException(
+            String.format("Unable to find session with ID: %s. Session was %s", id, removalInfo));
+      }
+
+      // Check if the SessionId itself carries a close reason
+      String closeReason = id.getCloseReason();
+      if (closeReason != null) {
+        throw new NoSuchSessionException(
+            String.format("Unable to find session with ID: %s. Reason: %s", id, closeReason));
+      }
+
       throw new NoSuchSessionException("Unable to find session with ID: " + id);
     }
     return session;
@@ -127,6 +153,21 @@ public class LocalSessionMap extends SessionMap {
 
     Session removedSession = knownSessions.remove(id);
 
+    // The SessionId carries its close reason, track it in the cache
+    String closeReason = id.getCloseReason();
+    if (removedSession != null) {
+      String reasonText = closeReason != null ? closeReason : "session closed (reason unknown)";
+      recentlyRemovedSessions.put(id, new SessionRemovalInfo(reasonText, removedSession.getUri()));
+      LOG.fine(String.format("Tracked removal for session %s with reason: %s", id, reasonText));
+    } else if (closeReason != null) {
+      // Session wasn't in knownSessions, but track it anyway since we know the reason
+      recentlyRemovedSessions.put(id, new SessionRemovalInfo(closeReason, null));
+      LOG.fine(
+          String.format(
+              "Session %s not found in knownSessions, but tracked removal with reason: %s",
+              id, closeReason));
+    }
+
     try (Span span = tracer.getCurrentContext().createSpan("local_sessionmap.remove")) {
       AttributeMap attributeMap = tracer.createAttributeMap();
       attributeMap.put(AttributeKey.LOGGER_CLASS.getKey(), getClass().getName());
@@ -135,15 +176,16 @@ public class LocalSessionMap extends SessionMap {
 
       String sessionDeletedMessage =
           String.format(
-              "Deleted session from local Session Map, Id: %s, Node: %s",
+              "Deleted session from local Session Map, Id: %s, Node: %s, Reason: %s",
               id,
-              removedSession != null ? String.valueOf(removedSession.getUri()) : "unidentified");
+              removedSession != null ? String.valueOf(removedSession.getUri()) : "unidentified",
+              closeReason != null ? closeReason : "unknown");
       span.addEvent(sessionDeletedMessage, attributeMap);
       LOG.info(sessionDeletedMessage);
     }
   }
 
-  private void batchRemoveByUri(URI externalUri, Class<? extends Event> eventClass) {
+  private void batchRemoveByUri(URI externalUri, SessionClosedReason closeReason) {
     Set<SessionId> sessionsToRemove = knownSessions.getSessionsByUri(externalUri);
 
     if (sessionsToRemove.isEmpty()) {
@@ -152,17 +194,24 @@ public class LocalSessionMap extends SessionMap {
 
     knownSessions.batchRemove(sessionsToRemove);
 
+    // Mark each SessionId with the close reason and track removal info
+    for (SessionId sessionId : sessionsToRemove) {
+      sessionId.setCloseReason(closeReason.getReasonText());
+      recentlyRemovedSessions.put(
+          sessionId, new SessionRemovalInfo(closeReason.getReasonText(), externalUri));
+    }
+
     try (Span span = tracer.getCurrentContext().createSpan("local_sessionmap.batch_remove")) {
       AttributeMap attributeMap = tracer.createAttributeMap();
       attributeMap.put(AttributeKey.LOGGER_CLASS.getKey(), getClass().getName());
-      attributeMap.put("event.class", eventClass.getName());
+      attributeMap.put("removal.reason", closeReason.getReasonText());
       attributeMap.put("node.uri", externalUri.toString());
       attributeMap.put("sessions.count", sessionsToRemove.size());
 
       String batchRemoveMessage =
           String.format(
-              "Batch removed %d sessions from local Session Map for Node %s (triggered by %s)",
-              sessionsToRemove.size(), externalUri, eventClass.getSimpleName());
+              "Batch removed %d sessions from local Session Map for Node %s (reason: %s)",
+              sessionsToRemove.size(), externalUri, closeReason);
       span.addEvent(batchRemoveMessage, attributeMap);
       LOG.info(batchRemoveMessage);
     }
@@ -177,7 +226,7 @@ public class LocalSessionMap extends SessionMap {
       return sessions.get(id);
     }
 
-    public Session put(SessionId id, Session session) {
+    public void put(SessionId id, Session session) {
       synchronized (coordinationLock) {
         Session previous = sessions.put(id, session);
 
@@ -189,8 +238,6 @@ public class LocalSessionMap extends SessionMap {
         if (sessionUri != null) {
           sessionsByUri.computeIfAbsent(sessionUri, k -> ConcurrentHashMap.newKeySet()).add(id);
         }
-
-        return previous;
       }
     }
 
@@ -245,7 +292,8 @@ public class LocalSessionMap extends SessionMap {
 
     public Set<SessionId> getSessionsByUri(URI uri) {
       Set<SessionId> result = sessionsByUri.get(uri);
-      return (result != null && !result.isEmpty()) ? result : Set.of();
+      // Return a copy to prevent concurrent modification issues
+      return (result != null && !result.isEmpty()) ? new HashSet<>(result) : Set.of();
     }
 
     public Set<Map.Entry<SessionId, Session>> entrySet() {

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
@@ -283,8 +283,8 @@ public class LocalSessionMap extends SessionMap {
 
     public Set<SessionId> getSessionsByUri(URI uri) {
       Set<SessionId> result = sessionsByUri.get(uri);
-      // Return a copy to prevent concurrent modification issues
-      return (result != null && !result.isEmpty()) ? new HashSet<>(result) : Set.of();
+      // Return an immutable copy to prevent concurrent modification issues
+      return (result != null && !result.isEmpty()) ? Set.copyOf(result) : Set.of();
     }
 
     public Set<Map.Entry<SessionId, Session>> entrySet() {

--- a/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/local/LocalSessionMap.java
@@ -71,7 +71,10 @@ public class LocalSessionMap extends SessionMap {
 
     this.bus = Require.nonNull("Event bus", bus);
 
-    bus.addListener(SessionClosedEvent.listener(this::remove));
+    // Listen to SessionClosedEvent and extract both sessionId and reason
+    bus.addListener(
+        SessionClosedEvent.listener(
+            data -> removeWithReason(data.getSessionId(), data.getReason())));
 
     bus.addListener(
         NodeRemovedEvent.listener(
@@ -135,13 +138,6 @@ public class LocalSessionMap extends SessionMap {
             String.format("Unable to find session with ID: %s. Session was %s", id, removalInfo));
       }
 
-      // Check if the SessionId itself carries a close reason
-      String closeReason = id.getCloseReason();
-      if (closeReason != null) {
-        throw new NoSuchSessionException(
-            String.format("Unable to find session with ID: %s. Reason: %s", id, closeReason));
-      }
-
       throw new NoSuchSessionException("Unable to find session with ID: " + id);
     }
     return session;
@@ -149,23 +145,19 @@ public class LocalSessionMap extends SessionMap {
 
   @Override
   public void remove(SessionId id) {
+    removeWithReason(id, SessionClosedReason.QUIT_COMMAND);
+  }
+
+  private void removeWithReason(SessionId id, SessionClosedReason reason) {
     Require.nonNull("Session ID", id);
+    Require.nonNull("Reason", reason);
 
     Session removedSession = knownSessions.remove(id);
 
-    // The SessionId carries its close reason, track it in the cache
-    String closeReason = id.getCloseReason();
+    String reasonText = reason.getReasonText();
     if (removedSession != null) {
-      String reasonText = closeReason != null ? closeReason : "session closed (reason unknown)";
       recentlyRemovedSessions.put(id, new SessionRemovalInfo(reasonText, removedSession.getUri()));
       LOG.fine(String.format("Tracked removal for session %s with reason: %s", id, reasonText));
-    } else if (closeReason != null) {
-      // Session wasn't in knownSessions, but track it anyway since we know the reason
-      recentlyRemovedSessions.put(id, new SessionRemovalInfo(closeReason, null));
-      LOG.fine(
-          String.format(
-              "Session %s not found in knownSessions, but tracked removal with reason: %s",
-              id, closeReason));
     }
 
     try (Span span = tracer.getCurrentContext().createSpan("local_sessionmap.remove")) {
@@ -179,7 +171,7 @@ public class LocalSessionMap extends SessionMap {
               "Deleted session from local Session Map, Id: %s, Node: %s, Reason: %s",
               id,
               removedSession != null ? String.valueOf(removedSession.getUri()) : "unidentified",
-              closeReason != null ? closeReason : "unknown");
+              reasonText);
       span.addEvent(sessionDeletedMessage, attributeMap);
       LOG.info(sessionDeletedMessage);
     }
@@ -194,9 +186,8 @@ public class LocalSessionMap extends SessionMap {
 
     knownSessions.batchRemove(sessionsToRemove);
 
-    // Mark each SessionId with the close reason and track removal info
+    // Track removal info for each session
     for (SessionId sessionId : sessionsToRemove) {
-      sessionId.setCloseReason(closeReason.getReasonText());
       recentlyRemovedSessions.put(
           sessionId, new SessionRemovalInfo(closeReason.getReasonText(), externalUri));
     }

--- a/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/redis/RedisBackedSessionMap.java
@@ -76,7 +76,7 @@ public class RedisBackedSessionMap extends SessionMap {
     this.bus = Require.nonNull("Event bus", bus);
     this.connection = new GridRedisClient(serverUri);
     this.serverUri = serverUri;
-    this.bus.addListener(SessionClosedEvent.listener(this::remove));
+    this.bus.addListener(SessionClosedEvent.sessionListener(this::remove));
 
     this.bus.addListener(
         NodeRemovedEvent.listener(

--- a/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
@@ -88,12 +88,6 @@ public class RemoteSessionMap extends SessionMap {
 
     Session session = makeRequest(new HttpRequest(GET, "/se/grid/session/" + id), Session.class);
     if (session == null) {
-      // Check if the SessionId carries a close reason
-      String closeReason = id.getCloseReason();
-      if (closeReason != null) {
-        throw new NoSuchSessionException(
-            String.format("Unable to find session with ID: %s. %s", id, closeReason));
-      }
       throw new NoSuchSessionException("Unable to find session with ID: " + id);
     }
     return session;

--- a/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
@@ -88,6 +88,12 @@ public class RemoteSessionMap extends SessionMap {
 
     Session session = makeRequest(new HttpRequest(GET, "/se/grid/session/" + id), Session.class);
     if (session == null) {
+      // Check if the SessionId carries a close reason
+      String closeReason = id.getCloseReason();
+      if (closeReason != null) {
+        throw new NoSuchSessionException(
+            String.format("Unable to find session with ID: %s. %s", id, closeReason));
+      }
       throw new NoSuchSessionException("Unable to find session with ID: " + id);
     }
     return session;

--- a/java/src/org/openqa/selenium/remote/SessionId.java
+++ b/java/src/org/openqa/selenium/remote/SessionId.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.remote;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
@@ -29,6 +30,7 @@ import org.openqa.selenium.json.JsonException;
 public class SessionId implements Serializable {
 
   private final String opaqueKey;
+  private @Nullable String closeReason;
 
   public SessionId(UUID uuid) {
     this(Require.nonNull("Session ID key", uuid).toString());
@@ -36,6 +38,35 @@ public class SessionId implements Serializable {
 
   public SessionId(String opaqueKey) {
     this.opaqueKey = Require.nonNull("Session ID key", opaqueKey);
+    this.closeReason = null; // Session is alive initially
+  }
+
+  /**
+   * Sets the reason why this session was closed. Once set, indicates the session is no longer
+   * active.
+   *
+   * @param reason The reason for session closure
+   */
+  public void setCloseReason(String reason) {
+    this.closeReason = reason;
+  }
+
+  /**
+   * Gets the reason why this session was closed, if any.
+   *
+   * @return The close reason, or null if the session is still active
+   */
+  public @Nullable String getCloseReason() {
+    return closeReason;
+  }
+
+  /**
+   * Checks if this session has been closed.
+   *
+   * @return true if the session has a close reason set, false otherwise
+   */
+  public boolean isClosed() {
+    return closeReason != null;
   }
 
   @Override
@@ -53,8 +84,18 @@ public class SessionId implements Serializable {
     return obj instanceof SessionId && opaqueKey.equals(((SessionId) obj).opaqueKey);
   }
 
-  private String toJson() {
-    return opaqueKey;
+  private Object toJson() {
+    // For backward compatibility, serialize as string when there's no closeReason
+    // This ensures SessionId works properly in URLs and simple contexts
+    if (closeReason == null) {
+      return opaqueKey;
+    }
+
+    // When there is a closeReason, serialize as Map to preserve the metadata
+    Map<String, Object> json = new HashMap<>();
+    json.put("value", opaqueKey);
+    json.put("closeReason", closeReason);
+    return json;
   }
 
   private static SessionId fromJson(Object raw) {
@@ -65,7 +106,12 @@ public class SessionId implements Serializable {
     if (raw instanceof Map) {
       Map<?, ?> map = (Map<?, ?>) raw;
       if (map.get("value") instanceof String) {
-        return new SessionId(String.valueOf(map.get("value")));
+        SessionId sessionId = new SessionId(String.valueOf(map.get("value")));
+        // Restore closeReason if present
+        if (map.get("closeReason") instanceof String) {
+          sessionId.setCloseReason(String.valueOf(map.get("closeReason")));
+        }
+        return sessionId;
       }
     }
 

--- a/java/src/org/openqa/selenium/remote/SessionId.java
+++ b/java/src/org/openqa/selenium/remote/SessionId.java
@@ -18,8 +18,6 @@
 package org.openqa.selenium.remote;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -30,7 +28,6 @@ import org.openqa.selenium.json.JsonException;
 public class SessionId implements Serializable {
 
   private final String opaqueKey;
-  private @Nullable String closeReason;
 
   public SessionId(UUID uuid) {
     this(Require.nonNull("Session ID key", uuid).toString());
@@ -38,35 +35,6 @@ public class SessionId implements Serializable {
 
   public SessionId(String opaqueKey) {
     this.opaqueKey = Require.nonNull("Session ID key", opaqueKey);
-    this.closeReason = null; // Session is alive initially
-  }
-
-  /**
-   * Sets the reason why this session was closed. Once set, indicates the session is no longer
-   * active.
-   *
-   * @param reason The reason for session closure
-   */
-  public void setCloseReason(String reason) {
-    this.closeReason = reason;
-  }
-
-  /**
-   * Gets the reason why this session was closed, if any.
-   *
-   * @return The close reason, or null if the session is still active
-   */
-  public @Nullable String getCloseReason() {
-    return closeReason;
-  }
-
-  /**
-   * Checks if this session has been closed.
-   *
-   * @return true if the session has a close reason set, false otherwise
-   */
-  public boolean isClosed() {
-    return closeReason != null;
   }
 
   @Override
@@ -85,34 +53,12 @@ public class SessionId implements Serializable {
   }
 
   private Object toJson() {
-    // For backward compatibility, serialize as string when there's no closeReason
-    // This ensures SessionId works properly in URLs and simple contexts
-    if (closeReason == null) {
-      return opaqueKey;
-    }
-
-    // When there is a closeReason, serialize as Map to preserve the metadata
-    Map<String, Object> json = new HashMap<>();
-    json.put("value", opaqueKey);
-    json.put("closeReason", closeReason);
-    return json;
+    return opaqueKey;
   }
 
   private static SessionId fromJson(Object raw) {
     if (raw instanceof String) {
       return new SessionId(String.valueOf(raw));
-    }
-
-    if (raw instanceof Map) {
-      Map<?, ?> map = (Map<?, ?>) raw;
-      if (map.get("value") instanceof String) {
-        SessionId sessionId = new SessionId(String.valueOf(map.get("value")));
-        // Restore closeReason if present
-        if (map.get("closeReason") instanceof String) {
-          sessionId.setCloseReason(String.valueOf(map.get("closeReason")));
-        }
-        return sessionId;
-      }
     }
 
     throw new JsonException("Unable to coerce session id from " + raw);

--- a/java/test/org/openqa/selenium/grid/node/NodeTest.java
+++ b/java/test/org/openqa/selenium/grid/node/NodeTest.java
@@ -476,8 +476,8 @@ class NodeTest {
 
   @Test
   void quittingASessionShouldCauseASessionClosedEventToBeFired() {
-    AtomicReference<Object> obj = new AtomicReference<>();
-    bus.addListener(SessionClosedEvent.listener(obj::set));
+    AtomicReference<SessionId> obj = new AtomicReference<>();
+    bus.addListener(SessionClosedEvent.sessionListener(obj::set));
 
     Either<WebDriverException, CreateSessionResponse> response =
         node.newSession(createSessionRequest(caps));
@@ -488,7 +488,7 @@ class NodeTest {
     // Because we're using the event bus, we can't expect the event to fire instantly. We're using
     // an inproc bus, so in reality it's reasonable to expect the event to fire synchronously, but
     // let's play it safe.
-    Wait<AtomicReference<Object>> wait = new FluentWait<>(obj).withTimeout(ofSeconds(2));
+    Wait<AtomicReference<SessionId>> wait = new FluentWait<>(obj).withTimeout(ofSeconds(2));
     wait.until(ref -> ref.get() != null);
   }
 

--- a/java/test/org/openqa/selenium/grid/sessionmap/local/LocalSessionMapTest.java
+++ b/java/test/org/openqa/selenium/grid/sessionmap/local/LocalSessionMapTest.java
@@ -109,7 +109,24 @@ class LocalSessionMapTest {
 
     eventBus.fire(new SessionClosedEvent(sessionId));
 
-    assertThatThrownBy(() -> sessionMap.get(sessionId)).isInstanceOf(NoSuchSessionException.class);
+    assertThatThrownBy(() -> sessionMap.get(sessionId))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("session closed normally (QUIT command)");
+  }
+
+  @Test
+  void shouldIncludeCloseReasonInExceptionForTimeout() {
+    SessionId sessionId = new SessionId("test-session-timeout");
+    URI nodeUri = URI.create("http://localhost:5555");
+    Session session = createSession(sessionId, nodeUri);
+    sessionMap.add(session);
+
+    eventBus.fire(
+        new SessionClosedEvent(sessionId, SessionClosedEvent.SessionClosedReason.TIMEOUT));
+
+    assertThatThrownBy(() -> sessionMap.get(sessionId))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("session timed out due to inactivity");
   }
 
   @Test
@@ -131,8 +148,12 @@ class LocalSessionMapTest {
 
     eventBus.fire(new NodeRemovedEvent(nodeStatus));
 
-    assertThatThrownBy(() -> sessionMap.get(session1Id)).isInstanceOf(NoSuchSessionException.class);
-    assertThatThrownBy(() -> sessionMap.get(session2Id)).isInstanceOf(NoSuchSessionException.class);
+    assertThatThrownBy(() -> sessionMap.get(session1Id))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("node was removed from the grid");
+    assertThatThrownBy(() -> sessionMap.get(session2Id))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("node was removed from the grid");
 
     assertThat(sessionMap.get(session3Id)).isEqualTo(session3);
   }
@@ -156,8 +177,12 @@ class LocalSessionMapTest {
 
     eventBus.fire(new NodeRestartedEvent(previousNodeStatus));
 
-    assertThatThrownBy(() -> sessionMap.get(session1Id)).isInstanceOf(NoSuchSessionException.class);
-    assertThatThrownBy(() -> sessionMap.get(session2Id)).isInstanceOf(NoSuchSessionException.class);
+    assertThatThrownBy(() -> sessionMap.get(session1Id))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("node was restarted");
+    assertThatThrownBy(() -> sessionMap.get(session2Id))
+        .isInstanceOf(NoSuchSessionException.class)
+        .hasMessageContaining("node was restarted");
 
     assertThat(sessionMap.get(session3Id)).isEqualTo(session3);
   }

--- a/java/test/org/openqa/selenium/grid/sessionmap/local/LocalSessionMapTest.java
+++ b/java/test/org/openqa/selenium/grid/sessionmap/local/LocalSessionMapTest.java
@@ -45,6 +45,7 @@ import org.openqa.selenium.grid.data.NodeRestartedEvent;
 import org.openqa.selenium.grid.data.NodeStatus;
 import org.openqa.selenium.grid.data.Session;
 import org.openqa.selenium.grid.data.SessionClosedEvent;
+import org.openqa.selenium.grid.data.SessionClosedReason;
 import org.openqa.selenium.grid.data.Slot;
 import org.openqa.selenium.grid.data.SlotId;
 import org.openqa.selenium.remote.SessionId;
@@ -121,8 +122,7 @@ class LocalSessionMapTest {
     Session session = createSession(sessionId, nodeUri);
     sessionMap.add(session);
 
-    eventBus.fire(
-        new SessionClosedEvent(sessionId, SessionClosedEvent.SessionClosedReason.TIMEOUT));
+    eventBus.fire(new SessionClosedEvent(sessionId, SessionClosedReason.TIMEOUT));
 
     assertThatThrownBy(() -> sessionMap.get(sessionId))
         .isInstanceOf(NoSuchSessionException.class)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
https://github.com/SeleniumHQ/docker-selenium/issues/3025 - Selenium Grid throwing NoSuchSessionException – Session ID not found
```
  selenium.common.exceptions.InvalidSessionIdException: Message: Unable to find session with ID: 34ecd431-ae49-487d-b1ef-bef0fe750dd4
  Build info: version: '4.39.0-SNAPSHOT', revision: 'e0afdd3'
  System info: os.name: 'Linux', os.arch: 'amd64', os.version: '6.11.0-1018-azure', java.version: '21.0.8'
  Driver info: driver.version: unknown; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#invalidsessionidexception
  Stacktrace:
  org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 34ecd431-ae49-487d-b1ef-bef0fe750dd4
  Build info: version: '4.39.0-SNAPSHOT', revision: 'e0afdd3'
  System info: os.name: 'Linux', os.arch: 'amd64', os.version: '6.11.0-1018-azure', java.version: '21.0.8'
  Driver info: driver.version: unknown
  	at org.openqa.selenium.grid.sessionmap.local.LocalSessionMap.get(LocalSessionMap.java:119)
  	at org.openqa.selenium.grid.sessionmap.SessionMap.getUri(SessionMap.java:84)
  	at org.openqa.selenium.grid.router.HandleSession.lambda$loadSessionId$4(HandleSession.java:231)
  	at org.openqa.selenium.grid.router.HandleSession.execute(HandleSession.java:188)
  	at org.openqa.selenium.remote.http.Route$PredicatedRoute.handle(Route.java:398)
  	at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
  	at org.openqa.selenium.remote.http.Route$CombinedRoute.handle(Route.java:361)
  	at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
  	at org.openqa.selenium.grid.router.Router.execute(Router.java:89)
  	at org.openqa.selenium.grid.web.EnsureSpecCompliantResponseHeaders.lambda$apply$0(EnsureSpecCompliantResponseHeaders.java:34)
  	at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
  	at org.openqa.selenium.remote.http.Route$CombinedRoute.handle(Route.java:361)
  	at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
  	at org.openqa.selenium.remote.AddWebDriverSpecHeaders.lambda$apply$0(AddWebDriverSpecHeaders.java:35)
  	at org.openqa.selenium.remote.ErrorFilter.lambda$apply$0(ErrorFilter.java:44)
  	at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
  	at org.openqa.selenium.remote.ErrorFilter.lambda$apply$0(ErrorFilter.java:44)
  	at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
  	at org.openqa.selenium.netty.server.SeleniumHandler.lambda$channelRead0$0(SeleniumHandler.java:49)
  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
  	at java.base/java.lang.Thread.run(Thread.java:1583)
```

There are 3 events to trigger the removal of the session from LocalSessionMap. Possibility session closed on demand (QUIT command) or timed out, Node restarted, or Node removed (detach from grid and shutdown)

Based on triggered event, reason will be attached with closed timestamp for more info instead of a common message
> org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 1806b579-ae67-4525-a815-570bbdc74af1. Session was removed at 2025-12-02T02:47:55.132574294Z (2 seconds ago), reason: node was removed from the grid, node: http://172.19.0.13:5555


```
tests-1  | Build info: version: '4.39.0-SNAPSHOT', revision: 'Unknown'
tests-1  | System info: os.name: 'Linux', os.arch: 'aarch64', os.version: '6.12.54-linuxkit', java.version: '21.0.8'
tests-1  | Driver info: driver.version: unknown; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#invalidsessionidexception
tests-1  | Stacktrace:
tests-1  | org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 1806b579-ae67-4525-a815-570bbdc74af1. Session was removed at 2025-12-02T02:47:55.132574294Z (2 seconds ago), reason: node was removed from the grid, node: http://172.19.0.13:5555
tests-1  | Build info: version: '4.39.0-SNAPSHOT', revision: 'Unknown'
tests-1  | System info: os.name: 'Linux', os.arch: 'aarch64', os.version: '6.12.54-linuxkit', java.version: '21.0.8'
tests-1  | Driver info: driver.version: unknown
tests-1  |      at org.openqa.selenium.grid.sessionmap.local.LocalSessionMap.get(LocalSessionMap.java:135)
tests-1  |      at org.openqa.selenium.grid.sessionmap.SessionMap.getUri(SessionMap.java:84)
tests-1  |      at org.openqa.selenium.grid.router.HandleSession.lambda$loadSessionId$4(HandleSession.java:231)
tests-1  |      at io.opentelemetry.context.Context.lambda$wrap$2(Context.java:253)
tests-1  |      at org.openqa.selenium.grid.router.HandleSession.execute(HandleSession.java:188)
tests-1  |      at org.openqa.selenium.remote.http.Route$PredicatedRoute.handle(Route.java:398)
tests-1  |      at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
tests-1  |      at org.openqa.selenium.remote.http.Route$CombinedRoute.handle(Route.java:361)
tests-1  |      at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
tests-1  |      at org.openqa.selenium.grid.router.Router.execute(Router.java:89)
tests-1  |      at org.openqa.selenium.grid.web.EnsureSpecCompliantResponseHeaders.lambda$apply$0(EnsureSpecCompliantResponseHeaders.java:34)
tests-1  |      at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
tests-1  |      at org.openqa.selenium.remote.http.Route$CombinedRoute.handle(Route.java:361)
tests-1  |      at org.openqa.selenium.remote.http.Route.execute(Route.java:69)
tests-1  |      at org.openqa.selenium.remote.AddWebDriverSpecHeaders.lambda$apply$0(AddWebDriverSpecHeaders.java:35)
tests-1  |      at org.openqa.selenium.remote.ErrorFilter.lambda$apply$0(ErrorFilter.java:44)
tests-1  |      at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
tests-1  |      at org.openqa.selenium.remote.ErrorFilter.lambda$apply$0(ErrorFilter.java:44)
tests-1  |      at org.openqa.selenium.remote.http.Filter$1.execute(Filter.java:63)
tests-1  |      at org.openqa.selenium.netty.server.SeleniumHandler.lambda$channelRead0$0(SeleniumHandler.java:49)
tests-1  |      at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
tests-1  |      at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
tests-1  |      at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
tests-1  |      at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
tests-1  |      at java.base/java.lang.Thread.run(Thread.java:1583)

```

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Add session closure reason tracking throughout grid lifecycle

- Create SessionClosedReason enum with four closure scenarios

- Track recently removed sessions with removal info for diagnostics

- Enhance NoSuchSessionException with detailed closure reasons

- Update SessionId to carry close reason metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Session Closed"] --> B["SessionClosedReason Enum"]
  B --> C["SessionClosedEvent"]
  C --> D["SessionId.setCloseReason"]
  D --> E["LocalSessionMap"]
  E --> F["SessionRemovalInfo Cache"]
  F --> G["NoSuchSessionException with Details"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>SessionClosedReason.java</strong><dd><code>New enum for session closure reasons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-833fe536516ef311b5be03140104e126a242e083fc2ec3c6616c0ed9353042fc">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SessionRemovalInfo.java</strong><dd><code>New class to track session removal details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-e0e5aa4682ad3f4bd12d744e04e938721cb9d223c3fb99535a49bfc2922d5870">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SessionClosedEvent.java</strong><dd><code>Add reason parameter to SessionClosedEvent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-8205740ee45feb7aa1933430411508fff45a4c8f8195cfe0b59f440e78f08b54">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SessionId.java</strong><dd><code>Add close reason tracking to SessionId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-c5b09ea9aa7ec16a444542ec011f3305f89d73aee6239e9cb1f5f314a7426ca2">+49/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalNode.java</strong><dd><code>Pass SessionClosedReason to slot stop method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-edc2e1943a5d89fa45151a9d214cc608551c61101f237ca9a5993d6dd157b57b">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SessionSlot.java</strong><dd><code>Accept and propagate SessionClosedReason</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-f6f6aa2f002118f5a983cd076f893c5a56c2f5f5d4c0d09d6f296c45b8b3ef30">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalSessionMap.java</strong><dd><code>Track removed sessions with Caffeine cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-a695248e570684a11df57eeb89b45904fd436368f81ad223fceb74c8cdebef71">+61/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteSessionMap.java</strong><dd><code>Include close reason in exception messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-d3c4220235794d3c6d1589fd12f43cb235163c3e345710afc5be3b5042c4f244">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>LocalSessionMapTest.java</strong><dd><code>Add tests for session closure reasons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-e888c9c4959574dd0293b94a2899339877ba1dbc0e5b06ccbac5b9423789f0b6">+30/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Add Caffeine cache dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16678/files#diff-355dbc5fb5d5ad21ffb3b7ea46dac7b29d1ab25267c45c2574a5520d7475532b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

