### PR TITLE
[js] fix JS tests on RBE

### DIFF
--- a/.skipped-tests
+++ b/.skipped-tests
@@ -20,9 +20,6 @@
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverScreenshotTest-remote
 -//javascript/chrome-driver/...
--//javascript/selenium-webdriver:test-builder-test.js-chrome
--//javascript/selenium-webdriver:test-chrome-devtools-test.js-chrome
--//javascript/selenium-webdriver:test-firefox-options-test.js-firefox
 -//rb/spec/integration/selenium/webdriver/chrome:service-chrome
 -//rb/spec/integration/selenium/webdriver/chrome:service-chrome-remote
 -//rb/spec/integration/selenium/webdriver/edge:service-edge

--- a/javascript/selenium-webdriver/lib/webdriver.js
+++ b/javascript/selenium-webdriver/lib/webdriver.js
@@ -1380,20 +1380,12 @@ class WebDriver {
       }
     })
 
-    await connection.execute(
-      'Fetch.enable',
-      {
-        handleAuthRequests: true,
-      },
-      null,
-    )
-    await connection.execute(
-      'Network.setCacheDisabled',
-      {
-        cacheDisabled: true,
-      },
-      null,
-    )
+    await connection.send('Fetch.enable', {
+      handleAuthRequests: true,
+    })
+    await connection.send('Network.setCacheDisabled', {
+      cacheDisabled: true,
+    })
   }
 
   /**
@@ -1563,15 +1555,11 @@ class WebDriver {
       connection = this._cdpConnection
     }
 
-    await connection.execute('Page.enable', {}, null)
+    await connection.send('Page.enable', {})
 
-    await connection.execute(
-      'Runtime.evaluate',
-      {
-        expression: pinnedScript.creationScript(),
-      },
-      null,
-    )
+    await connection.send('Runtime.evaluate', {
+      expression: pinnedScript.creationScript(),
+    })
 
     let result = await connection.send('Page.addScriptToEvaluateOnNewDocument', {
       source: pinnedScript.creationScript(),
@@ -1597,23 +1585,15 @@ class WebDriver {
         connection = this._cdpConnection
       }
 
-      await connection.execute('Page.enable', {}, null)
+      await connection.send('Page.enable', {})
 
-      await connection.execute(
-        'Runtime.evaluate',
-        {
-          expression: script.removalScript(),
-        },
-        null,
-      )
+      await connection.send('Runtime.evaluate', {
+        expression: script.removalScript(),
+      })
 
-      await connection.execute(
-        'Page.removeScriptToEvaluateOnLoad',
-        {
-          identifier: script.scriptId,
-        },
-        null,
-      )
+      await connection.send('Page.removeScriptToEvaluateOnLoad', {
+        identifier: script.scriptId,
+      })
 
       delete this.pinnedScripts_[script.handle]
     }

--- a/javascript/selenium-webdriver/test/builder_test.js
+++ b/javascript/selenium-webdriver/test/builder_test.js
@@ -71,7 +71,7 @@ test.suite(function (env) {
 
       it(env.browser.name, async function () {
         let timeouts = { implicit: 0, pageLoad: 1000, script: 1000 }
-        driver = new Builder().setCapability('timeouts', timeouts).forBrowser(env.browser.name).build()
+        driver = env.builder().setCapability('timeouts', timeouts).build()
 
         let caps = await getCaps(driver)
         assert.deepEqual(caps.get('timeouts'), timeouts)

--- a/javascript/selenium-webdriver/test/firefox/options_test.js
+++ b/javascript/selenium-webdriver/test/firefox/options_test.js
@@ -27,7 +27,6 @@ const { locate } = require('../../lib/test/resources')
 const { until, By } = require('selenium-webdriver/index')
 
 const EXT_XPI = locate('common/extensions/webextensions-selenium-example.xpi')
-const WEBEXTENSION_EXTENSION_ID = 'webextensions-selenium-example@example.com.xpi'
 
 suite(
   function (env) {
@@ -43,15 +42,7 @@ suite(
       })
 
       describe('Options', function () {
-        let profileWithWebExtension
         let profileWithUserPrefs
-
-        before(async function createProfileWithWebExtension() {
-          profileWithWebExtension = await io.tmpDir()
-          let extensionsDir = path.join(profileWithWebExtension, 'extensions')
-          await io.mkdir(extensionsDir)
-          await io.write(path.join(extensionsDir, WEBEXTENSION_EXTENSION_ID), await io.read(EXT_XPI))
-        })
 
         before(async function createProfileWithUserPrefs() {
           profileWithUserPrefs = await io.tmpDir()
@@ -70,16 +61,6 @@ suite(
 
             await driver.get(Pages.echoPage)
             await verifyUserAgentWasChanged()
-          })
-
-          it('use profile with extension', async function () {
-            let options = env.builder().getFirefoxOptions() || new firefox.Options()
-            options.setProfile(profileWithWebExtension)
-
-            driver = env.builder().setFirefoxOptions(options).build()
-
-            await driver.get(Pages.echoPage)
-            await verifyWebExtensionWasInstalled()
           })
         })
 
@@ -127,14 +108,13 @@ suite(
 
           it('can add extra prefs on top of an existing profile', async function () {
             let options = env.builder().getFirefoxOptions() || new firefox.Options()
-            options.setPreference('general.useragent.override', 'foo;bar')
-            options.setProfile(profileWithWebExtension)
+            options.setPreference('general.useragent.override', 'baz;qux')
+            options.setProfile(profileWithUserPrefs)
 
             driver = env.builder().setFirefoxOptions(options).build()
 
             await driver.get(Pages.echoPage)
-            await verifyWebExtensionWasInstalled()
-            await verifyUserAgentWasChanged()
+            await verifyUserAgent('baz;qux')
           })
         })
 
@@ -185,8 +165,12 @@ suite(
       })
 
       async function verifyUserAgentWasChanged() {
+        await verifyUserAgent('foo;bar')
+      }
+
+      async function verifyUserAgent(expected) {
         let userAgent = await driver.executeScript('return window.navigator.userAgent')
-        assert.strictEqual(userAgent, 'foo;bar')
+        assert.strictEqual(userAgent, expected)
       }
 
       async function verifyWebExtensionWasInstalled() {


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Changing several `connection.execute` to `connection.send` when we want it to be blocking. 
* Use `env.builder()` instead of `new Builder()` so it uses the bazel configured values for the run
* I removed firefox options tests that I don't think work any more

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
More tests to follow up, just need to get things fixed first.

___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace deprecated `connection.execute()` calls with `connection.send()`

- Simplify CDP connection method signatures by removing null parameters

- Remove flaky Firefox WebExtension profile tests from test suite

- Re-enable JavaScript tests on RBE by fixing test compatibility issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CDP Connection Calls"] -->|Replace execute with send| B["Simplified Method Signatures"]
  C["Firefox Options Tests"] -->|Remove WebExtension tests| D["Stable Test Suite"]
  E["Test Configuration"] -->|Re-enable on RBE| F["Passing JS Tests"]
  B --> F
  D --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.js</strong><dd><code>Refactor CDP connection method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/lib/webdriver.js

<ul><li>Replace <code>connection.execute()</code> with <code>connection.send()</code> for CDP commands<br> <li> Remove null parameters from method calls (Fetch.enable, <br>Network.setCacheDisabled, Page.enable, Runtime.evaluate, <br>Page.removeScriptToEvaluateOnLoad)<br> <li> Simplify method signatures across network interception and pinned <br>script handling</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16777/files#diff-6729d326d7d3741f0830b9021904e5db3cbd69dcbfbe18ef047828eedc91304f">+17/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>builder_test.js</strong><dd><code>Simplify builder test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/test/builder_test.js

<ul><li>Replace manual Builder instantiation with <code>env.builder()</code> helper method<br> <li> Simplify test setup to use environment-provided builder configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16777/files#diff-6c682dc8683160d0a2bae1467a3446a240f13519e3024742d82850c9fdbcd80a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>options_test.js</strong><dd><code>Remove flaky WebExtension tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/test/firefox/options_test.js

<ul><li>Remove WebExtension profile creation and related test setup<br> <li> Delete flaky "use profile with extension" test case<br> <li> Refactor user agent verification into reusable <code>verifyUserAgent()</code> <br>helper function<br> <li> Simplify profile preference test to use single user preference profile</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16777/files#diff-74901e5f9e9de350b5042199a537a049aed84b5f94bb2ec604259afe14d0c27a">+8/-24</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.skipped-tests</strong><dd><code>Re-enable JavaScript tests on RBE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.skipped-tests

<ul><li>Remove three JavaScript test entries from skip list <br>(test-builder-test.js-chrome, test-chrome-devtools-test.js-chrome, <br>test-firefox-options-test.js-firefox)<br> <li> Re-enable previously skipped JavaScript tests on RBE</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16777/files#diff-f5b9e26559bdc4671c8a6fd4013e376a76cbdac0a1661ffbe585b7533c4700f7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

