### PR TITLE
[rb] Add support for full page screenshots in Chrome and Edge

### DIFF
--- a/rb/lib/selenium/webdriver/chromium/driver.rb
+++ b/rb/lib/selenium/webdriver/chromium/driver.rb
@@ -40,6 +40,7 @@ module Selenium
                       DriverExtensions::HasLogs,
                       DriverExtensions::HasLogEvents,
                       DriverExtensions::HasPinnedScripts,
+                      DriverExtensions::FullPageScreenshot,
                       DriverExtensions::PrintsPage].freeze
 
         protected

--- a/rb/lib/selenium/webdriver/chromium/features.rb
+++ b/rb/lib/selenium/webdriver/chromium/features.rb
@@ -28,7 +28,8 @@ module Selenium
           delete_network_conditions: [:delete, 'session/:session_id/chromium/network_conditions'],
           set_permission: [:post, 'session/:session_id/permissions'],
           get_available_log_types: [:get, 'session/:session_id/se/log/types'],
-          get_log: [:post, 'session/:session_id/se/log']
+          get_log: [:post, 'session/:session_id/se/log'],
+          full_page_screenshot: [:get, 'session/:session_id/screenshot/full']
         }.freeze
 
         def launch_app(id)
@@ -92,6 +93,10 @@ module Selenium
           rescue KeyError
             next
           end
+        end
+
+        def full_screenshot
+          execute :full_page_screenshot
         end
       end # Bridge
     end # Chromium

--- a/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
@@ -86,19 +86,6 @@ module Selenium
           ensure
             FileUtils.rm_rf(path)
           end
-
-          it 'saves a screenshot of the full page' do
-            driver.navigate.to url_for('printPage.html')
-            viewport_height = driver.execute_script('return window.innerHeight;')
-
-            path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.png"
-            screenshot = driver.save_screenshot(path, full_page: true)
-
-            _width, height = png_size(screenshot)
-            expect(height).to be > viewport_height
-          ensure
-            FileUtils.rm_rf(path)
-          end
         end
 
         describe '#logs' do

--- a/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb
@@ -86,6 +86,19 @@ module Selenium
           ensure
             FileUtils.rm_rf(path)
           end
+
+          it 'saves a screenshot of the full page' do
+            driver.navigate.to url_for('printPage.html')
+            viewport_height = driver.execute_script('return window.innerHeight;')
+
+            path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.png"
+            screenshot = driver.save_screenshot(path, full_page: true)
+
+            _width, height = png_size(screenshot)
+            expect(height).to be > viewport_height
+          ensure
+            FileUtils.rm_rf(path)
+          end
         end
 
         describe '#logs' do

--- a/rb/spec/integration/selenium/webdriver/takes_screenshot_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/takes_screenshot_spec.rb
@@ -95,18 +95,18 @@ module Selenium
 
         it 'takes full page screenshot', except: [{platform: :macosx,
                                                    reason: 'showing half resolution of what expected'}],
-                                         exclusive: {browser: :firefox} do
+                                         exclusive: {browser: %i[firefox chrome edge]} do
           viewport_width = driver.execute_script('return window.innerWidth;')
           viewport_height = driver.execute_script('return window.innerHeight;')
 
           screenshot = driver.save_screenshot path, full_page: true
           width, height = png_size(screenshot)
 
-          expect(width).to be >= viewport_width
+          expect(width).to be <= viewport_width
           expect(height).to be > viewport_height
         end
 
-        it 'does not take full page screenshot', only: {browser: %i[chrome edge safari safari_preview],
+        it 'does not take full page screenshot', only: {browser: %i[safari safari_preview],
                                                         reason: 'these browsers do not implement this feature'} do
           expect {
             driver.save_screenshot path, full_page: true


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Provides a quickfix for #14116.

### 💥 What does this PR do?
Implements full page screenshots for Chromium browsers for the Ruby language.

<!-- Describe what this change includes and how it works -->
It extends the Chromium driver with full page screenshot functionality, similar to how it was implemented before for the Firefox driver.  It uses Chrome's `session/:session_id/screenshot/full` endpoint.

### 🔧 Implementation Notes
Issue #14116 was originally opened to raise the issue that full page screenshots are not working for the ruby bindings in Chrome/Edge using `driver.save_screenshot(path, full_page: true)`. This is fixed here. 

### 💡 Additional Considerations
In Issue #14116 there is discussion about rewriting Selenium's screenshot functionality to use BiDi, and changing the API to something like `driver.page.screenshot(params)`. I believe rewriting to use BiDi can be done later, as well as changing the API. I am also not sure that there is a specification for taking full page screenshots with BiDi yet.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds full page screenshot support for Chrome in Ruby bindings

- Implements `full_screenshot` method in Chromium driver bridge

- Registers new `full_page_screenshot` endpoint for Chrome driver

- Includes integration test validating full page screenshot functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chrome Driver"] -->|extends with| B["FullPageScreenshot Extension"]
  B -->|calls| C["full_screenshot method"]
  C -->|executes| D["session/:session_id/screenshot/full endpoint"]
  D -->|returns| E["Full page screenshot PNG"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver.rb</strong><dd><code>Register FullPageScreenshot extension in Chromium driver</code>&nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/chromium/driver.rb

<ul><li>Adds <code>DriverExtensions::FullPageScreenshot</code> to the EXTENSIONS list for <br>Chromium driver<br> <li> Enables full page screenshot functionality for Chrome and Edge drivers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16725/files#diff-9ef08354de5aef5f0c364d19d03f60a26409cdc19ca41f88f61032de7276dde0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>features.rb</strong><dd><code>Implement full page screenshot bridge and endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/chromium/features.rb

<ul><li>Adds <code>full_page_screenshot</code> command mapping to Chrome's screenshot/full <br>endpoint<br> <li> Implements <code>full_screenshot</code> method in Bridge module to execute the <br>command<br> <li> Enables direct access to Chrome's native full page screenshot <br>capability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16725/files#diff-f96e5cfc0450c103dd66b2f68b18b8dc6b051e055a193329834ca6d095612fa7">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver_spec.rb</strong><dd><code>Add full page screenshot integration test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/chrome/driver_spec.rb

<ul><li>Adds integration test for full page screenshot functionality<br> <li> Verifies screenshot height exceeds viewport height for full page <br>capture<br> <li> Tests <code>save_screenshot</code> with <code>full_page: true</code> parameter<br> <li> Validates PNG file creation and size</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16725/files#diff-96906269824b89f9616aa049010d41ff4ca20f38493919ba65882ab7159e68ba">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

