### PR TITLE
add readable `toString()` to `org.openqa.selenium.remote.Browser`

### DIFF
--- a/java/src/org/openqa/selenium/remote/Browser.java
+++ b/java/src/org/openqa/selenium/remote/Browser.java
@@ -17,53 +17,21 @@
 
 package org.openqa.selenium.remote;
 
+import java.util.Set;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.internal.Require;
 
 /** Used to identify a browser based on its name. */
 public interface Browser {
 
-  Browser CHROME =
-      new Browser() {
-        @Override
-        public String browserName() {
-          return "chrome";
-        }
-
-        @Override
-        public boolean is(String browserName) {
-          return Browser.super.is(browserName) || "chrome-headless-shell".equals(browserName);
-        }
-      };
-  Browser EDGE =
-      new Browser() {
-        @Override
-        public String browserName() {
-          return "MicrosoftEdge";
-        }
-
-        @Override
-        public boolean is(String browserName) {
-          return Browser.super.is(browserName) || "msedge".equals(browserName);
-        }
-      };
-  Browser HTMLUNIT = () -> "htmlunit";
-  Browser IE = () -> "internet explorer";
-  Browser FIREFOX = () -> "firefox";
-  Browser OPERA = () -> "opera";
-  Browser SAFARI =
-      new Browser() {
-        @Override
-        public String browserName() {
-          return "safari";
-        }
-
-        @Override
-        public boolean is(String browserName) {
-          return Browser.super.is(browserName) || "Safari".equals(browserName);
-        }
-      };
-  Browser SAFARI_TECH_PREVIEW = () -> "Safari Technology Preview";
+  Browser CHROME = new NamedBrowser("chrome", "chrome-headless-shell");
+  Browser EDGE = new NamedBrowser("MicrosoftEdge", "msedge");
+  Browser HTMLUNIT = new NamedBrowser("htmlunit");
+  Browser IE = new NamedBrowser("internet explorer");
+  Browser FIREFOX = new NamedBrowser("firefox");
+  Browser OPERA = new NamedBrowser("opera");
+  Browser SAFARI = new NamedBrowser("safari", "Safari");
+  Browser SAFARI_TECH_PREVIEW = new NamedBrowser("Safari Technology Preview");
 
   String browserName();
 
@@ -78,5 +46,30 @@ public interface Browser {
 
   default String toJson() {
     return browserName();
+  }
+}
+
+class NamedBrowser implements Browser {
+  private final String name;
+  private final Set<String> otherNames;
+
+  protected NamedBrowser(String name, String... otherNames) {
+    this.name = Require.nonNull("Browser name", name);
+    this.otherNames = Set.of(otherNames);
+  }
+
+  @Override
+  public boolean is(String browserName) {
+    return Browser.super.is(browserName) || otherNames.contains(browserName);
+  }
+
+  @Override
+  public String browserName() {
+    return name;
+  }
+
+  @Override
+  public final String toString() {
+    return name;
   }
 }

--- a/java/test/org/openqa/selenium/remote/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/BUILD.bazel
@@ -34,6 +34,7 @@ java_test_suite(
         artifact("org.assertj:assertj-core"),
         artifact("com.google.guava:guava"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.junit.jupiter:junit-jupiter-params"),
         artifact("org.mockito:mockito-core"),
     ] + JUNIT5_DEPS,
 )

--- a/java/test/org/openqa/selenium/remote/BrowserTest.java
+++ b/java/test/org/openqa/selenium/remote/BrowserTest.java
@@ -1,0 +1,66 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BrowserTest {
+  @ParameterizedTest
+  @MethodSource("webBrowsers")
+  void browsersHaveReadableStringRepresentation(Browser browser, String toString) {
+    assertThat(browser).hasToString(toString);
+  }
+
+  @ParameterizedTest
+  @MethodSource("webBrowsers")
+  void is(Browser browser, String name) {
+    assertThat(browser.browserName()).isEqualTo(name);
+    assertThat(browser.is(name)).isTrue();
+    assertThat(browser.is("Netscape Navigator")).isFalse();
+  }
+
+  private static Stream<Arguments> webBrowsers() {
+    return Stream.of(
+        Arguments.of(Browser.CHROME, "chrome"),
+        Arguments.of(Browser.EDGE, "MicrosoftEdge"),
+        Arguments.of(Browser.HTMLUNIT, "htmlunit"),
+        Arguments.of(Browser.IE, "internet explorer"),
+        Arguments.of(Browser.FIREFOX, "firefox"),
+        Arguments.of(Browser.OPERA, "opera"),
+        Arguments.of(Browser.SAFARI, "safari"),
+        Arguments.of(Browser.SAFARI_TECH_PREVIEW, "Safari Technology Preview"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("alternativeBrowserNames")
+  void alternativeName(Browser browser, String alternativeName) {
+    assertThat(browser.is(alternativeName)).isTrue();
+  }
+
+  public static Stream<Arguments> alternativeBrowserNames() {
+    return Stream.of(
+        Arguments.of(Browser.CHROME, "chrome-headless-shell"),
+        Arguments.of(Browser.EDGE, "msedge"),
+        Arguments.of(Browser.SAFARI, "Safari"));
+  }
+}


### PR DESCRIPTION
### **User description**
I use `Browser` instances as parameter in parametrized tests. These parameters look unreadable in test reports:

* CHROME.toString() -> "org.openqa.selenium.remote.Browser$1@62e20a76"
* EDGE.toString() -> "org.openqa.selenium.remote.Browser$2@75ed9710"
* HTMLUNIT.toString() -> "org.openqa.selenium.remote.Browser$$Lambda$551/0x0000008001160af8@79da1ec0"

etc.

### 💥 What does this PR do?
1. adds method `toString()` to class `org.openqa.selenium.remote.Browser`
2. adds tests for it.


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Enhancement


___

### **Description**
- Refactors Browser interface to use NamedBrowser implementation class

- Adds readable toString() method returning browser name

- Consolidates duplicate browser matching logic into single class

- Adds comprehensive parametrized tests for all browsers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser Interface"] -->|refactored to use| B["NamedBrowser Class"]
  B -->|implements| C["toString()"]
  B -->|consolidates| D["Browser Matching Logic"]
  E["BrowserTest"] -->|tests| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Browser.java</strong><dd><code>Refactor Browser constants to use NamedBrowser class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/Browser.java

<ul><li>Refactors all Browser constants from anonymous inner classes to use <br>new <code>NamedBrowser</code> implementation<br> <li> Adds <code>NamedBrowser</code> inner class that implements <code>Browser</code> interface with <br><code>toString()</code> method<br> <li> Consolidates duplicate browser name matching logic into single <code>is()</code> <br>method using a <code>Set</code> of alternative names<br> <li> Imports <code>java.util.Set</code> for managing alternative browser names</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16873/files#diff-d31ead71c170e26d696053fdb1e894771d3f5e65db2b74dd2d9eb6bac93ee487">+34/-41</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowserTest.java</strong><dd><code>Add comprehensive Browser interface tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/BrowserTest.java

<ul><li>Adds parametrized test verifying readable <code>toString()</code> representation <br>for all browsers<br> <li> Adds parametrized test validating <code>browserName()</code> and <code>is()</code> methods for <br>each browser<br> <li> Adds parametrized test confirming alternative browser names are <br>recognized<br> <li> Tests all 8 browser types with their primary and alternative names</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16873/files#diff-33924ee41b5cf6425d3c0b12b449783db1f0a78961b801cd79eb44deb522f5a0">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

