### PR TITLE
[ci] Use macos-latest instead of macos-13 in Rust workflow

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -166,7 +166,7 @@ jobs:
 
   macos-stable:
     name: "MacOS Stable"
-    runs-on: macos-13
+    runs-on: macos-latest
     needs: tests
     if: github.event_name != 'schedule'
     env:
@@ -179,6 +179,7 @@ jobs:
       - name: "Update Rust"
         run: |
           rustup update
+          rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
           rustc -vV
       - name: "Build release binary"
@@ -198,7 +199,7 @@ jobs:
 
   macos-debug:
     name: "MacOS Debug"
-    runs-on: macos-13
+    runs-on: macos-latest
     needs: tests
     if: github.event_name != 'schedule'
     env:
@@ -211,6 +212,7 @@ jobs:
       - name: "Update Rust"
         run: |
           rustup update
+          rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
           rustc -vV
       - name: "Build release binary"


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
The macOS-13 based runner images are now retired. As a result, the rust workflow is not working, e.g.:

https://github.com/SeleniumHQ/selenium/actions/runs/20556482131

### 💥 What does this PR do?
This PR changes `macos-13` by `macos-latest` in the Rust workflow.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Update macOS runner from retired macos-13 to macos-latest

- Add x86_64-apple-darwin target to Rust toolchain setup

- Fix CI workflow failures due to deprecated runner image


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macos-13 runner<br/>deprecated"] -->|"replace with"| B["macos-latest runner"]
  C["Rust toolchain setup"] -->|"add target"| D["x86_64-apple-darwin"]
  D -->|"alongside"| E["aarch64-apple-darwin"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-rust.yml</strong><dd><code>Update macOS runner and add x86_64 Rust target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-rust.yml

<ul><li>Replace deprecated <code>macos-13</code> runner with <code>macos-latest</code> in two jobs <br>(macos-stable and macos-debug)<br> <li> Add <code>rustup target add x86_64-apple-darwin</code> command to Rust toolchain <br>setup in both jobs<br> <li> Ensures compatibility with current macOS runner images and supports <br>both Intel and Apple Silicon architectures</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16803/files#diff-5162db340096b281e8c77ef016f0595e9b7a63e9cb48605a43b685301b4b5ee0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

