### PR TITLE
[dotnet] [bidi] Properly return shared buffer when disposing websocket

### DIFF
--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -28,12 +28,12 @@ using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.BiDi;
 
-class WebSocketTransport(Uri _uri) : ITransport, IDisposable
+sealed class WebSocketTransport(Uri _uri) : ITransport, IDisposable
 {
     private readonly static ILogger _logger = Internal.Logging.Log.GetLogger<WebSocketTransport>();
 
     private readonly ClientWebSocket _webSocket = new();
-    private readonly byte[] _receiveBuffer = ArrayPool<byte>.Shared.Rent(1024 * 8);
+    private byte[] _receiveBuffer = ArrayPool<byte>.Shared.Rent(1024 * 8);
 
     private readonly SemaphoreSlim _socketSendSemaphoreSlim = new(1, 1);
     private readonly MemoryStream _sharedMemoryStream = new();
@@ -92,28 +92,36 @@ class WebSocketTransport(Uri _uri) : ITransport, IDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~WebSocketTransport()
+    {
+        Dispose(false);
+    }
+
+    private void Dispose(bool disposing)
+    {
         if (_disposed)
         {
             return;
         }
 
-        _webSocket.Dispose();
-        _sharedMemoryStream.Dispose();
-        _socketSendSemaphoreSlim.Dispose();
-        ReleaseBuffer();
-        _disposed = true;
-    }
+        if (disposing)
+        {
+            _webSocket.Dispose();
+            _sharedMemoryStream.Dispose();
+            _socketSendSemaphoreSlim.Dispose();
+        }
 
-    ~WebSocketTransport()
-    {
-        ReleaseBuffer();
-    }
-
-    private void ReleaseBuffer()
-    {
         if (_receiveBuffer is not null)
         {
             ArrayPool<byte>.Shared.Return(_receiveBuffer);
+
+            _receiveBuffer = null!;
         }
+
+        _disposed = true;
     }
 }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #16801 

### 💥 What does this PR do?
Introduces `Dispose(bool disposing)` method to make sure shared buffer returned back to the pool only once.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Implements proper IDisposable pattern with Dispose(bool) method

- Ensures shared buffer returned to pool only once during disposal

- Prevents double-disposal of managed resources

- Seals class and nullifies buffer reference after return


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocketTransport"] -->|"implements"| B["IDisposable pattern"]
  B -->|"Dispose method"| C["calls Dispose(bool)"]
  C -->|"disposing=true"| D["dispose managed resources"]
  C -->|"disposing=false"| E["skip managed resources"]
  D -->|"then"| F["return buffer to pool once"]
  E -->|"then"| F
  F -->|"nullify buffer"| G["prevent double-return"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebSocketTransport.cs</strong><dd><code>Implement standard IDisposable pattern with proper cleanup</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/WebSocketTransport.cs

<ul><li>Changed class from unsealed to sealed to prevent inheritance issues<br> <li> Changed <code>_receiveBuffer</code> from readonly to mutable field to allow <br>nullification<br> <li> Refactored Dispose() to call new Dispose(bool disposing) method with <br>GC.SuppressFinalize()<br> <li> Implemented Dispose(bool disposing) pattern to separate managed and <br>unmanaged resource cleanup<br> <li> Moved buffer return logic to Dispose(bool) and nullified buffer after <br>return to prevent double-disposal<br> <li> Updated finalizer to call Dispose(false) instead of directly calling <br>ReleaseBuffer()</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16804/files#diff-5ce7072dc525c523c3a724fea6d2c6b86111f746e4f993b3761bcb40163dee3a">+22/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

