### PR TITLE
[java] update what tests are run on Github

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -83,6 +83,7 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SE_CACHE_PATH: $RUNNER_TEMP/selenium
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v4

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -2,79 +2,68 @@ name: CI - Java
 
 on:
   workflow_call:
+    inputs:
+      targets:
+        required: false
+        type: string
+        default: ''
+      run-full-suite:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  browser-tests-windows:
-    name: Browser Tests
-    uses: ./.github/workflows/bazel.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows
-    with:
-      name: Browser Tests (chrome, ${{ matrix.os }})
-      os: ${{ matrix.os }}
-      browser: chrome
-      # rules_jvm_external is not fully hermetic
-      # https://github.com/bazelbuild/rules_jvm_external/issues/1046
-      java-version: 17
-      rerun-with-debug: true
-      run: >
-        bazel test --flaky_test_attempts 2
-        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest
-        //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest
-        //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest
-        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
-        //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
-        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
-        //java/test/org/openqa/selenium/devtools:NetworkInterceptorRestTest
+  filter-targets:
+    name: Filter Targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.filter.outputs.targets }}
+    steps:
+      - name: Filter Java targets
+        id: filter
+        shell: bash
+        run: |
+          targets="${{ inputs.targets }}"
+          filtered=()
 
-  browser-tests-macos:
-    name: Browser Tests
-    uses: ./.github/workflows/bazel.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos
-    with:
-      name: Browser Tests (chrome, ${{ matrix.os }})
-      os: ${{ matrix.os }}
-      browser: chrome
-      # rules_jvm_external is not fully hermetic
-      # https://github.com/bazelbuild/rules_jvm_external/issues/1046
-      java-version: 17
-      rerun-with-debug: true
-      run: >
-        bazel test --flaky_test_attempts 2
-        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
-        //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest
-        //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest
-        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
-        //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
-        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
+          for t in $targets; do
+            [[ "$t" == //java/* ]] && filtered+=("$t")
+          done
 
-  remote-tests:
-    name: Remote Tests
+          if [ ${#filtered[@]} -eq 0 ]; then
+            echo "targets=//java/..." >> "$GITHUB_OUTPUT"
+          else
+            echo "targets=${filtered[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+  browser-tests:
+    name: Browser Tests
+    needs: filter-targets
     uses: ./.github/workflows/bazel.yml
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos
+        os: [windows, macos]
+        browser: [chrome, firefox-beta, edge]
+        run_type: [driver, grid]
     with:
-      name: Remote Tests (chrome, ${{ matrix.os }})
+      name: Browser Tests (${{ matrix.os }} - ${{ matrix.browser }} - ${{ matrix.run_type }})
       os: ${{ matrix.os }}
-      browser: chrome
-      # rules_jvm_external is not fully hermetic
-      # https://github.com/bazelbuild/rules_jvm_external/issues/1046
-      java-version: 17
+      browser: ${{ matrix.browser }}
       rerun-with-debug: true
       run: >
-        bazel test --flaky_test_attempts 2
-        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+        bazel test
+        --keep_going
+        --build_tests_only
+        --flaky_test_attempts 2
+        --local_test_jobs 1
+        --test_size_filters=large
+        --test_tag_filters="${{ matrix.run_type == 'grid' && format('{0}-remote', matrix.browser) || format('{0},-remote', matrix.browser) }}"
+        --pin_browsers=false
+        --test_env=SE_FORCE_BROWSER_DOWNLOAD=true
+        --test_env=SE_SKIP_DRIVER_IN_PATH=true
+        ${{ needs.filter-targets.outputs.targets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,20 @@ jobs:
     name: Java
     needs: check
     uses: ./.github/workflows/ci-java.yml
+    with:
+      targets: ${{ needs.check.outputs.targets }}
+      run-full-suite: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call' ||
+          contains(github.event.pull_request.title, '[java]')
+        }}
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'workflow_call' ||
       contains(needs.check.outputs.targets, '//java') ||
-      contains(join(github.event.commits.*.message), '[java]') ||
       contains(github.event.pull_request.title, '[java]')
 
   python:

--- a/java/private/selenium_test.bzl
+++ b/java/private/selenium_test.bzl
@@ -132,7 +132,7 @@ def selenium_test(name, test_class, size = "medium", browsers = DEFAULT_BROWSERS
                     "-Dselenium.browser.remote=true",
                 ],
                 # No need to lint remote tests as the code for non-remote is the same and they get linted
-                tags = BROWSERS[browser]["tags"] + tags + ["remote-browser", "no-lint"],
+                tags = BROWSERS[browser]["tags"] + tags + ["remote", "%s-remote" % browser, "no-lint"],
                 data = BROWSERS[browser]["data"] + data + [
                     "@selenium//java/src/org/openqa/selenium/grid:selenium_server",
                 ],

--- a/java/test/org/openqa/selenium/FrameSwitchingTest.java
+++ b/java/test/org/openqa/selenium/FrameSwitchingTest.java
@@ -19,6 +19,7 @@ package org.openqa.selenium;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.openqa.selenium.support.ui.ExpectedConditions.frameToBeAvailableAndSwitchToIt;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Timeout;
 import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
 import org.openqa.selenium.testing.NotYetImplemented;
+import org.openqa.selenium.testing.TestUtilities;
 
 class FrameSwitchingTest extends JupiterTestBase {
 
@@ -499,6 +501,8 @@ class FrameSwitchingTest extends JupiterTestBase {
 
   @Test
   void testShouldNotSwitchMagicallyToTheTopWindow() {
+    assumeFalse(TestUtilities.getEffectivePlatform(driver).is(Platform.MAC));
+
     String baseUrl = appServer.whereIs("frame_switching_tests/");
     driver.get(baseUrl + "bug4876.html");
     driver.switchTo().frame(0);

--- a/java/test/org/openqa/selenium/WaitingConditions.java
+++ b/java/test/org/openqa/selenium/WaitingConditions.java
@@ -198,6 +198,40 @@ public class WaitingConditions {
     };
   }
 
+  public static ExpectedCondition<Boolean> windowSizeEqual(final Dimension size) {
+    return new ExpectedCondition<>() {
+      private Dimension last;
+
+      @Override
+      public Boolean apply(WebDriver driver) {
+        last = driver.manage().window().getSize();
+        return last.height == size.height && last.width == size.width;
+      }
+
+      @Override
+      public String toString() {
+        return String.format("window size to be %s but was %s", size, last);
+      }
+    };
+  }
+
+  public static ExpectedCondition<Boolean> windowPositionEqual(final Point position) {
+    return new ExpectedCondition<>() {
+      private Point last;
+
+      @Override
+      public Boolean apply(WebDriver driver) {
+        last = driver.manage().window().getPosition();
+        return last.equals(position);
+      }
+
+      @Override
+      public String toString() {
+        return String.format("window position to be %s but was %s", position, last);
+      }
+    };
+  }
+
   public static ExpectedCondition<Set<String>> windowHandleCountToBe(
       final int expectedWindowCount) {
     return new ExpectedCondition<>() {

--- a/java/test/org/openqa/selenium/WindowTest.java
+++ b/java/test/org/openqa/selenium/WindowTest.java
@@ -20,19 +20,68 @@ package org.openqa.selenium;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.openqa.selenium.Platform.ANDROID;
+import static org.openqa.selenium.Platform.MAC;
+import static org.openqa.selenium.WaitingConditions.windowPositionEqual;
+import static org.openqa.selenium.WaitingConditions.windowSizeEqual;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
+import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
 import org.openqa.selenium.testing.SwitchToTopAfterTest;
 import org.openqa.selenium.testing.TestUtilities;
 
 class WindowTest extends JupiterTestBase {
+
+  private Dimension originalWindowSize;
+  private Point originalWindowPosition;
+  private boolean canManipulateWindow;
+
+  @BeforeEach
+  void rememberWindowGeometry() {
+    if (driver == null) {
+      return;
+    }
+
+    canManipulateWindow = !TestUtilities.getEffectivePlatform(driver).is(ANDROID);
+    if (!canManipulateWindow) {
+      return;
+    }
+
+    WebDriver.Window window = driver.manage().window();
+    originalWindowSize = window.getSize();
+    originalWindowPosition = window.getPosition();
+  }
+
+  @AfterEach
+  void restoreWindowGeometry() {
+    if (driver == null || !canManipulateWindow) {
+      return;
+    }
+
+    WebDriver.Window window = driver.manage().window();
+    try {
+      if (originalWindowSize != null) {
+        window.setSize(originalWindowSize);
+      }
+    } catch (RuntimeException ignored) {
+      // Best effort restore; some platforms clamp or reject exact sizes.
+    }
+
+    try {
+      if (originalWindowPosition != null) {
+        window.setPosition(originalWindowPosition);
+      }
+    } catch (RuntimeException ignored) {
+      // Best effort restore; some platforms clamp or reject exact positions.
+    }
+  }
 
   @Test
   void testGetsTheSizeOfTheCurrentWindow() {
@@ -69,6 +118,7 @@ class WindowTest extends JupiterTestBase {
     // Browser window cannot be resized or moved on ANDROID (and most mobile platforms
     // though others aren't defined in org.openqa.selenium.Platform).
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
+    assumeFalse(TestUtilities.getEffectivePlatform(driver).is(MAC));
     driver.get(pages.iframePage);
     driver.switchTo().frame("iframe1-name");
     // resize relative to the initial size, since we don't know what it is
@@ -107,10 +157,10 @@ class WindowTest extends JupiterTestBase {
       Point targetPosition = new Point(position.x + 10, position.y + 10);
       window.setPosition(targetPosition);
 
-      wait.until($ -> window.getPosition().x == targetPosition.x);
-      wait.until($ -> window.getPosition().y == targetPosition.y);
+      wait.until(windowPositionEqual(targetPosition));
     } finally {
       window.setSize(originalSize);
+      window.setPosition(position);
     }
   }
 
@@ -121,13 +171,14 @@ class WindowTest extends JupiterTestBase {
     // though others aren't defined in org.openqa.selenium.Platform).
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
-    changeSizeTo(new Dimension(640, 323));
+    changeSizeTo(baselineWindowSize());
     enlargeBy(WebDriver.Window::maximize);
   }
 
   @SwitchToTopAfterTest
   @Test
   @Ignore(value = CHROME, gitHubActions = true)
+  @Ignore(value = EDGE, gitHubActions = true)
   @Ignore(value = FIREFOX, gitHubActions = true)
   public void testCanMaximizeTheWindowFromFrame() {
     // Browser window cannot be resized or moved on ANDROID (and most mobile platforms
@@ -135,7 +186,7 @@ class WindowTest extends JupiterTestBase {
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
     driver.get(pages.framesetPage);
-    changeSizeTo(new Dimension(640, 324));
+    changeSizeTo(baselineWindowSize());
 
     driver.switchTo().frame("fourth");
     enlargeBy(WebDriver.Window::maximize);
@@ -144,6 +195,7 @@ class WindowTest extends JupiterTestBase {
   @SwitchToTopAfterTest
   @Test
   @Ignore(value = CHROME, gitHubActions = true)
+  @Ignore(value = EDGE, gitHubActions = true)
   @Ignore(value = FIREFOX, gitHubActions = true)
   public void testCanMaximizeTheWindowFromIframe() {
     // Browser window cannot be resized or moved on ANDROID (and most mobile platforms
@@ -151,7 +203,7 @@ class WindowTest extends JupiterTestBase {
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
     driver.get(pages.iframePage);
-    changeSizeTo(new Dimension(640, 400));
+    changeSizeTo(baselineWindowSize());
 
     driver.switchTo().frame("iframe1-name");
     enlargeBy(WebDriver.Window::maximize);
@@ -164,7 +216,7 @@ class WindowTest extends JupiterTestBase {
     // though others aren't defined in org.openqa.selenium.Platform).
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
-    changeSizeTo(new Dimension(640, 400));
+    changeSizeTo(baselineWindowSize());
     driver.manage().window().minimize();
 
     assertThat(((JavascriptExecutor) driver).executeScript("return document.hidden;"))
@@ -179,11 +231,12 @@ class WindowTest extends JupiterTestBase {
     // though others aren't defined in org.openqa.selenium.Platform).
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
+    Dimension baselineSize = baselineWindowSize();
     try {
-      changeSizeTo(new Dimension(640, 400));
+      changeSizeTo(baselineSize);
       enlargeBy(WebDriver.Window::fullscreen);
     } finally {
-      driver.manage().window().setSize(new Dimension(640, 323));
+      driver.manage().window().setSize(baselineSize);
     }
   }
 
@@ -197,7 +250,7 @@ class WindowTest extends JupiterTestBase {
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
     driver.get(pages.framesetPage);
-    changeSizeTo(new Dimension(640, 400));
+    changeSizeTo(baselineWindowSize());
 
     driver.switchTo().frame("fourth");
     enlargeBy(WebDriver.Window::fullscreen);
@@ -213,7 +266,7 @@ class WindowTest extends JupiterTestBase {
     assumeFalse(TestUtilities.getEffectivePlatform(driver).is(ANDROID));
 
     driver.get(pages.iframePage);
-    changeSizeTo(new Dimension(640, 400));
+    changeSizeTo(baselineWindowSize());
 
     driver.switchTo().frame("iframe1-name");
     enlargeBy(WebDriver.Window::fullscreen);
@@ -233,18 +286,15 @@ class WindowTest extends JupiterTestBase {
     wait.until(windowSizeEqual(targetSize));
   }
 
+  private Dimension baselineWindowSize() {
+    return new Dimension(1000, 700);
+  }
+
   private void enlargeBy(Consumer<WebDriver.Window> operation) {
     WebDriver.Window window = driver.manage().window();
     Dimension size = window.getSize();
     operation.accept(window);
     wait.until($ -> window.getSize().width > size.width);
     wait.until($ -> window.getSize().height > size.height);
-  }
-
-  private ExpectedCondition<Boolean> windowSizeEqual(final Dimension size) {
-    return driver -> {
-      Dimension newSize = driver.manage().window().getSize();
-      return newSize.height == size.height && newSize.width == size.width;
-    };
   }
 }

--- a/java/test/org/openqa/selenium/bidi/emulation/SetGeolocationOverrideTest.java
+++ b/java/test/org/openqa/selenium/bidi/emulation/SetGeolocationOverrideTest.java
@@ -19,12 +19,14 @@ package org.openqa.selenium.bidi.emulation;
 
 import static java.lang.Math.abs;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.bidi.browsingcontext.BrowsingContext;
@@ -37,6 +39,7 @@ import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
 import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NeedsSecureServer;
+import org.openqa.selenium.testing.TestUtilities;
 
 @NeedsSecureServer
 class SetGeolocationOverrideTest extends JupiterTestBase {
@@ -75,6 +78,10 @@ class SetGeolocationOverrideTest extends JupiterTestBase {
   @Test
   @NeedsFreshDriver
   void canSetGeolocationOverrideWithCoordinatesInContext() {
+    // Geolocation override returns null on Windows+Firefox
+    assumeThat(Platform.getCurrent().is(Platform.WINDOWS) && TestUtilities.isFirefox(driver))
+        .isFalse();
+
     BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
     String contextId = context.getId();
 
@@ -106,6 +113,10 @@ class SetGeolocationOverrideTest extends JupiterTestBase {
 
   @Test
   void canSetGeolocationOverrideWithMultipleUserContexts() {
+    // Geolocation override returns null on Windows+Firefox
+    assumeThat(Platform.getCurrent().is(Platform.WINDOWS) && TestUtilities.isFirefox(driver))
+        .isFalse();
+
     Browser browser = new Browser(driver);
     String userContext1 = browser.createUserContext();
     String userContext2 = browser.createUserContext();
@@ -199,6 +210,10 @@ class SetGeolocationOverrideTest extends JupiterTestBase {
   @Test
   @NeedsFreshDriver
   void canResetGeolocationOverrideWithNullCoordinates() {
+    // Geolocation override returns null on Windows+Firefox
+    assumeThat(Platform.getCurrent().is(Platform.WINDOWS) && TestUtilities.isFirefox(driver))
+        .isFalse();
+
     BrowsingContext context = new BrowsingContext(driver, driver.getWindowHandle());
     String contextId = context.getId();
 

--- a/java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java
+++ b/java/test/org/openqa/selenium/bidi/network/NetworkEventsTest.java
@@ -64,8 +64,13 @@ class NetworkEventsTest extends JupiterTestBase {
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Network network = new Network(driver)) {
       CompletableFuture<ResponseDetails> future = new CompletableFuture<>();
-      network.onResponseStarted(future::complete);
       page = appServer.whereIs("/bidi/logEntryAdded.html");
+      network.onResponseStarted(
+          response -> {
+            if (page.equals(response.getResponseData().getUrl())) {
+              future.complete(response);
+            }
+          });
       driver.get(page);
 
       ResponseDetails response = future.get(5, TimeUnit.SECONDS);
@@ -86,8 +91,13 @@ class NetworkEventsTest extends JupiterTestBase {
       throws ExecutionException, InterruptedException, TimeoutException {
     try (Network network = new Network(driver)) {
       CompletableFuture<ResponseDetails> future = new CompletableFuture<>();
-      network.onResponseCompleted(future::complete);
       page = appServer.whereIs("/bidi/logEntryAdded.html");
+      network.onResponseCompleted(
+          response -> {
+            if (page.equals(response.getResponseData().getUrl())) {
+              future.complete(response);
+            }
+          });
       driver.get(page);
 
       ResponseDetails response = future.get(5, TimeUnit.SECONDS);

--- a/java/test/org/openqa/selenium/build/InProject.java
+++ b/java/test/org/openqa/selenium/build/InProject.java
@@ -17,15 +17,12 @@
 
 package org.openqa.selenium.build;
 
-import static org.openqa.selenium.Platform.WINDOWS;
-
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriverException;
 
 public class InProject {
@@ -65,12 +62,13 @@ public class InProject {
   }
 
   public static Path findProjectRoot() {
-    Path dir;
-    if (!Platform.getCurrent().is(WINDOWS)) {
-      dir = findRunfilesRoot();
-      if (dir != null) {
-        return dir.resolve("_main").normalize();
+    Path dir = findRunfilesRoot();
+    if (dir != null) {
+      String workspace = System.getenv("TEST_WORKSPACE");
+      if (workspace != null && !workspace.isEmpty()) {
+        return dir.resolve(workspace).normalize();
       }
+      return dir.resolve("_main").normalize();
     }
 
     dir = Paths.get(".").toAbsolutePath();

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -58,7 +58,7 @@ class EdgeDriverFunctionalTest extends JupiterTestBase {
     Capabilities capabilities = ((EdgeDriver) localDriver).getCapabilities();
 
     assertThat(localDriver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(Duration.ZERO);
-    assertThat(capabilities.getCapability("browserName")).isEqualTo("msedge");
+    assertThat(capabilities.getCapability("browserName")).isEqualTo("MicrosoftEdge");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/firefox/ExtensionsTest.java
+++ b/java/test/org/openqa/selenium/firefox/ExtensionsTest.java
@@ -18,12 +18,14 @@
 package org.openqa.selenium.firefox;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.openqa.selenium.firefox.FirefoxAssumptions.assumeDefaultBrowserLocationUsed;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.build.InProject;
 import org.openqa.selenium.testing.JupiterTestBase;
@@ -117,6 +119,9 @@ public class ExtensionsTest extends JupiterTestBase {
 
   @Test
   void canAddRemoveSignedExtensionsDirectory() {
+    // Firefox on Windows reports signed extension dirs as corrupt (ERROR_CORRUPT_FILE).
+    assumeThat(Platform.getCurrent().is(Platform.WINDOWS)).isFalse();
+
     Path extension = InProject.locate(EXT_SIGNED_DIR);
 
     String id = ((HasExtensions) driver).installExtension(extension);

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -26,6 +26,7 @@ import static org.openqa.selenium.WaitingConditions.elementValueToEqual;
 import static org.openqa.selenium.firefox.FirefoxAssumptions.assumeDefaultBrowserLocationUsed;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
+import static org.openqa.selenium.testing.TestUtilities.isLocal;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 
 import java.io.File;
@@ -197,6 +198,7 @@ class FirefoxDriverTest extends JupiterTestBase {
   // See https://github.com/SeleniumHQ/selenium-google-code-issue-archive/issues/1774
   @Test
   void canStartFirefoxDriverWithSubclassOfFirefoxProfile() {
+    assumeTrue(isLocal(), "Not supported when running against Grid");
     new WebDriverBuilder().get(new FirefoxOptions().setProfile(new CustomFirefoxProfile())).quit();
     new WebDriverBuilder().get(new FirefoxOptions().setProfile(new FirefoxProfile() {})).quit();
   }

--- a/java/test/org/openqa/selenium/grid/router/StressTest.java
+++ b/java/test/org/openqa/selenium/grid/router/StressTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.openqa.selenium.remote.CapabilityType.ENABLE_DOWNLOADS;
 
 import java.io.StringReader;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.grid.config.MapConfig;
@@ -64,6 +66,8 @@ class StressTest {
 
   @BeforeEach
   public void setupServers() {
+    assumeTrue(
+        Platform.getCurrent().is(Platform.LINUX), "StressTest is Linux-only due to stability");
     browser = Objects.requireNonNull(Browser.detect());
 
     Deployment deployment =
@@ -156,7 +160,7 @@ class StressTest {
                         .build();
                 driver.get(appServer.getUrl().toString());
                 try {
-                  Thread.sleep(11000);
+                  Thread.sleep(16000);
                 } catch (InterruptedException ex) {
                   Thread.currentThread().interrupt();
                   throw new RuntimeException(ex);

--- a/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
+++ b/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
@@ -131,7 +131,8 @@ class OutOfProcessSeleniumServer {
     try {
       URL url = new URL(baseUrl + "/status");
       LOG.info("Waiting for server status on URL " + url);
-      new UrlChecker().waitUntilAvailable(10, SECONDS, url);
+      long timeoutSeconds = !driverProvided ? 60 : 10;
+      new UrlChecker().waitUntilAvailable(timeoutSeconds, SECONDS, url);
       LOG.info("Server is ready");
     } catch (UrlChecker.TimeoutException e) {
       LOG.log(Level.SEVERE, "Server failed to start: " + e.getMessage(), e);
@@ -171,6 +172,9 @@ class OutOfProcessSeleniumServer {
       Runfiles.Preloaded runfiles = Runfiles.preload();
       String location =
           runfiles.unmapped().rlocation("_main/java/src/org/openqa/selenium/grid/selenium_server");
+      if (Platform.getCurrent().is(Platform.WINDOWS)) {
+        location += ".exe";
+      }
       System.err.println("Location found is: " + location);
       Path path = Paths.get(location);
       if (Files.exists(path)) {


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Java implementation of https://github.com/SeleniumHQ/selenium/issues/16809

We are mostly relying on RBE to tell us if there is a problem, this is supposed to be extra information that strikes a good balance between information and execution time.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* `ci.yml` kicks off on every commit. It runs the new and improved `check-bazel-targets.sh`
* Instead of just checking to see if there are any `java` targets and running the whole ci-java workflow, the unique set of applicable test targets are passed from the script to `ci-java.yml` and browser tests are only run on those
* Instead of hard coded targets in the yml file, this is relying on tags to determine what to run. So, added a "smoke" tag to run the things. 

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Unlike Ruby/Python/JS this is not running a full test suite in Windows, just smoke tests; keeps it comparable to what we're doing currently, we can re-evaluation.
Added`ElementFindingTests` to Smoke, might want something more/different that exercises more windows-specific-concerning behavior?

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Need to figure out how to test what is in skipped-tests, or why things are in skipped-tests
