### PR TITLE
When calling `webdriver.close()` for the last tab, `quit()` the webdriver

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -414,6 +413,11 @@ public class RemoteWebDriver
 
   @Override
   public void close() {
+    // no-op if session id is null. We're only going to make ourselves unhappy
+    if (sessionId == null) {
+      return;
+    }
+
     if (this instanceof HasDevTools) {
       // This is a brute force approach to "solving" the problem of a hanging
       // CDP connection. Take a look at
@@ -433,13 +437,11 @@ public class RemoteWebDriver
 
     Response response = execute(DriverCommand.CLOSE);
     Object value = response.getValue();
-    List<String> windowHandles = (ArrayList<String>) value;
+    List<String> windowHandles = (List<String>) value;
 
-    if (windowHandles.isEmpty() && this instanceof HasBiDi) {
-      // If no top-level browsing contexts are open after calling close, it indicates that the
-      // WebDriver session is closed.
-      // If the WebDriver session is closed, the BiDi session also needs to be closed.
-      ((HasBiDi) this).maybeGetBiDi().ifPresent(BiDi::close);
+    if (windowHandles == null || windowHandles.isEmpty()) {
+      // Time to quit the browser if it was the last opened window.
+      quit();
     }
   }
 

--- a/java/test/org/openqa/selenium/SessionHandlingTest.java
+++ b/java/test/org/openqa/selenium/SessionHandlingTest.java
@@ -17,22 +17,30 @@
 
 package org.openqa.selenium;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.testing.JupiterTestBase;
 import org.openqa.selenium.testing.NoDriverAfterTest;
 import org.openqa.selenium.testing.NotYetImplemented;
 
 class SessionHandlingTest extends JupiterTestBase {
 
+  @BeforeEach
+  void setUp() {
+    assertThat(getSessionId()).isNotNull();
+  }
+
   @NoDriverAfterTest
   @Test
   void callingQuitMoreThanOnceOnASessionIsANoOp() {
     driver.quit();
-    sleepTight(3000);
+    waitUntilBrowserFullyClosed();
     driver.quit();
   }
 
@@ -42,7 +50,7 @@ class SessionHandlingTest extends JupiterTestBase {
   @NotYetImplemented(SAFARI)
   public void callingQuitAfterClosingTheLastWindowIsANoOp() {
     driver.close();
-    sleepTight(3000);
+    waitUntilBrowserFullyClosed();
     driver.quit();
   }
 
@@ -50,7 +58,7 @@ class SessionHandlingTest extends JupiterTestBase {
   @Test
   void callingAnyOperationAfterClosingTheLastWindowShouldThrowAnException() {
     driver.close();
-    sleepTight(3000);
+    waitUntilBrowserFullyClosed();
     assertThatExceptionOfType(NoSuchSessionException.class).isThrownBy(driver::getCurrentUrl);
   }
 
@@ -58,21 +66,22 @@ class SessionHandlingTest extends JupiterTestBase {
   @Test
   void callingAnyOperationAfterQuitShouldThrowAnException() {
     driver.quit();
-    sleepTight(3000);
+    waitUntilBrowserFullyClosed();
     assertThatExceptionOfType(NoSuchSessionException.class).isThrownBy(driver::getCurrentUrl);
   }
 
   @Test
-  void shouldContinueAfterSleep() {
-    sleepTight(10000);
-    driver.getWindowHandle(); // should not throw
+  void shouldContinueAfterSleep() throws InterruptedException {
+    assertThatCode(() -> driver.getWindowHandle()).doesNotThrowAnyException();
+    Thread.sleep(100);
+    assertThatCode(() -> driver.getWindowHandle()).doesNotThrowAnyException();
   }
 
-  private void sleepTight(long duration) {
-    try {
-      Thread.sleep(duration);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+  private void waitUntilBrowserFullyClosed() {
+    wait.until($ -> getSessionId() == null);
+  }
+
+  private SessionId getSessionId() {
+    return ((RemoteWebDriver) driver).getSessionId();
   }
 }


### PR DESCRIPTION
### **User description**
Before:
```java
RemoteWebDriver driver = new RemoteWebDriver();
driver.close(); // result: driver still has SessionID
driver.close(); // result: NoSuchSessionException: invalid session id
```

Now:
```java
RemoteWebDriver driver = new RemoteWebDriver();
driver.close(); // result: driver.getSessionId() == null
driver.close(); // result: no-op (same behaviour as in `quit()` method)
```


### 🔧 Thoughts
I am not yet sure this is the right change. :) 
Let it be in a "Draft" status by now. 


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Auto-quit webdriver when closing last tab instead of leaving session open

- Replace hardcoded sleep with dynamic wait for session closure

- Reduce SessionHandlingTest execution time from 28 to 10 seconds

- Handle null window handles and improve session cleanup logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["close() called"] --> B{"Last window?"}
  B -->|Yes| C["quit() invoked"]
  B -->|No| D["Return normally"]
  C --> E["Session ID nullified"]
  D --> E
  F["Test: sleepTight"] --> G["waitUntilBrowserFullyClosed"]
  G --> H["Poll until sessionId == null"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Auto-quit on last window close and improve session handling</code></dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<ul><li>Added null check at start of <code>close()</code> method to return early if session <br>already closed<br> <li> Changed logic to call <code>quit()</code> when closing last window instead of just <br>closing BiDi session<br> <li> Replaced ArrayList cast with generic List type for window handles<br> <li> Improved null safety by checking for null or empty window handles <br>before quit decision</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16714/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SessionHandlingTest.java</strong><dd><code>Replace hardcoded sleeps with dynamic session closure waits</code></dd></summary>
<hr>

java/test/org/openqa/selenium/SessionHandlingTest.java

<ul><li>Replaced all <code>sleepTight()</code> calls with <code>waitUntilBrowserFullyClosed()</code> <br>dynamic wait method<br> <li> Added <code>setUp()</code> method to verify session ID is not null before each test<br> <li> Implemented <code>waitUntilBrowserFullyClosed()</code> helper that polls until <br>session ID becomes null<br> <li> Simplified <code>shouldContinueAfterSleep()</code> test to use assertion helpers <br>instead of long sleep<br> <li> Removed hardcoded 3-second and 10-second sleep calls throughout test <br>class</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16714/files#diff-886b6cf6c1d7925ee6330f65c532d5122c6f5ae7519bbb2fc64390ff55fad2be">+23/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

