### PR TITLE
[java] restore ClientConfig constructor used by Appium (for backward compatibility)

### DIFF
--- a/java/src/org/openqa/selenium/remote/http/ClientConfig.java
+++ b/java/src/org/openqa/selenium/remote/http/ClientConfig.java
@@ -46,6 +46,27 @@ public class ClientConfig {
       URI baseUri,
       Duration connectionTimeout,
       Duration readTimeout,
+      Filter filters,
+      Proxy proxy,
+      Credentials credentials,
+      SSLContext sslContext,
+      String version) {
+    this(
+        baseUri,
+        connectionTimeout,
+        readTimeout,
+        defaultWsTimeout(),
+        filters,
+        proxy,
+        credentials,
+        sslContext,
+        version);
+  }
+
+  protected ClientConfig(
+      URI baseUri,
+      Duration connectionTimeout,
+      Duration readTimeout,
       Duration wsTimeout,
       Filter filters,
       Proxy proxy,
@@ -66,17 +87,29 @@ public class ClientConfig {
   public static ClientConfig defaultConfig() {
     return new ClientConfig(
         null,
-        Duration.ofSeconds(
-            Long.parseLong(System.getProperty("webdriver.httpclient.connectionTimeout", "10"))),
-        Duration.ofSeconds(
-            Long.parseLong(System.getProperty("webdriver.httpclient.readTimeout", "180"))),
-        Duration.ofSeconds(
-            Long.parseLong(System.getProperty("webdriver.httpclient.wsTimeout", "30"))),
+        defaultConnectionTimeout(),
+        defaultReadTimeout(),
+        defaultWsTimeout(),
         DEFAULT_FILTER,
         null,
         null,
         null,
         System.getProperty("webdriver.httpclient.version", null));
+  }
+
+  private static Duration defaultWsTimeout() {
+    return Duration.ofSeconds(
+        Long.parseLong(System.getProperty("webdriver.httpclient.wsTimeout", "30")));
+  }
+
+  private static Duration defaultReadTimeout() {
+    return Duration.ofSeconds(
+        Long.parseLong(System.getProperty("webdriver.httpclient.readTimeout", "180")));
+  }
+
+  private static Duration defaultConnectionTimeout() {
+    return Duration.ofSeconds(
+        Long.parseLong(System.getProperty("webdriver.httpclient.connectionTimeout", "10")));
   }
 
   public ClientConfig baseUri(URI baseUri) {


### PR DESCRIPTION
### **User description**
This constructor disappeared in PR https://github.com/SeleniumHQ/selenium/pull/16796 when `wsTimeout` parameter was added.

But Appium still uses it.
People would not be able to update Selenium version, while staying on a previous Appium version.


### 💥 What does this PR do?
Restores `ClientConfig` constructor (without `wsTimeout` parameter) that existed in Selenium 4.39.0.


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Restores removed `ClientConfig` constructor for backward compatibility

- Constructor without `wsTimeout` parameter used by Appium

- Delegates to full constructor with default `wsTimeout` value

- Extracts timeout defaults into private helper methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ClientConfig constructor<br/>without wsTimeout"] -->|delegates to| B["ClientConfig constructor<br/>with wsTimeout"]
  B -->|uses| C["defaultWsTimeout()"]
  B -->|uses| D["defaultReadTimeout()"]
  B -->|uses| E["defaultConnectionTimeout()"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientConfig.java</strong><dd><code>Restore constructor and extract timeout defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/http/ClientConfig.java

<ul><li>Adds new protected constructor without <code>wsTimeout</code> parameter that <br>delegates to existing constructor<br> <li> Extracts timeout default values into three private static helper <br>methods (<code>defaultWsTimeout()</code>, <code>defaultReadTimeout()</code>, <br><code>defaultConnectionTimeout()</code>)<br> <li> Refactors <code>defaultConfig()</code> method to use the new helper methods for <br>cleaner code<br> <li> Maintains backward compatibility with Appium and other clients using <br>the old constructor signature</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16874/files#diff-f5e5b92eba50aa73e4c79c703519f180bb869a8badfb3049021aa0e295767017">+39/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

