### PR TITLE
Java chrome beta

### DIFF
--- a/java/browsers.bzl
+++ b/java/browsers.bzl
@@ -8,6 +8,16 @@ chromedriver_jvm_flags = select({
     "//conditions:default": [],
 })
 
+chromedriver_beta_jvm_flags = select({
+    "@selenium//common:use_pinned_linux_chrome": [
+        "-Dwebdriver.chrome.driver=$(location @linux_beta_chromedriver//:chromedriver)",
+    ],
+    "@selenium//common:use_pinned_macos_chrome": [
+        "-Dwebdriver.chrome.driver=$(location @mac_beta_chromedriver//:chromedriver)",
+    ],
+    "//conditions:default": [],
+})
+
 chrome_jvm_flags = select({
     "@selenium//common:use_pinned_linux_chrome": [
         "-Dwebdriver.chrome.binary=$(location @linux_chrome//:chrome-linux64/chrome)",
@@ -25,6 +35,24 @@ chrome_jvm_flags = select({
     ],
     "//conditions:default": [],
 }) + chromedriver_jvm_flags
+
+chrome_beta_jvm_flags = select({
+    "@selenium//common:use_pinned_linux_chrome": [
+        "-Dwebdriver.chrome.binary=$(location @linux_beta_chrome//:chrome-linux64/chrome)",
+    ],
+    "@selenium//common:use_pinned_macos_chrome": [
+        "-Dwebdriver.chrome.binary=$(location @mac_beta_chrome//:Chrome.app)/Contents/MacOS/Chrome",
+    ],
+    "@selenium//common:use_local_chromedriver": [],
+    "//conditions:default": [
+        "-Dselenium.skiptest=false",
+    ],
+}) + select({
+    "@selenium//common:use_headless_browser": [
+        "-Dwebdriver.headless=true",
+    ],
+    "//conditions:default": [],
+}) + chromedriver_beta_jvm_flags
 
 edgedriver_jvm_flags = select({
     "@selenium//common:use_pinned_linux_edge": [

--- a/java/private/selenium_test.bzl
+++ b/java/private/selenium_test.bzl
@@ -1,6 +1,7 @@
 load(
     "//common:browsers.bzl",
     "COMMON_TAGS",
+    "chrome_beta_data",
     "chrome_data",
     "edge_data",
     "firefox_beta_data",
@@ -23,6 +24,12 @@ BROWSERS = {
         "jvm_flags": ["-Dselenium.browser=chrome"] + chrome_jvm_flags,
         "data": chrome_data,
         "tags": COMMON_TAGS + ["chrome"],
+    },
+    "chrome-beta": {
+        "deps": ["//java/src/org/openqa/selenium/chrome"],
+        "jvm_flags": ["-Dselenium.browser=chrome"] + chrome_jvm_flags,
+        "data": chrome_beta_data,
+        "tags": COMMON_TAGS + ["chrome", "chrome-beta"],
     },
     "edge": {
         "deps": ["//java/src/org/openqa/selenium/edge"],

--- a/java/private/selenium_test.bzl
+++ b/java/private/selenium_test.bzl
@@ -9,6 +9,7 @@ load(
 )
 load(
     "//java:browsers.bzl",
+    "chrome_beta_jvm_flags",
     "chrome_jvm_flags",
     "edge_jvm_flags",
     "firefox_beta_jvm_flags",
@@ -27,7 +28,7 @@ BROWSERS = {
     },
     "chrome-beta": {
         "deps": ["//java/src/org/openqa/selenium/chrome"],
-        "jvm_flags": ["-Dselenium.browser=chrome"] + chrome_jvm_flags,
+        "jvm_flags": ["-Dselenium.browser=chrome"] + chrome_beta_jvm_flags,
         "data": chrome_beta_data,
         "tags": COMMON_TAGS + ["chrome", "chrome-beta"],
     },


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Run Java tests on RBE with chrome-beta

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
We added chrome beta a while back for Ruby, didn't add it in other places. Easy to wire it up in Java

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
May still need to adjust which tests are run with which prod vs beta since everything on both is probably unnecessary


___

### **PR Type**
Enhancement


___

### **Description**
- Add Chrome Beta support to Java test infrastructure

- Define Chrome Beta JVM flags for driver and binary configuration

- Register Chrome Beta as a new browser option in test configuration

- Support Chrome Beta on Linux and macOS platforms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Java Test Config"] -->|"adds Chrome Beta"| B["browsers.bzl"]
  B -->|"defines flags"| C["chromedriver_beta_jvm_flags"]
  B -->|"defines flags"| D["chrome_beta_jvm_flags"]
  E["selenium_test.bzl"] -->|"imports Beta data"| F["chrome_beta_data"]
  E -->|"imports Beta flags"| G["chrome_beta_jvm_flags"]
  E -->|"registers"| H["chrome-beta browser"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browsers.bzl</strong><dd><code>Define Chrome Beta JVM flags and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/browsers.bzl

<ul><li>Add <code>chromedriver_beta_jvm_flags</code> variable with Linux and macOS Chrome <br>Beta driver locations<br> <li> Add <code>chrome_beta_jvm_flags</code> variable combining Chrome Beta binary paths <br>and driver flags<br> <li> Configure headless mode support for Chrome Beta tests</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16860/files#diff-ad0bca897057955246aaec216b44757be96883601b6982e99c1369feaed3f5c3">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>selenium_test.bzl</strong><dd><code>Register Chrome Beta as test browser option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/private/selenium_test.bzl

<ul><li>Import <code>chrome_beta_data</code> and <code>chrome_beta_jvm_flags</code> from common and Java <br>browser configs<br> <li> Add new "chrome-beta" entry to BROWSERS dictionary with Chrome Beta <br>dependencies and flags<br> <li> Tag Chrome Beta tests with "chrome" and "chrome-beta" labels</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16860/files#diff-c6a9f045730f9990372d889be0356c359bba64ca703df92832ac0a7747b1984d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

