### PR TITLE
[bazel] Flag fixes for the RBE

### DIFF
--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -7,6 +7,9 @@ build:rbe --remote_cache=grpcs://gypsum.cluster.engflow.com
 # The number of cores available
 build:rbe -j 50
 
+# Always pin the browser when running remotely
+build:rbe --//common:pin_browsers
+
 build:rbe --define=EXECUTOR=remote
 build:rbe --experimental_inmemory_dotd_files
 build:rbe --experimental_inmemory_jdeps_files
@@ -20,7 +23,6 @@ build:rbe --extra_execution_platforms=//common/remote-build:platform
 build:rbe --extra_toolchains=//common/remote-build:cc-toolchain
 build:rbe --host_platform=//common/remote-build:platform
 build:rbe --platforms=//common/remote-build:platform
-build:rbe --cxxopt=-std=c++14
 
 # The Docker images are running Linux
 build:rbe --cpu=k8


### PR DESCRIPTION
### **User description**
The c++ version is set properly in the main `.bazelrc` and changing it here doesn't help.

We should also always use a pinned browser in the RBE.


___

### **PR Type**
Enhancement


___

### **Description**
- Add browser pinning flag for RBE builds

- Remove redundant C++ standard flag from RBE config

- Simplify remote build configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RBE Configuration"] -->|Add pin_browsers flag| B["Browser Pinning Enabled"]
  A -->|Remove cxxopt flag| C["Simplified Config"]
  B --> D["Remote Build Execution"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.bazelrc.remote</strong><dd><code>Update RBE configuration flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.bazelrc.remote

<ul><li>Added <code>--//common:pin_browsers</code> flag to ensure pinned browsers in RBE <br>builds<br> <li> Removed redundant <code>--cxxopt=-std=c++14</code> flag (already set in main <br><code>.bazelrc</code>)<br> <li> Added clarifying comment for browser pinning configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16785/files#diff-81c4b7362f2e859c22b1d4cbe205f550889ee1aa9a0999552a385ab643ee1451">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

