### PR TITLE
[java] Fix asserts for maps and sets

### DIFF
--- a/java/test/org/openqa/selenium/ProxyTest.java
+++ b/java/test/org/openqa/selenium/ProxyTest.java
@@ -19,6 +19,7 @@ package org.openqa.selenium;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.openqa.selenium.Proxy.ProxyType.AUTODETECT;
 import static org.openqa.selenium.Proxy.ProxyType.DIRECT;
 import static org.openqa.selenium.Proxy.ProxyType.MANUAL;
@@ -28,7 +29,6 @@ import static org.openqa.selenium.Proxy.ProxyType.UNSPECIFIED;
 import static org.openqa.selenium.remote.CapabilityType.PROXY;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -235,7 +235,7 @@ class ProxyTest {
     assertThat(json.get("socksVersion")).isEqualTo(5);
     assertThat(json.get("socksUsername")).isEqualTo("test1");
     assertThat(json.get("socksPassword")).isEqualTo("test2");
-    assertThat(json.get("noProxy")).isEqualTo(List.of("localhost", "127.0.0.*"));
+    assertThat(json.get("noProxy")).asInstanceOf(LIST).containsExactly("localhost", "127.0.0.*");
     assertThat(json.entrySet()).hasSize(9);
   }
 

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
@@ -17,12 +17,14 @@
 
 package org.openqa.selenium.bidi.browsingcontext;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
+import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -511,8 +513,12 @@ class BrowsingContextTest extends JupiterTestBase {
     // Comparing expected PDF is a hard problem.
     // As long as we are sending the parameters correctly it should be fine.
     // Trusting the browsers to do the right thing.
-    // Hence, just checking if the response is base64 encoded string.
+    // Hence, just checking if the response is base64 encoded string looking like PDF.
     assertThat(printPage).contains("JVBER");
+    byte[] pdf = Base64.getDecoder().decode(printPage);
+    assertThat(pdf)
+        .containsSequence("%PDF-".getBytes(US_ASCII))
+        .containsSequence("%%EOF".getBytes(US_ASCII));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeOptionsTest.java
@@ -32,7 +32,6 @@ import static org.openqa.selenium.remote.CapabilityType.TIMEOUTS;
 import java.io.File;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +49,7 @@ import org.openqa.selenium.testing.TestUtilities;
 class ChromeOptionsTest {
 
   @Test
+  @SuppressWarnings("unchecked")
   void optionsAsMapShouldBeImmutable() {
     Map<String, Object> options = new ChromeOptions().asMap();
     assertThatExceptionOfType(UnsupportedOperationException.class)
@@ -99,12 +99,13 @@ class ChromeOptionsTest {
     assertThat(mappedOptions.get("strictFileInteractability")).isEqualTo(true);
     assertThat(mappedOptions.get(ENABLE_DOWNLOADS)).isEqualTo(true);
 
-    Map<String, Long> expectedTimeouts = new HashMap<>();
-    expectedTimeouts.put("implicit", 1000L);
-    expectedTimeouts.put("pageLoad", 2000L);
-    expectedTimeouts.put("script", 3000L);
-
-    assertThat(expectedTimeouts).isEqualTo(mappedOptions.get("timeouts"));
+    assertThat(mappedOptions.get("timeouts"))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "implicit", 1000L,
+                "pageLoad", 2000L,
+                "script", 3000L));
   }
 
   @Test
@@ -113,15 +114,15 @@ class ChromeOptionsTest {
     chromeOptions.setImplicitWaitTimeout(Duration.ofSeconds(1));
 
     Map<String, Object> mappedOptions = chromeOptions.asMap();
-    Map<String, Long> expectedTimeouts = new HashMap<>();
-
-    expectedTimeouts.put("implicit", 1000L);
-    assertThat(expectedTimeouts).isEqualTo(mappedOptions.get("timeouts"));
+    assertThat(mappedOptions.get("timeouts"))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("implicit", 1000L));
 
     chromeOptions.setPageLoadTimeout(Duration.ofSeconds(2));
-    expectedTimeouts.put("pageLoad", 2000L);
     Map<String, Object> mappedOptions2 = chromeOptions.asMap();
-    assertThat(expectedTimeouts).isEqualTo(mappedOptions2.get("timeouts"));
+    assertThat(mappedOptions2.get("timeouts"))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("implicit", 1000L, "pageLoad", 2000L));
   }
 
   @Test
@@ -130,11 +131,9 @@ class ChromeOptionsTest {
     chromeOptions.setCapability(TIMEOUTS, Map.of("implicit", 1000));
     chromeOptions.setPageLoadTimeout(Duration.ofSeconds(2));
 
-    Map<String, Number> expectedTimeouts = new HashMap<>();
-    expectedTimeouts.put("implicit", 1000);
-    expectedTimeouts.put("pageLoad", 2000L);
-
-    assertThat(chromeOptions.asMap().get("timeouts")).isEqualTo(expectedTimeouts);
+    assertThat(chromeOptions.asMap().get("timeouts"))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("implicit", 1000, "pageLoad", 2000L));
   }
 
   @Test
@@ -395,6 +394,6 @@ class ChromeOptionsTest {
     var caps = new MutableCapabilities();
     var merged = original.merge(caps);
 
-    assertThat(merged.asMap()).isEqualTo(original.asMap());
+    assertThat(merged.asMap()).containsExactlyInAnyOrderEntriesOf(original.asMap());
   }
 }

--- a/java/test/org/openqa/selenium/firefox/FirefoxProfileTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxProfileTest.java
@@ -171,7 +171,7 @@ class FirefoxProfileTest {
         Arrays.stream(sysTemp.list())
             .filter(f -> f.endsWith("webdriver-profile"))
             .collect(Collectors.toSet());
-    assertThat(after).isEqualTo(before);
+    assertThat(after).containsExactlyInAnyOrderElementsOf(before);
   }
 
   @Test
@@ -184,14 +184,16 @@ class FirefoxProfileTest {
 
     File dir = Zip.unzipToTempDir(json, "webdriver", "duplicated");
 
-    File prefs = new File(dir, "user.js");
-    assertThat(prefs).exists();
+    try {
+      File prefs = new File(dir, "user.js");
+      assertThat(prefs).exists();
 
-    try (Stream<String> lines = Files.lines(prefs.toPath())) {
-      assertThat(lines).anyMatch(s -> s.contains("i.like.cheese"));
+      try (Stream<String> lines = Files.lines(prefs.toPath())) {
+        assertThat(lines).anyMatch(s -> s.contains("i.like.cheese"));
+      }
+    } finally {
+      FileHandler.delete(dir);
     }
-
-    FileHandler.delete(dir);
   }
 
   private List<String> readGeneratedProperties(FirefoxProfile profile) throws Exception {

--- a/java/test/org/openqa/selenium/firefox/GeckoDriverServiceTest.java
+++ b/java/test/org/openqa/selenium/firefox/GeckoDriverServiceTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import java.io.File;
 import java.time.Duration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -34,18 +33,23 @@ import org.junit.jupiter.api.Test;
 class GeckoDriverServiceTest {
 
   @Test
-  void builderPassesTimeoutToDriverService() {
-    File exe = new File("someFile");
+  void builderUsesDefaultTimeoutForDriverService() {
     Duration defaultTimeout = Duration.ofSeconds(20);
-    Duration customTimeout = Duration.ofSeconds(60);
 
     GeckoDriverService.Builder builderMock = spy(GeckoDriverService.Builder.class);
     builderMock.build();
 
     verify(builderMock).createDriverService(any(), anyInt(), eq(defaultTimeout), any(), any());
+  }
 
-    builderMock.withTimeout(customTimeout);
+  @Test
+  void builderPassesTimeoutToDriverService() {
+    Duration customTimeout = Duration.ofSeconds(60);
+    GeckoDriverService.Builder builderMock =
+        spy(GeckoDriverService.Builder.class).withTimeout(customTimeout);
+
     builderMock.build();
+
     verify(builderMock).createDriverService(any(), anyInt(), eq(customTimeout), any(), any());
   }
 

--- a/java/test/org/openqa/selenium/grid/config/ConcatenatingConfigTest.java
+++ b/java/test/org/openqa/selenium/grid/config/ConcatenatingConfigTest.java
@@ -20,7 +20,6 @@ package org.openqa.selenium.grid.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ConcatenatingConfigTest {
@@ -38,7 +37,7 @@ class ConcatenatingConfigTest {
                 "FOO_", "should not show up",
                 "BAR_FOOD_IS", "cheese sticks"));
 
-    assertThat(config.getSectionNames()).isEqualTo(Set.of("cheese", "vegetables"));
+    assertThat(config.getSectionNames()).containsExactlyInAnyOrder("cheese", "vegetables");
   }
 
   @Test
@@ -54,6 +53,6 @@ class ConcatenatingConfigTest {
                 "FOO_", "should not show up",
                 "BAR_FOOD_IS", "cheese sticks"));
 
-    assertThat(config.getOptions("cheese")).isEqualTo(Set.of("current", "selected"));
+    assertThat(config.getOptions("cheese")).containsExactlyInAnyOrder("current", "selected");
   }
 }

