### PR TITLE
[bazel+js]: Avoid shadowing directory with test name

### DIFF
--- a/javascript/atoms/BUILD.bazel
+++ b/javascript/atoms/BUILD.bazel
@@ -403,7 +403,7 @@ closure_js_deps(
 )
 
 closure_test_suite(
-    name = "test",
+    name = "closure-test",
     data = [
         ":atoms",
         ":deps",

--- a/javascript/atoms/README.md
+++ b/javascript/atoms/README.md
@@ -14,7 +14,7 @@ the code in your IDE of choice, and then run the tests in a
 browser. You can do this by starting a debug server:
 
 ```shell
-bazel run javascript/atoms:test_debug_server
+bazel run javascript/atoms:closure-test_debug_server
 ```
 
 And then navigating to: <http://localhost:2310/filez/_main/javascript/atoms/>
@@ -32,12 +32,12 @@ the `bazel run` command.
 You can run all the tests for a browser using:
 
 ```shell
-bazel test //javascript/atoms:test{,-chrome,-edge,-safari}
+bazel test //javascript/atoms:closure-test{,-chrome,-edge,-safari}
 ```
 
 You can also filter to a specific test using the name of the file
 stripped of it's `.html` suffix. For example:
 
 ```shell
-bazel test --test_filter=shown_test --//common:headless=false javascript/atoms:test-chrome
+bazel test --test_filter=shown_test --//common:headless=false javascript/atoms:closure-test-chrome
 ```

--- a/javascript/chrome-driver/BUILD.bazel
+++ b/javascript/chrome-driver/BUILD.bazel
@@ -165,7 +165,7 @@ closure_js_deps(
 )
 
 closure_test_suite(
-    name = "test",
+    name = "closure-test",
     data = [
         ":all_files",
         ":deps",

--- a/javascript/webdriver/BUILD.bazel
+++ b/javascript/webdriver/BUILD.bazel
@@ -64,7 +64,7 @@ closure_js_deps(
 )
 
 closure_test_suite(
-    name = "test",
+    name = "closure-test",
     data = [
         ":all_files",
         ":deps",


### PR DESCRIPTION
### **User description**
The test target name `test` collides with the source directory `test/` containing the test HTML files. When Bazel builds the runfiles tree:

* The default `test` target (named `test`) places its binary at `_main/javascript/atoms/test` (a file)
* The test HTML files should be at `_main/javascript/atoms/test/*.html` (in a directory)
* Since the binary occupies the test path as a file, the `test/` directory with HTML files cannot exist in the runfiles `Files.find()` returns 0 test files because the test directory doesn't exist (it's a file instead)

Renaming the tests avoids this problem.

Insert facepalm -->here<--


___

### **PR Type**
Bug fix


___

### **Description**
- Rename test targets from `test` to `closure-test` to avoid shadowing

- Prevents file/directory collision in Bazel runfiles tree

- Fixes test discovery issue where HTML test files were inaccessible

- Updates documentation and examples with new target names


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test target named 'test'"] -->|"Collides with"| B["test/ directory"]
  B -->|"Causes"| C["Runfiles tree conflict"]
  C -->|"Results in"| D["0 test files found"]
  E["Rename to 'closure-test'"] -->|"Resolves"| C
  E -->|"Enables"| F["Proper test discovery"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Rename atoms test target to closure-test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/BUILD.bazel

<ul><li>Renamed <code>closure_test_suite</code> target from <code>test</code> to <code>closure-test</code><br> <li> Resolves file/directory shadowing issue in Bazel runfiles</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16784/files#diff-ec232f272761ab6df3676fa879ce6209ac8af32960d6fd9671895c196c4afb01">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Rename chrome-driver test target to closure-test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/chrome-driver/BUILD.bazel

<ul><li>Renamed <code>closure_test_suite</code> target from <code>test</code> to <code>closure-test</code><br> <li> Prevents naming collision with test directory</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16784/files#diff-0edc40a9496364995c82ecb78a965fe60297714379c24fd5f645f957fd522ff5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Rename webdriver test target to closure-test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/webdriver/BUILD.bazel

<ul><li>Renamed <code>closure_test_suite</code> target from <code>test</code> to <code>closure-test</code><br> <li> Aligns with other JavaScript test target naming changes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16784/files#diff-66f7bae124a8ea541bc51d575b007d6686fb0db7e45b812ba03190773b13e673">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation with new test target name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/atoms/README.md

<ul><li>Updated debug server command to use <code>closure-test_debug_server</code><br> <li> Updated test execution examples to reference <code>closure-test</code> target<br> <li> Updated test filtering example with new target name</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16784/files#diff-eb683b09415dc648b9ac97a2ad53077bcef36a4894f2b92e4aa7de8bd5366785">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

