### PR TITLE
[py] Add support for full page screenshots in Chrome and Edge

### DIFF
--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -44,7 +44,7 @@ class ChromiumRemoteConnection(RemoteConnection):
     def _remote_commands(self, vendor_prefix):
         remote_commands = {
             "launchApp": ("POST", "/session/$sessionId/chromium/launch_app"),
-            "getFullPageScreenshot": ("POST", "/session/$sessionId/screenshot/full"),
+            "getFullPageScreenshot": ("GET", "/session/$sessionId/screenshot/full"),
             "setPermissions": ("POST", "/session/$sessionId/permissions"),
             "setNetworkConditions": ("POST", "/session/$sessionId/chromium/network_conditions"),
             "getNetworkConditions": ("GET", "/session/$sessionId/chromium/network_conditions"),

--- a/py/selenium/webdriver/chromium/remote_connection.py
+++ b/py/selenium/webdriver/chromium/remote_connection.py
@@ -44,6 +44,7 @@ class ChromiumRemoteConnection(RemoteConnection):
     def _remote_commands(self, vendor_prefix):
         remote_commands = {
             "launchApp": ("POST", "/session/$sessionId/chromium/launch_app"),
+            "getFullPageScreenshot": ("POST", "/session/$sessionId/screenshot/full"),
             "setPermissions": ("POST", "/session/$sessionId/permissions"),
             "setNetworkConditions": ("POST", "/session/$sessionId/chromium/network_conditions"),
             "getNetworkConditions": ("GET", "/session/$sessionId/chromium/network_conditions"),

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -282,7 +282,7 @@ class ChromiumDriver(RemoteWebDriver):
         Example:
             driver.get_full_page_screenshot_as_base64()
         """
-        return self.execute("FULL_PAGE_SCREENSHOT")["value"]
+        return self.execute("getFullPageScreenshot")["value"]
 
     def download_file(self, *args, **kwargs):
         """Download file functionality is not implemented for Chromium driver."""

--- a/py/selenium/webdriver/chromium/webdriver.py
+++ b/py/selenium/webdriver/chromium/webdriver.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import base64
+import warnings
 
 from selenium.webdriver.chromium.options import ChromiumOptions
 from selenium.webdriver.chromium.remote_connection import ChromiumRemoteConnection
@@ -216,6 +218,71 @@ class ChromiumDriver(RemoteWebDriver):
             pass
         finally:
             self.service.stop()
+
+    def get_full_page_screenshot_as_file(self, filename) -> bool:
+        """Save a full document screenshot of the current window to a PNG image file.
+
+        Args:
+            filename: The full path you wish to save your screenshot to. This
+                should end with a `.png` extension.
+
+        Returns:
+            False if there is any IOError, else returns True. Use full paths in your filename.
+
+        Example:
+            driver.get_full_page_screenshot_as_file("/Screenshots/foo.png")
+        """
+        if not filename.lower().endswith(".png"):
+            warnings.warn(
+                "name used for saved screenshot does not match file type. It should end with a `.png` extension",
+                UserWarning,
+            )
+        png = self.get_full_page_screenshot_as_png()
+        try:
+            with open(filename, "wb") as f:
+                f.write(png)
+        except OSError:
+            return False
+        finally:
+            del png
+        return True
+
+    def save_full_page_screenshot(self, filename) -> bool:
+        """Save a full document screenshot of the current window to a PNG image file.
+
+        Args:
+            filename: The full path you wish to save your screenshot to. This
+                should end with a `.png` extension.
+
+        Returns:
+            False if there is any IOError, else returns True. Use full paths in your filename.
+
+        Example:
+            driver.save_full_page_screenshot("/Screenshots/foo.png")
+        """
+        return self.get_full_page_screenshot_as_file(filename)
+
+    def get_full_page_screenshot_as_png(self) -> bytes:
+        """Get the full document screenshot of the current window as binary data.
+
+        Returns:
+            Binary data of the screenshot.
+
+        Example:
+            driver.get_full_page_screenshot_as_png()
+        """
+        return base64.b64decode(self.get_full_page_screenshot_as_base64().encode("ascii"))
+
+    def get_full_page_screenshot_as_base64(self) -> str:
+        """Get the full document screenshot of the current window as a base64-encoded string.
+
+        Returns:
+            Base64 encoded string of the screenshot.
+
+        Example:
+            driver.get_full_page_screenshot_as_base64()
+        """
+        return self.execute("FULL_PAGE_SCREENSHOT")["value"]
 
     def download_file(self, *args, **kwargs):
         """Download file functionality is not implemented for Chromium driver."""

--- a/py/selenium/webdriver/firefox/webdriver.py
+++ b/py/selenium/webdriver/firefox/webdriver.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import base64
 import os
 import warnings

--- a/py/test/selenium/webdriver/chrome/chrome_takes_full_page_screenshots_tests.py
+++ b/py/test/selenium/webdriver/chrome/chrome_takes_full_page_screenshots_tests.py
@@ -1,0 +1,34 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+
+import filetype
+
+
+def test_get_full_page_screenshot_as_base64(driver, pages):
+    pages.load("simpleTest.html")
+    result = base64.b64decode(driver.get_full_page_screenshot_as_base64())
+    kind = filetype.guess(result)
+    assert kind is not None and kind.mime == "image/png"
+
+
+def test_get_full_page_screenshot_as_png(driver, pages):
+    pages.load("simpleTest.html")
+    result = driver.get_full_page_screenshot_as_png()
+    kind = filetype.guess(result)
+    assert kind is not None and kind.mime == "image/png"

--- a/py/test/selenium/webdriver/edge/edge_takes_full_page_screenshots_tests.py
+++ b/py/test/selenium/webdriver/edge/edge_takes_full_page_screenshots_tests.py
@@ -1,0 +1,34 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+
+import filetype
+
+
+def test_get_full_page_screenshot_as_base64(driver, pages):
+    pages.load("simpleTest.html")
+    result = base64.b64decode(driver.get_full_page_screenshot_as_base64())
+    kind = filetype.guess(result)
+    assert kind is not None and kind.mime == "image/png"
+
+
+def test_get_full_page_screenshot_as_png(driver, pages):
+    pages.load("simpleTest.html")
+    result = driver.get_full_page_screenshot_as_png()
+    kind = filetype.guess(result)
+    assert kind is not None and kind.mime == "image/png"


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Similar to #16725 for Ruby
Python implementation of #14116

### 💥 What does this PR do?

This PR adds support for full page screenshots for Chrome and Edge via `session/{session_id}/screenshot/full` endpoint (like Firefox already has).

### 🔧 Implementation Notes

This essentially implements the same methods that the FireFox WebDriver class uses in the Chromium WebDriver class, so Chrome and Edge can use them.


### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add full page screenshot methods to Chromium WebDriver

- Implement four screenshot methods with different output formats

- Add comprehensive tests for Chrome and Edge browsers

- Methods support base64, PNG binary, and file output formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chromium WebDriver"] -->|"add methods"| B["get_full_page_screenshot_as_base64"]
  A -->|"add methods"| C["get_full_page_screenshot_as_png"]
  A -->|"add methods"| D["get_full_page_screenshot_as_file"]
  A -->|"add methods"| E["save_full_page_screenshot"]
  B -->|"decode"| C
  C -->|"write to file"| D
  D -->|"alias"| E
  F["Chrome Tests"] -->|"verify"| B
  F -->|"verify"| C
  G["Edge Tests"] -->|"verify"| B
  G -->|"verify"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add four full page screenshot methods to Chromium</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/chromium/webdriver.py

<ul><li>Add imports for <code>base64</code> and <code>warnings</code> modules<br> <li> Implement <code>get_full_page_screenshot_as_base64()</code> method to retrieve full <br>page screenshot as base64-encoded string<br> <li> Implement <code>get_full_page_screenshot_as_png()</code> method to decode base64 to <br>binary PNG data<br> <li> Implement <code>get_full_page_screenshot_as_file()</code> method to save screenshot <br>to file with validation<br> <li> Implement <code>save_full_page_screenshot()</code> as alias method for file saving</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16727/files#diff-10fa59c3fd96a0c31762373ca8d7373c0ab669a437ae957b1a17ea1377b20608">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Minor formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/firefox/webdriver.py

- Add blank line after license header for consistency


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16727/files#diff-89ba579445647535b74423c7bf4b8be79ef1ce33847a2768e623c3083a33545d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome_takes_full_page_screenshots_tests.py</strong><dd><code>Add Chrome full page screenshot tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/chrome/chrome_takes_full_page_screenshots_tests.py

<ul><li>Create new test file for Chrome full page screenshots<br> <li> Add test for <code>get_full_page_screenshot_as_base64()</code> method<br> <li> Add test for <code>get_full_page_screenshot_as_png()</code> method<br> <li> Verify returned data is valid PNG format using filetype library</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16727/files#diff-7851e3a8a2214e17ded0a683a49ba4490902e870f1f34708057d99206b51c553">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge_takes_full_page_screenshots_tests.py</strong><dd><code>Add Edge full page screenshot tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/test/selenium/webdriver/edge/edge_takes_full_page_screenshots_tests.py

<ul><li>Create new test file for Edge full page screenshots<br> <li> Add test for <code>get_full_page_screenshot_as_base64()</code> method<br> <li> Add test for <code>get_full_page_screenshot_as_png()</code> method<br> <li> Verify returned data is valid PNG format using filetype library</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16727/files#diff-f518ce8622f4a8f0e5441f7e369c0fcb7482dfe1502cb34df9d1528037beb1af">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

