### PR TITLE
[py] fix mypy errors with types and type hints

### DIFF
--- a/py/selenium/webdriver/common/bidi/cdp.py
+++ b/py/selenium/webdriver/common/bidi/cdp.py
@@ -300,6 +300,8 @@ class CdpBase:
             data: event as a JSON dictionary
         """
         global devtools
+        if devtools is None:
+            raise RuntimeError("CDP devtools module not loaded. Call import_devtools() first.")
         event = devtools.util.parse_json_event(data)
         logger.debug("Received event: %s", event)
         to_remove = set()
@@ -424,6 +426,8 @@ class CdpConnection(CdpBase, trio.abc.AsyncResource):
     async def connect_session(self, target_id) -> "CdpSession":
         """Returns a new :class:`CdpSession` connected to the specified target."""
         global devtools
+        if devtools is None:
+            raise RuntimeError("CDP devtools module not loaded. Call import_devtools() first.")
         session_id = await self.execute(devtools.target.attach_to_target(target_id, True))
         session = CdpSession(self.ws, session_id, target_id)
         self.sessions[session_id] = session

--- a/py/selenium/webdriver/common/webdriver.py
+++ b/py/selenium/webdriver/common/webdriver.py
@@ -16,11 +16,14 @@
 # under the License.
 
 
+from selenium.webdriver.common.service import Service
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 
 class LocalWebDriver(RemoteWebDriver):
     """Base class for local WebDrivers."""
+
+    service: Service  # Service instance, set by subclasses before super().__init__()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/py/selenium/webdriver/remote/remote_connection.py
+++ b/py/selenium/webdriver/remote/remote_connection.py
@@ -415,6 +415,8 @@ class RemoteConnection:
         Returns:
             A dictionary with the server's parsed JSON response.
         """
+        if self._client_config is None:
+            raise RuntimeError("ClientConfig not initialized")
         parsed_url = parse.urlparse(url)
         headers = self.get_remote_connection_headers(parsed_url, self._client_config.keep_alive)
         auth_header = self._client_config.get_auth_header()

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1052,10 +1052,10 @@ class WebDriver(BaseWebDriver):
             return self._devtools, self._websocket_connection
         if self.caps["browserName"].lower() == "firefox":
             raise RuntimeError("CDP support for Firefox has been removed. Please switch to WebDriver BiDi.")
-        
+
         if not isinstance(self.command_executor, RemoteConnection):
             raise WebDriverException("command_executor must be a RemoteConnection instance for CDP support")
