### PR TITLE
[java][py][rb][js][dotnet] rerun failing tests when requested

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -174,6 +174,9 @@ jobs:
         run: sudo safaridriver --enable
       - name: Run Bazel
         shell: bash
+        env:
+          MSYS_NO_PATHCONV: 1
+          MSYS2_ARG_CONV_EXCL: "*"
         run: |
           set -o pipefail
           mkdir bazel-testlogs

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -184,10 +184,12 @@ jobs:
       - name: Parse Bazel log for failures
         if: always()
         shell: bash
-        run: >
-          tac bazel-testlogs/bazel-console.log |
-          awk '/PASSED in/ {exit} /FAILED in/ {print $1}' |
-          tac > bazel-testlogs/bazel-failures.txt
+        run: |
+          awk '
+            /PASSED in/ {n=0; delete a; next}
+            /FAILED in/ {a[++n]=$1}
+            END {for (i=1; i<=n; i++) print a[i]}
+          ' bazel-testlogs/bazel-console.log > bazel-testlogs/bazel-failures.txt
       - name: Rerun failures with debug
         if: failure() && inputs.rerun-with-debug
         shell: bash

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -179,8 +179,8 @@ jobs:
           MSYS2_ARG_CONV_EXCL: "*"
         run: |
           set -o pipefail
-          mkdir bazel-testlogs
-          ${{ inputs.run }} 2>&1 | tee bazel-testlogs/bazel-console.log
+          mkdir -p build
+          ${{ inputs.run }} 2>&1 | tee build/bazel-console.log
       - name: Parse Bazel log for failures
         if: always()
         shell: bash
@@ -189,14 +189,14 @@ jobs:
             /PASSED in/ {n=0; delete a; next}
             /FAILED in/ {a[++n]=$1}
             END {for (i=1; i<=n; i++) print a[i]}
-          ' bazel-testlogs/bazel-console.log > bazel-testlogs/bazel-failures.txt
+          ' build/bazel-console.log > build/bazel-failures.txt
       - name: Rerun failures with debug
         if: failure() && inputs.rerun-with-debug
         shell: bash
         run: |
-          if [ -s bazel-testlogs/bazel-failures.txt ]; then
+          if [ -s build/bazel-failures.txt ]; then
             base_cmd=$(echo "${{ inputs.run }}" | sed 's| //[^ ]*||g')
-            targets=$(cat bazel-testlogs/bazel-failures.txt | tr '\n' ' ')
+            targets=$(cat build/bazel-failures.txt | tr '\n' ' ')
             $base_cmd --test_env=SE_DEBUG=true --flaky_test_attempts=1 $targets
           fi
       - name: Start SSH session
@@ -225,7 +225,7 @@ jobs:
           retention-days: 7
           path: |
             bazel-testlogs/**/*.log
-            bazel-testlogs/bazel-failures.txt
+            build/bazel-failures.txt
       - name: "Upload changes"
         if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -176,6 +176,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          mkdir bazel-testlogs
           ${{ inputs.run }} 2>&1 | tee bazel-testlogs/bazel-console.log
       - name: Parse Bazel log for failures
         if: always()

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -178,9 +178,10 @@ jobs:
           MSYS_NO_PATHCONV: 1
           MSYS2_ARG_CONV_EXCL: "*"
         run: |
-          set -o pipefail
           mkdir -p build
+          set +e
           ${{ inputs.run }} 2>&1 | tee build/bazel-console.log
+          exit ${PIPESTATUS[0]}
       - name: Parse Bazel log for failures
         if: always()
         shell: bash

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: string
         default: 'ignore-artifacts'
+      rerun-with-debug:
+        description: Rerun failing tests with debugging enabled
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bazel:
@@ -168,7 +173,26 @@ jobs:
         if: inputs.browser == 'safari'
         run: sudo safaridriver --enable
       - name: Run Bazel
-        run: ${{ inputs.run }}
+        shell: bash
+        run: |
+          set -o pipefail
+          ${{ inputs.run }} 2>&1 | tee bazel-testlogs/bazel-console.log
+      - name: Parse Bazel log for failures
+        if: always()
+        shell: bash
+        run: >
+          tac bazel-testlogs/bazel-console.log |
+          awk '/PASSED in/ {exit} /FAILED in/ {print $1}' |
+          tac > bazel-testlogs/bazel-failures.txt
+      - name: Rerun failures with debug
+        if: failure() && inputs.rerun-with-debug
+        shell: bash
+        run: |
+          if [ -s bazel-testlogs/bazel-failures.txt ]; then
+            base_cmd=$(echo "${{ inputs.run }}" | sed 's| //[^ ]*||g')
+            targets=$(cat bazel-testlogs/bazel-failures.txt | tr '\n' ' ')
+            $base_cmd --test_env=SE_DEBUG=true --flaky_test_attempts=1 $targets
+          fi
       - name: Start SSH session
         if: failure() && runner.debug == '1'
         uses: mxschmitt/action-tmate@v3
