### PR TITLE
[build] Pin Browsers in Bazel by default

### DIFF
--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -42,9 +42,6 @@ test:rbe --test_env=HOME=/home/dev
 # Make sure we sniff credentials properly
 build:rbe --credential_helper=gypsum.cluster.engflow.com=%workspace%/scripts/credential-helper.sh
 
-# Use pinned browsers when running remotely
-build:rbe --//common:pin_browsers
-
 # The remote build machines are pretty small, and 50 threads may leave them
 # thrashing, but our dev machines are a lot larger. Scale the workload so we
 # make reasonable usage of everything, everywhere, all at once.

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -24,4 +24,4 @@ jobs:
       os: windows
       run: |
         fsutil 8dot3name set 0
-        bazel test //dotnet/test/common:ElementFindingTest-firefox //dotnet/test/common:ElementFindingTest-chrome --pin_browsers=true
+        bazel test //dotnet/test/common:ElementFindingTest-firefox //dotnet/test/common:ElementFindingTest-chrome

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -23,7 +23,7 @@ jobs:
       java-version: 17
       run: |
         fsutil 8dot3name set 0
-        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest `
+        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest `
             //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest `
             //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest `
             //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest `
@@ -48,7 +48,7 @@ jobs:
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
       run: |
-        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote \
+        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote \
             //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest \
           //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest \
             //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest \
@@ -72,4 +72,4 @@ jobs:
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
       run: |
-        bazel test --flaky_test_attempts 3 --pin_browsers=true //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -114,7 +114,7 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
 
   browser-tests-windows:
     name: Browser Tests
@@ -135,7 +135,7 @@ jobs:
       cache-key: py-browser-${{ matrix.browser }}
       run: |
         fsutil 8dot3name set 0
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:common-${{ matrix.browser }}-bidi //py:test-${{ matrix.browser }}
 
   browser-tests-macos:
     name: Browser Tests
@@ -153,4 +153,4 @@ jobs:
       os: ${{ matrix.os }}
       cache-key: py-browser-${{ matrix.browser }}
       run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 --pin_browsers=true //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}
+        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:common-${{ matrix.browser }} //py:test-${{ matrix.browser }}

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -84,7 +84,6 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}
-        --pin_browsers
         //rb/spec/...
 
   integration-tests-remote:
@@ -111,5 +110,4 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}-remote
-        --pin_browsers
         //rb/spec/...

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ There are a number of bazel configurations specific for testing.
 ### Common Options Examples
 
 Here are examples of arguments we make use of in testing the Selenium code:
-* `--pin_browsers` - run specific browser versions defined in the build (versions are updated regularly)
+* `--pin_browsers=false` - use Selenium Manager to locate browsers/drivers
 * `--headless` - run browsers in headless mode (supported be Chrome, Edge and Firefox)
 * `--flaky_test_attempts 3` - re-run failed tests up to 3 times
 * `--local_test_jobs 1` - control parallelism of tests
@@ -491,19 +491,19 @@ echo '<X.Y.Z>' > rb/.ruby-version
 Run all tests with:
 
 ```shell
-bazel test //dotnet/test/common:AllTests --pin_browsers=true
+bazel test //dotnet/test/common:AllTests
 ```
 
 You can run specific tests by specifying the class name:
 
 ```shell
-bazel test //dotnet/test/common:ElementFindingTest --pin_browsers=true
+bazel test //dotnet/test/common:ElementFindingTest
 ```
 
 If the module supports multiple browsers:
 
 ```shell
-bazel test //dotnet/test/common:ElementFindingTest-edge --pin_browsers=true
+bazel test //dotnet/test/common:ElementFindingTest-edge
 ```
 
 </details>

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -7,6 +7,13 @@ bool_flag(
     build_setting_default = True,
 )
 
