### PR TITLE
[rust] ignore force download for Safari

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -500,6 +500,12 @@ pub trait SeleniumManager {
 
     fn discover_local_browser(&mut self) -> Result<(), Error> {
         let mut download_browser = self.is_force_browser_download();
+        if download_browser && self.is_safari() {
+            self.get_logger().debug(
+                "Force browser download requested for Safari, but downloads are not supported; using local discovery",
+            );
+            download_browser = false;
+        }
         if !download_browser && !self.is_electron() {
             let major_browser_version = self.get_major_browser_version();
             match self.discover_browser_version()? {


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Ignore/Log when --force-browser-download set for Safari

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
The 2 options are to error quickly or ignore. I went with the behavior that matches what happens when Edge is already downloaded and force download is enabled. Would be entirely valid to fail since user is asking for something that is not possible, but I think there is user convenience in being able to always set it in a matrix job on github, etc.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Ignore force browser download flag for Safari

- Log debug message when Safari download requested

- Use local discovery instead of attempting download


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Force download requested"] --> B{"Is Safari?"}
  B -->|Yes| C["Log debug message"]
  C --> D["Disable download flag"]
  D --> E["Use local discovery"]
  B -->|No| F["Proceed with download"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add Safari force download handling with logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<ul><li>Added check for Safari browser when force download is enabled<br> <li> Logs debug message explaining Safari downloads are unsupported<br> <li> Sets download flag to false for Safari to use local discovery instead<br> <li> Maintains existing behavior for other browsers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16825/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

