### PR TITLE
[java][rb][py][dotnet][js] use SE_DEBUG to enable debugging

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -31,7 +31,12 @@ internal class LogContextManager
     {
         var defaulLogHandler = new TextWriterHandler(Console.Error);
 
-        GlobalContext = new LogContext(LogEventLevel.Warn, null, null, [defaulLogHandler]);
+        // Enable debug logging if SE_DEBUG environment variable is set
+        var level = Environment.GetEnvironmentVariable("SE_DEBUG") is not null
+            ? LogEventLevel.Debug
+            : LogEventLevel.Warn;
+
+        GlobalContext = new LogContext(level, null, null, [defaulLogHandler]);
     }
 
     public ILogContext GlobalContext { get; }

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -27,8 +27,9 @@ public class Debug {
   static {
     boolean simpleProperty = Boolean.getBoolean("selenium.debug");
     boolean longerProperty = Boolean.getBoolean("selenium.webdriver.verbose");
+    boolean envVar = Boolean.parseBoolean(System.getenv("SE_DEBUG"));
 
-    IS_DEBUG = simpleProperty || longerProperty;
+    IS_DEBUG = simpleProperty || longerProperty || envVar;
   }
 
   private Debug() {

--- a/javascript/selenium-webdriver/lib/logging.js
+++ b/javascript/selenium-webdriver/lib/logging.js
@@ -482,6 +482,12 @@ class LogManager {
 
 const logManager = new LogManager()
 
+// Enable debug logging if SE_DEBUG or SELENIUM_VERBOSE environment variable is set
+if (typeof process !== 'undefined' && process.env && (process.env.SE_DEBUG || process.env.SELENIUM_VERBOSE)) {
+  logManager.root_.setLevel(Level.ALL)
+  logManager.root_.addHandler(consoleHandler)
+}
+
 /**
  * Retrieves a named logger, creating it in the process. This function will
  * implicitly create the requested logger, and any of its parents, if they

--- a/javascript/selenium-webdriver/lib/test/index.js
+++ b/javascript/selenium-webdriver/lib/test/index.js
@@ -19,7 +19,6 @@
 
 //const build = require('./build')
 const fileserver = require('./fileserver')
-const logging = require('selenium-webdriver/lib/logging')
 const testing = require('selenium-webdriver/testing')
 
 //const NO_BUILD = /^1|true$/i.test(process.env['SELENIUM_NO_BUILD'])
@@ -52,11 +51,6 @@ function suite(fn, options = undefined) {
 process.on('unhandledRejection', (reason) => {
   console.error('Unhandled promise rejection:', reason)
 })
-
-if (/^1|true$/i.test(process.env['SELENIUM_VERBOSE'])) {
-  logging.installConsoleHandler()
-  logging.getLogger(`${logging.Type.DRIVER}.http`).setLevel(logging.Level.ALL)
-}
 
 testing.init()
 

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
+import os
+
+# Enable debug logging if SE_DEBUG environment variable is set
+if os.environ.get("SE_DEBUG"):
+    logging.getLogger("selenium").setLevel(logging.DEBUG)
+    if not logging.getLogger("selenium").handlers:
+        logging.getLogger("selenium").addHandler(logging.StreamHandler())
+
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.chrome.webdriver import WebDriver as Chrome

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -20,9 +20,10 @@ import os
 
 # Enable debug logging if SE_DEBUG environment variable is set
 if os.environ.get("SE_DEBUG"):
-    logging.getLogger("selenium").setLevel(logging.DEBUG)
-    if not logging.getLogger("selenium").handlers:
-        logging.getLogger("selenium").addHandler(logging.StreamHandler())
+    logger = logging.getLogger("selenium")
+    logger.setLevel(logging.DEBUG)
+    if not logger.handlers:
+        logger.addHandler(logging.StreamHandler())
 
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeService

--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -95,7 +95,7 @@ module Selenium
     #
 
     def self.logger(**)
-      level = $DEBUG || ENV.key?('DEBUG') ? :debug : :info
+      level = $DEBUG || ENV.key?('DEBUG') || ENV.key?('SE_DEBUG') ? :debug : :info
       @logger ||= WebDriver::Logger.new('Selenium', default_level: level, **)
     end
   end # WebDriver


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

Most of the languages have different environment variables / system properties to enable debugging, this adds to whatever currently exists the ability to get the same functionality by setting the environment variable. Should be another option in troubleshooting to just tell people to run with the env set, or when running bazel add a quick `--test_env=DEBUG=1`

This standardizes on our `SE_*` convention, and is what Rust/Selenium Manager already use.

JS, I'm moving it from testing to lib, and opening it to all driver, not just http (doesn't seem to be that much more noise.


___

### **PR Type**
Enhancement


___

### **Description**
- Standardize debugging across all language bindings using SE_DEBUG environment variable

- Add SE_DEBUG support to Java, Python, Ruby, .NET, and JavaScript

- Move JavaScript debug logging from test utilities to main logging library

- Enable debug logging automatically when SE_DEBUG environment variable is set


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SE_DEBUG env var"] -->|Java| B["Debug.java checks SE_DEBUG"]
  A -->|Python| C["webdriver/__init__.py enables logging"]
  A -->|Ruby| D["webdriver.rb checks SE_DEBUG"]
  A -->|.NET| E["LogContextManager sets Debug level"]
  A -->|JavaScript| F["logging.js enables root logger"]
  B --> G["IS_DEBUG flag"]
  C --> H["selenium logger at DEBUG level"]
  D --> I["logger level set to debug"]
  E --> J["LogEventLevel.Debug"]
  F --> K["Level.ALL with console handler"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Debug.java</strong><dd><code>Add SE_DEBUG environment variable support to Java</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/internal/Debug.java

<ul><li>Added SE_DEBUG environment variable check alongside existing system <br>properties<br> <li> Parse SE_DEBUG using Boolean.parseBoolean(System.getenv("SE_DEBUG"))<br> <li> Include SE_DEBUG in IS_DEBUG flag evaluation with OR logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-f322d38827e87e96c514d3ffb4cdedf88d826ffd6631b65c3b573f44638faf5d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogContextManager.cs</strong><dd><code>Add SE_DEBUG environment variable support to .NET</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Logging/LogContextManager.cs

<ul><li>Check SE_DEBUG environment variable in LogContextManager constructor<br> <li> Dynamically set log level to Debug if SE_DEBUG is present, otherwise <br>Warn<br> <li> Apply selected level to GlobalContext initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-259c2c4f3567044d233aa46147d492b89964cbe4bc5e45fd976a03c88674007f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logging.js</strong><dd><code>Add SE_DEBUG support to JavaScript logging library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/lib/logging.js

<ul><li>Add SE_DEBUG and SELENIUM_VERBOSE environment variable checks after <br>LogManager initialization<br> <li> Enable root logger with Level.ALL and add console handler when either <br>variable is set<br> <li> Support both SE_DEBUG and legacy SELENIUM_VERBOSE for backward <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-194b908ceaeda8e3f7ea8470e103f320dbffe8344083eb7a0a8d141653e771b7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add SE_DEBUG environment variable support to Python</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/__init__.py

<ul><li>Add logging and os module imports<br> <li> Check SE_DEBUG environment variable on module initialization<br> <li> Configure selenium logger to DEBUG level and add StreamHandler if <br>SE_DEBUG is set</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-732bc7e9407665904a87e936982e0941f13539f354f03b205efcd65ed803d28d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webdriver.rb</strong><dd><code>Add SE_DEBUG environment variable support to Ruby</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver.rb

<ul><li>Add SE_DEBUG environment variable check to logger level determination<br> <li> Include SE_DEBUG alongside existing $DEBUG and DEBUG env var checks<br> <li> Set logger level to debug if any of the three conditions are true</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-466bb16488d591451fb792b49a46160b738684b47c7f311f6e043e7e4c395b6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Remove debug setup from test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/lib/test/index.js

<ul><li>Remove logging module import that is no longer needed<br> <li> Remove SELENIUM_VERBOSE debug setup code from test utilities<br> <li> Debug logging now handled centrally in logging.js library</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16816/files#diff-dad065424528fa2f5c879db7efe84ec63923b5add3b1aaeb3be9a7b79518f3aa">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

