### PR TITLE
[java] Provide default implementations for native HttpClient methods

### DIFF
--- a/java/src/org/openqa/selenium/grid/web/RoutableHttpClientFactory.java
+++ b/java/src/org/openqa/selenium/grid/web/RoutableHttpClientFactory.java
@@ -75,21 +75,6 @@ public class RoutableHttpClientFactory implements HttpClient.Factory {
         public WebSocket openSocket(HttpRequest request, WebSocket.Listener listener) {
           throw new UnsupportedOperationException("openSocket");
         }
-
-        @Override
-        public <T>
-            java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
-                java.net.http.HttpRequest request,
-                java.net.http.HttpResponse.BodyHandler<T> handler) {
-          throw new UnsupportedOperationException("sendAsyncNative is not supported");
-        }
-
-        @Override
-        public <T> java.net.http.HttpResponse<T> sendNative(
-            java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)
-            throws java.io.IOException, InterruptedException {
-          throw new UnsupportedOperationException("sendNative is not supported");
-        }
       };
     }
 

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriverBuilder.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriverBuilder.java
@@ -297,23 +297,6 @@ public class RemoteWebDriverBuilder {
               public HttpResponse execute(HttpRequest req) throws UncheckedIOException {
                 return handler.execute(req);
               }
-
-              @Override
-              public <T>
-                  java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>>
-                      sendAsyncNative(
-                          java.net.http.HttpRequest request,
-                          java.net.http.HttpResponse.BodyHandler<T> handler) {
-                throw new UnsupportedOperationException("sendAsyncNative is not supported");
-              }
-
-              @Override
-              public <T> java.net.http.HttpResponse<T> sendNative(
-                  java.net.http.HttpRequest request,
-                  java.net.http.HttpResponse.BodyHandler<T> handler)
-                  throws java.io.IOException, InterruptedException {
-                throw new UnsupportedOperationException("sendNative is not supported");
-              }
             };
           }
         };

--- a/java/src/org/openqa/selenium/remote/http/HttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/HttpClient.java
@@ -47,8 +47,11 @@ public interface HttpClient extends Closeable, HttpHandler {
    * @param handler the BodyHandler that determines how to handle the response body
    * @return a CompletableFuture containing the HTTP response
    */
-  <T> CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
-      java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler);
+  default <T> CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
+    java.net.http.HttpRequest request,
+    java.net.http.HttpResponse.BodyHandler<T> handler) {
+    throw new UnsupportedOperationException("sendAsyncNative is not supported by this HttpClient implementation");
+  }
 
   /**
    * Sends an HTTP request using java.net.http.HttpClient and allows specifying the BodyHandler.
@@ -60,10 +63,12 @@ public interface HttpClient extends Closeable, HttpHandler {
    * @throws java.io.IOException if an I/O error occurs
    * @throws InterruptedException if the operation is interrupted
    */
