### PR TITLE
create FakeWebDriver only if "browser=selenium-test"

### DIFF
--- a/java/test/org/openqa/selenium/remote/FakeWebDriverInfo.java
+++ b/java/test/org/openqa/selenium/remote/FakeWebDriverInfo.java
@@ -30,19 +30,21 @@ import org.openqa.selenium.WebDriverInfo;
 @AutoService(WebDriverInfo.class)
 public class FakeWebDriverInfo implements WebDriverInfo {
 
+  static final String FAKE_BROWSER = "selenium-test";
+
   @Override
   public String getDisplayName() {
-    return "selenium-test";
+    return FAKE_BROWSER;
   }
 
   @Override
   public Capabilities getCanonicalCapabilities() {
-    return new ImmutableCapabilities(BROWSER_NAME, "selenium-test");
+    return new ImmutableCapabilities(BROWSER_NAME, FAKE_BROWSER);
   }
 
   @Override
   public boolean isSupporting(Capabilities capabilities) {
-    return true;
+    return FAKE_BROWSER.equals(capabilities.getCapability(BROWSER_NAME));
   }
 
   @Override

--- a/java/test/org/openqa/selenium/remote/RemoteWebDriverBuilderTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteWebDriverBuilderTest.java
@@ -26,6 +26,8 @@ import static org.openqa.selenium.json.Json.JSON_UTF_8;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 import static org.openqa.selenium.remote.Browser.CHROME;
 import static org.openqa.selenium.remote.Browser.FIREFOX;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
+import static org.openqa.selenium.remote.FakeWebDriverInfo.FAKE_BROWSER;
 
 import java.io.File;
 import java.io.IOException;
@@ -338,7 +340,7 @@ class RemoteWebDriverBuilderTest {
 
     RemoteWebDriverBuilder builder =
         RemoteWebDriver.builder()
-            .oneOf(new ImmutableCapabilities("browser", "selenium-test"))
+            .oneOf(new ImmutableCapabilities(BROWSER_NAME, FAKE_BROWSER))
             .config(config)
             .connectingWith(clientConfig -> req -> CANNED_SESSION_RESPONSE);
 
@@ -385,7 +387,7 @@ class RemoteWebDriverBuilderTest {
       shouldUseWebDriverInfoToFindAMatchingDriverImplementationForRequestedCapabilitiesIfRemoteUrlNotSet() {
     WebDriver driver =
         RemoteWebDriver.builder()
-            .oneOf(new ImmutableCapabilities("browser", "selenium-test"))
+            .oneOf(new ImmutableCapabilities(BROWSER_NAME, FAKE_BROWSER))
             .connectingWith(config -> req -> CANNED_SESSION_RESPONSE)
             .build();
 


### PR DESCRIPTION
### **User description**
otherwise, FakeWebDriver is created every time when FakeWebDriverInfo is loaded before other *Infos from classpath (e.g. when running tests in IDEA).

### 💥 What does this PR do?
Fixes FakeWebDriver usage in tests



### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix FakeWebDriver instantiation to only occur when browser capability is "selenium-test"

- Change FakeWebDriverInfo.isSupporting() to validate browser name instead of accepting all capabilities

- Update test code to use BROWSER_NAME constant for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FakeWebDriverInfo.isSupporting()"] -->|"Previously: always true"| B["FakeWebDriver created unconditionally"]
  A -->|"Now: checks browser=selenium-test"| C["FakeWebDriver created only when needed"]
  D["Test code"] -->|"Use BROWSER_NAME constant"| E["Improved consistency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FakeWebDriverInfo.java</strong><dd><code>Restrict FakeWebDriver support to selenium-test browser</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/FakeWebDriverInfo.java

<ul><li>Modified <code>isSupporting()</code> method to validate that the browser capability <br>equals "selenium-test" instead of returning true for all capabilities<br> <li> Prevents FakeWebDriver from being instantiated when other <br>WebDriverInfo classes are available</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16898/files#diff-c75967c15ff218d7d50f2ed1b4de2167d80d7beba8b0ba2a2639f28c9101191f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Code consistency</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriverBuilderTest.java</strong><dd><code>Use BROWSER_NAME constant in test capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/remote/RemoteWebDriverBuilderTest.java

<ul><li>Added import for <code>BROWSER_NAME</code> constant from <code>CapabilityType</code><br> <li> Replaced hardcoded "browser" string with <code>BROWSER_NAME</code> constant in two <br>test cases<br> <li> Improves code consistency and maintainability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16898/files#diff-0754187c2e50fb09825b2e53914a3af3b2bd90e5b6dff1b619a3ac0b2408e30f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