-        
+
         self._websocket_connection = WebSocketConnection(
             ws_url,
             self.command_executor.client_config.websocket_timeout,

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1047,6 +1047,10 @@ class WebDriver(BaseWebDriver):
             return self._devtools, self._websocket_connection
         if self.caps["browserName"].lower() == "firefox":
             raise RuntimeError("CDP support for Firefox has been removed. Please switch to WebDriver BiDi.")
+        
+        if not isinstance(self.command_executor, RemoteConnection):
+            raise WebDriverException("command_executor must be a RemoteConnection instance for CDP support")
+        
         self._websocket_connection = WebSocketConnection(
             ws_url,
             self.command_executor.client_config.websocket_timeout,
@@ -1099,6 +1103,9 @@ class WebDriver(BaseWebDriver):
             ws_url = self.caps.get("webSocketUrl")
         else:
             raise WebDriverException("Unable to find url to connect to from capabilities")
+
+        if not isinstance(self.command_executor, RemoteConnection):
+            raise WebDriverException("command_executor must be a RemoteConnection instance for BiDi support")
 
         self._websocket_connection = WebSocketConnection(
             ws_url,

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1045,6 +1045,8 @@ class WebDriver(BaseWebDriver):
         if not ws_url:
             raise WebDriverException("Unable to find url to connect to from capabilities")
 
+        if cdp is None:
+            raise WebDriverException("CDP module not loaded")
         self._devtools = cdp.import_devtools(version)
         if self._websocket_connection:
             return self._devtools, self._websocket_connection

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -1035,7 +1035,10 @@ class WebDriver(BaseWebDriver):
         import_cdp()
         if self.caps.get("se:cdp"):
             ws_url = self.caps.get("se:cdp")
-            version = self.caps.get("se:cdpVersion").split(".")[0]
+            cdp_version = self.caps.get("se:cdpVersion")
+            if cdp_version is None:
+                raise WebDriverException("CDP version not found in capabilities")
+            version = cdp_version.split(".")[0]
         else:
             version, ws_url = self._get_cdp_details()
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
relates to #15697

### 💥 What does this PR do?
These changes help prevent runtime errors by providing clear error messages when required modules or configuration are missing. Additionally, there are minor enhancements to type annotations and imports.

Dependency and configuration validation:

* Added explicit checks to ensure the devtools module is loaded before handling events or connecting sessions in `cdp.py`, raising a `RuntimeError` if not. [[1]](diffhunk://#diff-e192596801445c69bdc9fcee1d7f7ff1c596f638ce38070a6e3e2bf38d5c04d6R303-R304) [[2]](diffhunk://#diff-e192596801445c69bdc9fcee1d7f7ff1c596f638ce38070a6e3e2bf38d5c04d6R429-R430)
* In `remote_connection.py`, added a check to ensure `_client_config` is initialized before making a request, raising a `RuntimeError` otherwise.
* In `remote/webdriver.py`, added checks in `start_devtools` and `_start_bidi` to ensure the CDP version is present in capabilities, the CDP module is loaded, and that `command_executor` is a `RemoteConnection` instance, raising clear exceptions if any are missing. [[1]](diffhunk://#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985L1038-R1058) [[2]](diffhunk://#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985R1112-R1114)

Codebase clarity and maintainability:

* Added a type annotation and import for the `service` attribute in `LocalWebDriver`, clarifying that it should be set by subclasses.

### 🔧 Implementation Notes
This pull request introduces several defensive programming improvements to the Selenium WebDriver codebase, primarily focused on validating dependencies and configuration before proceeding with key operations. Optional arguments were not changed to not to break backward compatibility. 

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add runtime validation checks for CDP and BiDi module dependencies

- Validate command_executor type and ClientConfig initialization before use

- Add explicit error messages for missing CDP version in capabilities

- Add Service type annotation to LocalWebDriver class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebDriver Methods"] -->|validate| B["CDP/BiDi Support"]
  C["RemoteConnection"] -->|check| D["ClientConfig"]
  E["CdpBase/CdpConnection"] -->|verify| F["devtools Module"]
  G["LocalWebDriver"] -->|annotate| H["Service Type"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cdp.py</strong><dd><code>Add devtools module validation in CDP methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/bidi/cdp.py

<ul><li>Added runtime check in <code>_handle_event()</code> to ensure devtools module is <br>loaded before accessing util<br> <li> Added runtime check in <code>connect_session()</code> to ensure devtools module is <br>loaded before accessing target<br> <li> Both checks raise RuntimeError with descriptive message if devtools is <br>None</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16827/files#diff-e192596801445c69bdc9fcee1d7f7ff1c596f638ce38070a6e3e2bf38d5c04d6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>remote_connection.py</strong><dd><code>Add ClientConfig initialization validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/remote_connection.py

<ul><li>Added runtime check in <code>_request()</code> method to validate _client_config is <br>initialized<br> <li> Raises RuntimeError with clear message if ClientConfig is None before <br>accessing keep_alive</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16827/files#diff-5019cddad7b56bf084add4e61d5467db0f87b1d817e8334b4333a47e7b969a14">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add comprehensive validation for CDP and BiDi support</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/remote/webdriver.py

<ul><li>Added null check for cdp_version in <code>start_devtools()</code> with descriptive <br>WebDriverException<br> <li> Added validation that cdp module is loaded before calling <br>import_devtools()<br> <li> Added type check to ensure command_executor is RemoteConnection <br>instance for CDP support<br> <li> Added type check to ensure command_executor is RemoteConnection <br>instance for BiDi support<br> <li> Improved code formatting with blank lines for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16827/files#diff-c87c150ed2a08f5293db58a06da8bf7f14c3a5582586c6270c1be661dfdd0985">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriver.py</strong><dd><code>Add Service type annotation to LocalWebDriver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/common/webdriver.py

<ul><li>Added import for Service class from selenium.webdriver.common.service<br> <li> Added type annotation for service attribute in LocalWebDriver class<br> <li> Clarifies that service should be set by subclasses before calling <br>super().__init__()</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16827/files#diff-5df10969ffa5d8ec5207d4468734f34ee7849672e7885e659768d02cf70cd499">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

