### PR TITLE
[java] fixes for running on windows

### DIFF
--- a/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
+++ b/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
@@ -20,12 +20,12 @@ package org.openqa.selenium.firefox;
 import static org.openqa.selenium.remote.Browser.FIREFOX;
 
 import com.google.auto.service.AutoService;
-import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Base64;
@@ -87,7 +87,7 @@ public class AddHasExtensions implements AugmenterProvider<HasExtensions>, Addit
         String encoded;
         try {
           if (Files.isDirectory(path)) {
-            encoded = Base64.getEncoder().encodeToString(Files.readAllBytes(zipDirectory(path)));
+            encoded = Base64.getEncoder().encodeToString(zipDirectory(path));
           } else {
             encoded = Base64.getEncoder().encodeToString(Files.readAllBytes(path));
           }
@@ -100,23 +100,25 @@ public class AddHasExtensions implements AugmenterProvider<HasExtensions>, Addit
                 INSTALL_EXTENSION, Map.of("addon", encoded, "temporary", temporary));
       }
 
-      private Path zipDirectory(Path path) throws IOException {
-        Path extZip = Paths.get(path.getFileName().toString() + ".zip");
-        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(extZip.toFile()))) {
+      private byte[] zipDirectory(Path path) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
           Files.walkFileTree(
               path,
               new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                     throws IOException {
-                  zos.putNextEntry(new ZipEntry(path.relativize(file).toString()));
+                  String entryName =
+                      path.relativize(file).toString().replace(File.separatorChar, '/');
+                  zos.putNextEntry(new ZipEntry(entryName));
                   Files.copy(file, zos);
                   zos.closeEntry();
                   return FileVisitResult.CONTINUE;
                 }
               });
         }
-        return extZip;
+        return baos.toByteArray();
       }
 
       @Override

--- a/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
+++ b/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -232,18 +233,24 @@ public class ProxyNodeWebsockets
 
     LOG.info("Establishing connection to " + uri);
 