+config_setting(
+    name = "use_pinned_browser",
+    flag_values = {
+        ":pin_browsers": "true",
+    },
+)
+
 bool_flag(
     name = "headless",
     build_setting_default = False,
@@ -38,13 +45,6 @@ config_setting(
 config_setting(
     name = "stamp",
     values = {"stamp": "true"},
-)
-
-config_setting(
-    name = "use_pinned_browser",
-    flag_values = {
-        ":pin_browsers": "true",
-    },
 )
 
 alias(

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -40,6 +40,13 @@ config_setting(
     values = {"stamp": "true"},
 )
 
+config_setting(
+    name = "use_pinned_browser",
+    flag_values = {
+        ":pin_browsers": "true",
+    },
+)
+
 alias(
     name = "chromedriver",
     actual = "@local_drivers//:chromedriver",

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -4,14 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 bool_flag(
     name = "pin_browsers",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "use_pinned_browser",
-    flag_values = {
-        ":pin_browsers": "true",
-    },
+    build_setting_default = True,
 )
 
 bool_flag(


### PR DESCRIPTION
### **User description**
### PR Reason
Everything in the CI is already pinning browsers (except remote python tests, where I think it was just an oversight, not intentional). Better to make it the default for bazel, and have users override if they want different behavior.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Changes default for pin_browsers from false to true
* Removes all unnecessary references for setting it

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Could have removed this entirely and used a new flag for use_selenium_manager or something, but this is more backwards compatible

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
I can't think of a good reason not to set this at this point.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement


___

### **Description**
- Changes default `pin_browsers` flag from false to true

- Removes explicit `--pin_browsers=true` from CI workflows

- Removes unused `use_pinned_browser` config setting

- Updates documentation to reflect new default behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pin_browsers default: false"] -->|"Change default"| B["pin_browsers default: true"]
  B -->|"Remove explicit flags"| C["CI workflows simplified"]
  B -->|"Remove config setting"| D["Unused use_pinned_browser removed"]
  B -->|"Update docs"| E["Documentation reflects new behavior"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Set pin_browsers default to true</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/BUILD.bazel

<ul><li>Changes <code>pin_browsers</code> bool_flag <code>build_setting_default</code> from <code>False</code> to <br><code>True</code><br> <li> Removes unused <code>use_pinned_browser</code> config_setting that checked the flag <br>value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-bd80cc63acf90472b05f2d3ef7d98e8a7266fc9d10c7016497d0fd24db9298f6">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.bazelrc.remote</strong><dd><code>Remove redundant remote pin_browsers config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.bazelrc.remote

<ul><li>Removes <code>build:rbe --//common:pin_browsers</code> line from remote build <br>configuration<br> <li> No longer needed since pinning is now the default behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-81c4b7362f2e859c22b1d4cbe205f550889ee1aa9a0999552a385ab643ee1451">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-dotnet.yml</strong><dd><code>Remove explicit pin_browsers flag from dotnet tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-dotnet.yml

<ul><li>Removes <code>--pin_browsers=true</code> flag from dotnet browser test command<br> <li> Flag is now redundant with new default behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-9f761b9e8edbe9c2db37b8ef3863ecc6318bc1930386c72585733ae09ae9016f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-java.yml</strong><dd><code>Remove explicit pin_browsers flags from java tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-java.yml

<ul><li>Removes <code>--pin_browsers=true</code> flag from three separate test commands<br> <li> Affects local browser tests, remote browser tests, and remote test <br>jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-6097d5fb92c6d1746b67c0e66c6d66f2f4b2e848d5fae5de189f7112e58da9cf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-python.yml</strong><dd><code>Remove explicit pin_browsers flags from python tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-python.yml

<ul><li>Removes <code>--pin_browsers=true</code> flag from three Python integration test <br>commands<br> <li> Affects Linux, Windows, and macOS test configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-a7ec86144013d78c9f1d734aa65a898e66b609638aa7b872491ee3858ebebbeb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-ruby.yml</strong><dd><code>Remove explicit pin_browsers flags from ruby tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-ruby.yml

<ul><li>Removes <code>--pin_browsers</code> flag from two Ruby test commands<br> <li> Affects both local and remote integration test configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-e71b669ae33da2f4e6f9e0858c13b326eaea0388934d0a21e3ebc31005b7aa90">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new pin_browsers default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updates documentation example from <code>--pin_browsers</code> to <br><code>--pin_browsers=false</code><br> <li> Changes description to clarify that false uses Selenium Manager <br>instead<br> <li> Removes <code>--pin_browsers=true</code> from all dotnet test examples</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16743/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

