### PR TITLE
[closure] Fix failing `//javascript/atoms:test-*` targets

### DIFF
--- a/.skipped-tests
+++ b/.skipped-tests
@@ -19,9 +19,6 @@
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-remote
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverScreenshotTest-remote
--//javascript/atoms:test-chrome
--//javascript/atoms:test-edge
--//javascript/atoms:test-firefox-beta
 -//javascript/chrome-driver/...
 -//javascript/selenium-webdriver:test-builder-test.js-chrome
 -//javascript/selenium-webdriver:test-chrome-devtools-test.js-chrome

--- a/javascript/atoms/action.js
+++ b/javascript/atoms/action.js
@@ -120,7 +120,7 @@ bot.action.clear = function (element) {
     // able to interact with this element anymore in Firefox.
     bot.action.LegacyDevice_.focusOnElement(element);
     if (goog.userAgent.GECKO) {
-      element.innerHTML = ' ';
+      element.textContent = ' ';
     } else {
       element.textContent = '';
     }

--- a/javascript/atoms/dom.js
+++ b/javascript/atoms/dom.js
@@ -540,10 +540,21 @@ bot.dom.isShown_ = function (elem, ignoreOpacity, displayedFn) {
     // Zero-sized elements should still be considered to have positive size
     // if they have a child element or text node with positive size, unless
     // the element has an 'overflow' style of 'hidden'.
+    // Note: Text nodes containing only structural whitespace (with newlines
+    // or tabs) are ignored as they are likely just HTML formatting, not
+    // visible content.
     return bot.dom.getEffectiveStyle(e, 'overflow') != 'hidden' &&
       goog.array.some(e.childNodes, function (n) {
-        return n.nodeType == goog.dom.NodeType.TEXT ||
-          (bot.dom.isElement(n) && positiveSize(n));
+        if (n.nodeType == goog.dom.NodeType.TEXT) {
+          var text = n.nodeValue;
+          // Ignore text nodes that are purely structural whitespace
+          // (contain newlines or tabs and nothing else besides spaces)
+          if (/^[\s]*$/.test(text) && /[\n\r\t]/.test(text)) {
+            return false;
+          }
+          return true;
+        }
+        return bot.dom.isElement(n) && positiveSize(n);
       });
   }
   if (!positiveSize(elem)) {
@@ -1412,9 +1423,13 @@ bot.dom.isNodeDistributedIntoShadowDom = function (node) {
 bot.dom.appendVisibleTextLinesFromElementInComposedDom_ = function (
   elem, lines) {
   if (elem.shadowRoot) {
+    // Get the effective styles from the shadow host element for text nodes in shadow DOM
+    var whitespace = bot.dom.getEffectiveStyle(elem, 'white-space');
+    var textTransform = bot.dom.getEffectiveStyle(elem, 'text-transform');
+
     goog.array.forEach(elem.shadowRoot.childNodes, function (node) {
       bot.dom.appendVisibleTextLinesFromNodeInComposedDom_(
-        node, lines, true, null, null);
+        node, lines, true, whitespace, textTransform);
     });
   }
 

--- a/javascript/atoms/events.js
+++ b/javascript/atoms/events.js
@@ -369,10 +369,15 @@ bot.events.KeyboardEventFactory_.prototype.create = function (target, opt_args) 
     event.ctrlKey = args.ctrlKey;
     event.metaKey = args.metaKey;
     event.shiftKey = args.shiftKey;
-    event.keyCode = args.charCode || args.keyCode;
-    if (goog.userAgent.WEBKIT || goog.userAgent.EDGE) {
-      event.charCode = (this == bot.events.EventType.KEYPRESS) ?
-        event.keyCode : 0;
+    if (goog.userAgent.GECKO) {
+      event.keyCode = args.charCode ? 0 : args.keyCode;
+      event.charCode = args.charCode;
+    } else {
+      event.keyCode = args.charCode || args.keyCode;
+      if (goog.userAgent.WEBKIT || goog.userAgent.EDGE) {
+        event.charCode = (this == bot.events.EventType.KEYPRESS) ?
+          event.keyCode : 0;
+      }
     }
   }
 

--- a/javascript/atoms/keyboard.js
+++ b/javascript/atoms/keyboard.js
@@ -496,7 +496,7 @@ bot.Keyboard.prototype.maybeSubmitForm_ = function (key) {
   if (key != bot.Keyboard.Keys.ENTER) {
     return;
   }
-  if (goog.userAgent.GECKO ||
+  if ((goog.userAgent.GECKO && !bot.userAgent.isEngineVersion(93)) ||
     !bot.dom.isElement(this.getElement(), goog.dom.TagName.INPUT)) {
     return;
   }

--- a/javascript/atoms/test/shown_test.html
+++ b/javascript/atoms/test/shown_test.html
@@ -300,7 +300,7 @@
       assertFalse(bot.dom.isShown(select));
       assertTrue('Select should be visible when ignoring opacity',
         bot.dom.isShown(select, true));
-      assertTrue(bot.dom.isShown(select.firstChild));
+      assertTrue(bot.dom.isShown(select.firstElementChild));
     }
 
     /** @see http://code.google.com/p/selenium/issues/detail?id=1941 */
@@ -374,7 +374,7 @@
     function testTableRowDefaultVisibility() {
       var elem = findElement({ id: 'visible-row' });
       assertTrue(isShown(elem));
-      assertTrue(isShown(elem.firstChild));
+      assertTrue(isShown(elem.firstElementChild));
     }
 
     function testTableRowCollapsedVisibility() {
@@ -384,14 +384,14 @@
       var elem = findElement({ id: 'collapsed-row' });
       expectedFailures.run(function () {
         assertFalse(isShown(elem));
-        assertFalse(isShown(elem.firstChild));
+        assertFalse(isShown(elem.firstElementChild));
       });
     }
 
     function testVisibleTableRowAfterCollapsedRow() {
       var elem = findElement({ id: 'post-collapsed-row' });
       assertTrue(isShown(elem));
-      assertTrue(isShown(elem.firstChild));
+      assertTrue(isShown(elem.firstElementChild));
     }
 
     function testDisplayContentsOverflowIgnored() {
@@ -406,7 +406,7 @@
     function testDetailsNonSummaryDescendantsVisibility() {
       var contents = findElement({ id: 'non-summary' });
       assertFalse(isShown(contents));
-      assertFalse(isShown(contents.firstChild));
+      assertFalse(isShown(contents.firstElementChild));
     }
 
     function testContentVisibleHidden() {

--- a/javascript/atoms/test/text_shadow_test.html
+++ b/javascript/atoms/test/text_shadow_test.html
@@ -54,15 +54,18 @@ limitations under the License.
       if (type == 'closed') {
         document.querySelector(`closed-shadow-element`)._shadowRoot.innerHTML = html;
       } else {
-        document.querySelector(`open-shadow-element`).shadowRoot.innerHTML = html;
+        // Set shadow DOM on ALL open-shadow-element instances
+        document.querySelectorAll(`open-shadow-element`).forEach(elem => {
+          elem.shadowRoot.innerHTML = html;
+        });
       }
     }
 
     function tearDown() {
-      let open = document.querySelector('open-shadow-element');
+      document.querySelectorAll('open-shadow-element').forEach(elem => {
+        elem.shadowRoot.innerHTML = '';
+      });
       let closed = document.querySelector('closed-shadow-element');
-
-      open.shadowRoot.innerHTML = '';
       closed._shadowRoot.innerHTML = '';
     }
 


### PR DESCRIPTION
### **User description**
And re-enable them in CI. These tests are only expected to pass when run with pinned browsers in the RBE.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix DOM visibility detection for text nodes with structural whitespace

- Correct keyboard event handling for Firefox browsers

- Fix form submission logic for Firefox engine version 93+

- Update shadow DOM text extraction to handle multiple instances

- Re-enable previously failing JavaScript atoms tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DOM Visibility Logic"] -->|"Filter structural whitespace"| B["Text Node Handling"]
  C["Keyboard Events"] -->|"Firefox-specific logic"| D["Event Creation"]
  E["Form Submission"] -->|"Version check"| F["Firefox 93+ Support"]
  G["Shadow DOM"] -->|"Multiple instances"| H["Text Extraction"]
  I["Test Configuration"] -->|"Remove skip entries"| J["Re-enable Atoms Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dom.js</strong><dd><code>Improve DOM visibility and shadow DOM text handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/dom.js

<ul><li>Enhanced text node visibility detection to ignore structural <br>whitespace (newlines, tabs)<br> <li> Added regex check to filter text nodes containing only whitespace with <br>structural characters<br> <li> Fixed shadow DOM text extraction to retrieve effective styles from <br>shadow host element<br> <li> Pass whitespace and text-transform styles to child node processing</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-53bbf9a76b3e18a714284bd37ffdbcb670cbf537319cdaee94aacca31bcc497d">+18/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.js</strong><dd><code>Fix keyboard event handling for Firefox</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/events.js

<ul><li>Added Firefox-specific keyboard event handling logic<br> <li> Set keyCode to 0 for charCode events in Firefox, preserve keyCode <br>otherwise<br> <li> Maintain existing WebKit and Edge charCode behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-10821acf40d143a890e7216858a732f17f95ae418aac0c2bd209cb671b924576">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keyboard.js</strong><dd><code>Add Firefox 93+ version check for form submission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/keyboard.js

<ul><li>Add version check to exclude Firefox engine version 93+ from form <br>submission logic<br> <li> Prevent form auto-submission on Enter key for Firefox 93 and later</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-ffdc8d415da48f54d64757bd44d3a61c62082c5904a67f91fd62f0b27d075afe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shown_test.html</strong><dd><code>Update test assertions to use firstElementChild</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/test/shown_test.html

<ul><li>Replace deprecated firstChild with firstElementChild in test <br>assertions<br> <li> Update 5 test cases to use modern DOM API for element access<br> <li> Improves compatibility with modern browser implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-219f47070e34d2539f1f805d746688422a639046d2bd2ed05095b01af4ab39b9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>text_shadow_test.html</strong><dd><code>Fix shadow DOM setup for multiple element instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/test/text_shadow_test.html

<ul><li>Fix setCustomElement to update all open-shadow-element instances using <br>querySelectorAll<br> <li> Update tearDown to properly clear shadow DOM for all <br>open-shadow-element instances<br> <li> Prevent test interference by ensuring all shadow DOM instances are <br>cleaned</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-2b45504b60552efbfd99eb928ab23442ed097b1c54837a7f0066300111a87e93">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.skipped-tests</strong><dd><code>Re-enable JavaScript atoms tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.skipped-tests

<ul><li>Remove three JavaScript atoms test entries from skip list<br> <li> Re-enable //javascript/atoms:test-chrome, test-edge, and <br>test-firefox-beta<br> <li> Tests now expected to pass with pinned browsers in RBE</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16749/files#diff-f5b9e26559bdc4671c8a6fd4013e376a76cbdac0a1661ffbe585b7533c4700f7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

