### PR TITLE
[java] Be more tolerant to remote responses

### DIFF
--- a/java/src/org/openqa/selenium/remote/ErrorCodec.java
+++ b/java/src/org/openqa/selenium/remote/ErrorCodec.java
@@ -17,10 +17,14 @@
 
 package org.openqa.selenium.remote;
 
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import org.openqa.selenium.DetachedShadowRootException;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -88,7 +92,7 @@ public class ErrorCodec {
           new W3CError<>("unsupported operation", UnsupportedCommandException::new, 500),
           new W3CError<>("unknown command", UnsupportedCommandException::new, 404),
           new W3CError<>("unknown method", UnsupportedCommandException::new, 405),
-          new W3CError<>("unknown error", WebDriverException::new, 500));
+          DEFAULT_ERROR);
 
   private ErrorCodec() {
     // This will switch to being an interface at some point. Use `createDefault`
@@ -144,24 +148,28 @@ public class ErrorCodec {
 
   public WebDriverException decode(Map<String, Object> response) {
     if (!(response.get("value") instanceof Map)) {
-      throw new IllegalArgumentException("Unable to find mapping for " + response);
+      throw new InvalidResponseException("missing \"value\" field", response);
     }
 
     Map<?, ?> value = (Map<?, ?>) response.get("value");
-    if (!(value.get("error") instanceof String)) {
-      throw new IllegalArgumentException("Unable to find mapping for " + response);
+
+    Object error = requireNonNullElse(value.get("error"), "");
+    Object message = requireNonNullElseGet(value.get("message"), response::toString);
+
+    if (!(error instanceof String)) {
+      throw new InvalidResponseException("\"error\" field must be a string", response);
+    }
+    if (!(message instanceof String)) {
+      throw new InvalidResponseException("\"message\" field must be a string", response);
     }
 
-    String error = (String) value.get("error");
-    String message = value.get("message") instanceof String ? (String) value.get("message") : null;
-
-    W3CError<?> w3CError =
-        ERRORS.stream()
-            .filter(err -> error.equals(err.w3cErrorString))
-            .findFirst()
-            .orElse(DEFAULT_ERROR);
-
-    return w3CError.exceptionConstructor.apply(message);
+    Optional<W3CError<? extends WebDriverException>> w3CError =
+        ERRORS.stream().filter(err -> error.equals(err.w3cErrorString)).findFirst();
+    if (w3CError.isPresent()) {
+      return w3CError.get().exceptionConstructor.apply((String) message);
+    }
+    String extendedMessage = String.format("%s (error code: \"%s\")", message, error);
+    return DEFAULT_ERROR.exceptionConstructor.apply(extendedMessage);
   }
 
   private W3CError<? extends WebDriverException> fromThrowable(Throwable throwable) {

--- a/java/src/org/openqa/selenium/remote/InvalidResponseException.java
+++ b/java/src/org/openqa/selenium/remote/InvalidResponseException.java
@@ -1,0 +1,30 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote;
+
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class InvalidResponseException extends IllegalArgumentException {
+  private static final String w3cErrorFormat = "https://www.w3.org/TR/webdriver2/#errors";
+
+  public InvalidResponseException(String message, Map<String, Object> response) {
+    super(String.format("%s: %s%nSee %s", message, response, w3cErrorFormat));
+  }
+}

--- a/java/test/org/openqa/selenium/remote/ErrorCodecTest.java
+++ b/java/test/org/openqa/selenium/remote/ErrorCodecTest.java
@@ -17,12 +17,14 @@
 
 package org.openqa.selenium.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.text.ParseException;
 import java.util.Map;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.DetachedShadowRootException;
@@ -119,11 +121,53 @@ public class ErrorCodecTest {
     encodeAndCheck(new ClassNotFoundException(msg), "unknown error", msg);
   }
 
+  @Test
+  void decode_w3cCompliantResponse() {
+    assertThat(
+            errorCodec.decode(
+                Map.of(
+                    "value",
+                    Map.of(
+                        "error", "script timeout",
+                        "message", "Script timed out"))))
+        .isInstanceOf(ScriptTimeoutException.class)
+        .hasMessageStartingWith("Script timed out");
+  }
+
+  @Test
+  void decode_unknownError() {
+    assertThat(
+            errorCodec.decode(
+                Map.of(
+                    "value",
+                    Map.of(
+                        "error", "some.magic.error.code",
+                        "message", "Something unbelievable happened"))))
+        .isInstanceOf(WebDriverException.class)
+        .hasMessageStartingWith("Something unbelievable happened")
+        .hasMessageContaining("some.magic.error.code");
+  }
+
+  @Test
+  void decode_noValue() {
+    assertThatThrownBy(() -> errorCodec.decode(Map.of("unexpected", "format")))
+        .isInstanceOf(InvalidResponseException.class)
+        .hasMessageStartingWith("missing \"value\" field: {unexpected=format}")
+        .hasMessageContaining("See https://www.w3.org/TR/webdriver2/#errors");
+  }
+
+  @Test
+  void decode_noError() {
+    assertThat(errorCodec.decode(Map.of("value", Map.of("message", "Session was not created"))))
+        .isInstanceOf(WebDriverException.class)
+        .hasMessageStartingWith("Session was not created");
+  }
+
   void encodeAndCheck(Throwable toEncode, String expectedType, String expectedMessage) {
     Map<String, Object> encoded = errorCodec.encode(toEncode);
     Map<String, Object> value = (Map<String, Object>) encoded.get("value");
 
-    Assertions.assertThat(value.get("error")).isEqualTo(expectedType);
-    Assertions.assertThat(value.get("message")).isEqualTo(toEncode.getMessage());
+    assertThat(value.get("error")).isEqualTo(expectedType);
+    assertThat(value.get("message")).isEqualTo(toEncode.getMessage());
   }
 }


### PR DESCRIPTION
### **User description**
* Some responses don't contain the required field "error" - just treat them as "unknown error"
* If response doesn't contain the required field "message", just write the whole response as the message.


### 🔗 Related Issues
Improves #16389 

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Handle remote responses missing required "error" field gracefully

- Use response toString as fallback when "message" field missing

- Create InvalidResponseException for malformed response detection

- Add comprehensive test coverage for edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remote Response"] --> B{"Has 'value' field?"}
  B -->|No| C["Throw InvalidResponseException"]
  B -->|Yes| D{"Has 'error' field?"}
  D -->|No| E["Use empty string as error"]
  D -->|Yes| F{"Error is String?"}
  F -->|No| C
  F -->|Yes| G{"Match known error?"}
  G -->|Yes| H["Create specific exception"]
  G -->|No| I["Create WebDriverException with error code"]
  E --> J{"Has 'message' field?"}
  J -->|No| K["Use response toString"]
  J -->|Yes| L{"Message is String?"}
  L -->|No| C
  L -->|Yes| M["Use message value"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ErrorCodec.java</strong><dd><code>Improve remote response error handling robustness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/ErrorCodec.java

<ul><li>Added imports for <code>requireNonNullElse</code>, <code>requireNonNullElseGet</code>, and <br><code>Optional</code><br> <li> Replaced hardcoded "unknown error" with <code>DEFAULT_ERROR</code> constant<br> <li> Modified <code>decode()</code> method to handle missing "error" and "message" <br>fields<br> <li> Changed exception type from <code>IllegalArgumentException</code> to <br><code>InvalidResponseException</code><br> <li> Added fallback logic to use response toString when message is missing<br> <li> Enhanced unknown error handling to include error code in exception <br>message</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16797/files#diff-f6987d6baf3cb5724dbd2019407e6d6ba878465d8552611f4b4364cc24e0b51e">+21/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InvalidResponseException.java</strong><dd><code>New exception for malformed remote responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/InvalidResponseException.java

<ul><li>New exception class extending <code>IllegalArgumentException</code><br> <li> Formats error messages with response details and W3C spec reference<br> <li> Includes reference link to W3C WebDriver specification</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16797/files#diff-edb262cac2ee00af325c6c4286797c6457d978d6f09e960059bd687af895e8c7">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ErrorCodecTest.java</strong><dd><code>Add tests for edge case response handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/ErrorCodecTest.java

<ul><li>Added static imports for AssertJ assertions<br> <li> Added test for W3C compliant response decoding<br> <li> Added test for unknown error code handling with error code in message<br> <li> Added test for missing "value" field validation<br> <li> Added test for missing "error" field tolerance<br> <li> Updated existing assertion calls to use static imports</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16797/files#diff-ee34e356da934e4409817747fe82f8fdfc7113ce617b9d371db42532474a3434">+47/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