--- a/java/test/org/openqa/selenium/ie/InternetExplorerOptionsTest.java
+++ b/java/test/org/openqa/selenium/ie/InternetExplorerOptionsTest.java
@@ -102,15 +102,14 @@ class InternetExplorerOptionsTest {
 
   @Test
   void shouldSetIeOptionsCapabilityWhenConstructedFromExistingCapabilities() {
-    InternetExplorerOptions expected = new InternetExplorerOptions();
-    expected.setCapability("requireWindowFocus", true);
-
     DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
     desiredCapabilities.setPlatform(Platform.WINDOWS);
     InternetExplorerOptions seen = new InternetExplorerOptions(desiredCapabilities);
     seen.setCapability("requireWindowFocus", true);
 
-    assertThat(seen.getCapability(IE_OPTIONS)).isEqualTo(expected.getCapability(IE_OPTIONS));
+    assertThat(seen.getCapability(IE_OPTIONS))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("requireWindowFocus", true));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/interactions/PointerInputTest.java
+++ b/java/test/org/openqa/selenium/interactions/PointerInputTest.java
@@ -52,8 +52,8 @@ class PointerInputTest {
         new Json().toType(rawJson, ActionSequenceJson.class, PropertySetting.BY_FIELD);
 
     assertThat(json.actions).hasSize(1);
-    ActionJson firstAction = json.actions.get(0);
-    assertThat(firstAction.origin).containsEntry(W3C.getEncodedElementKey(), "12345");
+    assertThat(json.actions.get(0).origin)
+        .containsExactlyInAnyOrderEntriesOf(Map.of(W3C.getEncodedElementKey(), "12345"));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/interactions/WheelInputTest.java
+++ b/java/test/org/openqa/selenium/interactions/WheelInputTest.java
@@ -56,8 +56,8 @@ class WheelInputTest {
         new Json().toType(rawJson, ActionSequenceJson.class, PropertySetting.BY_FIELD);
 
     assertThat(json.actions).hasSize(1);
-    ActionJson firstAction = json.actions.get(0);
-    assertThat(firstAction.origin).containsEntry(W3C.getEncodedElementKey(), "12345");
+    assertThat(json.actions.get(0).origin)
+        .containsExactlyInAnyOrderEntriesOf(Map.of(W3C.getEncodedElementKey(), "12345"));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/json/JsonInputTest.java
+++ b/java/test/org/openqa/selenium/json/JsonInputTest.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.json;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 import static org.openqa.selenium.json.JsonType.BOOLEAN;
 import static org.openqa.selenium.json.JsonType.END_COLLECTION;
@@ -51,164 +52,181 @@ class JsonInputTest {
 
   @Test
   void shouldParseBooleanValues() {
-    JsonInput input = newInput("true");
-    assertThat(input.peek()).isEqualTo(BOOLEAN);
-    assertThat(input.nextBoolean()).isTrue();
+    try (JsonInput input = newInput("true")) {
+      assertThat(input.peek()).isEqualTo(BOOLEAN);
+      assertThat(input.nextBoolean()).isTrue();
+    }
 
-    input = newInput("false");
-    assertThat(input.peek()).isEqualTo(BOOLEAN);
-    assertThat(input.nextBoolean()).isFalse();
+    try (JsonInput input = newInput("false")) {
+      assertThat(input.peek()).isEqualTo(BOOLEAN);
+      assertThat(input.nextBoolean()).isFalse();
+    }
   }
 
   @Test
   void shouldParseNonDecimalNumbersAsLongs() {
-    JsonInput input = newInput("42");
-    assertThat(input.peek()).isEqualTo(NUMBER);
-    assertThat(input.nextNumber()).isEqualTo(42L);
+    try (JsonInput input = newInput("42")) {
+      assertThat(input.peek()).isEqualTo(NUMBER);
+      assertThat(input.nextNumber()).isEqualTo(42L);
+    }
   }
 
   @Test
   void shouldParseDecimalNumbersAsDoubles() {
-    JsonInput input = newInput("42.0");
-    assertThat(input.peek()).isEqualTo(NUMBER);
-    assertThat((Double) input.nextNumber()).isEqualTo(42.0d);
+    try (JsonInput input = newInput("42.0")) {
+      assertThat(input.peek()).isEqualTo(NUMBER);
+      assertThat((Double) input.nextNumber()).isEqualTo(42.0d);
+    }
   }
 
   @Test
   void shouldHandleNullValues() {
-    JsonInput input = newInput("null");
-    assertThat(input.peek()).isEqualTo(NULL);
-    assertThat(input.nextNull()).isNull();
+    try (JsonInput input = newInput("null")) {
+      assertThat(input.peek()).isEqualTo(NULL);
+      assertThat(input.nextNull()).isNull();
+    }
   }
 
   @Test
   void shouldBeAbleToReadAString() {
-    JsonInput input = newInput("\"cheese\"");
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThat(input.nextString()).isEqualTo("cheese");
+    try (JsonInput input = newInput("\"cheese\"")) {
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThat(input.nextString()).isEqualTo("cheese");
+    }
   }
 
   @Test
   void shouldBeAbleToHandleAnUnterminatedString() {
-    JsonInput input = newInput("\"cheese");
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThatExceptionOfType(JsonException.class)
-        .isThrownBy(input::nextString)
-        .withMessageStartingWith("Unterminated string");
+    try (JsonInput input = newInput("\"cheese")) {
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThatExceptionOfType(JsonException.class)
+          .isThrownBy(input::nextString)
+          .withMessageStartingWith("Unterminated string");
+    }
   }
 
   @Test
   void shouldBeAbleToReadTheEmptyString() {
-    JsonInput input = newInput("\"\"");
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThat(input.nextString()).isEmpty();
+    try (JsonInput input = newInput("\"\"")) {
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThat(input.nextString()).isEmpty();
+    }
   }
 
   @Test
   void anEmptyArrayHasNoContents() {
-    JsonInput input = newInput("[]");
-    assertThat(input.peek()).isEqualTo(START_COLLECTION);
-    input.beginArray();
-    assertThat(input.hasNext()).isFalse();
-    assertThat(input.peek()).isEqualTo(END_COLLECTION);
-    input.endArray();
+    try (JsonInput input = newInput("[]")) {
+      assertThat(input.peek()).isEqualTo(START_COLLECTION);
+      input.beginArray();
+      assertThat(input.hasNext()).isFalse();
+      assertThat(input.peek()).isEqualTo(END_COLLECTION);
+      input.endArray();
+    }
   }
 
   @Test
   void anArrayWithASingleElementHasNextButOnlyOneValue() {
-    JsonInput input = newInput("[ \"peas\"]");
-    input.beginArray();
-    assertThat(input.nextString()).isEqualTo("peas");
-    input.endArray();
+    try (JsonInput input = newInput("[ \"peas\"]")) {
+      input.beginArray();
+      assertThat(input.nextString()).isEqualTo("peas");
+      input.endArray();
+    }
   }
 
   @Test
   void anArrayWithMultipleElementsReturnsTrueFromHasNextMoreThanOnce() {
-    JsonInput input = newInput("[\"brie\", \"cheddar\"]");
-    input.beginArray();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextString()).isEqualTo("brie");
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextString()).isEqualTo("cheddar");
-    assertThat(input.hasNext()).isFalse();
-    input.endArray();
+    try (JsonInput input = newInput("[\"brie\", \"cheddar\"]")) {
+      input.beginArray();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextString()).isEqualTo("brie");
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextString()).isEqualTo("cheddar");
+      assertThat(input.hasNext()).isFalse();
+      input.endArray();
+    }
   }
 
   @Test
   void callingHasNextWhenNotInAnArrayOrMapIsAnError() {
-    JsonInput input = newInput("\"cheese\"");
-    assertThatExceptionOfType(JsonException.class).isThrownBy(input::hasNext);
+    try (JsonInput input = newInput("\"cheese\"")) {
+      assertThatThrownBy(input::hasNext)
+          .isInstanceOf(JsonException.class)
+          .hasMessageStartingWith(
+              "Unable to determine if an item has next when not in a container type");
+    }
   }
 
   @Test
   void anEmptyMapHasNoContents() {
-    JsonInput input = newInput("{      }");
-    assertThat(input.peek()).isEqualTo(START_MAP);
-    input.beginObject();
-    assertThat(input.hasNext()).isFalse();
-    assertThat(input.peek()).isEqualTo(END_MAP);
-    input.endObject();
+    try (JsonInput input = newInput("{      }")) {
+      assertThat(input.peek()).isEqualTo(START_MAP);
+      input.beginObject();
+      assertThat(input.hasNext()).isFalse();
+      assertThat(input.peek()).isEqualTo(END_MAP);
+      input.endObject();
+    }
   }
 
   @Test
   void canReadAMapWithASingleEntry() {
-    JsonInput input = newInput("{\"cheese\": \"feta\"}");
-    input.beginObject();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.peek()).isEqualTo(NAME);
-    assertThat(input.nextName()).isEqualTo("cheese");
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThat(input.nextString()).isEqualTo("feta");
-    assertThat(input.hasNext()).isFalse();
-    input.endObject();
+    try (JsonInput input = newInput("{\"cheese\": \"feta\"}")) {
+      input.beginObject();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.peek()).isEqualTo(NAME);
+      assertThat(input.nextName()).isEqualTo("cheese");
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThat(input.nextString()).isEqualTo("feta");
+      assertThat(input.hasNext()).isFalse();
+      input.endObject();
+    }
   }
 
   @Test
   void canReadAMapWithManyEntries() {
-    JsonInput input =
-        newInput(
-            "{" + "\"cheese\": \"stilton\"," + "\"vegetable\": \"peas\"," + "\"random\": 42" + "}");
-
-    assertThat(input.peek()).isEqualTo(START_MAP);
-    input.beginObject();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.peek()).isEqualTo(NAME);
-    assertThat(input.nextName()).isEqualTo("cheese");
-    assertThat(input.nextString()).isEqualTo("stilton");
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.peek()).isEqualTo(NAME);
-    assertThat(input.nextName()).isEqualTo("vegetable");
-    assertThat(input.nextString()).isEqualTo("peas");
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.peek()).isEqualTo(NAME);
-    assertThat(input.nextName()).isEqualTo("random");
-    assertThat(input.nextNumber()).isEqualTo(42L);
-    assertThat(input.hasNext()).isFalse();
-    assertThat(input.peek()).isEqualTo(END_MAP);
-    input.endObject();
+    String json = "{'cheese': 'stilton', 'vegetable': 'peas', 'random': 42}".replace('\'', '"');
+    try (JsonInput input = newInput(json)) {
+      assertThat(input.peek()).isEqualTo(START_MAP);
+      input.beginObject();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.peek()).isEqualTo(NAME);
+      assertThat(input.nextName()).isEqualTo("cheese");
+      assertThat(input.nextString()).isEqualTo("stilton");
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.peek()).isEqualTo(NAME);
+      assertThat(input.nextName()).isEqualTo("vegetable");
+      assertThat(input.nextString()).isEqualTo("peas");
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.peek()).isEqualTo(NAME);
+      assertThat(input.nextName()).isEqualTo("random");
+      assertThat(input.nextNumber()).isEqualTo(42L);
+      assertThat(input.hasNext()).isFalse();
+      assertThat(input.peek()).isEqualTo(END_MAP);
+      input.endObject();
+    }
   }
 
   @Test
   void nestedMapIsFine() {
-    JsonInput input = newInput("{\"map\": {\"child\": [\"hello\",\"world\"]}}");
+    try (JsonInput input = newInput("{\"map\": {\"child\": [\"hello\",\"world\"]}}")) {
 
-    input.beginObject();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextName()).isEqualTo("map");
-    input.beginObject();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextName()).isEqualTo("child");
-    input.beginArray();
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextString()).isEqualTo("hello");
-    assertThat(input.hasNext()).isTrue();
-    assertThat(input.nextString()).isEqualTo("world");
-    assertThat(input.hasNext()).isFalse();
-    input.endArray();
-    assertThat(input.hasNext()).isFalse();
-    input.endObject();
-    assertThat(input.hasNext()).isFalse();
-    input.endObject();
+      input.beginObject();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextName()).isEqualTo("map");
+      input.beginObject();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextName()).isEqualTo("child");
+      input.beginArray();
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextString()).isEqualTo("hello");
+      assertThat(input.hasNext()).isTrue();
+      assertThat(input.nextString()).isEqualTo("world");
+      assertThat(input.hasNext()).isFalse();
+      input.endArray();
+      assertThat(input.hasNext()).isFalse();
+      input.endObject();
+      assertThat(input.hasNext()).isFalse();
+      input.endObject();
+    }
   }
 
   @Test
