### PR TITLE
[build][rb][py] use arm binaries for mac

### DIFF
--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -123,10 +123,10 @@ js_library(
 
     pkg_archive(
         name = "mac_edge",
-        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/39c16afe-6ffe-42f8-aa82-4dd057fcf1d5/MicrosoftEdge-143.0.3650.96.pkg",
-        sha256 = "3fbb541e2761d0421073aa288c227738c6e133bf3fc4ecc3897495bf78ea4a19",
+        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/154ecf14-a4ec-4db2-b067-dfadc9975380/MicrosoftEdge-143.0.3650.139.pkg",
+        sha256 = "b46a657b6edf2cfcb5eba490b63f10f039a711cd8e6e2f62e87819d9f207dae9",
         move = {
-            "MicrosoftEdge-143.0.3650.96.pkg/Payload/Microsoft Edge.app": "Edge.app",
+            "MicrosoftEdge-143.0.3650.139.pkg/Payload/Microsoft Edge.app": "Edge.app",
         },
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -165,8 +165,8 @@ js_library(
 
     http_archive(
         name = "linux_edgedriver",
-        url = "https://msedgedriver.microsoft.com/143.0.3650.96/edgedriver_linux64.zip",
-        sha256 = "0f38c81a3571a2aa734f6aa0797dc8c218e41f164be6a727ddf4ba3b5bb3a6bd",
+        url = "https://msedgedriver.microsoft.com/143.0.3650.139/edgedriver_linux64.zip",
+        sha256 = "bdb28942eb3de0d5c0316d6adb1032c223d4a650dc0ef89fe1aed98dc7c088c8",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -182,8 +182,8 @@ js_library(
 
     http_archive(
         name = "mac_edgedriver",
-        url = "https://msedgedriver.microsoft.com/143.0.3650.96/edgedriver_mac64.zip",
-        sha256 = "99c35f51ea4ece7cce9cd640899872c72442f712c811225be867c692f8131282",
+        url = "https://msedgedriver.microsoft.com/143.0.3650.139/edgedriver_mac64.zip",
+        sha256 = "ecf175a76da54e5f2bfe60c8a94df86d823225dd448abfecf56b18b9cbd9b5a3",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -220,9 +220,9 @@ js_library(
     )
     http_archive(
         name = "mac_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/143.0.7499.192/mac-x64/chrome-mac-x64.zip",
-        sha256 = "8ee39f3f60dca99aef8bddef79c46fd135db5614987f9eed6cf25f3918910271",
-        strip_prefix = "chrome-mac-x64",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/143.0.7499.192/mac-arm64/chrome-mac-arm64.zip",
+        sha256 = "c90e053355e233a7eb668c1a202f83a7aff72a30f8786835750b86371cd4065e",
+        strip_prefix = "chrome-mac-arm64",
         patch_cmds = [
             "mv 'Google Chrome for Testing.app' Chrome.app",
             "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
@@ -259,9 +259,9 @@ js_library(
 
     http_archive(
         name = "mac_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/143.0.7499.192/mac-x64/chromedriver-mac-x64.zip",
-        sha256 = "2e104f71d6bc9e28cb475ae3f7cd5d4e475dde130cd28af7e23ab58c4dce4d74",
-        strip_prefix = "chromedriver-mac-x64",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/143.0.7499.192/mac-arm64/chromedriver-mac-arm64.zip",
+        sha256 = "30f79f97d3a3cd391b459694b718b4b90524e1f15e0aeb47d59d13fa9a7372ee",
+        strip_prefix = "chromedriver-mac-arm64",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -298,9 +298,9 @@ js_library(
     )
     http_archive(
         name = "mac_beta_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/144.0.7559.31/mac-x64/chrome-mac-x64.zip",
-        sha256 = "1fe7c08ea99c141ea3502c1b478ce7f9a687199b489e419f50ca8a248eacaad7",
-        strip_prefix = "chrome-mac-x64",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/144.0.7559.31/mac-arm64/chrome-mac-arm64.zip",
+        sha256 = "d2c6c15b3efbd9823ec5f7d712c09dfd5894a917c619263cc15f42f151677595",
+        strip_prefix = "chrome-mac-arm64",
         patch_cmds = [
             "mv 'Google Chrome for Testing.app' Chrome.app",
             "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
@@ -337,9 +337,9 @@ js_library(
 
     http_archive(
         name = "mac_beta_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/144.0.7559.31/mac-x64/chromedriver-mac-x64.zip",
-        sha256 = "eab345eaf4255430b62cebfb3f4728c3b8468f85a4a61f90eae550aa4dad6048",
-        strip_prefix = "chromedriver-mac-x64",
+        url = "https://storage.googleapis.com/chrome-for-testing-public/144.0.7559.31/mac-arm64/chromedriver-mac-arm64.zip",
+        sha256 = "be9525554cb863f6391c7b2bdbf95b95dc8b73cd6e42a692806b953d639255ff",
+        strip_prefix = "chromedriver-mac-arm64",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -106,8 +106,8 @@ js_library(
 
     http_archive(
         name = "mac_geckodriver",
-        url = "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-macos.tar.gz",
-        sha256 = "b5627bfc29801b8752c9f1e7699018963c39c076aab6576dc14fcb1ce7a256f6",
+        url = "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-macos-aarch64.tar.gz",
+        sha256 = "c045c8c0d859e6045defbb1c31b37ebeb3c942fc61daaf11e21fc634f2d71c52",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -182,8 +182,8 @@ js_library(
 
     http_archive(
         name = "mac_edgedriver",
-        url = "https://msedgedriver.microsoft.com/143.0.3650.139/edgedriver_mac64.zip",
-        sha256 = "ecf175a76da54e5f2bfe60c8a94df86d823225dd448abfecf56b18b9cbd9b5a3",
+        url = "https://msedgedriver.microsoft.com/143.0.3650.139/edgedriver_mac64_m1.zip",
+        sha256 = "097fe109a758d201a0f59801e44e5cfdbce5cce8bd4054fd39534b5a2410206b",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -165,8 +165,8 @@ js_library(
 
     http_archive(
         name = "linux_edgedriver",
-        url = "https://msedgedriver.microsoft.com/143.0.3650.139/edgedriver_linux64.zip",
-        sha256 = "bdb28942eb3de0d5c0316d6adb1032c223d4a650dc0ef89fe1aed98dc7c088c8",
+        url = "https://msedgedriver.microsoft.com/143.0.3650.96/edgedriver_linux64.zip",
+        sha256 = "0f38c81a3571a2aa734f6aa0797dc8c218e41f164be6a727ddf4ba3b5bb3a6bd",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -299,7 +299,7 @@ js_library(
         f"https://msedgedriver.microsoft.com/LATEST_RELEASE_{major_version}_MACOS",
     )
     macos_version = r.data.decode("utf-16").strip()
-    mac = "https://msedgedriver.microsoft.com/%s/edgedriver_mac64.zip" % macos_version
+    mac = "https://msedgedriver.microsoft.com/%s/edgedriver_mac64_m1.zip" % macos_version
     sha = calculate_hash(mac)
     content = (
         content
@@ -358,7 +358,7 @@ js_library(
                 % (url, sha)
             )
 
-        if a["name"].endswith("-macos.tar.gz"):
+        if a["name"].endswith("-macos-aarch64.tar.gz"):
             url = a["browser_download_url"]
             sha = calculate_hash(url)
             content = (

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -299,7 +299,9 @@ js_library(
         f"https://msedgedriver.microsoft.com/LATEST_RELEASE_{major_version}_MACOS",
     )
     macos_version = r.data.decode("utf-16").strip()
-    mac = "https://msedgedriver.microsoft.com/%s/edgedriver_mac64_m1.zip" % macos_version
+    mac = (
+        "https://msedgedriver.microsoft.com/%s/edgedriver_mac64_m1.zip" % macos_version
+    )
     sha = calculate_hash(mac)
     content = (
         content

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -74,7 +74,7 @@ js_library(
     )
 """
 
-    url = [d["url"] for d in drivers if d["platform"] == "mac-x64"][0]
+    url = [d["url"] for d in drivers if d["platform"] == "mac-arm64"][0]
     sha = calculate_hash(url)
 
     content += f"""
@@ -82,7 +82,7 @@ js_library(
         name = "mac_{workspace_prefix}chromedriver",
         url = "{url}",
         sha256 = "{sha}",
-        strip_prefix = "chromedriver-mac-x64",
+        strip_prefix = "chromedriver-mac-arm64",
         build_file_content = \"\"\"
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -131,14 +131,14 @@ js_library(
     )
 """
 
-    url = [d["url"] for d in chrome_downloads if d["platform"] == "mac-x64"][0]
+    url = [d["url"] for d in chrome_downloads if d["platform"] == "mac-arm64"][0]
     sha = calculate_hash(url)  # Calculate SHA for Mac chrome
 
     content += f"""    http_archive(
         name = "mac_{workspace_prefix}chrome",
         url = "{url}",
         sha256 = "{sha}",
-        strip_prefix = "chrome-mac-x64",
+        strip_prefix = "chrome-mac-arm64",
         patch_cmds = [
             "mv 'Google Chrome for Testing.app' Chrome.app",
             "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",


### PR DESCRIPTION
### **User description**
Things are timing out on the mac servers trying to use x64 binaries on mac. 

We should be ok to update unless any devs are on old macs?

I'll test Python & Ruby since both run tests on mac in GHA.


___

### **PR Type**
Enhancement


___

### **Description**
- Switch macOS binaries from x64 to ARM64 architecture

- Update Chrome and ChromeDriver to ARM64 versions

- Update Edge and EdgeDriver to latest versions

- Update Python script to reference ARM64 platform identifiers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS x64 binaries"] -->|"Update to ARM64"| B["Chrome/ChromeDriver ARM64"]
  A -->|"Update to ARM64"| C["Edge/EdgeDriver ARM64"]
  D["pinned_browsers.py"] -->|"Update platform filter"| E["mac-arm64 references"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.bzl</strong><dd><code>Update macOS binaries to ARM64 architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/repositories.bzl

<ul><li>Updated macOS Chrome from x64 to arm64 architecture with new URL and <br>SHA256<br> <li> Updated macOS ChromeDriver from x64 to arm64 with corresponding hash<br> <li> Updated macOS beta Chrome and ChromeDriver to arm64 versions<br> <li> Updated Edge and EdgeDriver URLs and hashes to version 143.0.3650.139</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16897/files#diff-25d82cd18102fed27d3202000e1f1b3a56a85ad2848236d91989cd30a3952401">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pinned_browsers.py</strong><dd><code>Update platform identifiers to ARM64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/pinned_browsers.py

<ul><li>Changed platform filter from <code>mac-x64</code> to <code>mac-arm64</code> for ChromeDriver <br>lookup<br> <li> Changed platform filter from <code>mac-x64</code> to <code>mac-arm64</code> for Chrome lookup<br> <li> Updated strip_prefix values to reference <code>chrome-mac-arm64</code> and <br><code>chromedriver-mac-arm64</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16897/files#diff-9bc520a03e2388594f328bfa1305be5eebb75ae0ce2966be57e29b6ea6e0df78">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

