### PR TITLE
[java] Fix flaky tests

### DIFF
--- a/java/src/org/openqa/selenium/netty/server/NettyServer.java
+++ b/java/src/org/openqa/selenium/netty/server/NettyServer.java
@@ -128,6 +128,10 @@ public class NettyServer implements Server<NettyServer> {
 
   @Override
   public void stop() {
+    if (!isStarted()) {
+      return;
+    }
+
     try {
       Future<?> bossShutdown = bossGroup.shutdownGracefully();
       Future<?> workerShutdown = workerGroup.shutdownGracefully();

--- a/java/test/org/openqa/selenium/bidi/BiDiSessionCleanUpTest.java
+++ b/java/test/org/openqa/selenium/bidi/BiDiSessionCleanUpTest.java
@@ -20,25 +20,30 @@ package org.openqa.selenium.bidi;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WindowType;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.testing.drivers.Browser;
 
-class BiDiSessionCleanUpTest {
+final class BiDiSessionCleanUpTest {
 
-  private FirefoxDriver driver;
+  private final FirefoxDriver driver =
+      new FirefoxDriver(((FirefoxOptions) Browser.FIREFOX.getCapabilities()).enableBiDi());
+
+  @AfterEach
+  void closeBrowser() {
+    try {
+      driver.quit();
+    } catch (NoSuchSessionException ignore) { // browser already closed by test
+    }
+  }
 
   @Test
   void shouldNotCloseBiDiSessionIfOneWindowIsClosed() {
-    FirefoxOptions options = (FirefoxOptions) Browser.FIREFOX.getCapabilities();
-    // Enable BiDi
-    options.enableBiDi();
-
-    driver = new FirefoxDriver(options);
-
     BiDi biDi = driver.getBiDi();
 
     BiDiSessionStatus status = biDi.getBidiSessionStatus();
@@ -54,17 +59,10 @@ class BiDiSessionCleanUpTest {
     BiDiSessionStatus statusAfterClosing = biDi.getBidiSessionStatus();
     assertThat(statusAfterClosing).isNotNull();
     assertThat(status.getMessage()).isEqualTo("Session already started");
-    driver.quit();
   }
 
   @Test
   void shouldCloseBiDiSessionIfLastWindowIsClosed() {
-    FirefoxOptions options = (FirefoxOptions) Browser.FIREFOX.getCapabilities();
-    // Enable BiDi
-    options.enableBiDi();
-
-    driver = new FirefoxDriver(options);
-
     BiDi biDi = driver.getBiDi();
 
     BiDiSessionStatus status = biDi.getBidiSessionStatus();

--- a/java/test/org/openqa/selenium/testing/JupiterTestBase.java
+++ b/java/test/org/openqa/selenium/testing/JupiterTestBase.java
@@ -77,6 +77,7 @@ public abstract class JupiterTestBase {
         LOG.log(Level.WARNING, "appServer is restarted with secureServer=true", ex);
         environment.stop();
         environment = new InProcessTestEnvironment(true);
+        appServer = environment.getAppServer();
       }
     }
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Fixes few Java tests

### 🔧 Implementation Notes
See every commit separately

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent NPE in NettyServer.stop() when called on already stopped server

- Fix appServer reference after test environment restart with secure mode

- Ensure browser cleanup in BiDiSessionCleanUpTest using @AfterEach

- Refactor test setup to use field initialization instead of manual setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NettyServer.stop()"] -->|"add isStarted check"| B["Prevent NPE on double stop"]
  C["JupiterTestBase"] -->|"update appServer reference"| D["Fix secure env restart"]
  E["BiDiSessionCleanUpTest"] -->|"add @AfterEach cleanup"| F["Ensure browser closure"]
  E -->|"field initialization"| G["Simplify test setup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NettyServer.java</strong><dd><code>Prevent NPE when stopping already stopped server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/netty/server/NettyServer.java

<ul><li>Add <code>isStarted()</code> check at beginning of <code>stop()</code> method to prevent NPE<br> <li> Return early if server is not running to avoid null pointer on <br><code>this.channel</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16862/files#diff-57c60fc836f525b5afc69e40a878b32d5c8dc58e48345cf72624b2c48486781b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BiDiSessionCleanUpTest.java</strong><dd><code>Add guaranteed browser cleanup with @AfterEach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/BiDiSessionCleanUpTest.java

<ul><li>Add <code>@AfterEach</code> method to ensure browser cleanup even if test fails<br> <li> Initialize <code>driver</code> as field with BiDi-enabled FirefoxOptions<br> <li> Remove manual <code>driver.quit()</code> calls from test methods<br> <li> Catch <code>NoSuchSessionException</code> in cleanup for already-closed browsers<br> <li> Make class <code>final</code> and reorganize imports</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16862/files#diff-1b2ac2efc18ef0c906bc159179e683bb9d22b805302dc8b2bdb54fe6a66d2837">+16/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JupiterTestBase.java</strong><dd><code>Update appServer reference after environment restart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/JupiterTestBase.java

<ul><li>Update <code>appServer</code> reference after restarting test environment in secure <br>mode<br> <li> Fixes issue where appServer was still pointing to previous non-secure <br>environment<br> <li> Prevents DNS resolution errors when accessing secure URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16862/files#diff-b63297bc768ca812e8b803878284f87c82fb681cdda15ec93bf4190195f3f814">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

