### PR TITLE
[dotnet] get tests working on windows with bazel

### DIFF
--- a/dotnet/private/dotnet_nunit_test_suite.bzl
+++ b/dotnet/private/dotnet_nunit_test_suite.bzl
@@ -107,6 +107,10 @@ def _is_test(src, test_suffixes):
             return True
     return False
 
+_NUNIT_ARGS = [
+    "--workers=1",  # Bazel tests share a single driver instance; prevent NUnit parallelism
+]
+
 def dotnet_nunit_test_suite(
         name,
         srcs,
@@ -162,7 +166,7 @@ def dotnet_nunit_test_suite(
                     srcs = lib_srcs + [src] + ["@rules_dotnet//dotnet/private/rules/common/nunit:shim.cs"],
                     deps = deps + extra_deps,
                     target_frameworks = target_frameworks,
-                    args = _BROWSERS[browser]["args"] + _HEADLESS_ARGS,
+                    args = _NUNIT_ARGS + _BROWSERS[browser]["args"] + _HEADLESS_ARGS,
                     data = data + _BROWSERS[browser]["data"],
                     tags = tags + [browser] + COMMON_TAGS + _BROWSERS[browser]["tags"],
                     size = size,

--- a/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
+++ b/dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs
@@ -88,7 +88,16 @@ internal class WebExtensionTest : BiDiTestFixture
     {
         try
         {
-            return Bazel.Runfiles.Create().Rlocation($"_main/{path}");
+            var runfiles = Bazel.Runfiles.Create();
+            string resolved = runfiles.Rlocation($"_main/{path}");
+            if (!string.IsNullOrEmpty(resolved))
+            {
+                return resolved;
+            }
+
+            // For directories, locate a file inside and get parent (runfiles manifest only lists files)
+            string manifestPath = runfiles.Rlocation($"_main/{path}/manifest.json");
+            return Path.GetDirectoryName(manifestPath) ?? Path.GetFullPath(path);
         }
         catch (FileNotFoundException)
         {

--- a/dotnet/test/common/WebElementTest.cs
+++ b/dotnet/test/common/WebElementTest.cs
@@ -142,7 +142,12 @@ public class WebElementTest : DriverTestFixture
         IWebElement submit = driver.FindElement(By.Id("submittingButton"));
         submit.Submit();
 
-        Assert.That(driver.Url, Does.StartWith(resultPage));
+        Assert.That(
+            () =>
+                WaitFor(
+                    () => driver.Url.StartsWith(resultPage),
+                    "We are not redirected to the resultPage after submitting web element"),
+            Throws.Nothing);
     }
 
     [Test]

--- a/dotnet/test/firefox/BUILD.bazel
+++ b/dotnet/test/firefox/BUILD.bazel
@@ -23,5 +23,6 @@ dotnet_nunit_test_suite(
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/common:fixtures",
         nuget_package("NUnit"),
+        nuget_package("Runfiles"),
     ],
 )

--- a/dotnet/test/firefox/FirefoxDriverTest.cs
+++ b/dotnet/test/firefox/FirefoxDriverTest.cs
@@ -333,6 +333,7 @@ public class FirefoxDriverTest : DriverTestFixture
     }
 
     [Test]
+    [IgnorePlatform("windows", "Signed directory add-on install fails on Windows (ERROR_CORRUPT_FILE).")]
     public void ShouldInstallAndUninstallSignedDirAddon()
     {
         FirefoxDriver firefoxDriver = driver as FirefoxDriver;
@@ -372,9 +373,18 @@ public class FirefoxDriverTest : DriverTestFixture
 
     private string GetPath(string name)
     {
-        string sCurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        string sFile = Path.Combine(sCurrentDirectory, "../../../../common/extensions/" + name);
-        return Path.GetFullPath(sFile);
+        try
+        {
+            // For directories, locate a file inside and get parent (runfiles manifest only lists files)
+            string path = Bazel.Runfiles.Create().Rlocation($"_main/common/extensions/{name}/manifest.json");
+            return Path.GetDirectoryName(path);
+        }
+        catch (FileNotFoundException)
+        {
+            string sCurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string sFile = Path.Combine(sCurrentDirectory, "../../../../common/extensions/" + name);
+            return Path.GetFullPath(sFile);
+        }
     }
 
     private static bool PlatformHasNativeEvents()


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
Breaking this out from #16818 

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Do not run bazel tests in parallel
* Bazel runfiles doesn't do directories, just files; for Mac/Linux the directory symlinks work as files, in Windows it does not work, need to get a file and then walk up to the parent directory 
* Guard one test and add synchronization to another

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* We could use a relative path without Runfiles, but this seemed easier fix.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix .NET tests on Windows with Bazel by handling runfiles directories

- Prevent NUnit test parallelism to avoid driver instance conflicts

- Add synchronization to WebElementTest.ShouldSubmitElement test

- Guard Firefox signed directory addon test on Windows platform


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bazel Runfiles<br/>Directory Handling"] -->|"Fallback to<br/>manifest.json"| B["Get Parent<br/>Directory Path"]
  C["NUnit Test<br/>Parallelism"] -->|"Add --workers=1"| D["Sequential<br/>Test Execution"]
  E["WebElement<br/>Submit Test"] -->|"Add WaitFor<br/>Synchronization"| F["Reliable URL<br/>Verification"]
  G["Firefox Addon<br/>Test"] -->|"Platform Guard"| H["Skip on<br/>Windows"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebExtensionTest.cs</strong><dd><code>Handle Bazel runfiles directory resolution on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/WebExtension/WebExtensionTest.cs

<ul><li>Modified <code>LocateRelativePath</code> to handle Bazel runfiles directory <br>resolution on Windows<br> <li> Added fallback logic to locate manifest.json file and extract parent <br>directory when direct path resolution fails<br> <li> Maintains backward compatibility with FileNotFoundException catch <br>block</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16853/files#diff-fd6bd42f706660eae4316fd107cd6a0d72b36b16c91e19dd8b03a89d16bb6bf7">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebElementTest.cs</strong><dd><code>Add synchronization to element submit test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/WebElementTest.cs

<ul><li>Added synchronization to <code>ShouldSubmitElement</code> test using <code>WaitFor</code> helper<br> <li> Wrapped URL assertion in lambda with explicit wait condition<br> <li> Prevents race condition where URL redirect hasn't completed yet</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16853/files#diff-271aea78d57d047ea870a091816b50b553a592280fd1b6b910ed0e5a1d22328c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverTest.cs</strong><dd><code>Guard Firefox addon test and fix path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/firefox/FirefoxDriverTest.cs

<ul><li>Added <code>IgnorePlatform</code> attribute to <br><code>ShouldInstallAndUninstallSignedDirAddon</code> test<br> <li> Skips test on Windows due to ERROR_CORRUPT_FILE issue with signed <br>directory addons<br> <li> Refactored <code>GetPath</code> method to use Bazel Runfiles for directory <br>resolution<br> <li> Added fallback to legacy path resolution for non-Bazel environments</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16853/files#diff-0ab06d3248144f57868f7615a95675e208584dbc4209ae447dd64dbde783b094">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dotnet_nunit_test_suite.bzl</strong><dd><code>Disable NUnit test parallelism for Bazel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/dotnet_nunit_test_suite.bzl

<ul><li>Introduced <code>_NUNIT_ARGS</code> constant with <code>--workers=1</code> flag<br> <li> Prevents NUnit test parallelism since Bazel tests share single driver <br>instance<br> <li> Applied <code>_NUNIT_ARGS</code> to all browser test configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16853/files#diff-65f802c0ae644f7ea3922edf4a1844d2a020c9cbd42b837916e7e009aa887442">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add Runfiles NuGet dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/firefox/BUILD.bazel

<ul><li>Added <code>Runfiles</code> NuGet package dependency to Firefox test suite<br> <li> Enables Bazel runfiles API usage for path resolution in tests</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16853/files#diff-cb9faadb9b4293cdb8a46ef9727345f74ebf9c150317ebbbafc7d04770cdd418">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

