### PR TITLE
[java] Allow downloading files from old Grid server

### DIFF
--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -18,9 +18,9 @@
 package org.openqa.selenium.remote;
 
 import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.SEVERE;
-import static org.openqa.selenium.HasDownloads.DownloadedFile;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 
 import java.io.BufferedInputStream;
@@ -69,6 +69,7 @@ import org.openqa.selenium.PrintsPage;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -83,6 +84,7 @@ import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.io.Zip;
 import org.openqa.selenium.logging.LocalLogs;
 import org.openqa.selenium.logging.LoggingHandler;
 import org.openqa.selenium.logging.Logs;
@@ -730,12 +732,24 @@ public class RemoteWebDriver
   public void downloadFile(String fileName, Path targetLocation) throws IOException {
     requireDownloadsEnabled(capabilities);
 
-    Response response = execute(DriverCommand.GET_DOWNLOADED_FILE, Map.of("name", fileName));
+    try {
+      Response response = execute(DriverCommand.GET_DOWNLOADED_FILE, Map.of("name", fileName));
 
-    Contents.Supplier content = (Contents.Supplier) response.getValue();
-    try (InputStream fileContent = content.get()) {
-      Files.createDirectories(targetLocation);
-      Files.copy(new BufferedInputStream(fileContent), targetLocation.resolve(fileName));
+      Contents.Supplier content = (Contents.Supplier) response.getValue();
+      try (InputStream fileContent = content.get()) {
+        Files.createDirectories(targetLocation);
+        Files.copy(new BufferedInputStream(fileContent), targetLocation.resolve(fileName));
+      }
+    } catch (UnsupportedCommandException e) {
+      String error = requireNonNull(e.getMessage(), e.toString()).split("\n", 2)[0];
+      LOG.log(
+          Level.WARNING,
+          "You have too old Selenium Grid version, please upgrade it. Caused by: {0}",
+          error);
+
+      Response response = execute(DriverCommand.DOWNLOAD_FILE, Map.of("name", fileName));
+      String contents = ((Map<String, String>) response.getValue()).get("contents");
+      Zip.unzip(contents, targetLocation.toFile());
     }
   }
 


### PR DESCRIPTION
### **User description**
### The problem
Users with
* Selenium client 4.39 or newer
* Selenium Grid 4.38 or older

cannot download files from Grid. 

### 🔧 Implementation Notes
Endpoint "/se/files/:name" was added in Selenium 4.39.0. If user has upgraded only Selenium client version (but not the server!) then method `remoteDriver.downloadFile()` fails with "unsupported command" exception.

Now the download method will work again, falling back to the old endpoint `POST /se/files` (which is slow for large files).


### 🔗 Related Issues
See issue #16612 and PR #16627.

### 💡 Additional Considerations
After some time, we can remove this fallback. Probably starting from Selenium 5.0.0

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Add fallback to old Grid endpoint for file downloads

- Support clients with newer Selenium but older Grid versions

- Gracefully handle UnsupportedCommandException with warning log

- Maintain backwards compatibility for file download functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["downloadFile request"] --> B{"Try new endpoint<br/>/se/files/:name"}
  B -->|Success| C["Stream file content"]
  B -->|UnsupportedCommandException| D["Log warning about<br/>old Grid version"]
  D --> E["Fallback to old endpoint<br/>POST /se/files"]
  E --> F["Unzip file contents"]
  C --> G["Save to target location"]
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Add fallback for legacy Grid file download endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<ul><li>Added try-catch block to handle UnsupportedCommandException when new <br>endpoint fails<br> <li> Implemented fallback to legacy POST /se/files endpoint for older Grid <br>servers<br> <li> Added warning log message when old Grid version is detected<br> <li> Imported UnsupportedCommandException and Zip utility classes<br> <li> Refactored file download logic to support both new and old Grid <br>endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16839/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

