### PR TITLE
[rb] wait for grid to actually be ready when starting server

### DIFF
--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -76,7 +76,6 @@ jobs:
       os: ${{ matrix.os }}
       ruby-version: ${{ matrix.ruby-version }}
       run: >
-        bazel clean &&
         bazel test
         --keep_going
         --build_tests_only
@@ -105,7 +104,6 @@ jobs:
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
       run: >
-        bazel clean &&
         bazel test
         --keep_going
         --build_tests_only
@@ -113,4 +111,29 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}
+        //rb/spec/...
+
+  integration-tests-remote:
+    name: Remote Tests
+    needs: build
+    uses: ./.github/workflows/bazel.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - browser: edge
+            os: macos
+    with:
+      name: Remote Tests (${{ matrix.browser }}, ${{ matrix.os }})
+      browser: ${{ matrix.browser }}
+      os: ${{ matrix.os }}
+      java-version: 17
+      run: >
+        bazel test
+        --keep_going
+        --build_tests_only
+        --flaky_test_attempts 3
+        --local_test_jobs 1
+        --test_size_filters large
+        --test_tag_filters ${{ matrix.browser }}-remote
         //rb/spec/...

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -76,6 +76,7 @@ jobs:
       os: ${{ matrix.os }}
       ruby-version: ${{ matrix.ruby-version }}
       run: >
+        bazel clean &&
         bazel test
         --keep_going
         --build_tests_only
@@ -104,6 +105,7 @@ jobs:
       browser: ${{ matrix.browser }}
       os: ${{ matrix.os }}
       run: >
+        bazel clean &&
         bazel test
         --keep_going
         --build_tests_only
@@ -111,29 +113,4 @@ jobs:
         --local_test_jobs 1
         --test_size_filters large
         --test_tag_filters ${{ matrix.browser }}
-        //rb/spec/...
-
-  integration-tests-remote:
-    name: Remote Tests
-    needs: build
-    uses: ./.github/workflows/bazel.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - browser: edge
-            os: macos
-    with:
-      name: Remote Tests (${{ matrix.browser }}, ${{ matrix.os }})
-      browser: ${{ matrix.browser }}
-      os: ${{ matrix.os }}
-      java-version: 17
-      run: >
-        bazel test
-        --keep_going
-        --build_tests_only
-        --flaky_test_attempts 3
-        --local_test_jobs 1
-        --test_size_filters large
-        --test_tag_filters ${{ matrix.browser }}-remote
         //rb/spec/...

--- a/rb/lib/selenium/server.rb
+++ b/rb/lib/selenium/server.rb
@@ -21,6 +21,7 @@ require 'selenium/webdriver/common/child_process'
 require 'selenium/webdriver/common/port_prober'
 require 'selenium/webdriver/common/socket_poller'
 require 'net/http'
+require 'json'
 
 module Selenium
   #
@@ -203,7 +204,7 @@ module Selenium
 
     def start
       process.start
-      poll_for_service
+      poll_for_ready
 
       process.wait unless @background
     end
@@ -220,11 +221,14 @@ module Selenium
     end
 
     def status_ok?
-      return false unless @process&.alive? && socket.connected?
+      return false unless @process&.alive? && socket_connected?
 
       Net::HTTP.start(@host, @port, open_timeout: 2, read_timeout: 2) do |http|
-        response = http.get('/wd/hub/status')
-        response.is_a?(Net::HTTPSuccess)
+        response = http.get('/status')
+        return false unless response.is_a?(Net::HTTPSuccess)
+
+        status = JSON.parse(response.body)
+        status.dig('value', 'ready') == true
       end
     rescue StandardError
       false
@@ -268,10 +272,20 @@ module Selenium
       end
     end
 
-    def poll_for_service
-      return if socket.connected?
+    def poll_for_ready
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      loop do
+        return if status_ok?
 
-      raise Error, "remote server not launched in #{@timeout} seconds"
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        raise Error, "remote server not ready in #{@timeout} seconds" if elapsed > @timeout
+
+        sleep 0.5
+      end
+    end
+
+    def socket_connected?
+      @socket_connected ||= socket.connected?
     end
 
     def poll_for_shutdown

--- a/rb/sig/lib/selenium/server.rbs
+++ b/rb/sig/lib/selenium/server.rbs
@@ -26,6 +26,8 @@ module Selenium
 
     @socket: WebDriver::SocketPoller
 
+    @socket_connected: bool?
+
     class Error < StandardError
     end
 
