### PR TITLE
[dotnet] [bidi] Support SetScreenSettingsOverrideAsync method in Emulation module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -70,6 +70,13 @@ public sealed class EmulationModule : Module
         return await Broker.ExecuteCommandAsync(new SetScreenOrientationOverrideCommand(@params), options, _jsonContext.SetScreenOrientationOverrideCommand, _jsonContext.SetScreenOrientationOverrideResult).ConfigureAwait(false);
     }
 
+    public async Task<SetScreenSettingsOverrideResult> SetScreenSettingsOverrideAsync(ScreenArea? screenArea, SetScreenSettingsOverrideOptions? options = null)
+    {
+        var @params = new SetScreenSettingsOverrideParameters(screenArea, options?.Contexts, options?.UserContexts);
+
+        return await Broker.ExecuteCommandAsync(new SetScreenSettingsOverrideCommand(@params), options, _jsonContext.SetScreenSettingsOverrideCommand, _jsonContext.SetScreenSettingsOverrideResult).ConfigureAwait(false);
+    }
+
     public async Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(double latitude, double longitude, SetGeolocationCoordinatesOverrideOptions? options = null)
     {
         var coordinates = new GeolocationCoordinates(latitude, longitude, options?.Accuracy, options?.Altitude, options?.AltitudeAccuracy, options?.Heading, options?.Speed);
@@ -114,6 +121,8 @@ public sealed class EmulationModule : Module
 [JsonSerializable(typeof(SetScriptingEnabledResult))]
 [JsonSerializable(typeof(SetScreenOrientationOverrideCommand))]
 [JsonSerializable(typeof(SetScreenOrientationOverrideResult))]
+[JsonSerializable(typeof(SetScreenSettingsOverrideCommand))]
+[JsonSerializable(typeof(SetScreenSettingsOverrideResult))]
 [JsonSerializable(typeof(SetGeolocationOverrideCommand))]
 [JsonSerializable(typeof(SetGeolocationOverrideResult))]
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
@@ -1,0 +1,39 @@
+// <copyright file="SetScreenSettingsOverrideCommand.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.Emulation;
+
+internal sealed class SetScreenSettingsOverrideCommand(SetScreenSettingsOverrideParameters @params)
+    : Command<SetScreenSettingsOverrideParameters, SetScreenSettingsOverrideResult>(@params, "emulation.setScreenSettingsOverride");
+
+internal sealed record SetScreenSettingsOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScreenArea? ScreenArea, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
+
+public sealed class SetScreenSettingsOverrideOptions : CommandOptions
+{
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+}
+
+public sealed record ScreenArea(long Width, long Height);
+
+public sealed record SetScreenSettingsOverrideResult : EmptyResult;

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -168,6 +168,21 @@ class EmulationTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
+    public void CanSetScreenSettingsOverride()
+    {
+        var screenArea = new ScreenArea(300, 200);
+
+        Assert.That(async () =>
+        {
+            await bidi.Emulation.SetScreenSettingsOverrideAsync(screenArea, new() { Contexts = [context] });
+        },
+        Throws.Nothing);
+    }
+
+    [Test]
     public void CanSetGeolocationCoordinatesOverride()
     {
         Assert.That(async () =>


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenSettingsOverride

### 💥 What does this PR do?
Adds `SetScreenSettingsOverrideAsync` method in Emulation module.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `SetScreenSettingsOverrideAsync` method to Emulation module

- Implements command, parameters, options, and result types

- Includes comprehensive test coverage with browser compatibility checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EmulationModule"] -->|"adds method"| B["SetScreenSettingsOverrideAsync"]
  B -->|"uses"| C["SetScreenSettingsOverrideCommand"]
  C -->|"with parameters"| D["SetScreenSettingsOverrideParameters"]
  D -->|"contains"| E["ScreenArea"]
  C -->|"returns"| F["SetScreenSettingsOverrideResult"]
  G["EmulationTest"] -->|"tests"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmulationModule.cs</strong><dd><code>Add SetScreenSettingsOverrideAsync method implementation</code>&nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs

<ul><li>Adds <code>SetScreenSettingsOverrideAsync</code> method following existing pattern<br> <li> Registers <code>SetScreenSettingsOverrideCommand</code> and <br><code>SetScreenSettingsOverrideResult</code> for JSON serialization<br> <li> Maintains consistency with other emulation override methods</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16704/files#diff-326495cc635fdb9686d337228f031a251b2aaed55960d7096b1345e0f1c267ff">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SetScreenSettingsOverrideCommand.cs</strong><dd><code>Implement SetScreenSettingsOverride command and related types</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs

<ul><li>Creates new command class <code>SetScreenSettingsOverrideCommand</code> for BiDi <br>communication<br> <li> Defines <code>SetScreenSettingsOverrideParameters</code> record with <code>ScreenArea</code> <br>property<br> <li> Implements <code>SetScreenSettingsOverrideOptions</code> with context and user <br>context support<br> <li> Defines <code>ScreenArea</code> record with width and height properties<br> <li> Creates <code>SetScreenSettingsOverrideResult</code> as empty result type</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16704/files#diff-fc18ddb3af05aa4e157440fc7d434cbbfbf939a0c664e82c5233d7eefefef91e">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmulationTest.cs</strong><dd><code>Add test for SetScreenSettingsOverride functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Emulation/EmulationTest.cs

<ul><li>Adds test method <code>CanSetScreenSettingsOverride</code> to verify functionality<br> <li> Includes browser compatibility checks ignoring Chrome, Edge, and <br>Firefox<br> <li> Tests method with <code>ScreenArea</code> parameter and context options<br> <li> Verifies method executes without throwing exceptions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16704/files#diff-33ef1ac6efefab8202da67be679d33d4ca9d7e6460fd265468aaddce41026938">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