-  <T> java.net.http.HttpResponse<T> sendNative(
-      java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)
-      throws java.io.IOException, InterruptedException;
-
+  default <T> java.net.http.HttpResponse<T> sendNative(
+    java.net.http.HttpRequest request,
+    java.net.http.HttpResponse.BodyHandler<T> handler)
+    throws java.io.IOException, InterruptedException {
+    throw new UnsupportedOperationException("sendNative is not supported by this HttpClient implementation");
+  }
   interface Factory {
 
     /**

--- a/java/test/org/openqa/selenium/grid/testing/PassthroughHttpClient.java
+++ b/java/test/org/openqa/selenium/grid/testing/PassthroughHttpClient.java
@@ -48,19 +48,6 @@ public class PassthroughHttpClient implements HttpClient {
     throw new UnsupportedOperationException("openSocket");
   }
 
-  @Override
-  public <T> java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
-      java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler) {
-    throw new UnsupportedOperationException("sendAsyncNative");
-  }
-
-  @Override
-  public <T> java.net.http.HttpResponse<T> sendNative(
-      java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)
-      throws java.io.IOException, InterruptedException {
-    throw new UnsupportedOperationException("sendNative");
-  }
-
   public static class Factory implements HttpClient.Factory {
 
     private final Routable handler;

--- a/java/test/org/openqa/selenium/remote/ProtocolHandshakeTest.java
+++ b/java/test/org/openqa/selenium/remote/ProtocolHandshakeTest.java
@@ -194,19 +194,5 @@ class ProtocolHandshakeTest {
     public WebSocket openSocket(HttpRequest request, WebSocket.Listener listener) {
       throw new UnsupportedOperationException("openSocket");
     }
-
-    @Override
-    public <T>
-        java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
-            java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler) {
-      throw new UnsupportedOperationException("sendAsyncNative");
-    }
-
-    @Override
-    public <T> java.net.http.HttpResponse<T> sendNative(
-        java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)
-        throws java.io.IOException, InterruptedException {
-      throw new UnsupportedOperationException("sendNative");
-    }
   }
 }

--- a/java/test/org/openqa/selenium/remote/http/NativeHttpClientMethodsTest.java
+++ b/java/test/org/openqa/selenium/remote/http/NativeHttpClientMethodsTest.java
@@ -243,6 +243,8 @@ class NativeHttpClientMethodsTest {
       return CompletableFuture.completedFuture(mockResponse);
     }
 
+
+
     @Override
     public <T> java.net.http.HttpResponse<T> sendNative(
         java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)


### PR DESCRIPTION
### **User description**
This change prevents compilation errors in `HttpClient` implementations that do not support
native Java HTTP operations by providing default implementations for the newly added methods.

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #16673

### 💥 What does this PR do?
This PR makes the newly introduced native HTTP client methods (`sendNative` and
`sendAsyncNative`) optional by providing default implementations in the
`HttpClient` interface.

The default implementations throw `UnsupportedOperationException`, preserving the
previous behavior for clients that do not support Java 11 native HTTP APIs, while
allowing implementations such as `JdkHttpClient` to override and provide full
support.

### 🔧 Implementation Notes
- The methods are implemented as `default` in the `HttpClient` interface to avoid
  breaking existing implementations.
- Redundant overrides that only threw `UnsupportedOperationException` were removed
  from internal and test HTTP client implementations.
- Implementations that support native HTTP operations (e.g. `JdkHttpClient`) remain
  unchanged and continue to provide concrete behavior.

Alternative approaches considered:
- Making the methods abstract (rejected due to breaking existing implementations).
- Introducing a separate sub-interface for native HTTP support (rejected due to
  added complexity and limited benefit).

### 💡 Additional Considerations
- Existing behavior is preserved for all current `HttpClient` implementations.
- No functional changes for users unless they explicitly rely on the new native
  HTTP methods.
- Unit tests continue to validate both supported and unsupported implementations.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Adds default implementations for native HTTP methods in `HttpClient` interface

- Removes redundant method overrides from multiple implementations

- Methods now throw `UnsupportedOperationException` by default

- Allows implementations to optionally override native HTTP support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HttpClient Interface"] -->|"adds default implementations"| B["sendAsyncNative()"]
  A -->|"adds default implementations"| C["sendNative()"]
  B -->|"throws UnsupportedOperationException"| D["Default Behavior"]
  C -->|"throws UnsupportedOperationException"| D
  E["Implementation Classes"] -->|"remove redundant overrides"| F["RoutableHttpClientFactory"]
  E -->|"remove redundant overrides"| G["RemoteWebDriverBuilder"]
  E -->|"remove redundant overrides"| H["PassthroughHttpClient"]
  E -->|"remove redundant overrides"| I["ProtocolHandshakeTest"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpClient.java</strong><dd><code>Add default implementations for native HTTP methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/http/HttpClient.java

<ul><li>Converts <code>sendAsyncNative()</code> from abstract to default method with <br><code>UnsupportedOperationException</code><br> <li> Converts <code>sendNative()</code> from abstract to default method with <br><code>UnsupportedOperationException</code><br> <li> Provides default implementations that preserve backward compatibility<br> <li> Allows subclasses to optionally override with actual implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-6a1f282027c9479c3edbe3b86a73c116bc7b8c36a3e4d77a7fa4edc61cfe4bd6">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RoutableHttpClientFactory.java</strong><dd><code>Remove redundant native HTTP method overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/web/RoutableHttpClientFactory.java

<ul><li>Removes redundant <code>sendAsyncNative()</code> override that only threw exception<br> <li> Removes redundant <code>sendNative()</code> override that only threw exception<br> <li> Relies on default implementations from <code>HttpClient</code> interface</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-1155119ab5aeab263bf90d1d3964e53885c70612b7e2c5cef8ad01f6a98231c2">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriverBuilder.java</strong><dd><code>Remove redundant native HTTP method overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriverBuilder.java

<ul><li>Removes redundant <code>sendAsyncNative()</code> override that only threw exception<br> <li> Removes redundant <code>sendNative()</code> override that only threw exception<br> <li> Relies on default implementations from <code>HttpClient</code> interface</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-d1186f8b43bcd7148629d75c680f59e0ccde5e49d2ab2c641dc94b825d7710e2">+0/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PassthroughHttpClient.java</strong><dd><code>Remove redundant native HTTP method overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/grid/testing/PassthroughHttpClient.java

<ul><li>Removes redundant <code>sendAsyncNative()</code> override that only threw exception<br> <li> Removes redundant <code>sendNative()</code> override that only threw exception<br> <li> Relies on default implementations from <code>HttpClient</code> interface</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-ce77376896cf1116067357f1a1a5c02a663db38f9f1c0d604a9ecb89a26ffd28">+0/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProtocolHandshakeTest.java</strong><dd><code>Remove redundant native HTTP method overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/ProtocolHandshakeTest.java

<ul><li>Removes redundant <code>sendAsyncNative()</code> override that only threw exception<br> <li> Removes redundant <code>sendNative()</code> override that only threw exception<br> <li> Relies on default implementations from <code>HttpClient</code> interface</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-71233881af8467d697936454b5779e8895c1d1f7d34341ba5e401f278126b3ec">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NativeHttpClientMethodsTest.java</strong><dd><code>Minor formatting adjustments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/http/NativeHttpClientMethodsTest.java

<ul><li>Adds whitespace formatting between method implementations<br> <li> No functional changes to test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16781/files#diff-78b320cb23e11eaafc08acbf8b85bc92eebe8a63f00b92bc8741c0d6a1a4ab75">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

