### PR TITLE
[build] build selenium manager for tests

### DIFF
--- a/common/manager/BUILD.bazel
+++ b/common/manager/BUILD.bazel
@@ -11,15 +11,24 @@ package(
 
 alias(
     name = "selenium-manager-linux",
-    actual = "@download_sm_linux//file",
+    actual = select({
+        "//common:use_pinned_browser": "@download_sm_linux//file",
+        "//conditions:default": "//rust:selenium-manager-linux",
+    }),
 )
 
 alias(
     name = "selenium-manager-macos",
-    actual = "@download_sm_macos//file",
+    actual = select({
+        "//common:use_pinned_browser": "@download_sm_macos//file",
+        "//conditions:default": "//rust:selenium-manager-macos",
+    }),
 )
 
 alias(
     name = "selenium-manager-windows",
-    actual = "@download_sm_windows//file",
+    actual = select({
+        "//common:use_pinned_browser": "@download_sm_windows//file",
+        "//conditions:default": "//rust:selenium-manager-windows",
+    }),
 )


### PR DESCRIPTION
*Note*: This code includes #16743 for it to work

### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
This code fixed constant build churn by always downloading latest manager: https://github.com/SeleniumHQ/selenium/pull/13314
But this doesn't work when you change selenium manager code locally.

Conditional is now
* if pin_browsers - download instead of build
* if stamp - download instead of build
* else build instead of download

@bonigarcia / @diemol does this look right to you?


___

### **PR Type**
Enhancement


___

### **Description**
- Conditionally build or download Selenium Manager based on build flags

- Download when using pinned browsers or stamped builds

- Build locally when developing Selenium Manager code

- Reduces build churn while supporting local development


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Configuration"] --> B{Check Conditions}
  B -->|use_pinned_browser| C["Download Manager"]
  B -->|stamp| C
  B -->|else| D["Build Manager Locally"]
  C --> E["Selenium Manager Binary"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Build</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add conditional build vs download logic for Selenium Manager</code></dd></summary>
<hr>

common/manager/BUILD.bazel

<ul><li>Replaced static download references with conditional <code>select()</code> <br>statements<br> <li> Added logic to download when <code>use_pinned_browser</code> or <code>stamp</code> flags are set<br> <li> Added logic to build locally from <code>//rust:selenium-manager-*</code> targets <br>otherwise<br> <li> Applied same conditional pattern to Linux, macOS, and Windows manager <br>aliases</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16736/files#diff-908bad3a70cc237209bf55461e241f14098951ea6de3910de078273965bcdba2">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