@@ -240,7 +258,7 @@ class JsonInputTest {
     try (JsonInput in = new JsonInput(new StringReader(raw), new JsonTypeCoercer(), BY_NAME)) {
       List<Integer> array = in.readArray(Integer.class);
 
-      assertThat(array).isEqualTo(List.of(1, 2, 3, 4));
+      assertThat(array).containsExactly(1, 2, 3, 4);
     }
   }
 
@@ -250,9 +268,10 @@ class JsonInputTest {
     Random r = new Random();
     String raw =
         Stream.generate(() -> "" + chars[r.nextInt(4)]).limit(150).collect(Collectors.joining());
-    JsonInput input = newInput("\"" + raw + "\"");
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThat(input.nextString()).isEqualTo(raw);
+    try (JsonInput input = newInput("\"" + raw + "\"")) {
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThat(input.nextString()).isEqualTo(raw);
+    }
   }
 
   @Test
@@ -261,14 +280,15 @@ class JsonInputTest {
     Random r = new Random();
     String raw =
         Stream.generate(() -> "" + chars[r.nextInt(4)]).limit(150).collect(Collectors.joining());
-    JsonInput input = newInput("\"" + raw);
-    assertThat(input.peek()).isEqualTo(STRING);
-    assertThatExceptionOfType(JsonException.class)
-        .isThrownBy(input::nextString)
-        .withMessageStartingWith(
-            String.format(
-                "Unterminated string: %s. Last 128 characters read: %s",
-                raw, raw.substring(raw.length() - 128)));
+    try (JsonInput input = newInput("\"" + raw)) {
+      assertThat(input.peek()).isEqualTo(STRING);
+      assertThatExceptionOfType(JsonException.class)
+          .isThrownBy(input::nextString)
+          .withMessageStartingWith(
+              String.format(
+                  "Unterminated string: %s. Last 128 characters read: %s",
+                  raw, raw.substring(raw.length() - 128)));
+    }
   }
 
   @Test
@@ -312,6 +332,7 @@ class JsonInputTest {
       return message;
     }
 
