### PR TITLE
[py] Don't compare object identity in conftest

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -333,7 +333,7 @@ def driver(request):
     marker = request.node.get_closest_marker(f"xfail_{driver_class.lower()}")
     if marker is not None:
         if "run" in marker.kwargs:
-            if marker.kwargs["run"] is False:
+            if not marker.kwargs["run"]:
                 pytest.skip()
                 yield
                 return
@@ -474,7 +474,7 @@ def clean_driver(request):
     marker = request.node.get_closest_marker(f"xfail_{driver_class.lower()}")
     if marker is not None:
         if "run" in marker.kwargs:
-            if marker.kwargs["run"] is False:
+            if not marker.kwargs["run"]:
                 pytest.skip()
                 yield
                 return


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

This is a tiny change to use Falsy comparisons instead of comparing object identity for booleans.

### 🔧 Implementation Notes

This should affect anything.. just changing unpythonic code.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup


___

### **PR Type**
Enhancement


___

### **Description**
- Replace identity comparison with falsy check for booleans

- Improve code pythonicity in conftest fixtures

- Apply consistent boolean comparison pattern across file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["marker.kwargs['run'] is False"] -- "refactor to" --> B["not marker.kwargs['run']"]
  B -- "applied in" --> C["driver fixture"]
  B -- "applied in" --> D["clean_driver fixture"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Replace identity comparison with falsy boolean checks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<ul><li>Replace <code>is False</code> identity comparison with <code>not</code> operator in two <br>locations<br> <li> Update boolean check in <code>driver</code> fixture at line 337<br> <li> Update boolean check in <code>clean_driver</code> fixture at line 478<br> <li> Improves code style to follow Python conventions for boolean <br>evaluation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16723/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

