### PR TITLE
[rust] fix support for Edge beta versions on Windows

### DIFF
--- a/rust/src/edge.rs
+++ b/rust/src/edge.rs
@@ -24,9 +24,9 @@ use crate::metadata::{
     create_driver_metadata, get_driver_version_from_metadata, get_metadata, write_metadata,
 };
 use crate::{
-    BETA, DASH_DASH_VERSION, DEV, ENV_PROGRAM_FILES_X86, Logger, NIGHTLY, OFFLINE_REQUEST_ERR_MSG,
-    REG_PV_ARG, REG_VERSION_ARG, STABLE, SeleniumManager, create_http_client, get_binary_extension,
-    path_to_string,
+    BETA, DASH_DASH_VERSION, DEV, ENV_PROGRAM_FILES, ENV_PROGRAM_FILES_X86, Logger, NIGHTLY,
+    OFFLINE_REQUEST_ERR_MSG, REG_PV_ARG, REG_VERSION_ARG, STABLE, SeleniumManager,
+    create_http_client, get_binary_extension, path_to_string,
 };
 use anyhow::Error;
 use reqwest::Client;
@@ -491,21 +491,25 @@ impl SeleniumManager for EdgeManager {
             };
             Ok(browser_in_cache.join(macos_app_name))
         } else if WINDOWS.is(self.get_os()) {
-            let browser_path = if self.is_unstable(browser_version) {
-                self.get_browser_path_from_version(browser_version)
-                    .to_string()
+            // Stable Edge MSI installs to Program Files (x86) for compatibility
+            // Beta/Dev/Canary MSIs install to Program Files
+            let (browser_path, program_files_env) = if self.is_unstable(browser_version) {
+                (
+                    self.get_browser_path_from_version(browser_version)
+                        .to_string(),
+                    ENV_PROGRAM_FILES,
+                )
             } else {
-                format!(
-                    r"Microsoft\Edge\Application\{}\msedge.exe",
-                    self.get_browser_version()
+                (
+                    format!(
+                        r"Microsoft\Edge\Application\{}\msedge.exe",
+                        self.get_browser_version()
+                    ),
+                    ENV_PROGRAM_FILES_X86,
                 )
             };
-            let mut full_browser_path = Path::new(&browser_path).to_path_buf();
-            if WINDOWS.is(self.get_os()) {
-                let env_value = env::var(ENV_PROGRAM_FILES_X86).unwrap_or_default();
-                let parent_path = Path::new(&env_value);
-                full_browser_path = parent_path.join(&browser_path);
-            }
+            let env_value = env::var(program_files_env).unwrap_or_default();
+            let full_browser_path = Path::new(&env_value).join(&browser_path);
             Ok((&path_to_string(&full_browser_path)).into())
         } else {
             Ok(browser_in_cache.join(format!(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -313,56 +313,77 @@ pub trait SeleniumManager {
             browser_version
         ));
 
-        // Checking if browser version is in the cache
+        // Checking if browser version already in expected location
         let browser_binary_path = self.get_browser_binary_path(original_browser_version)?;
         if browser_binary_path.exists() {
+            let location_note = if WINDOWS.is(self.get_os()) && self.is_edge() {
+                " (Edge uses system path, not cache)"
+            } else {
+                ""
+            };
             self.get_logger().debug(format!(
-                "{} {} already exists",
+                "{} {} already exists at {}{}",
                 self.get_browser_name(),
-                browser_version
+                browser_version,
+                browser_binary_path.display(),
+                location_note
             ));
-        } else {
-            // If browser is not available, download it
-            if WINDOWS.is(self.get_os()) && self.is_edge() && !self.is_windows_admin() {
-                return Err(anyhow!(format_one_arg(
-                    NOT_ADMIN_FOR_EDGE_INSTALLER_ERR_MSG,
-                    self.get_browser_name(),
-                )));
-            }
-
-            let browser_path_in_cache = self.get_browser_path_in_cache()?;
-            let mut lock = Lock::acquire(self.get_logger(), &browser_path_in_cache, None)?;
-            if !lock.exists() && browser_binary_path.exists() {
-                self.get_logger().debug(format!(
-                    "Browser already in cache: {}",
-                    browser_binary_path.display()
-                ));
-                self.set_browser_path(path_to_string(&browser_binary_path));
-                return Ok(Some(browser_binary_path.clone()));
-            }
-
-            let browser_url = self.get_browser_url_for_download(original_browser_version)?;
-            self.get_logger().debug(format!(
-                "Downloading {} {} from {}",
-                self.get_browser_name(),
-                self.get_browser_version(),
-                browser_url
-            ));
-            let (_tmp_folder, driver_zip_file) =
-                download_to_tmp_folder(self.get_http_client(), browser_url, self.get_logger())?;
-
-            let browser_label_for_download =
-                self.get_browser_label_for_download(original_browser_version)?;
-            uncompress(
-                &driver_zip_file,
-                &browser_path_in_cache,
-                self.get_logger(),
-                self.get_os(),
-                None,
-                browser_label_for_download,
-            )?;
-            lock.release();
+            self.set_browser_path(path_to_string(&browser_binary_path));
+            return Ok(Some(browser_binary_path));
         }
+
+        // Browser not available, download it
+        if WINDOWS.is(self.get_os()) && self.is_edge() && !self.is_windows_admin() {
+            return Err(anyhow!(format_one_arg(
+                NOT_ADMIN_FOR_EDGE_INSTALLER_ERR_MSG,
+                self.get_browser_name(),
+            )));
+        }
+
+        let browser_path_in_cache = self.get_browser_path_in_cache()?;
+        let mut lock = Lock::acquire(self.get_logger(), &browser_path_in_cache, None)?;
+        // If lock file was deleted, another process held it and released (deleting the file).
+        // Check if that process already downloaded the browser.
+        if !lock.exists() && browser_binary_path.exists() {
+            self.get_logger().debug(format!(
+                "{} {} now available at {}",
+                self.get_browser_name(),
+                browser_version,
+                browser_binary_path.display()
+            ));
+            self.set_browser_path(path_to_string(&browser_binary_path));
+            return Ok(Some(browser_binary_path.clone()));
+        }
+
+        let browser_url = self.get_browser_url_for_download(original_browser_version)?;
+        // Edge on Windows: MSI installs to system path, not cache
+        let install_note = if WINDOWS.is(self.get_os()) && self.is_edge() {
+            " (will install to system path via MSI)"
+        } else {
+            ""
+        };
+        self.get_logger().debug(format!(
+            "Downloading {} {} from {}{}",
+            self.get_browser_name(),
+            self.get_browser_version(),
+            browser_url,
+            install_note
+        ));
+        let (_tmp_folder, driver_zip_file) =
+            download_to_tmp_folder(self.get_http_client(), browser_url, self.get_logger())?;
+
+        let browser_label_for_download =
+            self.get_browser_label_for_download(original_browser_version)?;
+        uncompress(
+            &driver_zip_file,
+            &browser_path_in_cache,
+            self.get_logger(),
+            self.get_os(),
+            None,
+            browser_label_for_download,
+        )?;
+        lock.release();
+
         if browser_binary_path.exists() {
             self.set_browser_path(path_to_string(&browser_binary_path));
             Ok(Some(browser_binary_path))


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->


### 💥 What does this PR do?
* SM was looking for installation in the wrong place for non-stable versions of Edge on Windows
* Updates logging messages for confusing behavior with Edge on Windows

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Edge beta/dev/canary installation path detection on Windows

- Use correct Program Files environment variable for unstable Edge versions

- Improve logging messages to clarify Edge system path behavior on Windows

- Simplify browser path resolution logic for Windows Edge installations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Edge Version Detection"] -->|"Unstable Beta/Dev/Canary"| B["Use Program Files"]
  A -->|"Stable"| C["Use Program Files x86"]
  B --> D["Correct MSI Installation Path"]
  C --> D
  E["Improved Logging"] -->|"System Path Clarity"| F["Better User Feedback"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge.rs</strong><dd><code>Fix Edge Windows installation path selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/edge.rs

<ul><li>Added <code>ENV_PROGRAM_FILES</code> import for unstable Edge versions<br> <li> Fixed browser path resolution to use correct Program Files directory <br>based on Edge version stability<br> <li> Refactored Windows path logic to determine environment variable <br>dynamically instead of always using x86 variant<br> <li> Simplified path construction by removing redundant OS check</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16806/files#diff-dcd62c3bd133281f5bd97d8a876bcf753d7a4f3edd6ccbacf44eff3e9fcc484e">+19/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Improve logging clarity for Edge Windows behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<ul><li>Enhanced debug logging to show actual browser binary path location<br> <li> Added clarifying notes for Edge on Windows about system path vs cache <br>behavior<br> <li> Improved log messages when browser already exists or is being <br>downloaded<br> <li> Restructured control flow to return early when browser exists, <br>reducing nesting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16806/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+60/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

