### PR TITLE
[build][rb] remove unnecessary log output from windows runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,7 @@ build:macos --host_cxxopt=-std=c++17
 build:windows --cxxopt=/std:c++17
 build:windows --host_cxxopt=/std:c++17
 build:windows --per_file_copt=external/protobuf\\+.*@/w
+build:windows --host_per_file_copt=external/protobuf\\+.*@/w
 common --define=protobuf_allow_msvc=true
 
 # For build stamping

--- a/.bazelrc
+++ b/.bazelrc
@@ -64,8 +64,13 @@ build --incompatible_strict_action_env
 
 # Required to get `protobuf` compiling, which is required for `rules_closure`
 build --incompatible_enable_cc_toolchain_resolution
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17
+build:macos --host_cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17
+build:windows --per_file_copt=external/protobuf\\+.*@/w
 common --define=protobuf_allow_msvc=true
 
 # For build stamping


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
Windows run throw a bunch of protobuf errors/warnings/info in the logs that are not needed. This should fix that. 

Tagging [rb] just to get those tests run to verify.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace generic C++ standard flags with platform-specific configurations

- Add Windows-specific protobuf compiler warning suppression flag

- Ensure proper C++ standard compilation across Linux, macOS, and Windows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generic build flags"] -- "split by platform" --> B["Linux/macOS: -std=c++17"]
  A -- "split by platform" --> C["Windows: /std:c++17"]
  C -- "add warning suppression" --> D["Windows protobuf config"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.bazelrc</strong><dd><code>Platform-specific C++ standards and Windows protobuf warning </code><br><code>suppression</code></dd></summary>
<hr>

.bazelrc

<ul><li>Replaced generic <code>build --cxxopt</code> and <code>build --host_cxxopt</code> flags with <br>platform-specific variants<br> <li> Added <code>build:linux</code> and <code>build:macos</code> configurations using <code>-std=c++17</code> <br>syntax<br> <li> Added <code>build:windows</code> configuration using <code>/std:c++17</code> (MSVC syntax)<br> <li> Added Windows-specific <code>per_file_copt</code> flag to suppress protobuf <br>compiler warnings with <code>/w</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16876/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

