### PR TITLE
[py] update how python tests are filtered and run on github

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -84,6 +84,7 @@ jobs:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SE_AVOID_STATS: true
+      SE_CACHE_PATH: $RUNNER_TEMP/selenium
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v4

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -2,22 +2,24 @@ name: CI - Python
 
 on:
   workflow_call:
+    inputs:
+      targets:
+        required: false
+        type: string
+        default: ''
+      run-full-suite:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Build
-      run: |
-        bazel build //py:selenium-wheel //py:selenium-sdist
-
   docs:
     name: Documentation
+    if: ${{ inputs.run-full-suite }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source tree
@@ -38,6 +40,7 @@ jobs:
 
   typing:
     name: Type Checker
+    if: ${{ inputs.run-full-suite }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source tree
@@ -58,7 +61,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    needs: build
+    if: ${{ inputs.run-full-suite }}
     uses: ./.github/workflows/bazel.yml
     strategy:
       fail-fast: false
@@ -71,31 +74,50 @@ jobs:
       python-version: ${{ matrix.python-version }}
       run: bazel test --local_test_jobs 1 //py:unit
 
-  remote-tests:
-    name: Remote Tests
-    needs: build
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Integration Tests Remote
-      browser: yes
-      run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-remote
+  filter-targets:
+    name: Filter Targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.filter.outputs.targets }}
+    steps:
+      - name: Filter Python targets
+        id: filter
+        shell: bash
+        run: |
+          targets="${{ inputs.targets }}"
+          filtered=()
+
+          for t in $targets; do
+            [[ "$t" == //py* ]] && filtered+=("$t")
+          done
+
+          if [ ${#filtered[@]} -eq 0 ]; then
+            echo "targets=//py/..." >> "$GITHUB_OUTPUT"
+          else
+            echo "targets=${filtered[*]}" >> "$GITHUB_OUTPUT"
+          fi
 
   browser-tests:
     name: Browser Tests
-    needs: build
+    needs: filter-targets
     uses: ./.github/workflows/bazel.yml
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, chrome-bidi, edge]
+        browser: [chrome, firefox, chrome-bidi, chrome-remote]
         os: [windows]
         include:
           - browser: safari
             os: macos
     with:
-      name: Integration Tests (${{ matrix.browser }})
+      name: Browser Tests (${{ matrix.browser }}, ${{ matrix.os }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
-      run: |
-        bazel test --local_test_jobs 1 --flaky_test_attempts 3 //py:test-${{ matrix.browser }}
+      run: >
+        bazel test
+        --keep_going
+        --build_tests_only
+        --flaky_test_attempts 3
+        --local_test_jobs 1
+        --test_tag_filters=${{ matrix.browser }}
+        ${{ needs.filter-targets.outputs.targets }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -104,13 +104,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, chrome-bidi, chrome-remote]
+        browser: [chrome, firefox]
+        bidi: [true, false]
         os: [windows]
         include:
           - browser: safari
+            bidi: false
             os: macos
     with:
-      name: Browser Tests (${{ matrix.browser }}, ${{ matrix.os }})
+      name: Browser Tests (${{ matrix.browser }}${{ matrix.bidi && '-bidi' || '' }})
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
       run: >
@@ -119,5 +121,5 @@ jobs:
         --build_tests_only
         --flaky_test_attempts 3
         --local_test_jobs 1
-        --test_tag_filters=${{ matrix.browser }}
+        --test_tag_filters=${{ matrix.bidi && format('{0}-bidi', matrix.browser) || format('{0},-bidi,-remote', matrix.browser) }}
         ${{ needs.filter-targets.outputs.targets }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -74,6 +74,17 @@ jobs:
       python-version: ${{ matrix.python-version }}
       run: bazel test --local_test_jobs 1 //py:unit
 
+  requirements:
+    name: Requirements Lock
+    if: ${{ inputs.run-full-suite }}
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Requirements Lock
+      os: ubuntu
+      python-version: '3.10'
+      run: bazel test //py:requirements.test
+
+
   filter-targets:
     name: Filter Targets
     runs-on: ubuntu-latest
@@ -121,5 +132,6 @@ jobs:
         --build_tests_only
         --flaky_test_attempts 3
         --local_test_jobs 1
+        --test_size_filters large
         --test_tag_filters=${{ matrix.bidi && format('{0}-bidi', matrix.browser) || format('{0},-bidi,-remote', matrix.browser) }}
         ${{ needs.filter-targets.outputs.targets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,20 @@ jobs:
     name: Python
     needs: check
     uses: ./.github/workflows/ci-python.yml
+    with:
+      targets: ${{ needs.check.outputs.targets }}
+      run-full-suite: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call' ||
+          contains(github.event.pull_request.title, '[py]')
+        }}
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'workflow_call' ||
       contains(needs.check.outputs.targets, '//py') ||
-      contains(join(github.event.commits.*.message), '[py]') ||
       contains(github.event.pull_request.title, '[py]')
 
   ruby:

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -499,7 +499,11 @@ BROWSER_TESTS = {
         ] + BROWSERS[browser]["args"],
         data = BROWSERS[browser]["data"],
         env_inherit = ["DISPLAY"],
-        tags = ["no-sandbox"] + BROWSERS[browser]["tags"],
+        tags = [
+            "bidi",
+            "no-sandbox",
+            "%s-bidi" % browser,
+        ] + BROWSERS[browser]["tags"],
         deps = [
             ":init-tree",
             ":selenium",
@@ -541,7 +545,7 @@ BROWSER_TESTS = {
             "no-sandbox",
             "remote",
             "%s-remote" % browser,
-        ],
+        ] + BROWSERS[browser]["tags"],
         deps = [
             ":init-tree",
             ":selenium",

--- a/py/test/selenium/webdriver/common/bidi_emulation_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_emulation_tests.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
+
 import pytest
 
 from selenium.webdriver.common.bidi.emulation import (
@@ -117,6 +119,7 @@ def test_emulation_initialized(driver):
     assert isinstance(driver.emulation, Emulation)
 
 
+@pytest.mark.xfail_firefox(reason="Firefox BiDi geolocation override does not work with contexts parameter")
 def test_set_geolocation_override_with_coordinates_in_context(driver, pages):
     context_id = driver.current_window_handle
     pages.load("blank.html")
@@ -132,6 +135,10 @@ def test_set_geolocation_override_with_coordinates_in_context(driver, pages):
     assert abs(result["accuracy"] - coords.accuracy) < 1.0, f"Accuracy mismatch: {result['accuracy']}"
 
 
+@pytest.mark.xfail_firefox(
+    condition=sys.platform == "win32",
+    reason="Firefox + Windows: navigator.geolocation.getCurrentPosition returns None",
+)
 def test_set_geolocation_override_with_coordinates_in_user_context(driver, pages):
     # Create a user context
     user_context = driver.browser.create_user_context()
@@ -156,6 +163,10 @@ def test_set_geolocation_override_with_coordinates_in_user_context(driver, pages
     driver.browser.remove_user_context(user_context)
 
 
+@pytest.mark.xfail_firefox(
+    condition=sys.platform == "win32",
+    reason="Firefox + Windows: navigator.geolocation.getCurrentPosition returns None",
+)
 def test_set_geolocation_override_all_coords(driver, pages):
     context_id = driver.current_window_handle
     pages.load("blank.html")
@@ -181,6 +192,10 @@ def test_set_geolocation_override_all_coords(driver, pages):
     driver.browsing_context.close(context_id)
 
 
+@pytest.mark.xfail_firefox(
+    condition=sys.platform == "win32",
+    reason="Firefox + Windows: navigator.geolocation.getCurrentPosition returns None",
+)
 def test_set_geolocation_override_with_multiple_contexts(driver, pages):
     # Create two browsing contexts
     context1_id = driver.browsing_context.create(type=WindowTypes.TAB)
@@ -214,6 +229,10 @@ def test_set_geolocation_override_with_multiple_contexts(driver, pages):
     driver.browsing_context.close(context2_id)
 
 
+@pytest.mark.xfail_firefox(
+    condition=sys.platform == "win32",
+    reason="Firefox + Windows: navigator.geolocation.getCurrentPosition returns None",
+)
 def test_set_geolocation_override_with_multiple_user_contexts(driver, pages):
     # Create two user contexts
     user_context1 = driver.browser.create_user_context()


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Python implementation of https://github.com/SeleniumHQ/selenium/issues/16809

We are mostly relying on RBE to tell us if there is a problem, this is supposed to be extra information that strikes a good balance between information and execution time.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* First, I made it so that remote isn't tied to one browser. Bazel supports chrome and firefox, but this is quickly adjustable
* `ci.yml` kicks off on every commit. It runs the new and improved `check-bazel-targets.sh`
* Instead of just checking to see if there are any `py` targets and running the whole ci-python workflow, the unique set of applicable test targets are passed from the script to `ci-python.yml` and browser tests are only run on those
* Additionally, docs/steep/unit tests are only run if the PR includes "[py]" or is executed manually (passed into `ci-python.yml` from `ci.yml` with a `run-full-suite` argument.
* Even if tagged `[py]`, if only a subset of python tests are matched, only those will be run 

* Removed build instead of gating all tests on it. Most of the build is executed by the applicable tests as necessary. If there is something weird that breaks building, it'll get detected in nightly run
* As far as browser tests changed, it removes the edge tests for now for consistency with other bindings


### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
We may want to filter this further, and I'd like to add testing on beta versions of chrome/firefox 
Is there a reason why the remote tests are running on Windows and not in RBE? Can we remove `skip-rbe` and try to run more things in RBE?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Decouple remote testing from specific browser driver

- Filter Python tests by affected files in CI workflow

- Conditionally run docs/typing/unit tests on [py] tag

- Generate separate remote test targets for Chrome and Firefox

- Remove build job dependency from test execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -->|"check-bazel-targets.sh"| B["Affected Files"]
  B -->|"bazel query"| C["Test Targets"]
  C -->|"targets output"| D["ci-python.yml"]
  D -->|"run-full-suite"| E["Docs/Typing/Unit Tests"]
  D -->|"filter-targets"| F["Browser Tests"]
  F -->|"--remote flag"| G["Remote Driver"]
  G -->|"Chrome/Firefox"| H["Test Execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Decouple remote testing from driver class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/conftest.py

<ul><li>Removed <code>remote</code> from static drivers list and added <code>--remote</code> <br>command-line option<br> <li> Decoupled remote testing from driver class, now uses <code>is_remote</code> <br>property<br> <li> Updated <code>_initialize_driver()</code> to use <code>webdriver.Remote()</code> when <code>--remote</code> <br>flag is set<br> <li> Simplified fixture logic in <code>firefox_options</code> and <code>chromium_options</code> to <br>check <code>--remote</code> flag instead of driver class<br> <li> Removed remote-specific option handling and <br><code>SupportedBidiDrivers.remote</code> entry</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16814/files#diff-98e9e290ede5d0c7ac9e7df5b49edf63f5df5fcc946b7736e4a6139e4cda26e3">+33/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>check-bazel-targets.sh</strong><dd><code>Improve target filtering with universe limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/github-actions/check-bazel-targets.sh

<ul><li>Added strict error handling with <code>set -euo pipefail</code><br> <li> Limited universe to binding roots only using <code>BINDINGS_UNIVERSE</code> <br>variable<br> <li> Fixed bazel query to properly map changed files to targets<br> <li> Excluded manual test tags from results<br> <li> Added deduplication of returned targets</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16814/files#diff-6b8abebbae3ba9df24a8d73fd37c3b4e4b6787e8b5fc671e2507bec1e492e975">+23/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-python.yml</strong><dd><code>Refactor CI workflow with conditional test execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-python.yml

<ul><li>Added workflow inputs for <code>targets</code> and <code>run-full-suite</code> parameters<br> <li> Removed build job dependency from all test jobs<br> <li> Made docs, typing, and unit-tests conditional on <code>run-full-suite</code> input<br> <li> Added new <code>filter-targets</code> job to filter targets for Python<br> <li> Replaced <code>test-remote</code> with <code>test-chrome-remote</code> and <code>test-firefox-remote</code> <br>targets<br> <li> Changed browser matrix from <code>[chrome, firefox, chrome-bidi, edge]</code> to <br><code>[chrome, firefox, chrome-bidi, chrome-remote]</code><br> <li> Updated test execution to use tag filters instead of hardcoded test <br>targets</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16814/files#diff-a7ec86144013d78c9f1d734aa65a898e66b609638aa7b872491ee3858ebebbeb">+45/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add target filtering to Python workflow trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Pass <code>targets</code> and <code>run-full-suite</code> outputs from check job to Python <br>workflow<br> <li> Set <code>run-full-suite</code> to true only for scheduled runs, manual dispatch, <br>or <code>[py]</code> tag in PR title<br> <li> Removed commit message check for <code>[py]</code> tag</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16814/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Generate per-browser remote test targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/BUILD.bazel

<ul><li>Replaced single <code>test-remote</code> target with generated targets for Chrome <br>and Firefox<br> <li> Added <code>--remote</code> flag to test arguments instead of <code>--driver=remote</code><br> <li> Added browser-specific test sources and arguments to remote test <br>targets<br> <li> Added tag filters <code>chrome-remote</code> and <code>firefox-remote</code> for test selection<br> <li> Removed Edge from remote tests for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16814/files#diff-3e8ff3a52e8e6c0b195ea328e17c50ba6d90abca1ce1624110607da20691d7a9">+37/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

