### PR TITLE
#16720 avoid failing because of temporary Chrome internal files

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -53,6 +53,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.time.Clock;
@@ -792,7 +793,10 @@ public class LocalNode extends Node implements Closeable {
     File[] files = Optional.ofNullable(downloadsDirectory.listFiles()).orElse(new File[] {});
     List<String> fileNames = Arrays.stream(files).map(File::getName).collect(Collectors.toList());
     List<DownloadedFile> fileInfos =
-        Arrays.stream(files).map(this::getFileInfo).collect(Collectors.toList());
+        Arrays.stream(files)
+            .map(this::getFileInfo)
+            .filter(file -> file.getLastModifiedTime() > 0)
+            .collect(Collectors.toList());
 
     Map<String, Object> data =
         Map.of(
@@ -810,6 +814,8 @@ public class LocalNode extends Node implements Closeable {
           attributes.creationTime().toMillis(),
           attributes.lastModifiedTime().toMillis(),
           attributes.size());
+    } catch (NoSuchFileException e) {
+      return new DownloadedFile(file.getName(), -1, -1, -1);
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to get file attributes: " + file.getAbsolutePath(), e);
     }


### PR DESCRIPTION
### **User description**
... that Chrome downloads and immediately deletes.

### 🔗 Related Issues
Fixes #16720



### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Handle temporary Chrome files deleted during download listing

- Catch NoSuchFileException when file attributes cannot be read

- Filter out files with invalid modification times from results


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["listDownloadedFiles"] --> B["stream files"]
  B --> C["getFileInfo"]
  C --> D["readAttributes"]
  D --> E{"File exists?"}
  E -->|Yes| F["return DownloadedFile"]
  E -->|No| G["catch NoSuchFileException"]
  G --> H["return DownloadedFile with -1 values"]
  F --> I["filter by lastModifiedTime > 0"]
  H --> I
  I --> J["collect results"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalNode.java</strong><dd><code>Handle temporary Chrome files in download listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/local/LocalNode.java

<ul><li>Added import for <code>NoSuchFileException</code> to handle missing files<br> <li> Modified <code>getFileInfo()</code> method to catch <code>NoSuchFileException</code> and return <br>a DownloadedFile with -1 sentinel values<br> <li> Added filter in <code>listDownloadedFiles()</code> to exclude files with invalid <br>modification times (value of -1)<br> <li> Prevents failures when Chrome temporarily downloads and deletes <br>internal files during listing</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16722/files#diff-edc2e1943a5d89fa45151a9d214cc608551c61101f237ca9a5993d6dd157b57b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

