### PR TITLE
Fix bug in FileHandler: it always failed on MacOS

### DIFF
--- a/java/src/org/openqa/selenium/io/FileHandler.java
+++ b/java/src/org/openqa/selenium/io/FileHandler.java
@@ -17,16 +17,16 @@
 
 package org.openqa.selenium.io;
 
+import static java.util.Locale.ROOT;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
+import java.util.*;
 
 /** Utility methods for common filesystem activities */
 public class FileHandler {
@@ -42,10 +42,10 @@ public class FileHandler {
 
   private static InputStream locateResource(Class<?> forClassLoader, String name)
       throws IOException {
-    String arch =
-        Objects.requireNonNull(System.getProperty("os.arch")).toLowerCase(Locale.ENGLISH) + "/";
-    List<String> alternatives = Arrays.asList(name, "/" + name, arch + name, "/" + arch + name);
-    if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("mac")) {
+    String arch = requireNonNull(System.getProperty("os.arch")).toLowerCase(ROOT) + "/";
+    List<String> alternatives =
+        new ArrayList<>(List.of(name, "/" + name, arch + name, "/" + arch + name));
+    if (System.getProperty("os.name").toLowerCase(ROOT).contains("mac")) {
       alternatives.add("mac/" + name);
       alternatives.add("/mac/" + name);
     }


### PR DESCRIPTION
### **User description**
The `alternatives` list is immutable, so trying to add `"mac/" + name` to it always failed.

P.S. I suspect this class is not used anymore, and should be removed.


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix immutable list error in FileHandler on macOS

- Convert immutable Arrays.asList to mutable ArrayList

- Simplify imports and use static constants

- Enable dynamic addition of macOS-specific resource paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Immutable Arrays.asList"] -->|"Replace with"| B["Mutable ArrayList"]
  B -->|"Enables"| C["Add macOS paths dynamically"]
  D["Locale.ENGLISH"] -->|"Replace with"| E["Locale.ROOT"]
  F["Objects.requireNonNull"] -->|"Replace with"| G["Static import requireNonNull"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileHandler.java</strong><dd><code>Fix macOS resource path handling with mutable list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/io/FileHandler.java

<ul><li>Changed <code>alternatives</code> from immutable <code>Arrays.asList()</code> to mutable <br><code>ArrayList</code> to allow adding macOS-specific paths<br> <li> Replaced <code>Locale.ENGLISH</code> with static import of <code>Locale.ROOT</code> for <br>consistency<br> <li> Replaced <code>Objects.requireNonNull()</code> with static import for cleaner code<br> <li> Consolidated wildcard import for <code>java.util.*</code> to reduce import clutter</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16771/files#diff-6b9adce3a2137262e499f93062848cf9fb1962a076dc153500ecebcb33a132bf">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

