### PR TITLE
[java] Speed up tests, improve test logging and build script

### DIFF
--- a/java/src/dev/selenium/tools/javadoc/BUILD.bazel
+++ b/java/src/dev/selenium/tools/javadoc/BUILD.bazel
@@ -14,7 +14,7 @@ java_binary(
     ],
     deps = [
         "//java/src/org/openqa/selenium:core",
-        "//java/src/org/openqa/selenium/os",
+        "//java/src/org/openqa/selenium/io",
         "@rules_jvm_external//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
     ],
 )

--- a/java/src/org/openqa/selenium/io/BUILD.bazel
+++ b/java/src/org/openqa/selenium/io/BUILD.bazel
@@ -4,6 +4,7 @@ java_library(
     name = "io",
     srcs = glob(["*.java"]),
     visibility = [
+        "//java/src/dev/selenium/tools/javadoc:__pkg__",
         "//java/src/dev/selenium/tools/modules:__pkg__",
         "//java/src/org/openqa/selenium:__pkg__",
         "//java/src/org/openqa/selenium/os:__pkg__",

--- a/java/test/org/openqa/selenium/testing/BUILD.bazel
+++ b/java/test/org/openqa/selenium/testing/BUILD.bazel
@@ -66,6 +66,7 @@ java_library(
         artifact("org.junit.platform:junit-platform-commons"),
         artifact("org.eclipse.mylyn.github:org.eclipse.egit.github.core"),
         artifact("org.assertj:assertj-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )
 

--- a/java/test/org/openqa/selenium/testing/JupiterTestBase.java
+++ b/java/test/org/openqa/selenium/testing/JupiterTestBase.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,7 +74,7 @@ public abstract class JupiterTestBase {
       } catch (IllegalStateException ex) {
         // this should not happen with bazel, a new JVM is used for each class
         // the annotation is on class level, so we should never see this
-        LOG.info("appServer is restarted with secureServer=true");
+        LOG.log(Level.WARNING, "appServer is restarted with secureServer=true", ex);
         environment.stop();
         environment = new InProcessTestEnvironment(true);
       }

--- a/java/test/org/openqa/selenium/testing/SeleniumExtension.java
+++ b/java/test/org/openqa/selenium/testing/SeleniumExtension.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -293,7 +294,8 @@ public class SeleniumExtension
 
     try {
       current.driver.quit();
-    } catch (RuntimeException ignored) {
+    } catch (RuntimeException e) {
+      LOG.log(Level.SEVERE, "Failed to quit browser: ", e);
       // fall through
     }
 

--- a/java/test/org/openqa/selenium/testing/SeleniumExtension.java
+++ b/java/test/org/openqa/selenium/testing/SeleniumExtension.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
@@ -96,7 +97,7 @@ public class SeleniumExtension
     if (noDriverBeforeTest.isPresent()) {
       NoDriverBeforeTest annotation = noDriverBeforeTest.get();
       if (current.matches(annotation.value())) {
-        LOG.info("Destroying driver before test " + context.getDisplayName());
+        LOG.info(() -> "Destroying driver before test " + displayName(context));
         removeDriver();
         nullDriver = true;
         return;
@@ -107,19 +108,27 @@ public class SeleniumExtension
     if (needsFreshDriver.isPresent()) {
       NeedsFreshDriver annotation = needsFreshDriver.get();
       if (current.matches(annotation.value())) {
-        LOG.info("Restarting driver before test " + context.getDisplayName());
+        LOG.info(() -> "Restarting driver before test " + displayName(context));
         removeDriver();
       }
     }
 
     // TraceMethodNameRule.starting
-    LOG.info(">>> Starting " + context.getDisplayName());
+    LOG.info(() -> ">>> Starting " + displayName(context));
 
     // NotYetImplementedRule
     failedWithNotYetImplemented = false;
 
     // Remote builds
     failedWithRemoteBuild = false;
+  }
+
+  @NonNull
+  private static String displayName(ExtensionContext context) {
+    return context
+        .getTestClass()
+        .map(testClass -> testClass.getSimpleName() + '.' + context.getDisplayName())
+        .orElse(context.getDisplayName());
   }
 
   @Override
@@ -129,7 +138,7 @@ public class SeleniumExtension
     switchToTopRule.apply();
 
     // TraceMethodNameRule.finished
-    LOG.info("<<< Finished  " + context.getDisplayName());
+    LOG.info(() -> "<<< Finished  " + displayName(context));
 
     // CaptureLoggingRule
     captureLoggingRule.endLogCapture();
@@ -251,9 +260,9 @@ public class SeleniumExtension
       return null;
     }
 
-    LOG.info("CREATING DRIVER");
+    LOG.info(() -> "CREATING DRIVER");
     WebDriver driver = actuallyCreateDriver();
-    LOG.info("CREATED " + driver);
+    LOG.info(() -> "CREATED " + driver);
     return driver;
   }
 

--- a/java/test/org/openqa/selenium/testing/StaticResources.java
+++ b/java/test/org/openqa/selenium/testing/StaticResources.java
@@ -49,38 +49,44 @@ class StaticResources {
     BazelBuild bazel = new BazelBuild();
 
     // W3C emulation
-    bazel.build("//javascript/atoms/fragments:is-displayed");
-    copy("javascript/atoms/fragments/is-displayed.js", "org/openqa/selenium/remote/isDisplayed.js");
-    bazel.build("//javascript/webdriver/atoms:get-attribute");
+    copy(
+        "javascript/atoms/fragments/is-displayed.js",
+        "org/openqa/selenium/remote/isDisplayed.js",
+        () -> bazel.build("//javascript/atoms/fragments:is-displayed"));
+
     copy(
         "javascript/webdriver/atoms/get-attribute.js",
-        "org/openqa/selenium/remote/getAttribute.js");
+        "org/openqa/selenium/remote/getAttribute.js",
+        () -> bazel.build("//javascript/webdriver/atoms:get-attribute"));
 
     // Relative locators
-    bazel.build("//javascript/atoms/fragments:find-elements");
     copy(
         "javascript/atoms/fragments/find-elements.js",
-        "org/openqa/selenium/support/locators/findElements.js");
+        "org/openqa/selenium/support/locators/findElements.js",
+        () -> bazel.build("//javascript/atoms/fragments:find-elements"));
 
     // Firefox XPI
-    bazel.build("third_party/js/selenium:webdriver_json");
     copy(
         "third_party/js/selenium/webdriver_prefs.json",
-        "org/openqa/selenium/firefox/webdriver_prefs.json");
-    bazel.build("third_party/js/selenium:webdriver_xpi");
-    copy("third_party/js/selenium/webdriver.xpi", "org/openqa/selenium/firefox/xpi/webdriver.xpi");
+        "org/openqa/selenium/firefox/webdriver_prefs.json",
+        () -> bazel.build("third_party/js/selenium:webdriver_json"));
+    copy(
+        "third_party/js/selenium/webdriver.xpi",
+        "org/openqa/selenium/firefox/xpi/webdriver.xpi",
+        () -> bazel.build("third_party/js/selenium:webdriver_xpi"));
   }
 