@@ -73,7 +75,9 @@ module Selenium
 
     def process: () -> untyped
 
-    def poll_for_service: () -> nil?
+    def poll_for_ready: () -> nil?
+
+    def socket_connected?: () -> bool?
 
     def poll_for_shutdown: () -> nil?
 

--- a/rb/spec/unit/selenium/server_spec.rb
+++ b/rb/spec/unit/selenium/server_spec.rb
@@ -52,7 +52,7 @@ module Selenium
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: 1234, background: true)
-      allow(server).to receive(:socket).and_return(mock_poller)
+      allow(server).to receive_messages(socket: mock_poller, status_ok?: true)
 
       server.start
       expect(File).to have_received(:exist?).with('selenium_server_deploy.jar')
@@ -67,7 +67,7 @@ module Selenium
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: port)
-      allow(server).to receive(:socket).and_return(mock_poller)
+      allow(server).to receive_messages(socket: mock_poller, status_ok?: true)
       allow(mock_process).to receive(:wait)
 
       server.start
@@ -85,7 +85,7 @@ module Selenium
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', port: port, background: true)
-      allow(server).to receive(:socket).and_return(mock_poller)
+      allow(server).to receive_messages(socket: mock_poller, status_ok?: true)
 
       server << %w[foo bar]
 
@@ -109,7 +109,7 @@ module Selenium
         .and_return(mock_process)
 
       server = described_class.new('selenium_server_deploy.jar', background: true)
-      allow(server).to receive(:socket).and_return(mock_poller)
+      allow(server).to receive_messages(socket: mock_poller, status_ok?: true)
 
       server << %w[foo bar]
       server << '-Dwebdriver.chrome.driver=/bin/chromedriver'


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Similar to #16877 except for starting the server.

We're timing out sending a session request to the grid because it isn't ready for it, yet. We want a longer timeout for it to get ready, then a shorter timeout to fulfill the new session request.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Poll for ready status not just the socket connection


___

### **PR Type**
Bug fix


___

### **Description**
- Poll for actual server readiness status instead of just socket connection

- Check `/status` endpoint and verify `ready` flag in JSON response

- Implement longer timeout for server startup, shorter for session requests

- Update tests to mock `status_ok?` method instead of socket polling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Server Start"] --> B["poll_for_ready"]
  B --> C["Check status_ok?"]
  C --> D["Socket Connected?"]
  D --> E["HTTP GET /status"]
  E --> F["Parse JSON Response"]
  F --> G["Verify ready Flag"]
  G -->|Ready| H["Return Success"]
  G -->|Not Ready| I["Sleep & Retry"]
  I --> C
  G -->|Timeout| J["Raise Error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rb</strong><dd><code>Implement proper server readiness polling with status endpoint</code></dd></summary>
<hr>

rb/lib/selenium/server.rb

<ul><li>Added <code>require 'json'</code> for parsing HTTP response bodies<br> <li> Renamed <code>poll_for_service</code> to <code>poll_for_ready</code> with improved polling logic<br> <li> Enhanced <code>status_ok?</code> to check <code>/status</code> endpoint and verify <code>ready</code> flag in <br>JSON response<br> <li> Introduced <code>socket_connected?</code> helper method with caching via instance <br>variable<br> <li> Changed polling strategy to use longer timeout for server startup <br>readiness</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16896/files#diff-b79229af72183b83c001b2cebb5d6b26a49a807fea93c549b1ca11873dc672bb">+21/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_spec.rb</strong><dd><code>Update server tests to mock readiness status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/spec/unit/selenium/server_spec.rb

<ul><li>Updated four test cases to mock both <code>socket</code> and <code>status_ok?</code> methods <br>together<br> <li> Changed from <code>allow(server).to receive(:socket)</code> to <code>allow(server).to </code><br><code>receive_messages(socket: mock_poller, status_ok?: true)</code><br> <li> Ensures tests align with new polling mechanism that checks actual <br>server readiness</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16896/files#diff-2ee9a90f919428f99504c178e85e9cf08b738a0374be612657cdb50d58b4128c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rbs</strong><dd><code>Update type signatures for readiness polling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/sig/lib/selenium/server.rbs

<ul><li>Added <code>@socket_connected: bool?</code> instance variable declaration for <br>caching<br> <li> Renamed <code>poll_for_service</code> method signature to <code>poll_for_ready</code><br> <li> Added new <code>socket_connected?</code> method signature</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16896/files#diff-054c06e8bf0a0164818a78c526eb090bec35d347c8abe94771b2ba7a95fef091">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

