### PR TITLE
[py] Properly verify Selenium Manager exists

### DIFF
--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -80,7 +80,8 @@ class SeleniumManager:
 
         if (env_path := os.getenv("SE_MANAGER_PATH")) is not None:
             logger.debug(f"Selenium Manager set by env SE_MANAGER_PATH to: {env_path}")
-            path = Path(env_path)
+            path_candidate = Path(env_path)
+            path =  path_candidate if path_candidate.is_file() else None
         elif compiled_path.is_file():
             path = compiled_path
         else:

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import json
 import logging
 import os
@@ -55,13 +56,20 @@ class SeleniumManager:
 
     @staticmethod
     def _get_binary() -> Path:
-        """Determines the path of the correct Selenium Manager binary.
+        """Determines the path of the Selenium Manager binary.
+
+        Location of the binary is checked in this order:
+
+        1. location set in an environment variable
+        2. location where setuptools-rust places the compiled binary (built from the sdist package)
+        3. location where we ship binaries in the wheel package for the platform this is running on
+        4. give up
 
         Returns:
             The Selenium Manager executable location.
 
         Raises:
-            WebDriverException: If the platform is unsupported.
+            WebDriverException: If the platform is unsupported or Selenium Manager executable can't be found.
         """
         compiled_path = Path(__file__).parent.joinpath("selenium-manager")
         exe = sysconfig.get_config_var("EXE")
@@ -71,9 +79,9 @@ class SeleniumManager:
         path: Path | None = None
 
         if (env_path := os.getenv("SE_MANAGER_PATH")) is not None:
-            logger.debug("Selenium Manager set by env SE_MANAGER_PATH to: %s", env_path)
+            logger.debug(f"Selenium Manager set by env SE_MANAGER_PATH to: {env_path}")
             path = Path(env_path)
-        elif compiled_path.exists():
+        elif compiled_path.is_file():
             path = compiled_path
         else:
             allowed = {
@@ -87,7 +95,7 @@ class SeleniumManager:
 
             arch = platform.machine() if sys.platform in ("linux", "freebsd", "openbsd") else "any"
             if sys.platform in ["freebsd", "openbsd"]:
-                logger.warning("Selenium Manager binary may not be compatible with %s; verify settings", sys.platform)
+                logger.warning(f"Selenium Manager binary may not be compatible with {sys.platform}; verify settings")
 
             location = allowed.get((sys.platform, arch))
             if location is None:
@@ -98,7 +106,7 @@ class SeleniumManager:
         if path is None or not path.is_file():
             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")
 
-        logger.debug("Selenium Manager binary found at: %s", path)
+        logger.debug(f"Selenium Manager binary found at: {path}")
 
         return path
 

--- a/py/selenium/webdriver/common/selenium_manager.py
+++ b/py/selenium/webdriver/common/selenium_manager.py
@@ -81,7 +81,9 @@ class SeleniumManager:
         if (env_path := os.getenv("SE_MANAGER_PATH")) is not None:
             logger.debug(f"Selenium Manager set by env SE_MANAGER_PATH to: {env_path}")
             path_candidate = Path(env_path)
-            path =  path_candidate if path_candidate.is_file() else None
+            if not path_candidate.is_file():
+                raise WebDriverException(f"SE_MANAGER_PATH does not point to a file: {env_path}")
+            path = path_candidate
         elif compiled_path.is_file():
             path = compiled_path
         else:

--- a/py/test/selenium/webdriver/common/selenium_manager_tests.py
+++ b/py/test/selenium/webdriver/common/selenium_manager_tests.py
@@ -108,7 +108,7 @@ def test_error_if_invalid_env_path(monkeypatch):
 
     with pytest.raises(WebDriverException) as excinfo:
         SeleniumManager()._get_binary()
-    assert f"Unable to obtain working Selenium Manager binary; {sm_path}" in str(excinfo.value)
+    assert f"SE_MANAGER_PATH does not point to a file: {sm_path}" in str(excinfo.value)
 
 
 def test_run_successful():


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This PR makes a slight change to the logic for finding the Selenium Manager binary, so it doesn't give a false positive if there is a directory named `selenium-manager` where the executable should be if you build/install from source or a local sdist package. This also adds a check to verify the Selenium Manager binary exists if its location is specified in an environment variable, so it's clear why it is failing.

It also converts some old string formatting to use f-strings and adds information to the docstring about where we look for the binary.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix false positive when directory named `selenium-manager` exists instead of executable

- Change `compiled_path.exists()` to `compiled_path.is_file()` for proper verification

- Convert string formatting to f-strings for consistency

- Enhance docstring with binary search order and error conditions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Binary Detection Logic"] -->|Check env variable| B["SE_MANAGER_PATH"]
  A -->|Check compiled path| C["compiled_path.is_file"]
  C -->|Old: exists| D["False Positive<br/>on directory"]
  C -->|New: is_file| E["Correct verification<br/>of executable"]
  A -->|Check wheel package| F["Platform-specific binary"]
  A -->|Fail| G["WebDriverException"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.py</strong><dd><code>Fix binary detection and modernize string formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/selenium_manager.py

<ul><li>Changed <code>compiled_path.exists()</code> to <code>compiled_path.is_file()</code> to properly <br>verify executable instead of accepting directories<br> <li> Converted three logger calls from old string formatting (<code>%s</code>) to <br>f-strings<br> <li> Enhanced docstring with numbered list of binary search locations and <br>additional error condition documentation<br> <li> Added blank line after license header for PEP 8 compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16711/files#diff-5bb7b1c0cf9c81600e07ba0a6e3b612cd005cb9755ced8c3afe7a7c8e28f5ee2">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

