### PR TITLE
[rb] ensure the grid is properly restarted in tests when there is a problem

### DIFF
--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -219,6 +219,17 @@ module Selenium
       "http://#{@host}:#{@port}/wd/hub"
     end
 
+    def status_ok?
+      return false unless @process&.alive? && socket.connected?
+
+      Net::HTTP.start(@host, @port, open_timeout: 2, read_timeout: 2) do |http|
+        response = http.get('/wd/hub/status')
+        response.is_a?(Net::HTTPSuccess)
+      end
+    rescue StandardError
+      false
+    end
+
     def <<(arg)
       if arg.is_a?(Array)
         @additional_args += arg

--- a/rb/sig/lib/selenium/server.rbs
+++ b/rb/sig/lib/selenium/server.rbs
@@ -63,6 +63,8 @@ module Selenium
 
     def webdriver_url: () -> String
 
+    def status_ok?: () -> bool
+
     def <<: (untyped arg) -> untyped
 
     private

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |c|
   c.include(WebDriver::SpecSupport::Helpers)
 
   c.before(:suite) do
-    GlobalTestEnv.remote_server.start if GlobalTestEnv.driver == :remote && ENV['WD_REMOTE_URL'].nil?
+    GlobalTestEnv.ensure_grid if GlobalTestEnv.driver == :remote && ENV['WD_REMOTE_URL'].nil?
     GlobalTestEnv.print_env
   end
 

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -21,6 +21,13 @@ module Selenium
   module WebDriver
     module SpecSupport
       class TestEnvironment
+        REMOTE_DRIVER_ERRORS = [
+          Net::ReadTimeout,
+          Net::OpenTimeout,
+          Errno::ECONNRESET,
+          Errno::ECONNREFUSED
+        ].freeze
+
         attr_reader :driver
 
         def initialize
@@ -241,10 +248,20 @@ module Selenium
         end
 
         def remote_driver(**)
-          ensure_grid
+          ensure_grid unless ENV['WD_REMOTE_URL']
           url = ENV.fetch('WD_REMOTE_URL', remote_server.webdriver_url)
 
-          WebDriver::Driver.for(:remote, url: url, **)
+          attempts = 0
+          begin
+            attempts += 1
+            WebDriver::Driver.for(:remote, url: url, **)
+          rescue *REMOTE_DRIVER_ERRORS => e
+            raise if attempts > 1
+
+            WebDriver.logger.warn("Remote driver failed (#{e.class}: #{e.message}); restarting grid and retrying")
+            reset_remote_server.start unless ENV['WD_REMOTE_URL']
+            retry
+          end
         end
 
         def chrome_driver(service: nil, **)

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -125,13 +125,24 @@ module Selenium
         end
 
         def reset_remote_server
-          @remote_server&.stop
-          @remote_server = nil
+          begin
+            @remote_server&.stop
+          rescue StandardError => e
+            WebDriver.logger.warn("Remote server stop failed: #{e.class}: #{e.message}")
+          ensure
+            @remote_server = nil
+          end
           remote_server
         end
 
         def remote_server?
-          !@remote_server.nil?
+          @remote_server&.status_ok?
+        end
+
+        def ensure_grid
+          return if remote_server?
+
+          reset_remote_server.start
         end
 
         def remote_server_jar
@@ -230,6 +241,7 @@ module Selenium
         end
 
         def remote_driver(**)
+          ensure_grid
           url = ENV.fetch('WD_REMOTE_URL', remote_server.webdriver_url)
 
           WebDriver::Driver.for(:remote, url: url, **)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
We sometimes get test failures if the grid dies and it affects all tests after that. This should isolate the problem to the one place it happens, or if it is expected, will properly refresh.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Add method to server class to verify process & socket and then ping the status endpoint with 2 second timeout so it won't hang
* Add  `#ensure_grid` method to test_environment to make sure the grid is good every time a remote driver is created, and `before(:suite)`

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* This gets called on every `#reset_driver!` or when `driver` is used after a `#quit_driver`; By default it happens at the end of every failing test.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
I'm seeing a bunch of hard coded driver instantiation in the test code we need to remove

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `status_ok?` method to verify grid health via process, socket, and HTTP status endpoint

- Implement `ensure_grid` method to automatically restart grid before remote driver creation

- Improve error handling in `reset_remote_server` with try-catch-finally pattern

- Call `ensure_grid` in `remote_driver` and `before(:suite)` to prevent cascading test failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite Start"] -->|before:suite| B["ensure_grid"]
  C["Remote Driver Creation"] -->|remote_driver| B
  B -->|check status| D["status_ok?"]
  D -->|unhealthy| E["reset_remote_server"]
  E -->|start| F["Grid Running"]
  D -->|healthy| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rb</strong><dd><code>Add grid health status verification method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/server.rb

<ul><li>Add <code>status_ok?</code> method to verify grid health by checking process alive <br>status, socket connection, and HTTP status endpoint<br> <li> Includes 2-second timeout on HTTP request to prevent hanging<br> <li> Returns false on any StandardError to handle edge cases gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16842/files#diff-b79229af72183b83c001b2cebb5d6b26a49a807fea93c549b1ca11873dc672bb">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec_helper.rb</strong><dd><code>Use ensure_grid in test suite setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_helper.rb

<ul><li>Replace <code>remote_server.start</code> with <code>ensure_grid</code> call in <code>before(:suite)</code> <br>hook<br> <li> Ensures grid is properly initialized and healthy before test suite <br>runs</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16842/files#diff-9147927bbff15c8b0da05a9b44f258feaab8ef8bf1bf667de0f5fcd4eefea284">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Add grid health checks and auto-restart logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<ul><li>Wrap <code>remote_server.stop</code> in error handling to prevent failures from <br>blocking cleanup<br> <li> Change <code>remote_server?</code> to check <code>status_ok?</code> instead of nil check for <br>actual health verification<br> <li> Add <code>ensure_grid</code> method that restarts grid if it's not healthy<br> <li> Call <code>ensure_grid</code> in <code>remote_driver</code> method before creating remote driver <br>instances</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16842/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rbs</strong><dd><code>Update type signatures for status_ok?</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/server.rbs

- Add type signature for new `status_ok?` method returning boolean


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16842/files#diff-054c06e8bf0a0164818a78c526eb090bec35d347c8abe94771b2ba7a95fef091">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

