### PR TITLE
[rb] should not need long client timeout in tests

### DIFF
--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -170,7 +170,7 @@ module Selenium
 
         def create_driver!(listener: nil, http_client: nil, **, &block)
           check_for_previous_error
-          http_client ||= Remote::Http::Default.new(read_timeout: 20)
+          http_client ||= Remote::Http::Default.new(read_timeout: 30)
 
           method = :"#{driver}_driver"
           opts = {options: build_options(**), listener: listener, http_client: http_client}
@@ -227,12 +227,10 @@ module Selenium
           raise DriverInstantiationError, msg, @create_driver_error.backtrace
         end
 
-        def remote_driver(http_client: nil, **)
+        def remote_driver(**)
           url = ENV.fetch('WD_REMOTE_URL', remote_server.webdriver_url)
-          _ignore_default_client = http_client
-          remote_client = Remote::Http::Default.new(read_timeout: 30)
 
-          WebDriver::Driver.for(:remote, http_client: remote_client, url: url, **)
+          WebDriver::Driver.for(:remote, url: url, **)
         end
 
         def chrome_driver(service: nil, **)

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -227,10 +227,12 @@ module Selenium
           raise DriverInstantiationError, msg, @create_driver_error.backtrace
         end
 
-        def remote_driver(**)
+        def remote_driver(http_client: nil, **)
           url = ENV.fetch('WD_REMOTE_URL', remote_server.webdriver_url)
+          _ignore_default_client = http_client
+          remote_client = Remote::Http::Default.new(read_timeout: 30)
 
-          WebDriver::Driver.for(:remote, url: url, **)
+          WebDriver::Driver.for(:remote, http_client: remote_client, url: url, **)
         end
 
         def chrome_driver(service: nil, **)

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -168,15 +168,13 @@ module Selenium
           @root ||= Pathname.new('../../../../../../../').realpath(__FILE__)
         end
 
-        def create_driver!(listener: nil, **, &block)
+        def create_driver!(listener: nil, http_client: nil, **, &block)
           check_for_previous_error
+          http_client ||= Remote::Http::Default.new(read_timeout: 20)
 
           method = :"#{driver}_driver"
-          instance = if private_methods.include?(method)
-                       send(method, listener: listener, options: build_options(**))
-                     else
-                       WebDriver::Driver.for(driver, listener: listener, options: build_options(**))
-                     end
+          opts = {options: build_options(**), listener: listener, http_client: http_client}
+          instance = private_methods.include?(method) ? send(method, **opts) : WebDriver::Driver.for(driver, **opts)
           @create_driver_error_count -= 1 unless @create_driver_error_count.zero?
           if block
             begin


### PR DESCRIPTION
### **User description**
Whenever a ruby job gets into trouble, it hangs the build for hours unnecessarily.

### 💥 What does this PR do?
* reduces read timeouts to ~20~ 30 seconds for tests

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* ~20~ 30 seconds should be plenty for everything we're doing.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
* Doesn't actually prevent errors, just keeps things from getting out of hand when they happen.

Some remote tests and some large file transfer tests wanted 30 seconds. Could tweak further, this is easiest. Will adjust more if problems.

___

### **PR Type**
Enhancement


___

### **Description**
- Reduces read timeout to 20 seconds for test drivers

- Adds configurable http_client parameter to create_driver!

- Simplifies driver instantiation logic with ternary operator


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["create_driver! method"] -->|"adds http_client param"| B["Remote::Http::Default"]
  B -->|"sets read_timeout"| C["20 seconds"]
  A -->|"refactors logic"| D["Ternary operator"]
  D -->|"prevents hangs"| E["Faster test failures"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_environment.rb</strong><dd><code>Add configurable http_client with 20s timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb

<ul><li>Added <code>http_client</code> parameter to <code>create_driver!</code> method with default <br>20-second read timeout<br> <li> Refactored driver instantiation from if-else block to ternary operator<br> <li> Consolidated driver creation options into single <code>opts</code> hash for cleaner <br>code<br> <li> Prevents indefinite hangs by enforcing shorter timeout on test HTTP <br>clients</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16847/files#diff-884d159fa58dcbf2cdfec0003a9a72bf2a95fa661f3d2787ec801a3669521b6a">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

