### PR TITLE
fix flaky Ruby test `devtools_spec.rb`

### DIFF
--- a/common/src/web/service_worker.html
+++ b/common/src/web/service_worker.html
@@ -3,11 +3,13 @@
 <head>
   <title>Service Worker Test Page</title>
   <script>
-    if (navigator.serviceWorker) {
-      navigator.serviceWorker.register("/service-worker.js", { scope: "/" })
-        .then(() => navigator.serviceWorker.ready)
-        .then(() => console.debug("[Companion]", "Service worker registered!"));
-    }
+    setTimeout(() => {
+      if (navigator.serviceWorker) {
+        navigator.serviceWorker.register("/service-worker.js", { scope: "/" })
+          .then(() => navigator.serviceWorker.ready)
+          .then(() => console.debug("[Companion]", "Service worker registered!"));
+      }
+    }, 100)
   </script>
 </head>
 <body>

--- a/rb/lib/selenium/webdriver/common/error.rb
+++ b/rb/lib/selenium/webdriver/common/error.rb
@@ -120,6 +120,13 @@ module Selenium
       class NoSuchWindowError < WebDriverError; end
 
       #
+      # A command to find a devtools target could not be satisfied because
+      # the target could not be found.
+      #
+
+      class NoSuchTargetError < WebDriverError; end
+
+      #
       # The element does not have a shadow root.
       #
 

--- a/rb/lib/selenium/webdriver/devtools.rb
+++ b/rb/lib/selenium/webdriver/devtools.rb
@@ -84,7 +84,7 @@ module Selenium
       def start_session(target_type:)
         targets = target.get_targets.dig('result', 'targetInfos')
         found_target = targets.find { |target| target['type'] == target_type }
-        raise Error::WebDriverError, "Target type '#{target_type}' not found" unless found_target
+        raise Error::NoSuchTargetError, "Target type '#{target_type}' not found" unless found_target
 
         session = target.attach_to_target(target_id: found_target['targetId'], flatten: true)
         @session_id = session.dig('result', 'sessionId')

--- a/rb/spec/integration/selenium/webdriver/devtools_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/devtools_spec.rb
@@ -62,7 +62,8 @@ module Selenium
 
         it 'target type is service_worker' do
           driver.devtools.page.navigate(url: url_for('service_worker.html'))
-          sleep 0.5 # wait for service worker to register
+          wait_for_devtools_target(target_type: 'service_worker')
+
           target = driver.devtools(target_type: 'service_worker').target
           expect(target.get_target_info.dig('result', 'targetInfo', 'type')).to eq 'service_worker'
         end
@@ -70,7 +71,7 @@ module Selenium
         it 'throws an error for unknown target type' do
           driver.devtools.page.navigate(url: url_for('xhtmlTest.html'))
           expect { driver.devtools(target_type: 'unknown') }
-            .to raise_error(Selenium::WebDriver::Error::WebDriverError, "Target type 'unknown' not found")
+            .to raise_error(Selenium::WebDriver::Error::NoSuchTargetError, "Target type 'unknown' not found")
         end
       end
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/helpers.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/helpers.rb
@@ -97,6 +97,11 @@ module Selenium
           end
         end
 
+        def wait_for_devtools_target(target_type:)
+          wait = Wait.new(timeout: 3, ignore: Error::NoSuchTargetError)
+          wait.until { driver.devtools(target_type: target_type).target }
+        end
+
         def wait(timeout = 10)
           Wait.new(timeout: timeout)
         end


### PR DESCRIPTION
### **User description**
Wait until service worker gets registered. Sometimes it's slow and can take more than 0.5 seconds.

Example of failure:

```ruby
Failures:

  1) Selenium::WebDriver::DevTools#target target type is service_worker
     Failure/Error: target = driver.devtools(target_type: 'service_worker').target

     Selenium::WebDriver::Error::WebDriverError:
       Target type 'service_worker' not found
     # ./rb/lib/selenium/webdriver/devtools.rb:87:in `start_session'
     # ./rb/lib/selenium/webdriver/devtools.rb:34:in `initialize'
     # ./rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb:36:in `new'
     # ./rb/lib/selenium/webdriver/common/driver_extensions/has_devtools.rb:36:in `devtools'
     # ./rb/spec/integration/selenium/webdriver/devtools_spec.rb:66:in `block (3 levels) in <module:WebDriver>'
```

@jpawlyn FYI

### 🔗 Related Issues

For example, this build failed:
https://github.com/SeleniumHQ/selenium/actions/runs/19984104789/job/57315854174

### 💥 What does this PR do?
1. Waits until the service worker gets registered
2. Postpones the service worker registration for 100ms - it will make any similar test fail if developer forgets to wait. So we avoid flaky tests in future. 
3. Instead of generic class `WebDriverError "Target type 'unknown' not found"`, now a more specific subclass `NoSuchTargetError "Target type 'unknown' not found"` is thrown. 

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `NoSuchTargetError` exception for missing DevTools targets

- Replace hardcoded sleep with proper wait mechanism for service worker registration

- Introduce `wait_for_devtools_target` helper for reliable target detection

- Delay service worker registration by 100ms to catch timing issues early


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Worker Registration"] -->|100ms delay| B["Delayed Initialization"]
  C["DevTools Target Lookup"] -->|NoSuchTargetError| D["Specific Exception"]
  E["Test Execution"] -->|wait_for_devtools_target| F["Reliable Wait Logic"]
  B --> F
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rb</strong><dd><code>Add NoSuchTargetError exception class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/error.rb

<ul><li>Added new <code>NoSuchTargetError</code> exception class for DevTools target lookup <br>failures<br> <li> Provides specific error type instead of generic <code>WebDriverError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16693/files#diff-942df34e1c3e79a3a6ada80fc46e4ef30a799c7a133efdff252f8b3cce4d7ea1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Add wait_for_devtools_target helper method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/helpers.rb

<ul><li>Added new <code>wait_for_devtools_target</code> helper method with 3-second timeout<br> <li> Uses <code>Wait</code> with <code>ignore</code> parameter to handle <code>NoSuchTargetError</code> gracefully<br> <li> Provides reusable mechanism for waiting on DevTools target <br>availability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16693/files#diff-b37575be863b7dd72f570de1f87fbfd4e99e37039b665e97ad060be82c6097a6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devtools.rb</strong><dd><code>Use NoSuchTargetError for target lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/devtools.rb

<ul><li>Changed exception type from <code>WebDriverError</code> to <code>NoSuchTargetError</code> in <br><code>start_session</code> method<br> <li> Improves error specificity for target not found scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16693/files#diff-b6d82f9c2a8d4090c2550b0c5bd7790bc30a5ac791d292aafdf1315082f7166e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devtools_spec.rb</strong><dd><code>Replace sleep with proper wait helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/devtools_spec.rb

<ul><li>Replaced hardcoded <code>sleep 0.5</code> with <code>wait_for_devtools_target</code> helper call<br> <li> Updated error expectation to match new <code>NoSuchTargetError</code> exception <br>type<br> <li> Improves test reliability and readability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16693/files#diff-24c7598b2005b56054a3345c30b949245c29009fe6a1938f1c112cc75fedcfad">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_worker.html</strong><dd><code>Add 100ms delay to service worker registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/web/service_worker.html

<ul><li>Wrapped service worker registration in <code>setTimeout</code> with 100ms delay<br> <li> Intentionally slows down registration to expose timing issues in tests<br> <li> Ensures tests properly wait for service worker availability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16693/files#diff-597a0cd75099b2850105371d9e4e26686280d13d632fd5e66b95cf7efbdd9552">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