+    AtomicBoolean connectionReleased = new AtomicBoolean(false);
+
     HttpClient client = clientFactory.createClient(ClientConfig.defaultConfig().baseUri(uri));
     try {
       WebSocket upstream =
           client.openSocket(
               new HttpRequest(GET, uri.toString()),
-              new ForwardingListener(node, downstream, sessionConsumer, sessionId));
+              new ForwardingListener(
+                  node, downstream, sessionConsumer, sessionId, connectionReleased));
 
       return (msg) -> {
         try {
           upstream.send(msg);
         } finally {
           if (msg instanceof CloseMessage) {
+            if (connectionReleased.compareAndSet(false, true)) {
+              node.releaseConnection(sessionId);
+            }
             try {
               client.close();
             } catch (Exception e) {
@@ -254,6 +261,7 @@ public class ProxyNodeWebsockets
       };
     } catch (Exception e) {
       LOG.log(Level.WARNING, "Connecting to upstream websocket failed", e);
+      node.releaseConnection(sessionId);
       client.close();
       throw e;
     }
@@ -264,16 +272,19 @@ public class ProxyNodeWebsockets
     private final Consumer<Message> downstream;
     private final Consumer<SessionId> sessionConsumer;
     private final SessionId sessionId;
+    private final AtomicBoolean connectionReleased;
 
     public ForwardingListener(
         Node node,
         Consumer<Message> downstream,
         Consumer<SessionId> sessionConsumer,
-        SessionId sessionId) {
+        SessionId sessionId,
+        AtomicBoolean connectionReleased) {
       this.node = node;
       this.downstream = Objects.requireNonNull(downstream);
       this.sessionConsumer = Objects.requireNonNull(sessionConsumer);
       this.sessionId = Objects.requireNonNull(sessionId);
+      this.connectionReleased = Objects.requireNonNull(connectionReleased);
     }
 
     @Override
@@ -285,7 +296,9 @@ public class ProxyNodeWebsockets
     @Override
     public void onClose(int code, String reason) {
       downstream.accept(new CloseMessage(code, reason));
-      node.releaseConnection(sessionId);
+      if (connectionReleased.compareAndSet(false, true)) {
+        node.releaseConnection(sessionId);
+      }
     }
 
     @Override

--- a/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
@@ -167,11 +167,21 @@ class WebSocketUpgradeHandler extends ChannelInboundHandlerAdapter {
     if (frame instanceof CloseWebSocketFrame) {
       try {
         CloseWebSocketFrame close = (CloseWebSocketFrame) frame.retain();
+        // Invoke the consumer synchronously BEFORE sending the close response.
+        // This avoids race conditions when trying to reuse the connection slot.
+        Consumer<Message> consumer = ctx.channel().attr(key).getAndSet(null);
+        if (consumer != null) {
+          try {
+            consumer.accept(new CloseMessage(close.statusCode(), close.reasonText()));
+          } catch (Exception ex) {
+            LOG.log(Level.FINE, "failed to handle close message", ex);
+          }
+        }
         handshaker.close(ctx.channel(), close);
-        // Pass on to the rest of the channel
+        // Pass on to the rest of the channel for any other handlers
         ctx.fireChannelRead(close);
       } finally {
-        // set null to ensure we do not send another close
+        // ensure attribute is cleared even if consumer invocation failed
         ctx.channel().attr(key).set(null);
       }
     } else if (frame instanceof PingWebSocketFrame) {


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
I was running into issues getting our tests to pass consistently on Windows.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* use `byte[]` instead of `Path` for private `zipDirectory()`
* better socket release handling

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Honestly, not sure about this implementation, it just made the tests I was running pass, so definitely needs some Java expert eyes on it.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Firefox extension installation on Windows by using in-memory byte arrays

- Normalize ZIP entry paths to use forward slashes for cross-platform compatibility

- Prevent duplicate connection release in WebSocket handlers using atomic flag

- Ensure WebSocket close message is processed before sending close response


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Firefox Extension Installation"] -->|"Use ByteArrayOutputStream"| B["In-memory ZIP creation"]
  B -->|"Normalize paths"| C["Cross-platform ZIP entries"]
  D["WebSocket Connection Release"] -->|"Add AtomicBoolean flag"| E["Prevent duplicate release"]
  F["WebSocket Close Handler"] -->|"Process message first"| G["Avoid race conditions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddHasExtensions.java</strong><dd><code>Use in-memory ZIP creation for Firefox extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/firefox/AddHasExtensions.java

<ul><li>Changed <code>zipDirectory()</code> to return <code>byte[]</code> instead of <code>Path</code> using <br><code>ByteArrayOutputStream</code><br> <li> Removed file system operations that caused issues on Windows<br> <li> Normalized ZIP entry paths by replacing OS-specific separators with <br>forward slashes<br> <li> Simplified extension installation flow by eliminating temporary file <br>creation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16852/files#diff-e345c2afb1f003b942618b73e44ba836f5ec3dfd73e1eb8a8082de1a5a20a109">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProxyNodeWebsockets.java</strong><dd><code>Prevent duplicate WebSocket connection releases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java

<ul><li>Added <code>AtomicBoolean</code> flag to track connection release state and prevent <br>duplicates<br> <li> Updated <code>ForwardingListener</code> constructor to accept and use the atomic <br>flag<br> <li> Modified close message handling to check flag before releasing <br>connection<br> <li> Added connection release in exception handler to ensure cleanup on <br>connection failures</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16852/files#diff-d21ec9d4eb005abb0a30dfc5c4c0c4190c9d522243155ecae77b43a80a77b5bf">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebSocketUpgradeHandler.java</strong><dd><code>Process WebSocket close message before sending response</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java

<ul><li>Moved consumer invocation to occur BEFORE sending close response to <br>avoid race conditions<br> <li> Added null check and exception handling for consumer invocation<br> <li> Ensured channel attribute is cleared even if consumer processing fails<br> <li> Improved comments to clarify the order of operations and intent</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16852/files#diff-63e907e8a4c48c1dd28e3ca22c8d44fe014327576ad84980595b32a1de870a51">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

