### PR TITLE
[java] rework downloading files from Grid

### DIFF
--- a/common/src/web/downloads/download.html
+++ b/common/src/web/downloads/download.html
@@ -30,6 +30,11 @@
             File 2
           </a>
         </div>
+        <div class="form-group tp-align-right mt-3">
+          <a href="file-with-space 0 & _ ' ~.txt" id="file-3" download>
+            File 5
+          </a>
+        </div>
       </div>
 
     </div>

--- a/common/src/web/downloads/file-with-space 0 & _ ' ~.txt
+++ b/common/src/web/downloads/file-with-space 0 & _ ' ~.txt
@@ -1,0 +1,1 @@
+Hello, filename with space!

--- a/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
+++ b/java/src/org/openqa/selenium/grid/node/local/LocalNode.java
@@ -763,6 +763,8 @@ public class LocalNode extends Node implements Closeable {
         return listDownloadedFiles(downloadsDirectory);
       }
       if (req.getMethod().equals(HttpMethod.GET)) {
+        // Left here for backward compatibility.
+        // Remove this IF in Selenium 4.41, 4.42 or 4.43
         return getDownloadedFile(downloadsDirectory, extractFileName(req));
       }
       if (req.getMethod().equals(HttpMethod.DELETE)) {
@@ -837,6 +839,14 @@ public class LocalNode extends Node implements Closeable {
                         "Please specify file to download in payload as {\"name\":"
                             + " \"fileToDownload\"}"));
     File file = findDownloadedFile(downloadsDirectory, filename);
