### PR TITLE
[rust] only collect stats on stamped builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -78,7 +78,6 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SE_AVOID_STATS: true
     steps:
       - name: Checkout source tree
         uses: actions/checkout@v4

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -91,6 +91,10 @@ rust_library(
         ["src/**/*.rs"],
         exclude = ["main.rs"],
     ),
+    crate_features = select({
+        "//common:stamp": [],
+        "//conditions:default": ["avoid_stats"],
+    }),
     edition = "2024",
     visibility = ["//rust:__subpackages__"],
     deps = all_crate_deps(normal = True),

--- a/rust/Cargo.Bazel.lock
+++ b/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1516a316c77bba8f4f92ef0a103d79cb6171808128005d89cbe82ad22f081370",
+  "checksum": "15fc6f823e5b945ffdb6b09e450dca4b33a09988993f28301823b8da05d689fc",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,6 +42,9 @@ fs_extra = "1.3.0"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winver", "winnt", "sysinfoapi"] }
 
+[features]
+avoid_stats = []
+
 [dev-dependencies]
 assert_cmd = "2.0.17"
 is_executable = "1.0.5"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -132,7 +132,7 @@ impl ManagerConfig {
             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
             language_binding: StringKey(vec!["language-binding"], "").get_value(),
             selenium_version: StringKey(vec!["selenium-version"], "").get_value(),
-            avoid_stats: BooleanKey("avoid-stats", false).get_value(),
+            avoid_stats: BooleanKey("avoid-stats", cfg!(feature = "avoid_stats")).get_value(),
             skip_driver_in_path: BooleanKey("skip-driver-in-path", false).get_value(),
             skip_browser_in_path: BooleanKey("skip-browser-in-path", false).get_value(),
         }


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

I was testing with a locally built selenium manager and noticed it was sending stats to plausible. Not a huge deal in the scheme of things, but easy enough to toggle it by default.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Sets avoid stats to false by default, sets it to true when build is stamped (for release)

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
We're currently building for releases with cargo, so this toggle won't apply

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Disable stats collection by default in development builds

- Enable stats only for stamped/release builds via feature flag

- Remove hardcoded SE_AVOID_STATS environment variable from CI

- Add Cargo feature flag for conditional stats behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Development Build"] -->|"avoid_stats feature disabled"| B["Stats Enabled"]
  C["Stamped/Release Build"] -->|"avoid_stats feature enabled"| D["Stats Disabled"]
  E["CI Workflow"] -->|"Remove SE_AVOID_STATS env var"| F["Use Feature Flag Instead"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Make avoid_stats default conditional on feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/config.rs

<ul><li>Changed <code>avoid_stats</code> default from <code>false</code> to conditional based on <br><code>avoid_stats</code> feature flag<br> <li> Uses <code>cfg!(feature = "avoid_stats")</code> to determine default behavior at <br>compile time</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16826/files#diff-4f8685a05fdbb7fd7ae69236497d75cdc7df84d23be9d65ac019042dfc59df4f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add conditional feature flag based on build stamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/BUILD.bazel

<ul><li>Added <code>crate_features</code> selection based on build stamp status<br> <li> Enables <code>avoid_stats</code> feature for non-stamped builds<br> <li> Disables feature for stamped/release builds</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16826/files#diff-f61e0cab3fc6c7e1843594d5ef3fb58d3bd96878630213dfcd5a94ef4fdcc079">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Define avoid_stats Cargo feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/Cargo.toml

<ul><li>Added new <code>[features]</code> section with <code>avoid_stats</code> feature definition<br> <li> Feature is empty and used only for conditional compilation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16826/files#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bazel.yml</strong><dd><code>Remove hardcoded stats environment variable from CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bazel.yml

<ul><li>Removed hardcoded <code>SE_AVOID_STATS: true</code> environment variable from CI <br>jobs<br> <li> Stats behavior now controlled by build feature flag instead</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16826/files#diff-85e6e6bfc3047eb4fe69bf0f06238ddd442edf74266ad3a964ebfba26f46923c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

