### PR TITLE
[dotnet] [bidi] Allow consumer to combine input actions via identifier

### DIFF
--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -27,14 +27,14 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Input;
 
 [JsonConverter(typeof(InputSourceActionsConverter))]
-public abstract record SourceActions
+public abstract record SourceActions(string? Id = null)
 {
-    public string Id { get; } = Guid.NewGuid().ToString();
+    public string Id { get; init; } = Id ?? Guid.NewGuid().ToString();
 }
 
 public interface ISourceAction;
 
-public abstract record SourceActions<T> : SourceActions, IEnumerable<ISourceAction> where T : ISourceAction
+public abstract record SourceActions<T>(string? Id = null) : SourceActions(Id), IEnumerable<ISourceAction> where T : ISourceAction
 {
     public IList<ISourceAction> Actions { get; set; } = [];
 
@@ -51,7 +51,7 @@ public abstract record SourceActions<T> : SourceActions, IEnumerable<ISourceActi
 [JsonDerivedType(typeof(UpKey), "keyUp")]
 public interface IKeySourceAction : ISourceAction;
 
-public sealed record KeyActions : SourceActions<IKeySourceAction>
+public sealed record KeyActions(string? Id = null) : SourceActions<IKeySourceAction>(Id)
 {
     public KeyActions Type(string text)
     {
@@ -72,7 +72,7 @@ public sealed record KeyActions : SourceActions<IKeySourceAction>
 [JsonDerivedType(typeof(MovePointer), "pointerMove")]
 public interface IPointerSourceAction : ISourceAction;
 
-public sealed record PointerActions : SourceActions<IPointerSourceAction>
+public sealed record PointerActions(string? Id = null) : SourceActions<IPointerSourceAction>(Id)
 {
     public PointerParameters? Options { get; set; }
 }
@@ -82,13 +82,13 @@ public sealed record PointerActions : SourceActions<IPointerSourceAction>
 [JsonDerivedType(typeof(ScrollWheel), "scroll")]
 public interface IWheelSourceAction : ISourceAction;
 
-public sealed record WheelActions : SourceActions<IWheelSourceAction>;
+public sealed record WheelActions(string? Id = null) : SourceActions<IWheelSourceAction>(Id);
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(Pause), "pause")]
 public interface INoneSourceAction : ISourceAction;
 
-public sealed record NoneActions : SourceActions<None>;
+public sealed record NoneActions(string Id) : SourceActions<INoneSourceAction>(Id);
 
 public abstract record Key : IKeySourceAction;
 

--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -27,14 +27,11 @@ using System.Text.Json.Serialization;
 namespace OpenQA.Selenium.BiDi.Input;
 
 [JsonConverter(typeof(InputSourceActionsConverter))]
-public abstract record SourceActions(string? Id = null)
-{
-    public string Id { get; init; } = Id ?? Guid.NewGuid().ToString();
-}
+public abstract record SourceActions(string Id);
 
 public interface ISourceAction;
 
-public abstract record SourceActions<T>(string? Id = null) : SourceActions(Id), IEnumerable<ISourceAction> where T : ISourceAction
+public abstract record SourceActions<T>(string Id) : SourceActions(Id), IEnumerable<ISourceAction> where T : ISourceAction
 {
     public IList<ISourceAction> Actions { get; set; } = [];
 
@@ -51,7 +48,7 @@ public abstract record SourceActions<T>(string? Id = null) : SourceActions(Id), 
 [JsonDerivedType(typeof(UpKey), "keyUp")]
 public interface IKeySourceAction : ISourceAction;
 
-public sealed record KeyActions(string? Id = null) : SourceActions<IKeySourceAction>(Id)
+public sealed record KeyActions(string Id) : SourceActions<IKeySourceAction>(Id)
 {
     public KeyActions Type(string text)
     {
@@ -72,7 +69,7 @@ public sealed record KeyActions(string? Id = null) : SourceActions<IKeySourceAct
 [JsonDerivedType(typeof(MovePointer), "pointerMove")]
 public interface IPointerSourceAction : ISourceAction;
 
-public sealed record PointerActions(string? Id = null) : SourceActions<IPointerSourceAction>(Id)
+public sealed record PointerActions(string Id) : SourceActions<IPointerSourceAction>(Id)
 {
     public PointerParameters? Options { get; set; }
 }
@@ -82,13 +79,13 @@ public sealed record PointerActions(string? Id = null) : SourceActions<IPointerS
 [JsonDerivedType(typeof(ScrollWheel), "scroll")]
 public interface IWheelSourceAction : ISourceAction;
 
-public sealed record WheelActions(string? Id = null) : SourceActions<IWheelSourceAction>(Id);
+public sealed record WheelActions(string Id) : SourceActions<IWheelSourceAction>(Id);
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(Pause), "pause")]
 public interface INoneSourceAction : ISourceAction;
 
-public sealed record NoneActions(string? Id = null) : SourceActions<INoneSourceAction>(Id);
+public sealed record NoneActions(string Id) : SourceActions<INoneSourceAction>(Id);
 
 public abstract record Key : IKeySourceAction;
 

--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -88,7 +88,7 @@ public sealed record WheelActions(string? Id = null) : SourceActions<IWheelSourc
 [JsonDerivedType(typeof(Pause), "pause")]
 public interface INoneSourceAction : ISourceAction;
 
-public sealed record NoneActions(string Id) : SourceActions<INoneSourceAction>(Id);
+public sealed record NoneActions(string? Id = null) : SourceActions<INoneSourceAction>(Id);
 
 public abstract record Key : IKeySourceAction;
 

--- a/dotnet/test/common/BiDi/Input/CombinedInputActionsTest.cs
+++ b/dotnet/test/common/BiDi/Input/CombinedInputActionsTest.cs
@@ -32,20 +32,20 @@ internal class CombinedInputActionsTest : BiDiTestFixture
 
         await Task.Delay(3000);
 
-        await context.Input.PerformActionsAsync([new PointerActions {
+        await context.Input.PerformActionsAsync([new PointerActions("id0") {
             new MovePointer(300, 300),
             new DownPointer(0),
             new MovePointer(400, 400) { Duration = 2000, Width = 1, Twist = 1 },
             new UpPointer(0),
         }]);
 
-        await context.Input.PerformActionsAsync([new KeyActions {
+        await context.Input.PerformActionsAsync([new KeyActions("id1") {
             new DownKey('U'),
             new UpKey('U'),
             new Pause { Duration = 3000 }
         }]);
 
-        await context.Input.PerformActionsAsync([new PointerActions {
+        await context.Input.PerformActionsAsync([new PointerActions("id2") {
             new MovePointer(300, 300),
             new DownPointer(0),
             new MovePointer(400, 400) { Duration = 2000 },
@@ -63,7 +63,7 @@ internal class CombinedInputActionsTest : BiDiTestFixture
         var options = await context.LocateNodesAsync(new CssLocator("option"));
 
         await context.Input.PerformActionsAsync([
-            new PointerActions
+            new PointerActions("id0")
             {
                 new DownPointer(1),
                 new UpPointer(1),


### PR DESCRIPTION
### **User description**
Allowing user to specify the input actions logically combined:

```csharp
await context.Input.PerformActionsAsync([new KeyActions("my_act_1") {
            new DownKey('U')
        }]);

await context.Input.PerformActionsAsync([new KeyActions("my_act_1") {
            new UpKey('U'),
        }]);
```

Different commands, but logically combined via "my_act_1". In this example browser treats the combined actions as `Key Pressed` event. The same for `DownPointer + UpPointer = Click`.

### 🔧 Implementation Notes
`Id` property as required in `ctor` according spec.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Allow consumers to specify optional identifier for input actions

- Enable logical combination of multiple input action commands

- Add optional `Id` parameter to all source action record constructors

- Maintain backward compatibility with auto-generated IDs when not specified


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input Actions"] -->|"Optional Id parameter"| B["SourceActions base record"]
  B -->|"Propagate Id"| C["KeyActions"]
  B -->|"Propagate Id"| D["PointerActions"]
  B -->|"Propagate Id"| E["WheelActions"]
  B -->|"Propagate Id"| F["NoneActions"]
  C -->|"Combine via same Id"| G["Logical Action Groups"]
  D -->|"Combine via same Id"| G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SourceActions.cs</strong><dd><code>Add optional identifier parameter to input action records</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Input/SourceActions.cs

<ul><li>Modified <code>SourceActions</code> abstract record to accept optional <code>Id</code> parameter <br>in constructor<br> <li> Changed <code>Id</code> property from auto-generated to init-only, using provided <br>value or generating new GUID<br> <li> Updated <code>SourceActions<T></code> generic record to accept and propagate optional <br><code>Id</code> parameter<br> <li> Added optional <code>Id</code> parameter to <code>KeyActions</code>, <code>PointerActions</code>, <br><code>WheelActions</code> constructors<br> <li> Changed <code>NoneActions</code> to require <code>Id</code> parameter and inherit from <br><code>SourceActions<INoneSourceAction></code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16885/files#diff-dc6c1470615cd181310cb202d8e3a9b0a03846b04aacaeebbfeba3ffe25c5ce6">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