+    String contentType =
+        requireNonNullElseGet(
+            (String) incoming.get("format"), () -> MediaType.JSON_UTF_8.toString());
+
+    if (MediaType.OCTET_STREAM.toString().equalsIgnoreCase(contentType)) {
+      return fileAsBinaryResponse(file);
+    }
+
     String content = Zip.zip(file);
     Map<String, Object> data =
         Map.of(
@@ -847,12 +857,18 @@ public class LocalNode extends Node implements Closeable {
     return new HttpResponse().setContent(asJson(result));
   }
 
+  /** Left here for backward compatibility. Remove this method in Selenium 4.41, 4.42 or 4.43 */
+  @Deprecated
   private HttpResponse getDownloadedFile(File downloadsDirectory, String fileName)
       throws IOException {
     if (fileName.isEmpty()) {
       throw new WebDriverException("Please specify file to download in URL");
     }
     File file = findDownloadedFile(downloadsDirectory, fileName);
+    return fileAsBinaryResponse(file);
+  }
+
+  private HttpResponse fileAsBinaryResponse(File file) throws IOException {
     BasicFileAttributes attributes = readAttributes(file.toPath(), BasicFileAttributes.class);
     return new HttpResponse()
         .setHeader("Content-Type", MediaType.OCTET_STREAM.toString())

--- a/java/src/org/openqa/selenium/remote/DriverCommand.java
+++ b/java/src/org/openqa/selenium/remote/DriverCommand.java
@@ -218,7 +218,17 @@ public interface DriverCommand {
   String RESET_COOLDOWN = "resetCooldown";
   String GET_DOWNLOADABLE_FILES = "getDownloadableFiles";
   String DOWNLOAD_FILE = "downloadFile";
-  String GET_DOWNLOADED_FILE = "getDownloadedFile";
+
+  /**
+   * This endpoint was introduced in 4.39.0, but not used anymore since 4.40.0. Left here for
+   * backward compatibility (if someone uses Grid 4.40+, but Client 4.39.0).
+   *
+   * <p>Remove it in 4.41, 4.42 or 4.43.
+   *
+   * @deprecated use {@link #DOWNLOAD_FILE} instead
+   */
+  @Deprecated String GET_DOWNLOADED_FILE = "getDownloadedFile";
+
   String DELETE_DOWNLOADABLE_FILES = "deleteDownloadableFiles";
 
   static CommandPayload NEW_SESSION(Capabilities capabilities) {

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -18,11 +18,11 @@
 package org.openqa.selenium.remote;
 
 import static java.util.Collections.singleton;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.SEVERE;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 
+import com.google.common.net.MediaType;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -69,7 +69,6 @@ import org.openqa.selenium.PrintsPage;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -732,24 +731,23 @@ public class RemoteWebDriver
   public void downloadFile(String fileName, Path targetLocation) throws IOException {
     requireDownloadsEnabled(capabilities);
 
-    try {
-      Response response = execute(DriverCommand.GET_DOWNLOADED_FILE, Map.of("name", fileName));
-
+    Response response =
+        execute(
+            DriverCommand.DOWNLOAD_FILE,
+            Map.of("name", fileName, "format", MediaType.OCTET_STREAM.toString()));
+    if (response.getValue() instanceof Contents.Supplier) {
+      // Selenium Grid 4.40.0 or newer
       Contents.Supplier content = (Contents.Supplier) response.getValue();
       try (InputStream fileContent = content.get()) {
         Files.createDirectories(targetLocation);
         Files.copy(new BufferedInputStream(fileContent), targetLocation.resolve(fileName));
       }
-    } catch (UnsupportedCommandException e) {
-      String error = requireNonNull(e.getMessage(), e.toString()).split("\n", 2)[0];
-      LOG.log(
-          Level.WARNING,
-          "You have too old Selenium Grid version, please upgrade it. Caused by: {0}",
-          error);
-
-      Response response = execute(DriverCommand.DOWNLOAD_FILE, Map.of("name", fileName));
+    } else if (response.getValue() instanceof Map) {
+      // Selenium Grid 4.39.0 or older
       String contents = ((Map<String, String>) response.getValue()).get("contents");
       Zip.unzip(contents, targetLocation.toFile());
+    } else {
+      throw new UnsupportedOperationException("Unexpected grid response: " + response);
     }
   }
 

--- a/java/test/org/openqa/selenium/grid/router/RemoteWebDriverDownloadTest.java
+++ b/java/test/org/openqa/selenium/grid/router/RemoteWebDriverDownloadTest.java
@@ -35,9 +35,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasDownloads;
@@ -112,36 +116,48 @@ class RemoteWebDriverDownloadTest {
     driver.get(appServer.whereIs("downloads/download.html"));
     driver.findElement(By.id("file-1")).click();
     driver.findElement(By.id("file-2")).click();
-    waitForDownloadedFiles(driver, 2);
+    driver.findElement(By.id("file-3")).click();
+    waitForDownloadedFiles(driver, 3);
 
     @SuppressWarnings("deprecation")
     List<String> downloadableFiles = ((HasDownloads) driver).getDownloadableFiles();
-    assertThat(downloadableFiles).contains("file_1.txt", "file_2.jpg");
+    assertThat(downloadableFiles)
+        .contains("file_1.txt", "file_2.jpg", "file-with-space 0 & _ ' ~.txt");
 
     List<DownloadedFile> downloadedFiles = ((HasDownloads) driver).getDownloadedFiles();
     assertThat(downloadedFiles.stream().map(f -> f.getName()).collect(Collectors.toList()))
-        .contains("file_1.txt", "file_2.jpg");
+        .contains("file_1.txt", "file_2.jpg", "file-with-space 0 & _ ' ~.txt");
   }
 
-  @Test
+  @ParameterizedTest
+  @MethodSource("downloadableFiles")
   @Ignore(IE)
   @Ignore(SAFARI)
-  void canDownloadFiles() throws IOException {
+  void canDownloadFiles(By selector, String expectedFileName, String expectedFileContent)
+      throws IOException {
     driver = createWebdriver(capabilities);
 
     driver.get(appServer.whereIs("downloads/download.html"));
-    driver.findElement(By.id("file-1")).click();
+    driver.findElement(selector).click();
     waitForDownloadedFiles(driver, 1);
 
     DownloadedFile file = ((HasDownloads) driver).getDownloadedFiles().get(0);
+    assertThat(file.getName()).isEqualTo(expectedFileName);
 
     Path targetLocation = Files.createTempDirectory("download");
     ((HasDownloads) driver).downloadFile(file.getName(), targetLocation);
 
-    File localFile = targetLocation.resolve(file.getName()).toFile();
-    assertThat(localFile).hasName(file.getName());
+    File localFile = targetLocation.resolve(expectedFileName).toFile();
+    assertThat(localFile).hasName(expectedFileName);
     assertThat(localFile).hasSize(file.getSize());
-    assertThat(localFile).content().isEqualToIgnoringNewLines("Hello, World!");
+    assertThat(localFile).content().isEqualToIgnoringNewLines(expectedFileContent);
+  }
+
+  static Stream<Arguments> downloadableFiles() {
+    return Stream.of(
+        Arguments.of(By.id("file-1"), "file_1.txt", "Hello, World!"),
+        Arguments.of(
+            By.id("file-3"), "file-with-space 0 & _ ' ~.txt", "Hello, filename with space!"));
   }
 
   @Test


### PR DESCRIPTION
### **User description**
* remove the "new" endpoint `GET /se/files/:name` (that was recently added in 4.39.0)
* use the "old" endpoint `POST /se/files`, but with optional "format" parameter in payload. Possible values: "application/octet-stream" or "application/json" (default).

Endpoint `POST /se/files` can respond either in JSON or binary format depending on the "format" parameter.

* Currently only Java binding sends "format=application/octet-stream"
* Other bindings don't yet send "format" parameter, thus downloading file using the old method (which encodes file content into Base64 and Json).
  * Other bindings can gradually migrate to "format=application/octet-stream" as well in following releases.

As a side effect, this PR fixes downloading files with space in name. :)

### 🔄 Types of changes
- Bug fix (backwards compatible)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove deprecated `GET /se/files/:name` endpoint, use `POST /se/files` with Accept header

- Support binary file downloads via Accept: application/octet-stream header

- Fix downloading files with special characters (spaces, unicode, etc.)

- Add backward compatibility for older Grid versions (4.38.0 and earlier)

- Expand test coverage with parameterized tests for various filename types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client<br/>RemoteWebDriver"]
  OldEndpoint["Old Endpoint<br/>GET /se/files/:name"]
  NewEndpoint["New Endpoint<br/>POST /se/files<br/>+ Accept Header"]
  BinaryResponse["Binary Response<br/>application/octet-stream"]
  JsonResponse["JSON Response<br/>for older Grid"]
  
  Client -->|Remove| OldEndpoint
  Client -->|Use| NewEndpoint
  NewEndpoint -->|Accept: octet-stream| BinaryResponse
  NewEndpoint -->|Fallback| JsonResponse
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>LocalNode.java</strong><dd><code>Remove GET endpoint, add binary response support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-edc2e1943a5d89fa45151a9d214cc608551c61101f237ca9a5993d6dd157b57b">+7/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteWebDriver.java</strong><dd><code>Implement backward compatibility for file downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+7/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DriverCommand.java</strong><dd><code>Remove deprecated GET_DOWNLOADED_FILE command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-0ebc8850a70ad45102db2f0b1d321b78fb19228324c424b8685ce244eb0239f9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AbstractHttpCommandCodec.java</strong><dd><code>Add HTTP header support to command specifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-640f7348338f49b2894694516ec1682936ca87803d7602531a56de5b537d7745">+20/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpHeader.java</strong><dd><code>Add Accept header enum constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-886ff4a0fdaeb8711c2d7db0c50dbba58b069ee8c2e6abf066cbd6ae1ecfd303">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>RemoteWebDriverDownloadTest.java</strong><dd><code>Add parameterized tests for special character filenames</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-9fa7853865f740f79749383d114b7a744996f2a7c93af7872c6e5ef9aa8739c0">+40/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>download.html</strong><dd><code>Add download links for special character test files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-05e7ca48308fdda5cc9a98651a03d0e9a23047452cfbbf220f6a23cc6ab255e2">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>file-with-scandinavian-ø.txt</strong><dd><code>Add test file with scandinavian characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-dfddb3e525cd7534b887c2dc0e39a09a07ce29bdd2a5ad56bade48ad7bf9f5d7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>file-with-cyrillic-серцеєдність.txt</strong><dd><code>Add test file with cyrillic characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16844/files#diff-c63af3f0d6034a6c86f88c32efdd1bfae3087781f0963921058afe3c8bf65488">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>file-with-space 0 & _ ` ~.txt</strong><dd><code>Add test file with spaces and special characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

