### PR TITLE
[java] #16753 workaround for JDK bug JDK-8228970

### DIFF
--- a/java/src/org/openqa/selenium/BUILD.bazel
+++ b/java/src/org/openqa/selenium/BUILD.bazel
@@ -34,6 +34,7 @@ java_export(
     visibility = ["//visibility:public"],
     deps = [
         ":manifest",
+        "//java/src/org/openqa/selenium/io",
         artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/devtools/events/CdpEventTypes.java
+++ b/java/src/org/openqa/selenium/devtools/events/CdpEventTypes.java
@@ -17,11 +17,8 @@
 
 package org.openqa.selenium.devtools.events;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -32,6 +29,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.io.Read;
 import org.openqa.selenium.json.Json;
 import org.openqa.selenium.logging.EventType;
 
@@ -46,7 +44,7 @@ public class CdpEventTypes {
   public static EventType<ConsoleEvent> consoleEvent(Consumer<ConsoleEvent> handler) {
     Require.nonNull("Handler", handler);
 
-    return new EventType<ConsoleEvent>() {
+    return new EventType<>() {
       public void consume(ConsoleEvent event) {
         handler.accept(event);
       }
@@ -67,19 +65,9 @@ public class CdpEventTypes {
   public static EventType<Void> domMutation(Consumer<DomMutationEvent> handler) {
     Require.nonNull("Handler", handler);
 
-    String script;
-    try (InputStream stream =
-        CdpEventTypes.class.getResourceAsStream(
-            "/org/openqa/selenium/devtools/mutation-listener.js")) {
-      if (stream == null) {
-        throw new IllegalStateException("Unable to find helper script");
-      }
-      script = new String(stream.readAllBytes(), UTF_8);
-    } catch (IOException e) {
-      throw new IllegalStateException("Unable to read helper script");
-    }
+    String script = Read.resourceAsString("/org/openqa/selenium/devtools/mutation-listener.js");
 
-    return new EventType<Void>() {
+    return new EventType<>() {
       @Override
       public void consume(Void event) {
         handler.accept(null);

--- a/java/src/org/openqa/selenium/io/BUILD.bazel
+++ b/java/src/org/openqa/selenium/io/BUILD.bazel
@@ -5,6 +5,7 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = [
         "//java/src/dev/selenium/tools/modules:__pkg__",
+        "//java/src/org/openqa/selenium:__pkg__",
         "//java/src/org/openqa/selenium/os:__pkg__",
         "//java/test/org/openqa/selenium/io:__pkg__",
     ],

--- a/java/src/org/openqa/selenium/io/Read.java
+++ b/java/src/org/openqa/selenium/io/Read.java
@@ -1,0 +1,66 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.io;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/** Helper methods to read input stream and return the result in different formats. */
+public class Read {
+
+  private Read() {}
+
+  /**
+   * Equivalent to Java's built-in method {@link InputStream#readAllBytes()}. But the latter has <a
+   * href="https://bugs.openjdk.org/browse/JDK-8228970">a bug</a> in Java 11 (fixed only in Java
+   * 14+).
+   *
+   * <p>This method can be removed when we upgrade to Java 17+.
+   */
+  public static byte[] toByteArray(InputStream in) throws IOException {
+    int estimatedSize = Math.max(in.available(), 1024);
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream(estimatedSize)) {
+      byte[] buffer = new byte[4096];
+
+      int readCount;
+      while ((readCount = in.read(buffer)) != -1) {
+        out.write(buffer, 0, readCount);
+      }
+      return out.toByteArray();
+    }
+  }
+
+  public static String toString(InputStream in) throws IOException {
+    return new String(toByteArray(in), UTF_8);
+  }
+
+  public static String resourceAsString(String resource) {
+    try (InputStream stream = Read.class.getResourceAsStream(resource)) {
+      if (stream == null) {
+        throw new IllegalArgumentException("Resource not found: " + resource);
+      }
+      return toString(stream);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read resource " + resource, e);
+    }
+  }
+}

--- a/java/src/org/openqa/selenium/net/UrlChecker.java
+++ b/java/src/org/openqa/selenium/net/UrlChecker.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
+import org.openqa.selenium.io.Read;
 
 /** Polls a URL until a HTTP 200 response is received. */
 public class UrlChecker {
@@ -164,16 +165,17 @@ public class UrlChecker {
    * @param connection the connection to consume the input
    */
   private static void consume(HttpURLConnection connection) {
-    try {
-      InputStream data = connection.getErrorStream();
-      if (data == null) {
-        data = connection.getInputStream();
+    try (InputStream errorStream = connection.getErrorStream()) {
+      if (errorStream != null) {
+        Read.toByteArray(errorStream);
+      } else {
+        try (InputStream inputStream = connection.getInputStream()) {
+          if (inputStream != null) {
+            Read.toByteArray(inputStream);
+          }
+        }
       }
-      if (data != null) {
-        data.readAllBytes();
-        data.close();
-      }
-    } catch (IOException e) {
+    } catch (IOException ignore) {
       // swallow
     }
   }

--- a/java/src/org/openqa/selenium/remote/RemoteScript.java
+++ b/java/src/org/openqa/selenium/remote/RemoteScript.java
@@ -17,11 +17,8 @@
 
 package org.openqa.selenium.remote;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,6 +41,7 @@ import org.openqa.selenium.bidi.script.EvaluateResultExceptionValue;
 import org.openqa.selenium.bidi.script.EvaluateResultSuccess;
 import org.openqa.selenium.bidi.script.LocalValue;
 import org.openqa.selenium.bidi.script.RemoteValue;
+import org.openqa.selenium.io.Read;
 import org.openqa.selenium.json.Json;
 
 @Beta
@@ -85,17 +83,8 @@ class RemoteScript implements Script {
 
   @Override
   public long addDomMutationHandler(Consumer<DomMutation> consumer) {
-    String scriptValue;
-    try (InputStream stream =
-        RemoteScript.class.getResourceAsStream(
-            "/org/openqa/selenium/remote/bidi-mutation-listener.js")) {
-      if (stream == null) {
-        throw new IllegalStateException("Unable to find helper script");
-      }
-      scriptValue = new String(stream.readAllBytes(), UTF_8);
-    } catch (IOException e) {
-      throw new IllegalStateException("Unable to read helper script");
-    }
+    String scriptValue =
+        Read.resourceAsString("/org/openqa/selenium/remote/bidi-mutation-listener.js");
 
     this.script.addPreloadScript(scriptValue, List.of(new ChannelValue("channel_name")));
 

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.remote.codec.w3c;
 
+import static org.openqa.selenium.io.Read.resourceAsString;
 import static org.openqa.selenium.remote.DriverCommand.ACCEPT_ALERT;
 import static org.openqa.selenium.remote.DriverCommand.ACTIONS;
 import static org.openqa.selenium.remote.DriverCommand.CLEAR_ACTIONS_STATE;
@@ -72,10 +73,7 @@ import static org.openqa.selenium.remote.DriverCommand.SET_TIMEOUT;
 import static org.openqa.selenium.remote.DriverCommand.SUBMIT_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.UPLOAD_FILE;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -364,13 +362,8 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
           ATOM_SCRIPTS.computeIfAbsent(
               atomFileName,
               (fileName) -> {
-                String scriptName = "/org/openqa/selenium/remote/" + atomFileName;
-                String rawFunction;
-                try (InputStream stream = getClass().getResourceAsStream(scriptName)) {
-                  rawFunction = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-                } catch (IOException e) {
-                  throw new UncheckedIOException(e);
-                }
+                String rawFunction =
+                    resourceAsString("/org/openqa/selenium/remote/" + atomFileName);
                 String atomName = fileName.replace(".js", "");
                 return String.format(
                     "/* %s */return (%s).apply(null, arguments);", atomName, rawFunction);

--- a/java/src/org/openqa/selenium/remote/http/HttpMessage.java
+++ b/java/src/org/openqa/selenium/remote/http/HttpMessage.java
@@ -37,6 +37,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.io.Read;
 
 abstract class HttpMessage<M extends HttpMessage<M>> {
 
@@ -199,8 +200,8 @@ abstract class HttpMessage<M extends HttpMessage<M>> {
 
   @Deprecated
   public M setContent(Supplier<InputStream> supplier) {
-    try {
-      return setContent(Contents.bytes(supplier.get().readAllBytes()));
+    try (InputStream in = supplier.get()) {
+      return setContent(Contents.bytes(Read.toByteArray(in)));
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }

--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpMessages.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.openqa.selenium.io.Read;
 import org.openqa.selenium.remote.http.AddSeleniumUserAgent;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.Contents;
@@ -194,7 +195,7 @@ class JdkHttpMessages {
 
   private byte[] readResponseBody(java.net.http.HttpResponse<InputStream> response) {
     try (InputStream in = response.body()) {
-      return in.readAllBytes();
+      return Read.toByteArray(in);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/java/test/org/openqa/selenium/io/ReadTest.java
+++ b/java/test/org/openqa/selenium/io/ReadTest.java
@@ -1,0 +1,48 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.io;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+class ReadTest {
+  @Test
+  void canReadInputStreamToByteArray() throws IOException {
+    InputStream in = new ByteArrayInputStream("Hello, world".getBytes(UTF_8));
+    byte[] result = Read.toByteArray(in);
+    assertThat(result).asString().isEqualTo("Hello, world");
+  }
+
+  @Test
+  void canReadInputStreamToString() throws IOException {
+    InputStream in = new ByteArrayInputStream("Hello, world".getBytes(UTF_8));
+    String result = Read.toString(in);
+    assertThat(result).isEqualTo("Hello, world");
+  }
+
+  @Test
+  void canReadResourceFromClasspath() {
+    String script = Read.resourceAsString("/org/openqa/selenium/remote/isDisplayed.js");
+    assertThat(script).isNotBlank().contains("function(){");
+  }
+}


### PR DESCRIPTION
### **User description**
Replace all usages of JDK built-in method `stream.readAllBytes()` by our own (fixed) method `Read.toByteArray(stream)`.


### 🔗 Related Issues
https://github.com/SeleniumHQ/selenium/issues/16753

JDK bug: https://bugs.openjdk.org/browse/JDK-8228970

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Create new `Read` utility class with workaround for JDK-8228970 bug

- Replace all `stream.readAllBytes()` calls with `Read.toByteArray()`

- Add helper methods `toString()` and `resourceAsString()` for convenience

- Improve resource stream handling with proper try-with-resources patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JDK readAllBytes bug<br/>JDK-8228970"] -->|"Replace with"| B["Read.toByteArray<br/>custom implementation"]
  B -->|"Used by"| C["CdpEventTypes"]
  B -->|"Used by"| D["RemoteScript"]
  B -->|"Used by"| E["W3CHttpCommandCodec"]
  B -->|"Used by"| F["UrlChecker"]
  B -->|"Used by"| G["HttpMessage"]
  B -->|"Used by"| H["JdkHttpMessages"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Read.java</strong><dd><code>New utility class for safe stream reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-8e26087d14b1a82cf742472936b9e6dd12ae6ea503a96e27c9bb3718464ab93f">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>CdpEventTypes.java</strong><dd><code>Replace readAllBytes with Read.toString</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-5996519c2e6da13111268abea4679c48c185052bb4404a6e44998a4038206f07">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UrlChecker.java</strong><dd><code>Replace readAllBytes with Read.toByteArray</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-bcafad403a3c3f335c1ca4e54e4bde93e1eda08bcd9bfdaf5ebe3b65f8e549ce">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteScript.java</strong><dd><code>Use Read.resourceAsString for script loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-2dd377fafe600022ad5d68c420e0ddc45a81ef50bb6f399d6b81e259b61d6658">+2/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>W3CHttpCommandCodec.java</strong><dd><code>Replace readAllBytes with resourceAsString</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-d3ee2e9bb5279f45d35691b5fe24402e8b9d1b795b293ace7a5e4c4ec144d5f4">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpMessage.java</strong><dd><code>Replace readAllBytes with Read.toByteArray</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-964afdcb3dadea085ff510cc2d4b3f7bf635dbb38f7581c5889adfdb40d841ca">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JdkHttpMessages.java</strong><dd><code>Replace readAllBytes with Read.toByteArray</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-ec7563c46e877269e5a4120f673029ef7ce24c2772dd569f7fb06ed8638f6e8d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ReadTest.java</strong><dd><code>Add unit tests for Read utility class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-35695cf0fb50aba22fdab981cad4b91d26262f4fe8128bd1ce3f273d9dbc926d">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Add io module dependency to selenium</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-f92714d691b32bbcec53bc10402552a808677847af37928aeaeb65036ce47392">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Expand visibility for io module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16793/files#diff-e6c2c6b7a2738ad7420c15b9724c94fbd3cf5ad01e40f6bc0f459b539417bf09">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

