### PR TITLE
[dotnet] Stabilize ShouldTimeoutIfAPageTakesTooLongToRefresh test

### DIFF
--- a/dotnet/test/common/PageLoadingTest.cs
+++ b/dotnet/test/common/PageLoadingTest.cs
@@ -371,7 +371,7 @@ public class PageLoadingTest : DriverTestFixture
         WaitFor(TitleToBeEqualTo("XHTML Test Page"), "Title was not expected value");
     }
 
-    [Test, Repeat(50)]
+    [Test, Repeat(20)]
     [NeedsFreshDriver(IsCreatedAfterTest = true)]
     public void ShouldTimeoutIfAPageTakesTooLongToRefresh()
     {

--- a/dotnet/test/common/PageLoadingTest.cs
+++ b/dotnet/test/common/PageLoadingTest.cs
@@ -376,21 +376,14 @@ public class PageLoadingTest : DriverTestFixture
     public void ShouldTimeoutIfAPageTakesTooLongToRefresh()
     {
         // Get the sleeping servlet with a pause of 5 seconds
-        long pageLoadTimeout = 2;
-        long pageLoadTimeBuffer = 0;
-        string slowLoadingPageUrl = EnvironmentManager.Instance.UrlBuilder.WhereIs("sleep?time=" + (pageLoadTimeout + pageLoadTimeBuffer));
+        string slowLoadingPageUrl = EnvironmentManager.Instance.UrlBuilder.WhereIs("sleep?time=5");
         driver.Url = slowLoadingPageUrl;
 
         driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(2);
 
-        try
-        {
-            AssertPageLoadTimeoutIsEnforced(() => driver.Navigate().Refresh(), 2, 4);
-        }
-        finally
-        {
-            driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(300);
-        }
+        AssertPageLoadTimeoutIsEnforced(driver.Navigate().Refresh, 2, 4);
+
+        driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(300);
 
         // Load another page after get() timed out but before test HTTP server served previous page.
         driver.Url = xhtmlTestPage;

--- a/dotnet/test/common/PageLoadingTest.cs
+++ b/dotnet/test/common/PageLoadingTest.cs
@@ -371,7 +371,7 @@ public class PageLoadingTest : DriverTestFixture
         WaitFor(TitleToBeEqualTo("XHTML Test Page"), "Title was not expected value");
     }
 
-    [Test]
+    [Test, Repeat(50)]
     [NeedsFreshDriver(IsCreatedAfterTest = true)]
     public void ShouldTimeoutIfAPageTakesTooLongToRefresh()
     {

--- a/dotnet/test/common/PageLoadingTest.cs
+++ b/dotnet/test/common/PageLoadingTest.cs
@@ -371,7 +371,7 @@ public class PageLoadingTest : DriverTestFixture
         WaitFor(TitleToBeEqualTo("XHTML Test Page"), "Title was not expected value");
     }
 
-    [Test, Repeat(20)]
+    [Test]
     [NeedsFreshDriver(IsCreatedAfterTest = true)]
     public void ShouldTimeoutIfAPageTakesTooLongToRefresh()
     {
@@ -381,9 +381,14 @@ public class PageLoadingTest : DriverTestFixture
 
         driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(2);
 
-        AssertPageLoadTimeoutIsEnforced(driver.Navigate().Refresh, 2, 4);
-
-        driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(300);
+        try
+        {
+            AssertPageLoadTimeoutIsEnforced(driver.Navigate().Refresh, 2, 4);
+        }
+        finally
+        {
+            driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(300);
+        }
 
         // Load another page after get() timed out but before test HTTP server served previous page.
         driver.Url = xhtmlTestPage;


### PR DESCRIPTION
### **User description**
Stabilize ShouldTimeoutIfAPageTakesTooLongToRefresh test

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->


___

### **PR Type**
Tests


___

### **Description**
- Simplify test by removing unnecessary timeout buffer variables

- Replace lambda expression with method group in assertion call

- Hardcode sleep duration for clarity and consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] -->|Remove buffer variables| B["Hardcode sleep duration"]
  B -->|Simplify assertion| C["Use method group instead of lambda"]
  C -->|Result| D["Cleaner, more stable test"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PageLoadingTest.cs</strong><dd><code>Simplify page load timeout test implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/PageLoadingTest.cs

<ul><li>Removed <code>pageLoadTimeout</code> and <code>pageLoadTimeBuffer</code> variables, replaced <br>with hardcoded sleep duration of 5 seconds<br> <li> Changed <code>AssertPageLoadTimeoutIsEnforced()</code> call from lambda expression <br><code>() => driver.Navigate().Refresh()</code> to method group <br><code>driver.Navigate().Refresh</code><br> <li> Simplified URL construction by directly embedding the sleep time value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16880/files#diff-1c5300f3102242b5f109264ad1323c4f4302b02e6f152fbf45a2bccad7dc0fdf">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