-  private static void copy(String copyFrom, String copyTo) {
+  private static void copy(String copyFrom, String copyTo, Runnable build) {
     try {
       Path source = InProject.locate("bazel-bin").resolve(copyFrom);
       Path dest = InProject.locate("java/build/test").resolve(copyTo);
 
       if (Files.exists(dest)) {
-        // Assume we're good.
+        // Target file already exists, no need to copy.
         return;
       }
 
+      build.run();
       Files.createDirectories(dest.getParent());
       Files.copy(source, dest);
     } catch (IOException e) {

--- a/java/test/org/openqa/selenium/testing/StaticResources.java
+++ b/java/test/org/openqa/selenium/testing/StaticResources.java
@@ -63,6 +63,7 @@ class StaticResources {
         "org/openqa/selenium/support/locators/findElements.js");
 
     // Firefox XPI
+    bazel.build("third_party/js/selenium:webdriver_json");
     copy(
         "third_party/js/selenium/webdriver_prefs.json",
         "org/openqa/selenium/firefox/webdriver_prefs.json");

--- a/java/test/org/openqa/selenium/testing/drivers/ExternalDriverSupplier.java
+++ b/java/test/org/openqa/selenium/testing/drivers/ExternalDriverSupplier.java
@@ -104,6 +104,8 @@ class ExternalDriverSupplier implements Supplier<WebDriver> {
         return Optional.of(ctor.newInstance(desiredCapabilities));
       } catch (InvocationTargetException e) {
         throw new RuntimeException(e.getTargetException());
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -120,6 +122,8 @@ class ExternalDriverSupplier implements Supplier<WebDriver> {
         Class<? extends Supplier<WebDriver>> clazz =
             (Class<? extends Supplier<WebDriver>>) Class.forName(delegateClassName);
         return Optional.of(clazz);
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -144,11 +148,12 @@ class ExternalDriverSupplier implements Supplier<WebDriver> {
     @Override
     public WebDriver get() {
       try {
-        LOG.info("Waiting for server to be ready at " + serverUrl);
+        LOG.info(() -> "Waiting for server to be ready at " + serverUrl);
         new UrlChecker().waitUntilAvailable(60, SECONDS, new URL(serverUrl + "/status"));
-        LOG.info("Server is ready");
+        LOG.info(() -> "Server is ready at " + serverUrl);
       } catch (UrlChecker.TimeoutException e) {
-        throw new RuntimeException("The external server is not accepting commands", e);
+        throw new RuntimeException(
+            "The external server is not accepting commands at " + serverUrl, e);
       } catch (MalformedURLException e) {
         throw new RuntimeException(e);
       }

--- a/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
+++ b/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -176,6 +177,7 @@ class OutOfProcessSeleniumServer {
         return location;
       }
     } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to build server", e);
       // Fall through
     }
 

--- a/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
+++ b/java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java
@@ -134,7 +134,7 @@ class OutOfProcessSeleniumServer {
       new UrlChecker().waitUntilAvailable(10, SECONDS, url);
       LOG.info("Server is ready");
     } catch (UrlChecker.TimeoutException e) {
-      LOG.severe("Server failed to start: " + e.getMessage());
+      LOG.log(Level.SEVERE, "Server failed to start: " + e.getMessage(), e);
       process.shutdown();
       LOG.severe(process.getOutput());
       process = null;


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Small improvements:
1. speed up tests: run "bazel build" only if the target file doesn't yet exist.
   - We were **wasting ~1.1 seconds PER TEST** for re-running the same "bazel build" commands before every test! 
3. log the error if failed to close the browser
4. improve logging when preparing a browser for test
5. bugfix in build script: build "webdriver_prefs.json" before copying it
6. bugfix in build script: add missing dependency to javadoc generator

### 🔄 Types of changes
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Speed up tests by skipping redundant bazel builds when target files exist

- Improve logging with lazy evaluation and better error context

- Fix browser quit exception handling with proper error logging

- Fix build script bugs: correct bazel target and add missing dependency

- Enhance test logging with full class names for better traceability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] -->|Skip build if target exists| B["Faster Tests"]
  C["Exception Handling"] -->|Log errors properly| D["Better Debugging"]
  E["Build Scripts"] -->|Fix targets & dependencies| F["Correct Builds"]
  G["Logging"] -->|Lazy evaluation & context| H["Improved Traceability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JupiterTestBase.java</strong><dd><code>Add exception logging to appServer restart handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/JupiterTestBase.java

<ul><li>Import <code>Level</code> for structured logging<br> <li> Log exceptions with proper severity level when appServer restart fails<br> <li> Change from ignoring to logging warnings with exception context</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-b63297bc768ca812e8b803878284f87c82fb681cdda15ec93bf4190195f3f814">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutOfProcessSeleniumServer.java</strong><dd><code>Add proper exception logging for server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/drivers/OutOfProcessSeleniumServer.java

<ul><li>Import <code>Level</code> for structured logging<br> <li> Log server startup failures with proper severity and exception context<br> <li> Add logging for runfiles location resolution failures</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-a691c6dd772bc0cfb253df9794a719ce5ed9b68748ffe098f1a76a555eb0b531">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeleniumExtension.java</strong><dd><code>Improve logging with lazy evaluation and better context</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/SeleniumExtension.java

<ul><li>Import <code>Level</code> and <code>@NonNull</code> annotation<br> <li> Convert string concatenation logging to lazy evaluation with lambdas<br> <li> Add <code>displayName()</code> helper method to include class name in test logs<br> <li> Log browser quit failures with proper severity level</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-cfa0965ea8e2e8fca6e9c501cb0b8a16f16a251f7771a7e5fc973ff40513ebaf">+17/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StaticResources.java</strong><dd><code>Skip redundant bazel builds when targets exist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/StaticResources.java

<ul><li>Refactor <code>copy()</code> method to accept <code>Runnable build</code> parameter<br> <li> Only execute bazel build if target file doesn't already exist<br> <li> Fix bazel target from <code>webdriver_xpi</code> to <code>webdriver_json</code> for prefs file<br> <li> Improve code organization with better formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-a066eb4614265f806e5d7cfd050d4b8bffe805d056a066f78750b0ae7491d744">+18/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExternalDriverSupplier.java</strong><dd><code>Improve error handling and logging clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/drivers/ExternalDriverSupplier.java

<ul><li>Add explicit RuntimeException re-throw in exception handlers<br> <li> Improve error messages with server URL context<br> <li> Convert string concatenation to lazy evaluation in logging</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-fb04e65354a62b1f87744d084ed6a1e5e2c3277f6c02fcf2c9c1890052df3a62">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Fix missing dependency for javadoc generator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/dev/selenium/tools/javadoc/BUILD.bazel

<ul><li>Fix dependency from <code>//java/src/org/openqa/selenium/os</code> to <br><code>//java/src/org/openqa/selenium/io</code><br> <li> Correct module reference for <code>TemporaryFilesystem</code> class used by <br><code>JavadocJarMaker</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-ca187927f511b3b20f2a6f1763dc792a2b471591198a3046a50d276331102afe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add javadoc tool visibility to io module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/io/BUILD.bazel

<ul><li>Add visibility for <code>//java/src/dev/selenium/tools/javadoc:__pkg__</code><br> <li> Allow javadoc tool to access io module classes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-e6c2c6b7a2738ad7420c15b9724c94fbd3cf5ad01e40f6bc0f459b539417bf09">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add jspecify dependency for annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/BUILD.bazel

<ul><li>Add <code>org.jspecify:jspecify</code> artifact dependency<br> <li> Support <code>@NonNull</code> annotation usage in test code</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16843/files#diff-fa8dadbdf088bb790522cb525c0e63133064ccf11e1d2f3386c36f2fb8399dc5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

