### PR TITLE
[java] SE_DEBUG dumps all log output to stderr

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -35,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.remote.service.DriverFinder;
 import org.openqa.selenium.remote.service.DriverService;
 
@@ -273,8 +274,9 @@ public class ChromeDriverService extends DriverService {
       if (appendLog == null) {
         this.appendLog = Boolean.getBoolean(CHROME_DRIVER_APPEND_LOG_PROPERTY);
       }
-      if (verbose == null && Boolean.getBoolean(CHROME_DRIVER_VERBOSE_LOG_PROPERTY)) {
-        withVerbose(Boolean.getBoolean(CHROME_DRIVER_VERBOSE_LOG_PROPERTY));
+      if (Debug.isDebugAll()
+          || (verbose == null && Boolean.getBoolean(CHROME_DRIVER_VERBOSE_LOG_PROPERTY))) {
+        withVerbose(true);
       }
       if (silent == null && Boolean.getBoolean(CHROME_DRIVER_SILENT_OUTPUT_PROPERTY)) {
         withSilent(Boolean.getBoolean(CHROME_DRIVER_SILENT_OUTPUT_PROPERTY));

--- a/java/src/org/openqa/selenium/edge/EdgeDriverService.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverService.java
@@ -33,6 +33,7 @@ import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.remote.service.DriverFinder;
 import org.openqa.selenium.remote.service.DriverService;
 
@@ -267,8 +268,9 @@ public class EdgeDriverService extends DriverService {
       if (appendLog == null) {
         this.appendLog = Boolean.getBoolean(EDGE_DRIVER_APPEND_LOG_PROPERTY);
       }
-      if (verbose == null && Boolean.getBoolean(EDGE_DRIVER_VERBOSE_LOG_PROPERTY)) {
-        withVerbose(Boolean.getBoolean(EDGE_DRIVER_VERBOSE_LOG_PROPERTY));
+      if (Debug.isDebugAll()
+          || (verbose == null && Boolean.getBoolean(EDGE_DRIVER_VERBOSE_LOG_PROPERTY))) {
+        withVerbose(true);
       }
       if (silent == null && Boolean.getBoolean(EDGE_DRIVER_SILENT_OUTPUT_PROPERTY)) {
         withSilent(Boolean.getBoolean(EDGE_DRIVER_SILENT_OUTPUT_PROPERTY));

--- a/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
+++ b/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.service.DriverService;
 
@@ -233,11 +234,11 @@ public class GeckoDriverService extends FirefoxDriverService {
     @Override
     protected void loadSystemProperties() {
       parseLogOutput(GECKO_DRIVER_LOG_PROPERTY);
-      if (logLevel == null) {
-        String logFilePath = System.getProperty(GECKO_DRIVER_LOG_LEVEL_PROPERTY);
-        if (logFilePath != null) {
-          this.logLevel = FirefoxDriverLogLevel.fromString(logFilePath);
-        }
+      if (Debug.isDebugAll()) {
+        logLevel = FirefoxDriverLogLevel.DEBUG;
+      } else if (logLevel == null) {
+        logLevel =
+            FirefoxDriverLogLevel.fromString(System.getProperty(GECKO_DRIVER_LOG_LEVEL_PROPERTY));
       }
       if (logTruncate == null) {
         logTruncate = !Boolean.getBoolean(GECKO_DRIVER_LOG_NO_TRUNCATE);

--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -32,6 +32,7 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import org.openqa.selenium.grid.config.Config;
 import org.openqa.selenium.grid.config.ConfigException;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.tracing.Tracer;
 import org.openqa.selenium.remote.tracing.empty.NullTracer;
@@ -84,6 +85,9 @@ public class LoggingOptions {
 
   public void setLoggingLevel() {
     String configLevel = config.get(LOGGING_SECTION, "log-level").orElse(DEFAULT_LOG_LEVEL);
+    if (Debug.isDebugAll()) {
+      configLevel = Level.FINE.getName();
+    }
 
     try {
       level = Level.parse(configLevel.toUpperCase(Locale.ROOT));
@@ -189,7 +193,7 @@ public class LoggingOptions {
                 throw new UncheckedIOException(e);
               }
             })
-        .orElse(System.out);
+        .orElseGet(() -> Debug.isDebugAll() ? System.err : System.out);
   }
 
   public String getLogTimestampFormat() {

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -27,9 +27,8 @@ public class Debug {
   static {
     boolean simpleProperty = Boolean.getBoolean("selenium.debug");
     boolean longerProperty = Boolean.getBoolean("selenium.webdriver.verbose");
-    boolean envVar = Boolean.parseBoolean(System.getenv("SE_DEBUG"));
 
-    IS_DEBUG = simpleProperty || longerProperty || envVar;
+    IS_DEBUG = simpleProperty || longerProperty || isDebugAll();
   }
 
   private Debug() {
@@ -42,5 +41,9 @@ public class Debug {
 
   public static Level getDebugLogLevel() {
     return isDebugging() ? Level.INFO : Level.FINE;
+  }
+
+  public static boolean isDebugAll() {
+    return Boolean.parseBoolean(System.getenv("SE_DEBUG"));
   }
 }

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -27,6 +27,7 @@ public class Debug {
 
   private static final boolean IS_DEBUG;
   private static boolean loggerConfigured = false;
+  private static Logger seleniumLogger;
 
   static {
     IS_DEBUG =
@@ -54,12 +55,12 @@ public class Debug {
       return;
     }
 
-    Logger logger = Logger.getLogger("org.openqa.selenium");
-    logger.setLevel(Level.FINE);
+    seleniumLogger = Logger.getLogger("org.openqa.selenium");
+    seleniumLogger.setLevel(Level.FINE);
 
     StreamHandler handler = new StreamHandler(System.err, new SimpleFormatter());
     handler.setLevel(Level.FINE);
-    logger.addHandler(handler);
+    seleniumLogger.addHandler(handler);
     loggerConfigured = true;
   }
 }

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -17,9 +17,9 @@
 
 package org.openqa.selenium.internal;
 
-import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 
 /** Used to provide information about whether Selenium is running under debug mode. */
@@ -57,14 +57,7 @@ public class Debug {
     Logger logger = Logger.getLogger("org.openqa.selenium");
     logger.setLevel(Level.FINE);
 
-    Handler handler =
-        new StreamHandler(System.err, new DebugLogFormatter()) {
-          @Override
-          public synchronized void publish(java.util.logging.LogRecord record) {
-            super.publish(record);
-            flush();
-          }
-        };
+    StreamHandler handler = new StreamHandler(System.err, new SimpleFormatter());
     handler.setLevel(Level.FINE);
     logger.addHandler(handler);
     loggerConfigured = true;

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -17,18 +17,20 @@
 
 package org.openqa.selenium.internal;
 
+import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
 
 /** Used to provide information about whether Selenium is running under debug mode. */
 public class Debug {
 
   private static final boolean IS_DEBUG;
+  private static boolean loggerConfigured = false;
 
   static {
-    boolean simpleProperty = Boolean.getBoolean("selenium.debug");
-    boolean longerProperty = Boolean.getBoolean("selenium.webdriver.verbose");
-
-    IS_DEBUG = simpleProperty || longerProperty || isDebugAll();
+    IS_DEBUG =
+        Boolean.getBoolean("selenium.debug") || Boolean.getBoolean("selenium.webdriver.verbose");
   }
 
   private Debug() {
@@ -45,5 +47,26 @@ public class Debug {
 
   public static boolean isDebugAll() {
     return Boolean.parseBoolean(System.getenv("SE_DEBUG"));
+  }
+
+  public static void configureLogger() {
+    if (!isDebugAll() || loggerConfigured) {
+      return;
+    }
+
+    Logger logger = Logger.getLogger("org.openqa.selenium");
+    logger.setLevel(Level.FINE);
+
+    Handler handler =
+        new StreamHandler(System.err, new DebugLogFormatter()) {
+          @Override
+          public synchronized void publish(java.util.logging.LogRecord record) {
+            super.publish(record);
+            flush();
+          }
+        };
+    handler.setLevel(Level.FINE);
+    logger.addHandler(handler);
+    loggerConfigured = true;
   }
 }

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -114,6 +114,10 @@ public class RemoteWebDriver
         PrintsPage,
         TakesScreenshot {
 
+  static {
+    org.openqa.selenium.internal.Debug.configureLogger();
+  }
+
   private static final Logger LOG = Logger.getLogger(RemoteWebDriver.class.getName());
 
   /** Boolean system property that defines whether the tracing is enabled or not. */

--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -46,6 +46,7 @@ import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.net.UrlChecker;
@@ -482,7 +483,8 @@ public class DriverService implements Closeable {
         return;
       }
 
-      String logLocation = System.getProperty(logProperty, LOG_NULL);
+      String defaultLocation = Debug.isDebugAll() ? LOG_STDERR : LOG_NULL;
+      String logLocation = System.getProperty(logProperty, defaultLocation);
       switch (logLocation) {
         case LOG_STDOUT:
           withLogOutput(System.out);


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Existing `Debug.java` implementation uses a clever trick to provide additional debugging info via system property by logging things that are normally "FINE" level at "INFO" so they are seen by the user without messing with their other logging setup. (See #12892)

So when I implemented #16816 I did the easy thing ad used it to toggle the clever behavior. Except this usage isn't consistent in the codebase, so it doesn't actually do that much.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Keeps existing released behavior for the 2 system properties
* Firehoses all debugging info to stderr when `SE_DEBUG` is set.
* Overrides Grid & Driver logging settings to use level `FINE`/`DEBUG` sent to stderr
* Adds a handler for Selenium JUL, so it is additive to user's other logging solutions unless they explicitly remove selenium handlers elsewhere.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* This is a "firehose to stderr" solution
* If a user has `SE_DEBUG` set for Selenium manager this will add a lot of extra output, so could be `SE_DEBUG_ALL`?

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Other languages next

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `SE_DEBUG` environment variable support for comprehensive debug logging

- Routes all Selenium debug output to stderr when `SE_DEBUG` is enabled

- Overrides driver and grid logging to use `FINE`/`DEBUG` level with stderr output

- Configures JUL handler for Selenium package to capture all debug information


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SE_DEBUG["SE_DEBUG env var"]
  isDebugAll["isDebugAll() check"]
  configLogger["configureLogger()"]
  driverService["Driver Services"]
  gridLogging["Grid Logging"]
  julHandler["JUL Handler to stderr"]
  
  SE_DEBUG --> isDebugAll
  isDebugAll --> configLogger
  configLogger --> julHandler
  isDebugAll --> driverService
  isDebugAll --> gridLogging
  driverService --> julHandler
  gridLogging --> julHandler
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Debug.java</strong><dd><code>Add SE_DEBUG support and logger configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/internal/Debug.java

<ul><li>Separates <code>SE_DEBUG</code> environment variable check into new <code>isDebugAll()</code> <br>method<br> <li> Removes <code>SE_DEBUG</code> from static <code>IS_DEBUG</code> initialization<br> <li> Adds <code>configureLogger()</code> method to set up JUL handler for stderr output<br> <li> Creates <code>StreamHandler</code> with <code>DebugLogFormatter</code> for Selenium package <br>logging</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-f322d38827e87e96c514d3ffb4cdedf88d826ffd6631b65c3b573f44638faf5d">+31/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChromeDriverService.java</strong><dd><code>Enable verbose logging when SE_DEBUG is set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/chrome/ChromeDriverService.java

<ul><li>Imports <code>Debug</code> class for debug mode checking<br> <li> Checks <code>Debug.isDebugAll()</code> to enable verbose logging<br> <li> Simplifies verbose flag setting to use boolean <code>true</code> instead of <br>property value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-405c68a6b743ea8f4b340b5ea0c92c802a24109b4c38818335f6ca39511e2bc8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EdgeDriverService.java</strong><dd><code>Enable verbose logging when SE_DEBUG is set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/edge/EdgeDriverService.java

<ul><li>Imports <code>Debug</code> class for debug mode checking<br> <li> Checks <code>Debug.isDebugAll()</code> to enable verbose logging<br> <li> Simplifies verbose flag setting to use boolean <code>true</code> instead of <br>property value</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-62903f54af704e41bd4657395512ce9c62fa0d4966ef3f0f665fcc045e7b15c4">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GeckoDriverService.java</strong><dd><code>Set Firefox debug level when SE_DEBUG is enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/firefox/GeckoDriverService.java

<ul><li>Imports <code>Debug</code> class for debug mode checking<br> <li> Sets log level to <code>DEBUG</code> when <code>SE_DEBUG</code> is enabled<br> <li> Refactors log level property parsing to handle null values properly</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-a441a4f6b8b9cfb6e4e25122a31c17dbf86beae9bf02521e1516b27fcd130245">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoggingOptions.java</strong><dd><code>Route grid logging to stderr in debug mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/log/LoggingOptions.java

<ul><li>Imports <code>Debug</code> class for debug mode checking<br> <li> Overrides log level to <code>FINE</code> when <code>SE_DEBUG</code> is enabled<br> <li> Routes output to stderr instead of stdout when <code>SE_DEBUG</code> is active</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-df04b67d453fdda127e86957b1cb29596a05a07e711f9081cfa4af5ed7094a1b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RemoteWebDriver.java</strong><dd><code>Initialize debug logger on RemoteWebDriver load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/RemoteWebDriver.java

<ul><li>Adds static initializer block to configure logger on class load<br> <li> Calls <code>Debug.configureLogger()</code> to set up JUL handler for debug output</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-0cf141b01e48a733ec9037c51d8e610e7727d05a6b79aa0176def7c3a0fc311b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DriverService.java</strong><dd><code>Route driver service output to stderr in debug mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/remote/service/DriverService.java

<ul><li>Imports <code>Debug</code> class for debug mode checking<br> <li> Routes driver output to stderr by default when <code>SE_DEBUG</code> is enabled<br> <li> Uses <code>LOG_STDERR</code> as default location instead of <code>LOG_NULL</code> in debug mode</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16900/files#diff-6a2bf51c104e6ba92d3820843d8da94e8557501e8aa10e1a4734016c0f4a0d7c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

