### PR TITLE
[py] load bazel files first for local dev work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -579,9 +579,6 @@ namespace :py do
   task :local_dev do
     Bazel.execute('build', [], '//py:selenium')
     Rake::Task['grid'].invoke
-
-    FileUtils.rm_rf('py/selenium/webdriver/common/devtools/')
-    FileUtils.cp_r('bazel-bin/py/selenium/webdriver/.', 'py/selenium/webdriver', remove_destination: true)
   end
 
   desc 'Update generated Python files for local development'

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -22,11 +22,18 @@ from pathlib import Path
 
 import pytest
 
+import selenium
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.remote.server import Server
 from test.selenium.webdriver.common.network import get_lan_ip
 from test.selenium.webdriver.common.webserver import SimpleWebServer
+
+# Allow local sources to override, and fall back to Bazel-generated files when present.
+_repo_root = Path(__file__).resolve().parents[1]
+_bazel_pkg = _repo_root / "bazel-bin" / "py" / "selenium"
+if _bazel_pkg.is_dir() and str(_bazel_pkg) not in selenium.__path__:
+    selenium.__path__.append(str(_bazel_pkg))
 
 drivers = (
     "chrome",


### PR DESCRIPTION
### **User description**
The goal is to be able to run normal pytest in your IDE of choice and have it "just work"
But you should also be able to run bazel commands directly.
The current implementation causes problems with having two sources of truth, this implementation should let you switch between debugging with PyTest and a local Python environment and running bazel commands without errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Dynamically load Bazel-generated files for local development

- Append Bazel package path to selenium module path

- Simplify local dev setup by removing manual file copying

- Allow seamless switching between pytest and bazel workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["conftest.py imports selenium"] --> B["Check for bazel-bin/py/selenium"]
  B --> C["Append to selenium.__path__"]
  C --> D["Local sources override Bazel files"]
  E["Rakefile local_dev task"] --> F["Remove manual file copying"]
  F --> G["Simplified setup process"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add dynamic Bazel package path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<ul><li>Import selenium module at top level<br> <li> Add logic to detect and append Bazel-generated package path to <br><code>selenium.__path__</code><br> <li> Allow local sources to override Bazel files when both exist<br> <li> Enable fallback to Bazel-generated files when local sources <br>unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16764/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Simplify local dev task setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Remove manual file copying from <code>bazel-bin/py/selenium/webdriver</code> to <br><code>py/selenium/webdriver</code><br> <li> Remove devtools directory cleanup step<br> <li> Simplify local_dev task by relying on dynamic path loading</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16764/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

