### PR TITLE
[java] configurable timeout for BiDi commands

### DIFF
--- a/java/src/org/openqa/selenium/bidi/BiDi.java
+++ b/java/src/org/openqa/selenium/bidi/BiDi.java
@@ -52,6 +52,12 @@ public class BiDi implements Closeable {
     return connection.sendAndWait(command, timeout);
   }
 
+  public <X> X send(Command<X> command, Duration timeout) {
+    Require.nonNull("Command to send", command);
+    Require.nonNull("Timeout", timeout);
+    return connection.sendAndWait(command, timeout);
+  }
+
   public <X> long addListener(Event<X> event, Consumer<X> handler) {
     Require.nonNull("Event to listen for", event);
     Require.nonNull("Handler to call", handler);

--- a/java/src/org/openqa/selenium/bidi/BiDi.java
+++ b/java/src/org/openqa/selenium/bidi/BiDi.java
@@ -27,11 +27,12 @@ import org.openqa.selenium.internal.Require;
 
 public class BiDi implements Closeable {
 
-  private final Duration timeout = Duration.ofSeconds(30);
+  private final Duration timeout;
   private final Connection connection;
 
-  public BiDi(Connection connection) {
+  public BiDi(Connection connection, Duration timeout) {
     this.connection = Require.nonNull("WebSocket connection", connection);
+    this.timeout = Require.nonNull("WebSocket timeout", timeout);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/bidi/BiDiProvider.java
+++ b/java/src/org/openqa/selenium/bidi/BiDiProvider.java
@@ -78,7 +78,7 @@ public class BiDiProvider implements AugmenterProvider<HasBiDi> {
     HttpClient wsClient = clientFactory.createClient(wsConfig);
     Connection connection = new Connection(wsClient, wsUri.toString());
 
-    return new BiDi(connection);
+    return new BiDi(connection, wsConfig.wsTimeout());
   }
 
   private Optional<URI> getBiDiUrl(Capabilities caps) {

--- a/java/src/org/openqa/selenium/bidi/browsingcontext/BrowsingContext.java
+++ b/java/src/org/openqa/selenium/bidi/browsingcontext/BrowsingContext.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.bidi.browsingcontext;
 
 import java.io.StringReader;
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -134,17 +135,22 @@ public class BrowsingContext {
   }
 
   public NavigationResult navigate(String url) {
-    return this.bidi.send(
-        new Command<>(
-            "browsingContext.navigate", Map.of(CONTEXT, id, "url", url), navigationInfoMapper));
+    return navigate(url, ReadinessState.NONE);
   }
 
   public NavigationResult navigate(String url, ReadinessState readinessState) {
-    return this.bidi.send(
-        new Command<>(
-            "browsingContext.navigate",
-            Map.of(CONTEXT, id, "url", url, "wait", readinessState.toString()),
-            navigationInfoMapper));
+    return this.bidi.send(navigateCommand(url, readinessState));
+  }
+
+  public NavigationResult navigate(String url, ReadinessState readinessState, Duration timeout) {
+    return this.bidi.send(navigateCommand(url, readinessState), timeout);
+  }
+
+  private Command<NavigationResult> navigateCommand(String url, ReadinessState readinessState) {
+    return new Command<>(
+        "browsingContext.navigate",
+        Map.of(CONTEXT, id, "url", url, "wait", readinessState.toString()),
+        navigationInfoMapper);
   }
 
   public List<BrowsingContextInfo> getTree() {

--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -324,7 +324,7 @@ public class ChromiumDriver extends RemoteWebDriver
     org.openqa.selenium.bidi.Connection biDiConnection =
         new org.openqa.selenium.bidi.Connection(wsClient, wsUri.toString());
 
-    return Optional.of(new BiDi(biDiConnection));
+    return Optional.of(new BiDi(biDiConnection, wsConfig.wsTimeout()));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -259,7 +259,7 @@ public class FirefoxDriver extends RemoteWebDriver
     org.openqa.selenium.bidi.Connection biDiConnection =
         new org.openqa.selenium.bidi.Connection(wsClient, wsUri.toString());
 
-    return Optional.of(new BiDi(biDiConnection));
+    return Optional.of(new BiDi(biDiConnection, wsConfig.wsTimeout()));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/remote/http/ClientConfig.java
+++ b/java/src/org/openqa/selenium/remote/http/ClientConfig.java
@@ -35,6 +35,7 @@ public class ClientConfig {
   private final URI baseUri;
   private final Duration connectionTimeout;
   private final Duration readTimeout;
+  private final Duration wsTimeout;
   private final Filter filters;
   private final Proxy proxy;
   private final Credentials credentials;
@@ -45,6 +46,7 @@ public class ClientConfig {
       URI baseUri,
       Duration connectionTimeout,
       Duration readTimeout,
+      Duration wsTimeout,
       Filter filters,
       Proxy proxy,
       Credentials credentials,
@@ -53,6 +55,7 @@ public class ClientConfig {
     this.baseUri = baseUri;
     this.connectionTimeout = Require.nonNegative("Connection timeout", connectionTimeout);
     this.readTimeout = Require.nonNegative("Read timeout", readTimeout);
+    this.wsTimeout = Require.nonNegative("WebSocket timeout", wsTimeout);
     this.filters = Require.nonNull("Filters", filters);
     this.proxy = proxy;
     this.credentials = credentials;
@@ -67,6 +70,8 @@ public class ClientConfig {
             Long.parseLong(System.getProperty("webdriver.httpclient.connectionTimeout", "10"))),
         Duration.ofSeconds(
             Long.parseLong(System.getProperty("webdriver.httpclient.readTimeout", "180"))),
+        Duration.ofSeconds(
+            Long.parseLong(System.getProperty("webdriver.httpclient.wsTimeout", "30"))),
         DEFAULT_FILTER,
         null,
         null,
@@ -79,6 +84,7 @@ public class ClientConfig {
         Require.nonNull("Base URI", baseUri),
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters,
         proxy,
         credentials,
@@ -111,6 +117,7 @@ public class ClientConfig {
         baseUri,
         Require.nonNull("Connection timeout", timeout),
         readTimeout,
+        wsTimeout,
         filters,
         proxy,
         credentials,
@@ -127,6 +134,20 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         Require.nonNull("Read timeout", timeout),
+        wsTimeout,
+        filters,
+        proxy,
+        credentials,
+        sslContext,
+        version);
+  }
+
+  public ClientConfig wsTimeout(Duration timeout) {
+    return new ClientConfig(
+        baseUri,
+        connectionTimeout,
+        readTimeout,
+        Require.nonNull("WebSocket timeout", timeout),
         filters,
         proxy,
         credentials,
@@ -138,12 +159,17 @@ public class ClientConfig {
     return readTimeout;
   }
 
+  public Duration wsTimeout() {
+    return wsTimeout;
+  }
+
   public ClientConfig withFilter(Filter filter) {
     Require.nonNull("Filter", filter);
     return new ClientConfig(
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filter.andThen(DEFAULT_FILTER),
         proxy,
         credentials,
@@ -156,6 +182,7 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters.andThen(RETRY_FILTER),
         proxy,
         credentials,
@@ -172,6 +199,7 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters,
         Require.nonNull("Proxy", proxy),
         credentials,
@@ -188,6 +216,7 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters,
         proxy,
         Require.nonNull("Credentials", credentials),
@@ -204,6 +233,7 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters,
         proxy,
         credentials,
@@ -220,6 +250,7 @@ public class ClientConfig {
         baseUri,
         connectionTimeout,
         readTimeout,
+        wsTimeout,
         filters,
         proxy,
         credentials,
@@ -240,6 +271,8 @@ public class ClientConfig {
         + connectionTimeout
         + ", readTimeout="
         + readTimeout
+        + ", wsTimeout="
+        + wsTimeout
         + ", filters="
         + filters
         + ", proxy="

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java
@@ -17,7 +17,11 @@
 
 package org.openqa.selenium.bidi.browsingcontext;
 
+import static java.lang.System.currentTimeMillis;
+import static java.time.Duration.ofSeconds;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 
 import java.util.List;
@@ -29,6 +33,7 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
+import org.openqa.selenium.bidi.BiDiException;
 import org.openqa.selenium.bidi.module.BrowsingContextInspector;
 import org.openqa.selenium.bidi.module.Script;
 import org.openqa.selenium.testing.JupiterTestBase;
@@ -288,17 +293,22 @@ class BrowsingContextInspectorTest extends JupiterTestBase {
       inspector.onNavigationFailed(future::complete);
 
       BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
-      try {
-        context.navigate(
-            "http://invalid-domain-that-does-not-exist.test/", ReadinessState.COMPLETE);
-      } catch (Exception e) {
-        // Expect an exception due to navigation failure
-      }
 
-      NavigationInfo navigationInfo = future.get(5, TimeUnit.SECONDS);
+      assertThatThrownBy(
+              () ->
+                  context.navigate(
+                      "http://invalid-domain-that-does-not-exist.test/",
+                      ReadinessState.COMPLETE,
+                      ofSeconds(1)))
+          .as("Expect an exception due to navigation failure")
+          .isInstanceOf(BiDiException.class);
+
+      NavigationInfo navigationInfo = future.get(100, MILLISECONDS);
       assertThat(navigationInfo.getBrowsingContextId()).isEqualTo(context.getId());
       assertThat(navigationInfo.getUrl())
           .isEqualTo("http://invalid-domain-that-does-not-exist.test/");
+      assertThat(navigationInfo.getTimestamp())
+          .isBetween(currentTimeMillis() - 1000, currentTimeMillis());
     }
   }
 

--- a/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java
@@ -233,7 +233,7 @@ class NetworkCommandsTest extends JupiterTestBase {
       page = appServer.whereIs("basicAuth");
       BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
 
-      assertThatThrownBy(() -> browsingContext.navigate(page, COMPLETE))
+      assertThatThrownBy(() -> browsingContext.navigate(page, COMPLETE, Duration.ofMillis(200)))
           .isInstanceOf(WebDriverException.class);
     }
   }


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
1. Makes BiDi timeout configurable (currently it's hardcoded: 30 seconds).
2. Adds an optional timeout parameter to any BiDi command
3. Adds an optional timeout parameter to `BrowsingContext.navigate` method
4. Speeds up few tests by using shorter timeout when intentionally navigating to an invalid URL.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Makes BiDi timeout configurable via system property

- Adds optional timeout parameter to BiDi commands

- Adds optional timeout parameter to navigate method

- Speeds up tests using shorter timeouts for invalid URLs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["System Property<br/>webdriver.bidi.timeout"] -->|default 30s| B["BiDi timeout"]
  B -->|used by| C["send Command"]
  C -->|can override with| D["send Command Duration"]
  E["navigate method"] -->|calls| F["navigateCommand helper"]
  F -->|sent via| D
  D -->|enables faster tests| G["Invalid URL navigation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDi.java</strong><dd><code>Configurable BiDi timeout with command-level override</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/bidi/BiDi.java

<ul><li>Made timeout configurable via system property <code>webdriver.bidi.timeout</code> <br>with default of 30 seconds<br> <li> Added overloaded <code>send</code> method accepting optional <code>Duration</code> timeout <br>parameter<br> <li> Imported <code>parseLong</code> for parsing system property value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16796/files#diff-f0ed6d655b8c0ff47563631639d01d8f7a5f8e83a40db48456a2e9137e8ab0e6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.java</strong><dd><code>Add timeout parameter to navigate methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/bidi/browsingcontext/BrowsingContext.java

<ul><li>Added overloaded <code>navigate</code> method accepting optional <code>Duration</code> timeout <br>parameter<br> <li> Extracted navigation command creation into private <code>navigateCommand</code> <br>helper method<br> <li> Refactored existing navigate methods to use the new helper for code <br>reuse<br> <li> Imported <code>Duration</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16796/files#diff-14648f4359d170cc8f4c7f9f7c573da0cbf220e7340cd8391d6081284b982ea1">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextInspectorTest.java</strong><dd><code>Speed up navigation failure test with shorter timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextInspectorTest.java

<ul><li>Updated <code>canListenToNavigationFailedEvent</code> test to use 1-second timeout <br>for invalid URL navigation<br> <li> Changed assertion to expect <code>BiDiException</code> instead of generic exception <br>handling<br> <li> Reduced wait time for navigation event from 5 seconds to 100 <br>milliseconds<br> <li> Added timestamp validation for navigation info<br> <li> Added imports for <code>currentTimeMillis</code>, <code>ofSeconds</code>, <code>MILLISECONDS</code>, and <br><code>BiDiException</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16796/files#diff-7e31cdee71aec8f625eef511eb299619a501aab66ee1bf937eedec82921ad7e9">+17/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkCommandsTest.java</strong><dd><code>Speed up auth test with 200ms timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/network/NetworkCommandsTest.java

<ul><li>Updated <code>canContinueWithoutAuthCredentials</code> test to use 200-millisecond <br>timeout for invalid URL navigation<br> <li> Significantly reduces test execution time from 30 seconds to <br>near-instant failure</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16796/files#diff-56334c02fd23ebd6590a6ae6f44b2113bdbc325175c1273c4ef17a236119e517">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