+    @SuppressWarnings("unused")
     private static HasFromJsonWithJsonInputParameter fromJson(JsonInput input) {
       input.beginObject();
       input.nextName();

--- a/java/test/org/openqa/selenium/json/JsonOutputTest.java
+++ b/java/test/org/openqa/selenium/json/JsonOutputTest.java
@@ -25,6 +25,8 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 import static org.openqa.selenium.logging.LogType.BROWSER;
 import static org.openqa.selenium.logging.LogType.CLIENT;
@@ -45,13 +47,14 @@ import java.net.URL;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -99,9 +102,10 @@ class JsonOutputTest {
 
   @Test
   void shouldConvertAMapIntoAJsonObject() {
-    Map<String, String> toConvert = new HashMap<>();
-    toConvert.put("cheese", "cheddar");
-    toConvert.put("fish", "nice bit of haddock");
+    Map<String, String> toConvert =
+        Map.of(
+            "cheese", "cheddar",
+            "fish", "nice bit of haddock");
 
     String json = convert(toConvert);
 
@@ -125,7 +129,7 @@ class JsonOutputTest {
 
     JsonObject converted = JsonParser.parseString(json).getAsJsonObject();
     JsonArray allNames = converted.get("names").getAsJsonArray();
-    assertThat(allNames).hasSize(3);
+    assertThat(arrayAsString(allNames)).containsExactly("peter", "paul", "mary");
   }
 
   @Test
@@ -134,7 +138,7 @@ class JsonOutputTest {
 
     JsonObject converted = JsonParser.parseString(json).getAsJsonObject();
     JsonArray allNames = converted.get("something").getAsJsonArray();
-    assertThat(allNames).hasSize(2);
+    assertThat(arrayAsInt(allNames)).containsExactlyInAnyOrder(1, 43, 99, 20, 6, 7, 999);
   }
 
   @Test
@@ -305,7 +309,7 @@ class JsonOutputTest {
 
     Map<String, Object> value = new Json().toType(json, MAP_TYPE);
 
-    assertThat(value).isEqualTo(Map.of("a key", "a value"));
+    assertThat(value).containsExactlyInAnyOrderEntriesOf(Map.of("a key", "a value"));
   }
 
   @Test
@@ -314,7 +318,7 @@ class JsonOutputTest {
 
     Map<String, Object> value = new Json().toType(json, MAP_TYPE);
 
-    assertThat(value).isEqualTo(Map.of("a key", "a value"));
+    assertThat(value).containsExactlyInAnyOrderEntriesOf(Map.of("a key", "a value"));
   }
 
   @Test
@@ -362,7 +366,7 @@ class JsonOutputTest {
       }
       assertThat(json)
           .contains(
-              "\"lineNumber\": " + e.getLineNumber() + "",
+              "\"lineNumber\": " + e.getLineNumber(),
               "\"class\": \"" + e.getClass().getName() + "\"",
               "\"className\": \"" + e.getClassName() + "\"",
               "\"methodName\": \"" + e.getMethodName() + "\"");
@@ -410,7 +414,9 @@ class JsonOutputTest {
     RuntimeException clientError = new UnhandledAlertException("unhandled alert", "cheese!");
     Map<String, Object> obj = new Json().toType(new StringReader(convert(clientError)), Map.class);
     assertThat(obj).containsKey("alert");
-    assertThat(obj.get("alert")).isEqualTo(Map.of("text", "cheese!"));
+    assertThat(obj.get("alert"))
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("text", "cheese!"));
   }
 
   @Test
@@ -535,9 +541,10 @@ class JsonOutputTest {
   void shouldBeAbleToConvertACommand() {
     SessionId sessionId = new SessionId("some id");
     String commandName = "some command";
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("param1", "value1");
-    parameters.put("param2", "value2");
+    Map<String, Object> parameters =
+        Map.of(
+            "param1", "value1",
+            "param2", "value2");
     Command command = new Command(sessionId, commandName, parameters);
 
     String json = convert(command);
@@ -548,13 +555,13 @@ class JsonOutputTest {
     JsonPrimitive sid = converted.get("sessionId").getAsJsonPrimitive();
     assertThat(sid.getAsString()).isEqualTo(sessionId.toString());
 
-    assertThat(commandName).isEqualTo(converted.get("name").getAsString());
+    assertThat(converted.get("name").getAsString()).isEqualTo(commandName);
 
     assertThat(converted.has("parameters")).isTrue();
     JsonObject pars = converted.get("parameters").getAsJsonObject();
     assertThat(pars.entrySet()).hasSize(2);
-    assertThat(pars.get("param1").getAsString()).isEqualTo(parameters.get("param1"));
-    assertThat(pars.get("param2").getAsString()).isEqualTo(parameters.get("param2"));
+    assertThat(pars.get("param1").getAsString()).isEqualTo("value1");
+    assertThat(pars.get("param2").getAsString()).isEqualTo("value2");
   }
 
   @Test
@@ -589,7 +596,9 @@ class JsonOutputTest {
     }
 
     assertThat((Object) new Json().toType(builder.toString(), Object.class))
-        .isEqualTo(List.of("brie", "peas"));
+        .isInstanceOf(List.class)
+        .asInstanceOf(LIST)
+        .containsExactly("brie", "peas");
   }
 
   @Test
@@ -606,8 +615,11 @@ class JsonOutputTest {
           .endObject();
     }
 
-    assertThat((Object) new Json().toType(builder.toString(), MAP_TYPE))
-        .isEqualTo(Map.of("cheese", "brie", "vegetable", "peas"));
+    Map<String, String> parsedJson = new Json().toType(builder.toString(), MAP_TYPE);
+
+    assertThat(parsedJson)
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(Map.of("cheese", "brie", "vegetable", "peas"));
   }
 
   @Test
@@ -824,10 +836,7 @@ class JsonOutputTest {
 
     @SuppressWarnings("unused")
     public Set<?> getSomething() {
-      Set<Integer> integers = new HashSet<>();
-      integers.add(1);
-      integers.add(43);
-      return integers;
+      return Set.of(1, 43, 99, 20, 6, 7, 999);
     }
   }
 
@@ -839,7 +848,7 @@ class JsonOutputTest {
     }
   }
 
-  class JsonAware {
+  private static class JsonAware {
     private final String convertedValue;
 
     public JsonAware(String convertedValue) {
@@ -851,7 +860,7 @@ class JsonOutputTest {
     }
   }
 
-  class MappableJsonAware {
+  private static class MappableJsonAware {
     private final String convertedValue;
 
     public MappableJsonAware(String convertedValue) {
@@ -867,7 +876,7 @@ class JsonOutputTest {
     }
   }
 
-  class Mappable1 {
+  private static class Mappable1 {
     private final String key;
     private final Object value;
 
@@ -881,7 +890,7 @@ class JsonOutputTest {
     }
   }
 
-  class Mappable2 {
+  private static class Mappable2 {
     private final String key;
     private final Object value;
 
@@ -893,5 +902,17 @@ class JsonOutputTest {
     public Map<String, Object> toMap() {
       return Map.of(key, value);
     }
+  }
+
+  private static List<String> arrayAsString(JsonArray array) {
+    return StreamSupport.stream(array.spliterator(), false)
+        .map(e -> e.getAsString())
+        .collect(Collectors.toList());
+  }
+
+  private static List<Integer> arrayAsInt(JsonArray array) {
+    return StreamSupport.stream(array.spliterator(), false)
+        .map(e -> e.getAsInt())
+        .collect(Collectors.toList());
   }
 }

--- a/java/test/org/openqa/selenium/json/JsonTest.java
+++ b/java/test/org/openqa/selenium/json/JsonTest.java
@@ -73,7 +73,7 @@ class JsonTest {
     String converted = json.toJson(original);
     Object remade = json.toType(converted, MAP_TYPE);
 
-    assertThat(remade).isEqualTo(original);
+    assertThat(remade).asInstanceOf(MAP).containsExactlyInAnyOrderEntriesOf(original);
   }
 
   @Test
@@ -91,16 +91,16 @@ class JsonTest {
   @Test
   void shouldCoerceAListOfCapabilitiesIntoSomethingMutable() {
     // This is needed since Grid expects each of the capabilities to be mutable
-    List<Capabilities> expected =
-        List.of(
-            new ImmutableCapabilities("cheese", "brie"), new ImmutableCapabilities("peas", 42L));
+    ImmutableCapabilities capabilities1 = new ImmutableCapabilities("cheese", "brie");
+    ImmutableCapabilities capabilities2 = new ImmutableCapabilities("peas", 42L);
 
     Json json = new Json();
-    String raw = json.toJson(expected);
+    String raw = json.toJson(List.of(capabilities1, capabilities2));
     List<Capabilities> seen = json.toType(raw, new TypeToken<List<Capabilities>>() {}.getType());
 
-    assertThat(seen).isEqualTo(expected);
+    assertThat(seen).containsExactly(capabilities1, capabilities2);
     assertThat(seen.get(0)).isInstanceOf(MutableCapabilities.class);
+    assertThat(seen.get(1)).isInstanceOf(MutableCapabilities.class);
   }
 
   @Test

--- a/java/test/org/openqa/selenium/remote/DesiredCapabilitiesTest.java
+++ b/java/test/org/openqa/selenium/remote/DesiredCapabilitiesTest.java
@@ -37,9 +37,11 @@ class DesiredCapabilitiesTest {
         new ConcurrentHashMap<>();
 
     capabilitiesToDriver.put(new FirefoxOptions(), WebDriver.class);
-    capabilitiesToDriver.put(new FirefoxOptions(), WebDriver.class);
+    capabilitiesToDriver.put(new FirefoxOptions(), RemoteWebDriver.class);
 
-    assertThat(capabilitiesToDriver).hasSize(1);
+    assertThat(capabilitiesToDriver)
+        .hasSize(1)
+        .containsEntry(new FirefoxOptions(), RemoteWebDriver.class);
   }
 
   @Test

--- a/java/test/org/openqa/selenium/remote/NewSessionPayloadTest.java
+++ b/java/test/org/openqa/selenium/remote/NewSessionPayloadTest.java
@@ -18,8 +18,6 @@
 package org.openqa.selenium.remote;
 
 import static java.util.Collections.EMPTY_MAP;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
@@ -51,13 +49,13 @@ class NewSessionPayloadTest {
             "capabilities", singletonMap("alwaysMatch", singletonMap("browserName", "cheese")));
 
     try (NewSessionPayload payload = NewSessionPayload.create(caps)) {
-      assertThat(payload.getDownstreamDialects()).isEqualTo(singleton(W3C));
+      assertThat(payload.getDownstreamDialects()).containsExactly(W3C);
     }
 
     String json = new Json().toJson(caps);
     try (NewSessionPayload payload =
         NewSessionPayload.create(Contents.string(json, StandardCharsets.UTF_8))) {
-      assertThat(payload.getDownstreamDialects()).isEqualTo(singleton(W3C));
+      assertThat(payload.getDownstreamDialects()).containsExactly(W3C);
     }
   }
 
@@ -173,10 +171,9 @@ class NewSessionPayloadTest {
                         singletonMap("browserName", "firefox")))));
 
     assertThat(capabilities)
-        .isEqualTo(
-            List.of(
-                new ImmutableCapabilities("browserName", "foo", "platformName", "macos"),
-                new ImmutableCapabilities("browserName", "firefox", "platformName", "macos")));
+        .containsExactly(
+            new ImmutableCapabilities("browserName", "foo", "platformName", "macos"),
+            new ImmutableCapabilities("browserName", "firefox", "platformName", "macos"));
   }
 
   @Test
@@ -225,7 +222,7 @@ class NewSessionPayloadTest {
 
     try (NewSessionPayload payload = NewSessionPayload.create(raw)) {
       Map<String, Object> seen = payload.getMetadata();
-      assertThat(seen).isEqualTo(Map.of("se:meta", "cheese is good"));
+      assertThat(seen).containsExactlyInAnyOrderEntriesOf(Map.of("se:meta", "cheese is good"));
     }
   }
 
@@ -238,7 +235,7 @@ class NewSessionPayloadTest {
 
     try (NewSessionPayload payload = NewSessionPayload.create(raw)) {
       Map<String, Object> seen = payload.getMetadata();
-      assertThat(seen).isEqualTo(Map.of("se:good", "cheese"));
+      assertThat(seen).containsExactlyInAnyOrderEntriesOf(Map.of("se:good", "cheese"));
     }
   }
 
@@ -249,7 +246,7 @@ class NewSessionPayloadTest {
 
     try (NewSessionPayload payload = NewSessionPayload.create(raw)) {
       Map<String, Object> seen = payload.getMetadata();
-      assertThat(seen).isEqualTo(emptyMap());
+      assertThat(seen).isEmpty();
     }
   }
 
@@ -267,7 +264,7 @@ class NewSessionPayloadTest {
       fromDisk = payload.stream().collect(toList());
     }
 
-    assertThat(fromDisk).isEqualTo(presumablyFromMemory);
+    assertThat(fromDisk).containsExactlyElementsOf(presumablyFromMemory);
 
     return presumablyFromMemory;
   }

--- a/java/test/org/openqa/selenium/remote/RemoteLogsTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteLogsTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -136,26 +135,16 @@ class RemoteLogsTest {
 
   @Test
   void canGetAvailableLogTypes() {
-    List<String> remoteAvailableLogTypes = new ArrayList<>();
-    remoteAvailableLogTypes.add(LogType.PROFILER);
-    remoteAvailableLogTypes.add(LogType.SERVER);
-
+    List<String> remoteAvailableLogTypes = List.of(LogType.PROFILER, LogType.SERVER);
     when(executeMethod.execute(DriverCommand.GET_AVAILABLE_LOG_TYPES, null))
         .thenReturn(remoteAvailableLogTypes);
 
-    Set<String> localAvailableLogTypes = new HashSet<>();
-    localAvailableLogTypes.add(LogType.PROFILER);
-    localAvailableLogTypes.add(LogType.CLIENT);
-
+    Set<String> localAvailableLogTypes = Set.of(LogType.PROFILER, LogType.CLIENT);
     when(localLogs.getAvailableLogTypes()).thenReturn(localAvailableLogTypes);
-
-    Set<String> expected = new HashSet<>();
-    expected.add(LogType.CLIENT);
-    expected.add(LogType.PROFILER);
-    expected.add(LogType.SERVER);
 
     Set<String> availableLogTypes = remoteLogs.getAvailableLogTypes();
 
-    assertThat(availableLogTypes).isEqualTo(expected);
+    assertThat(availableLogTypes)
+        .containsExactlyInAnyOrder(LogType.CLIENT, LogType.PROFILER, LogType.SERVER);
   }
 }

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
@@ -796,17 +796,15 @@ class RemoteWebDriverUnitTest {
 
   @Test
   void getDownloadableFilesReturnsType() {
-    List<String> expectedFiles = List.of("file1.txt", "file2.pdf");
-
     WebDriverFixture fixture =
         new WebDriverFixture(
             new ImmutableCapabilities(ENABLE_DOWNLOADS, true),
             echoCapabilities,
-            valueResponder(Map.of("names", expectedFiles)));
+            valueResponder(Map.of("names", List.of("file1.txt", "file2.pdf"))));
 
     List<String> result = fixture.driver.getDownloadableFiles();
 
-    assertThat(result).isInstanceOf(List.class).isEqualTo(expectedFiles);
+    assertThat(result).containsExactly("file1.txt", "file2.pdf");
 
     fixture.verifyCommands(new CommandPayload(DriverCommand.GET_DOWNLOADABLE_FILES, emptyMap()));
   }

--- a/java/test/org/openqa/selenium/remote/W3CHandshakeResponseTest.java
+++ b/java/test/org/openqa/selenium/remote/W3CHandshakeResponseTest.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 
 import java.util.Map;
 import org.junit.jupiter.api.Tag;
@@ -45,9 +46,10 @@ class W3CHandshakeResponseTest {
     Response response = result.createResponse();
 
     assertThat(response.getState()).isEqualTo("success");
-    assertThat((int) response.getStatus()).isZero();
-
-    assertThat(response.getValue()).isEqualTo(caps.asMap());
+    assertThat(response.getStatus()).isEqualTo(0);
+    assertThat(response.getValue())
+        .asInstanceOf(MAP)
+        .containsExactlyInAnyOrderEntriesOf(caps.asMap());
   }
 
   @Test

--- a/java/test/org/openqa/selenium/remote/http/UrlTemplateTest.java
+++ b/java/test/org/openqa/selenium/remote/http/UrlTemplateTest.java
@@ -46,7 +46,7 @@ class UrlTemplateTest {
     UrlTemplate.Match match = new UrlTemplate("/i/like/{veggie}").match("/i/like/cake");
 
     assertThat(match.getUrl()).isEqualTo("/i/like/cake");
-    assertThat(match.getParameters()).isEqualTo(Map.of("veggie", "cake"));
+    assertThat(match.getParameters()).containsExactlyInAnyOrderEntriesOf(Map.of("veggie", "cake"));
   }
 
   @Test
@@ -55,7 +55,8 @@ class UrlTemplateTest {
         new UrlTemplate("/i/like/{flavor}/{veggie}").match("/i/like/sweet/cake");
 
     assertThat(match.getUrl()).isEqualTo("/i/like/sweet/cake");
-    assertThat(match.getParameters()).isEqualTo(Map.of("flavor", "sweet", "veggie", "cake"));
+    assertThat(match.getParameters())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("flavor", "sweet", "veggie", "cake"));
   }
 
   @Test
@@ -63,7 +64,7 @@ class UrlTemplateTest {
     UrlTemplate.Match match = new UrlTemplate("{cake}/type").match("cheese/type");
 
     assertThat(match.getUrl()).isEqualTo("cheese/type");
-    assertThat(match.getParameters()).isEqualTo(Map.of("cake", "cheese"));
+    assertThat(match.getParameters()).containsExactlyInAnyOrderEntriesOf(Map.of("cake", "cheese"));
   }
 
   @Test
@@ -72,7 +73,7 @@ class UrlTemplateTest {
         new UrlTemplate("/session/{id}/se/vnc").match("/prefix/session/1234/se/vnc", "/prefix");
 
     assertThat(match.getUrl()).isEqualTo("/session/1234/se/vnc");
-    assertThat(match.getParameters()).isEqualTo(Map.of("id", "1234"));
+    assertThat(match.getParameters()).containsExactlyInAnyOrderEntriesOf(Map.of("id", "1234"));
   }
 
   @Test
@@ -81,7 +82,7 @@ class UrlTemplateTest {
         new UrlTemplate("/session/{id}/se/vnc").match("/session/1234/se/vnc", "");
 
     assertThat(match.getUrl()).isEqualTo("/session/1234/se/vnc");
-    assertThat(match.getParameters()).isEqualTo(Map.of("id", "1234"));
+    assertThat(match.getParameters()).containsExactlyInAnyOrderEntriesOf(Map.of("id", "1234"));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/support/decorators/DecoratedOptionsTest.java
+++ b/java/test/org/openqa/selenium/support/decorators/DecoratedOptionsTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -90,8 +89,7 @@ class DecoratedOptionsTest {
 
   @Test
   void getCookies() {
-    Set<Cookie> cookies = new HashSet<>();
-    cookies.add(new Cookie("name", "value"));
+    Set<Cookie> cookies = Set.of(new Cookie("name", "value"));
     verifyFunction(WebDriver.Options::getCookies, cookies);
   }
 

--- a/java/test/org/openqa/selenium/support/decorators/DecoratedWebDriverTest.java
+++ b/java/test/org/openqa/selenium/support/decorators/DecoratedWebDriverTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -263,8 +262,7 @@ class DecoratedWebDriverTest {
 
   @Test
   void getWindowHandles() {
-    Set<String> handles = new HashSet<>();
-    handles.add("test");
+    Set<String> handles = Set.of("test");
     verifyFunction(WebDriver::getWindowHandles, handles);
   }
 

--- a/java/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
+++ b/java/test/org/openqa/selenium/support/pagefactory/ByChainedTest.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.support.pagefactory;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
@@ -24,7 +25,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -37,11 +37,11 @@ import org.openqa.selenium.WebElement;
 @Tag("UnitTests")
 class ByChainedTest {
 
-  private static final List<WebElement> NO_ELEMENTS = Collections.emptyList();
+  private static final List<WebElement> NO_ELEMENTS = emptyList();
 
   @Test
   void findElementZeroBy() {
-    final AllDriver driver = mock(AllDriver.class);
+    final AllDriver driver = mock();
 
     ByChained by = new ByChained();
     assertThatExceptionOfType(NoSuchElementException.class)
@@ -50,20 +50,18 @@ class ByChainedTest {
 
   @Test
   void findElementsZeroBy() {
-    final AllDriver driver = mock(AllDriver.class);
+    final AllDriver driver = mock();
 
     ByChained by = new ByChained();
-    assertThat(by.findElements(driver)).isEqualTo(new ArrayList<WebElement>());
+    assertThat(by.findElements(driver)).isEmpty();
   }
 
   @Test
   void findElementOneBy() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(WebElement.class, "webElement2");
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final List<WebElement> elems12 = List.of(elem1, elem2);
 
     when(driver.findElements(By.cssSelector("cheese"))).thenReturn(elems12);
 
@@ -73,25 +71,20 @@ class ByChainedTest {
 
   @Test
   void findElementsOneBy() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(WebElement.class, "webElement2");
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
 
-    when(driver.findElements(By.tagName("cheese"))).thenReturn(elems12);
+    when(driver.findElements(By.tagName("cheese"))).thenReturn(List.of(elem1, elem2));
 
     ByChained by = new ByChained(By.tagName("cheese"));
-    assertThat(by.findElements(driver)).isEqualTo(elems12);
+    assertThat(by.findElements(driver)).containsExactly(elem1, elem2);
   }
 
   @Test
   void findElementOneByEmpty() {
-    final AllDriver driver = mock(AllDriver.class);
-    final List<WebElement> elems = new ArrayList<>();
-
-    when(driver.findElements(By.name("cheese"))).thenReturn(elems);
+    final AllDriver driver = mock();
+    when(driver.findElements(By.name("cheese"))).thenReturn(emptyList());
 
     ByChained by = new ByChained(By.name("cheese"));
     assertThatExceptionOfType(NoSuchElementException.class)
@@ -100,34 +93,25 @@ class ByChainedTest {
 
   @Test
   void findElementsOneByEmpty() {
-    final AllDriver driver = mock(AllDriver.class);
-    final List<WebElement> elems = new ArrayList<>();
-
-    when(driver.findElements(By.name("cheese"))).thenReturn(elems);
+    final AllDriver driver = mock();
+    when(driver.findElements(By.name("cheese"))).thenReturn(emptyList());
 
     ByChained by = new ByChained(By.name("cheese"));
-    assertThat(by.findElements(driver)).isEqualTo(elems);
+    assertThat(by.findElements(driver)).isEmpty();
   }
 
   @Test
   void findElementTwoBy() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(AllElement.class, "webElement1");
-    final WebElement elem2 = mock(AllElement.class, "webElement2");
-    final WebElement elem3 = mock(AllElement.class, "webElement3");
-    final WebElement elem4 = mock(AllElement.class, "webElement4");
-    final WebElement elem5 = mock(AllElement.class, "webElement5");
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
-    final List<WebElement> elems34 = new ArrayList<>();
-    elems34.add(elem3);
-    elems34.add(elem4);
-    final List<WebElement> elems5 = new ArrayList<>();
-    elems5.add(elem5);
-    final List<WebElement> elems345 = new ArrayList<>();
-    elems345.addAll(elems34);
-    elems345.addAll(elems5);
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final WebElement elem3 = mock("webElement3");
+    final WebElement elem4 = mock("webElement4");
+    final WebElement elem5 = mock("webElement5");
+    final List<WebElement> elems12 = List.of(elem1, elem2);
+    final List<WebElement> elems34 = List.of(elem3, elem4);
+    final List<WebElement> elems5 = List.of(elem5);
+    final List<WebElement> elems345 = List.of(elem3, elem4, elem5);
 
     when(driver.findElements(By.cssSelector("cheese"))).thenReturn(elems12);
     when(elem1.findElements(By.cssSelector("photo"))).thenReturn(elems34);
@@ -139,25 +123,18 @@ class ByChainedTest {
 
   @Test
   void findElementTwoByEmptyParent() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(AllElement.class, "webElement2");
-    final WebElement elem3 = mock(AllElement.class, "webElement3");
-    final WebElement elem4 = mock(AllElement.class, "webElement4");
-    final WebElement elem5 = mock(AllElement.class, "webElement5");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final WebElement elem3 = mock("webElement3");
+    final WebElement elem4 = mock("webElement4");
+    final WebElement elem5 = mock("webElement5");
 
-    final List<WebElement> elems = new ArrayList<>();
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
-    final List<WebElement> elems34 = new ArrayList<>();
-    elems34.add(elem3);
-    elems34.add(elem4);
-    final List<WebElement> elems5 = new ArrayList<>();
-    elems5.add(elem5);
-    final List<WebElement> elems345 = new ArrayList<>();
-    elems345.addAll(elems34);
-    elems345.addAll(elems5);
+    final List<WebElement> elems = List.of();
+    final List<WebElement> elems12 = List.of(elem1, elem2);
+    final List<WebElement> elems34 = List.of(elem3, elem4);
+    final List<WebElement> elems5 = List.of(elem5);
+    final List<WebElement> elems345 = List.of(elem3, elem4, elem5);
 
     when(driver.findElements(By.name("cheese"))).thenReturn(elems);
 
@@ -168,53 +145,39 @@ class ByChainedTest {
 
   @Test
   void findElementsTwoByEmptyParent() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(AllElement.class, "webElement2");
-    final WebElement elem3 = mock(AllElement.class, "webElement3");
-    final WebElement elem4 = mock(AllElement.class, "webElement4");
-    final WebElement elem5 = mock(AllElement.class, "webElement5");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final WebElement elem3 = mock("webElement3");
+    final WebElement elem4 = mock("webElement4");
+    final WebElement elem5 = mock("webElement5");
 
-    final List<WebElement> elems = new ArrayList<>();
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
-    final List<WebElement> elems34 = new ArrayList<>();
-    elems34.add(elem3);
-    elems34.add(elem4);
-    final List<WebElement> elems5 = new ArrayList<>();
-    elems5.add(elem5);
-    final List<WebElement> elems345 = new ArrayList<>();
-    elems345.addAll(elems34);
-    elems345.addAll(elems5);
+    final List<WebElement> elems = List.of();
+    final List<WebElement> elems12 = List.of(elem1, elem2);
+    final List<WebElement> elems34 = List.of(elem3, elem4);
+    final List<WebElement> elems5 = List.of(elem5);
+    final List<WebElement> elems345 = List.of(elem3, elem4, elem5);
 
     when(driver.findElements(By.name("cheese"))).thenReturn(elems);
 
     ByChained by = new ByChained(By.name("cheese"), By.name("photo"));
-    assertThat(by.findElements(driver)).isEqualTo(elems);
+    assertThat(by.findElements(driver)).isEmpty();
   }
 
   @Test
   void findElementTwoByEmptyChild() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(AllElement.class, "webElement2");
-    final WebElement elem3 = mock(AllElement.class, "webElement3");
-    final WebElement elem4 = mock(AllElement.class, "webElement4");
-    final WebElement elem5 = mock(AllElement.class, "webElement5");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final WebElement elem3 = mock("webElement3");
+    final WebElement elem4 = mock("webElement4");
+    final WebElement elem5 = mock("webElement5");
 
-    final List<WebElement> elems = new ArrayList<>();
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
-    final List<WebElement> elems34 = new ArrayList<>();
-    elems34.add(elem3);
-    elems34.add(elem4);
-    final List<WebElement> elems5 = new ArrayList<>();
-    elems5.add(elem5);
-    final List<WebElement> elems345 = new ArrayList<>();
-    elems345.addAll(elems34);
-    elems345.addAll(elems5);
+    final List<WebElement> elems = List.of();
+    final List<WebElement> elems12 = List.of(elem1, elem2);
+    final List<WebElement> elems34 = List.of(elem3, elem4);
+    final List<WebElement> elems5 = List.of(elem5);
+    final List<WebElement> elems345 = List.of(elem3, elem4, elem5);
 
     when(driver.findElements(By.tagName("cheese"))).thenReturn(elems12);
     when(elem1.findElements(By.tagName("photo"))).thenReturn(elems);
@@ -226,38 +189,31 @@ class ByChainedTest {
 
   @Test
   void findElementsTwoByEmptyChild() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(AllElement.class, "webElement2");
-    final WebElement elem3 = mock(AllElement.class, "webElement3");
-    final WebElement elem4 = mock(AllElement.class, "webElement4");
-    final WebElement elem5 = mock(AllElement.class, "webElement5");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
+    final WebElement elem3 = mock("webElement3");
+    final WebElement elem4 = mock("webElement4");
+    final WebElement elem5 = mock("webElement5");
 
-    final List<WebElement> elems = new ArrayList<>();
-    final List<WebElement> elems12 = new ArrayList<>();
-    elems12.add(elem1);
-    elems12.add(elem2);
-    final List<WebElement> elems34 = new ArrayList<>();
-    elems34.add(elem3);
-    elems34.add(elem4);
-    final List<WebElement> elems5 = new ArrayList<>();
-    elems5.add(elem5);
-    final List<WebElement> elems345 = new ArrayList<>();
-    elems345.addAll(elems34);
-    elems345.addAll(elems5);
+    final List<WebElement> elems = List.of();
+    final List<WebElement> elems12 = List.of(elem1, elem2);
+    final List<WebElement> elems34 = List.of(elem3, elem4);
+    final List<WebElement> elems5 = List.of(elem5);
+    final List<WebElement> elems345 = List.of(elem3, elem4, elem5);
 
     when(driver.findElements(By.linkText("cheese"))).thenReturn(elems12);
     when(elem1.findElements(By.linkText("photo"))).thenReturn(elems);
     when(elem2.findElements(By.linkText("photo"))).thenReturn(elems5);
 
     ByChained by = new ByChained(By.linkText("cheese"), By.linkText("photo"));
-    assertThat(by.findElements(driver)).isEqualTo(elems5);
+    assertThat(by.findElements(driver)).containsExactly(elem5);
   }
 
   @Test
   void findElementsThreeBy_firstFindsOne_secondEmpty() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
 
     By by1 = By.name("by1");
     By by2 = By.name("by2");
@@ -274,9 +230,9 @@ class ByChainedTest {
 
   @Test
   void findElementThreeBy_firstFindsTwo_secondEmpty() {
-    final AllDriver driver = mock(AllDriver.class);
-    final WebElement elem1 = mock(WebElement.class, "webElement1");
-    final WebElement elem2 = mock(WebElement.class, "webElement2");
+    final AllDriver driver = mock();
+    final WebElement elem1 = mock("webElement1");
+    final WebElement elem2 = mock("webElement2");
 
     By by1 = By.name("by1");
     By by2 = By.name("by2");

--- a/java/test/org/openqa/selenium/support/pagefactory/DefaultElementLocatorTest.java
+++ b/java/test/org/openqa/selenium/support/pagefactory/DefaultElementLocatorTest.java
@@ -66,14 +66,13 @@ class DefaultElementLocatorTest {
     final By by = new ByIdOrName("list");
     final WebElement element1 = mock(WebElement.class, "webElement1");
     final WebElement element2 = mock(WebElement.class, "webElement2");
-    final List<WebElement> list = List.of(element1, element2);
 
-    when(driver.findElements(by)).thenReturn(list);
+    when(driver.findElements(by)).thenReturn(List.of(element1, element2));
 
     ElementLocator locator = newLocator(driver, f);
     List<WebElement> returnedList = locator.findElements();
 
-    assertThat(returnedList).isEqualTo(list);
+    assertThat(returnedList).containsExactly(element1, element2);
   }
 
   @Test

--- a/java/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
+++ b/java/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
@@ -248,15 +248,14 @@ class ExpectedConditionsTest {
 
   @Test
   void waitingForVisibilityOfAllElementsLocatedByReturnsListOfElements() {
-    List<WebElement> webElements = singletonList(mockElement);
     String testSelector = "testSelector";
 
-    when(mockDriver.findElements(By.cssSelector(testSelector))).thenReturn(webElements);
+    when(mockDriver.findElements(By.cssSelector(testSelector))).thenReturn(List.of(mockElement));
     when(mockElement.isDisplayed()).thenReturn(true);
 
     List<WebElement> returnedElements =
         wait.until(visibilityOfAllElementsLocatedBy(By.cssSelector(testSelector)));
-    assertThat(returnedElements).isEqualTo(webElements);
+    assertThat(returnedElements).containsExactly(mockElement);
   }
 
   @Test
@@ -299,11 +298,10 @@ class ExpectedConditionsTest {
 
   @Test
   void waitingForVisibilityOfAllElementsReturnsListOfElements() {
-    List<WebElement> webElements = singletonList(mockElement);
     when(mockElement.isDisplayed()).thenReturn(true);
 
-    List<WebElement> returnedElements = wait.until(visibilityOfAllElements(webElements));
-    assertThat(returnedElements).isEqualTo(webElements);
+    List<WebElement> returnedElements = wait.until(visibilityOfAllElements(List.of(mockElement)));
+    assertThat(returnedElements).containsExactly(mockElement);
   }
 
   @Test


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Fixes AssertJ's asserts for `java.util.Map`s and `java.util.Set`s.

### 🔧 Implementation Notes

The problem is that AssertJ's method `isEqualTo` doesn't always work for Sets and Maps because it assumes strict order of elements:
1. `assertThat(MAP).isEqualTo(Map.of(...))`  // can fail time-to-time because of different order of elements
2. `assertThat(SET).isEqualTo(Set.of(...))`  // can fail time-to-time because of different order of elements

In both cases, we have to replace `isEqualTo` by `containsExactlyInAnyOrderEntriesOf` or similar method.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace AssertJ `isEqualTo` with order-agnostic assertions for Maps and Sets

- Fix flaky tests that fail due to element ordering assumptions

- Improve PDF validation in BrowsingContextTest with content verification

- Simplify test setup code using modern Java collection literals

- Add proper resource management with try-with-resources blocks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AssertJ isEqualTo<br/>for Maps/Sets"] -->|Replace with| B["containsExactlyInAnyOrder<br/>Entries/Elements"]
  C["Flaky test assertions<br/>due to ordering"] -->|Fixed by| B
  D["Test code cleanup<br/>ArrayList/HashMap"] -->|Simplify to| E["List.of/Map.of<br/>Set.of"]
  F["Resource leaks<br/>JsonInput"] -->|Add| G["try-with-resources<br/>blocks"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>ProxyTest.java</strong><dd><code>Fix List assertion to use containsExactly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-ca908e0766b2f05327731f0ed690025988d0fe910c10bcceb75c473946c3a10a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChromeOptionsTest.java</strong><dd><code>Replace Map assertions with order-agnostic checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-a2da4c56efda1ff71535e17798b3e48b6599280a2e215d9837d082182061a584">+18/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>FirefoxProfileTest.java</strong><dd><code>Fix Set assertion and add resource cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-d5d268af2c0465ac699379659cc92bbf98c076ea742c37d60b4466eb57d9555c">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConcatenatingConfigTest.java</strong><dd><code>Replace Set assertions with containsExactlyInAnyOrder</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-04802cec7f34870a779847370cc02bb3e8be23919b2c621c58ef84bd098527d0">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>InternetExplorerOptionsTest.java</strong><dd><code>Fix Map capability assertion with order-agnostic check</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-913be24a7b5808d12186de132101c2ee9fd6984f2cf60c40eca4338d6c2ac0ef">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PointerInputTest.java</strong><dd><code>Replace Map assertion with containsExactlyInAnyOrderEntriesOf</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-ab9e99d497aff24cfe165a965e60e2d03054d8eaff3e74ec1f5eff2e04311fc5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WheelInputTest.java</strong><dd><code>Replace Map assertion with containsExactlyInAnyOrderEntriesOf</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-eb7bd1fc3f4dfe36ce8a7d870d14e8b836e00346a353622d2c1344e2168aa8d5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JsonInputTest.java</strong><dd><code>Add try-with-resources for resource management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-1cda9e5762ce05ff769e9273ce5c53ea8d016ba643ba86fee4166bc7d7acfa9e">+134/-113</a></td>

</tr>

<tr>
  <td><strong>JsonOutputTest.java</strong><dd><code>Replace Map/List assertions with order-agnostic checks</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-c47e9d5a8892925321a8b0b78158839de4b338c799f50f79ba0a36e76db04959">+48/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>JsonTest.java</strong><dd><code>Fix Map and List assertions for unordered collections</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-ca8b46815d2ed84d1c82776cf430ab11d8b9cdb91a4c904338c96dc482147623">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NewSessionPayloadTest.java</strong><dd><code>Replace Set/List assertions with order-agnostic checks</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-671acd7e9a5a075d497c1fa0cc26755c509e1f2ac86bfaeaa0b65c2460f4991a">+9/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteLogsTest.java</strong><dd><code>Simplify Set creation and fix assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-4c8b1a3ba73e016d51f3f7b77430e4ea836e3d0916256cf1d90138b8789f09a6">+4/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteWebDriverUnitTest.java</strong><dd><code>Replace List assertion with containsExactly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-0147a1bff443d7a62982143a4a8ff2a51826670b30a8bc03356a0414226ae5a8">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>W3CHandshakeResponseTest.java</strong><dd><code>Fix Map assertion with order-agnostic check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-f5d9992bc73f241e1cfa6f48de01fdea739d918920cd746608ed3a95b9a684c0">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UrlTemplateTest.java</strong><dd><code>Replace Map assertions with containsExactlyInAnyOrderEntriesOf</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-b8238e4c59654a23ec0581af1d02201e4c80ae8e8b5917c1b2cf7b0fb18f6d05">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ByChainedTest.java</strong><dd><code>Simplify test setup and fix assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-7432e03e4b945d5245070c5129e4803c7267e05a8702bd6b8cf82ede2ba9926d">+84/-128</a></td>

</tr>

<tr>
  <td><strong>DefaultElementLocatorTest.java</strong><dd><code>Replace List assertion with containsExactly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-db3f676e2a51fc8b0009e32c93979c618058806ed91aa256d4ae8fe15aff6f25">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExpectedConditionsTest.java</strong><dd><code>Replace List assertions with containsExactly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-b2f2749e03487e09885e11a89fc70c9fb0a1d5913534d357f7242412e987046d">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BrowsingContextTest.java</strong><dd><code>Improve PDF validation with content verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-f33a246a757eda5a55a8c9939d94f577af17d34ded65badfda87cff2da956c5c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SetNetworkConditionsTest.java</strong><dd><code>Add missing test method and imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-5073fc1fa15d4bac5ac6cef44f2f45bbb600d0fb72379e4ec6f010f224114847">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>GeckoDriverServiceTest.java</strong><dd><code>Split and clarify timeout builder tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-7e9691bee739620eae799ae2ee7af207080ecba0716c58e35c9300dfff858f50">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DesiredCapabilitiesTest.java</strong><dd><code>Improve Map entry assertion clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-d7f44c3d7abcda1d36c80c687086d5e355a6b18cc5724ff399e18199f0f08094">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Cleanup</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DecoratedOptionsTest.java</strong><dd><code>Simplify Set creation with Set.of</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-e4481e7f9103bbfaf9c72220cf801422dfb98888cb69caa52bf356e26cb1b3ff">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DecoratedWebDriverTest.java</strong><dd><code>Simplify Set creation with Set.of</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16808/files#diff-190c26600303f4ae1dac64bae6490c646c1098c6c29b1e108721738d62e56bd9">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

