### PR TITLE
[dotnet] [bidi] Fix context aware event handlers

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -135,7 +135,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationStartedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -146,7 +146,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationStartedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -157,7 +157,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnFragmentNavigatedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -168,7 +168,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnFragmentNavigatedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -179,7 +179,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnHistoryUpdatedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -190,7 +190,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnHistoryUpdatedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -201,7 +201,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDomContentLoadedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -212,7 +212,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDomContentLoadedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -223,7 +223,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnLoadAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -234,7 +234,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnLoadAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -245,7 +245,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -256,7 +256,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -267,7 +267,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDownloadEndAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -278,7 +278,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnDownloadEndAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -289,7 +289,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationAbortedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -300,7 +300,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationAbortedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -311,7 +311,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationFailedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -322,7 +322,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationFailedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -333,7 +333,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationCommittedAsync(e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 handler(e);
             }
@@ -344,7 +344,7 @@ public sealed record BrowsingContext
     {
         return BiDi.BrowsingContext.OnNavigationCommittedAsync(async e =>
         {
-            if (e.Context == this)
+            if (Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
@@ -361,7 +361,6 @@ public sealed record BrowsingContext
         return Id is not null ? StringComparer.Ordinal.GetHashCode(Id) : 0;
     }
 
-    // Includes Id only for brevity
     private bool PrintMembers(StringBuilder builder)
     {
         builder.Append($"Id = {Id}");

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -155,92 +155,200 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnFragmentNavigatedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Func<HistoryUpdatedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Action<HistoryUpdatedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDomContentLoadedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDomContentLoadedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDomContentLoadedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDomContentLoadedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnLoadAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnLoadAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnLoadAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnLoadAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnLoadAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnLoadAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadEndAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDownloadEndAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadEndAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnDownloadEndAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationAbortedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationAbortedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationAbortedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationAbortedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationFailedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationFailedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationFailedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationFailedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationCommittedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationCommittedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public bool Equals(BrowsingContext? other)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -133,12 +133,24 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationStartedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationStartedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationStartedAsync(async e =>
+        {
+            if (e.Context == this)
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnNavigationStartedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationStartedAsync(handler, options.WithContext(this));
+        return BiDi.BrowsingContext.OnNavigationStartedAsync(e =>
+        {
+            if (e.Context == this)
+            {
+                handler(e);
+            }
+        }, options.WithContext(this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)


### PR DESCRIPTION
### **User description**
Recently we went away from concept of `ContextEventArgs`, meaning handler should be aware itself.

Continuation of https://github.com/SeleniumHQ/selenium/pull/16694

### 🔧 Implementation Notes
I use `==` operator here, is it risky?

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap event handlers with context filtering logic

- Check if event context matches current instance before invoking

- Support both async and sync handler patterns consistently

- Ensure proper async/await handling with ConfigureAwait


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Handler Methods"] -->|"Wrap with context check"| B["Filter by e.Context == this"]
  B -->|"If match"| C["Invoke User Handler"]
  B -->|"If no match"| D["Skip Handler"]
  C -->|"Async handlers"| E["await with ConfigureAwait"]
  C -->|"Sync handlers"| F["Direct invocation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Implement context-aware event handler filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Wrapped all 16 event handler methods with context filtering logic<br> <li> Added <code>if (e.Context == this)</code> checks before invoking user handlers<br> <li> Maintained support for both <code>Action<T></code> and <code>Func<T, Task></code> handler patterns<br> <li> Applied <code>ConfigureAwait(false)</code> to async handler invocations for proper <br>async context</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16787/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+140/-20</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

