### PR TITLE
[rb] check driver status endpoint rather than socket connection

### DIFF
--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -130,7 +130,7 @@ module Selenium
         deadline = current_time + START_TIMEOUT
 
         loop do
-          error = connection_error?
+          error = check_connection_error
           return unless error
 
           raise Error::WebDriverError, "#{cannot_connect_error_text}: #{error}" if current_time > deadline
@@ -139,7 +139,7 @@ module Selenium
         end
       end
 
-      def connection_error?
+      def check_connection_error
         response = Net::HTTP.start(@host, @port, open_timeout: 0.5, read_timeout: 1) do |http|
           http.get('/status', {'Connection' => 'close'})
         end

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -144,10 +144,14 @@ module Selenium
           http.get('/status', {'Connection' => 'close'})
         end
 
-        "status returned #{response.code}\n#{response.body}" unless response.is_a?(Net::HTTPSuccess)
+        return "status returned #{response.code}\n#{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+        status = JSON.parse(response.body)
+        ready = status['ready'] || status.dig('value', 'ready')
+        "driver not ready: #{response.body}" unless ready
       rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EPIPE, Errno::ETIMEDOUT,
              Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, Net::OpenTimeout, Net::ReadTimeout,
-             EOFError, SocketError, Net::HTTPBadResponse => e
+             EOFError, SocketError, Net::HTTPBadResponse, JSON::ParserError => e
         "#{e.class}: #{e.message}"
       end
 

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -127,10 +127,32 @@ module Selenium
       end
 
       def connect_until_stable
-        socket_poller = SocketPoller.new @host, @port, START_TIMEOUT
-        return if socket_poller.connected?
+        deadline = current_time + START_TIMEOUT
 
-        raise Error::WebDriverError, cannot_connect_error_text
+        loop do
+          error = connection_error?
+          return unless error
+
+          raise Error::WebDriverError, "#{cannot_connect_error_text}: #{error}" if current_time > deadline
+
+          sleep 0.1
+        end
+      end
+
+      def connection_error?
+        response = Net::HTTP.start(@host, @port, open_timeout: 0.5, read_timeout: 1) do |http|
+          http.get('/status', {'Connection' => 'close'})
+        end
+
+        "status returned #{response.code}\n#{response.body}" unless response.is_a?(Net::HTTPSuccess)
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EPIPE, Errno::ETIMEDOUT,
+             Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, Net::OpenTimeout, Net::ReadTimeout,
+             EOFError, SocketError, Net::HTTPBadResponse => e
+        "#{e.class}: #{e.message}"
+      end
+
+      def current_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
       def cannot_connect_error_text

--- a/rb/sig/lib/selenium/webdriver/common/service_manager.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/service_manager.rbs
@@ -53,6 +53,10 @@ module Selenium
 
       def connect_until_stable: () -> untyped?
 
+      def connection_error?: () -> String?
+
+      def current_time: () -> Float
+
       def cannot_connect_error_text: () -> String
 
       def socket_lock: () -> untyped

--- a/rb/sig/lib/selenium/webdriver/common/service_manager.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/service_manager.rbs
@@ -53,7 +53,7 @@ module Selenium
 
       def connect_until_stable: () -> untyped?
 
-      def connection_error?: () -> String?
+      def check_connection_error: () -> String?
 
       def current_time: () -> Float
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
I'm getting issues in tests where the driver is hanging after starting. Right now we check the socket is connected and then send a session request where it hangs and dies. This code matches what Java, JS & .NET do by checking the status endpoint before continuing. Hopefully if there is a problem we find it here with a shorter timeout.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* starting a driver checks status endpoint instead of using socketpoller

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Considered actually looking at ready status, but other bindings don't do that, and probably not what we need here
Shouldn't be a breaking change, but need to test it thoroughly.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace socket polling with HTTP status endpoint check

- Align Ruby driver with Java, JS, and .NET implementations

- Add proper error handling and timeout management

- Improve connection diagnostics with detailed error messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Start Driver"] -->|"Old: SocketPoller"| B["Check Socket Connected"]
  A -->|"New: HTTP GET /status"| C["connection_error?"]
  C -->|"Success"| D["Return - Driver Ready"]
  C -->|"Error"| E["Retry with 0.1s delay"]
  E -->|"Within timeout"| C
  E -->|"Timeout exceeded"| F["Raise WebDriverError"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_manager.rb</strong><dd><code>Replace socket polling with HTTP status endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/common/service_manager.rb

<ul><li>Replaced <code>SocketPoller</code> with HTTP GET request to <code>/status</code> endpoint<br> <li> Implemented <code>connection_error?</code> method to handle HTTP requests and <br>connection exceptions<br> <li> Added <code>current_time</code> helper using <code>Process.clock_gettime</code> for monotonic <br>timing<br> <li> Enhanced error messages to include response codes and exception <br>details<br> <li> Changed polling loop to retry every 0.1 seconds until timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16877/files#diff-91325f9a98b4d10ef61117b88a24a3467a433e1a27a9a16d2b9d4046b1d92c4a">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