@@ -194,7 +218,8 @@ jobs:
           name: test-logs-${{ inputs.os }}-${{ inputs.name }}-${{ inputs.browser }}
           retention-days: 7
           path: |
-            **/*.log
+            bazel-testlogs/**/*.log
+            bazel-testlogs/bazel-failures.txt
       - name: "Upload changes"
         if: ${{ always() && inputs.artifact-name != 'ignore-artifacts' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -23,14 +23,15 @@ jobs:
       # rules_jvm_external is not fully hermetic
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
-      run: |
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest `
-            //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest `
-            //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest `
-            //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest `
-            //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest `
-            //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest `
-            //java/test/org/openqa/selenium/devtools:NetworkInterceptorRestTest
+      run: >
+        bazel test --flaky_test_attempts 3
+        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest
+        //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest
+        //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest
+        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
+        //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
+        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
+        //java/test/org/openqa/selenium/devtools:NetworkInterceptorRestTest
 
   browser-tests-macos:
     name: Browser Tests
@@ -47,13 +48,14 @@ jobs:
       # rules_jvm_external is not fully hermetic
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
-      run: |
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote \
-            //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest \
-          //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest \
-            //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest \
-            //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest \
-            //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
+      run: >
+        bazel test --flaky_test_attempts 3
+        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+        //java/test/org/openqa/selenium/federatedcredentialmanagement:FederatedCredentialManagementTest
+        //java/test/org/openqa/selenium/firefox:FirefoxDriverBuilderTest
+        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
+        //java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
+        //java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest
 
   remote-tests:
     name: Remote Tests
@@ -70,5 +72,6 @@ jobs:
       # rules_jvm_external is not fully hermetic
       # https://github.com/bazelbuild/rules_jvm_external/issues/1046
       java-version: 17
-      run: |
-        bazel test --flaky_test_attempts 3 //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
+      run: >
+        bazel test --flaky_test_attempts 3
+        //java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
Java is the only one that manages test logging reasonably; tests always buffer at debug level, then prints them to stdout if the test fails.
.NET always runs with logs enabled, which is not very performant.
Python/Ruby/JS do not provide good debug logs on failures, which is suboptimal

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* saves the console log in the bazel run
* parses tail of console log for failing targets
* reruns the failures with `--test_env=SE_DEBUG` to get full debug output

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* This runs the bazel command for windows in bash instead of pwsh to minimize tee conditionals; it should work, we'll see.
* This is disabled by default, and intended to be toggled by the non Java ci jobs
* Java was sending pwsh specific syntax, I made them OS agnostic
* The upload logs step that @asolntsev just added will only get the failing files when this is enabled. If Java only wants to see the failing files, it would be easy enough to parse `bazel-testlogs/bazel-failures.txt` and only get those logs

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
* Probably drop flaky retry attempts to 2 when this is used
* will want to disable .NET logging by default when it is added


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional workflow input to rerun failing tests with debug enabled

- Capture bazel console output and parse for failed test targets

- Rerun failed tests with `SE_DEBUG` environment variable for better logging

- Refactor Java CI workflow commands to use YAML multiline syntax

- Update artifact upload to focus on bazel-testlogs directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bazel Test Run"] -->|"Capture output"| B["Console Log"]
  B -->|"Parse failures"| C["Failed Targets List"]
  C -->|"If rerun-with-debug enabled"| D["Rerun with SE_DEBUG"]
  D -->|"Collect logs"| E["Upload Artifacts"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bazel.yml</strong><dd><code>Add test rerun with debug logging capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bazel.yml

<ul><li>Added <code>rerun-with-debug</code> boolean input parameter to workflow<br> <li> Modified "Run Bazel" step to capture console output to <br><code>bazel-testlogs/bazel-console.log</code><br> <li> Added "Parse Bazel log for failures" step to extract failed test <br>targets<br> <li> Added "Rerun failures with debug" step to rerun failed tests with <br><code>SE_DEBUG</code> environment variable<br> <li> Updated artifact upload to target <code>bazel-testlogs/**/*.log</code> and <br><code>bazel-testlogs/bazel-failures.txt</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16840/files#diff-85e6e6bfc3047eb4fe69bf0f06238ddd442edf74266ad3a964ebfba26f46923c">+27/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-java.yml</strong><dd><code>Refactor Java CI bazel commands formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-java.yml

<ul><li>Reformatted bazel test commands from backtick continuation to YAML <br>multiline syntax (<code>></code>)<br> <li> Improved readability by placing each test target on separate line<br> <li> Applied consistent formatting across browser-tests-windows, <br>browser-tests-macos, and remote-tests jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16840/files#diff-6097d5fb92c6d1746b67c0e66c6d66f2f4b2e848d5fae5de189f7112e58da9cf">+20/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

