### PR TITLE
[rb] output driver logs by default when debug is enabled

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -96,7 +96,12 @@ module Selenium
 
     def self.logger(**)
       level = $DEBUG || ENV.key?('DEBUG') || ENV.key?('SE_DEBUG') ? :debug : :info
-      @logger ||= WebDriver::Logger.new('Selenium', default_level: level, **)
+      @logger ||= WebDriver::Logger.new('Selenium', default_level: level, **).tap do |logger|
+        if ENV.key?('SE_DEBUG')
+          logger.debug!
+          logger.stderr!
+        end
+      end
     end
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -27,7 +27,7 @@ module Selenium
         DRIVER_PATH_ENV_KEY = 'SE_CHROMEDRIVER'
 
         def initialize(args: nil, **)
-          if WebDriver.logger.debug?
+          if ENV.key?('SE_DEBUG')
             args = Array(args.dup)
             warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -26,6 +26,16 @@ module Selenium
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_CHROMEDRIVER'
 
+        def initialize(path: nil, port: nil, log: nil, args: nil)
+          args ||= []
+          if WebDriver.logger.debug?
+            args.reject! { |arg| arg.start_with?('--log-level') }
+            args << '--verbose'
+          end
+
+          super
+        end
+
         def log
           return @log unless @log.is_a? String
 

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -26,10 +26,10 @@ module Selenium
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_CHROMEDRIVER'
 
-        def initialize(path: nil, port: nil, log: nil, args: nil)
-          args ||= []
+        def initialize(args: nil, **)
           if WebDriver.logger.debug?
-            args.reject! { |arg| arg.start_with?('--log-level') }
+            args = Array(args.dup)
+            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'
           end
 

--- a/rb/lib/selenium/webdriver/chrome/service.rb
+++ b/rb/lib/selenium/webdriver/chrome/service.rb
@@ -29,7 +29,7 @@ module Selenium
         def initialize(args: nil, **)
           if WebDriver.logger.debug?
             args = Array(args.dup)
-            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
+            warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'
           end
 

--- a/rb/lib/selenium/webdriver/common/logger.rb
+++ b/rb/lib/selenium/webdriver/common/logger.rb
@@ -55,9 +55,32 @@ module Selenium
         @ignored = Array(ignored)
         @allowed = Array(allowed)
         @first_warning = false
+        @level_forced = false
+        @output_forced = false
+      end
+
+      #
+      # Forces debug level and prevents it from being overridden.
+      #
+      def debug!
+        @level_forced = true
+        @logger.level = :debug
+      end
+
+      #
+      # Forces output to stderr and prevents it from being overridden.
+      #
+      def stderr!
+        @output_forced = true
+        @logger.reopen($stderr)
       end
 
       def level=(level)
+        if @level_forced
+          warn('Logger level is forced; ignoring override', id: :logger)
+          return
+        end
+
         if level == :info && @logger.level == :info
           info(':info is now the default log level, to see additional logging, set log level to :debug')
         end
@@ -71,6 +94,11 @@ module Selenium
       # @param [String] io
       #
       def output=(io)
+        if @output_forced
+          warn('Logger output is forced; ignoring override', id: :logger)
+          return
+        end
+
         @logger.reopen(io)
       end
 

--- a/rb/lib/selenium/webdriver/common/service.rb
+++ b/rb/lib/selenium/webdriver/common/service.rb
@@ -108,8 +108,6 @@ module Selenium
       private
 
       def warn_driver_log_override
-        return unless ENV.key?('SE_DEBUG')
-
         WebDriver.logger.warn('SE_DEBUG is set; overriding user-specified driver logging settings', id: :se_debug)
       end
     end # Service

--- a/rb/lib/selenium/webdriver/common/service.rb
+++ b/rb/lib/selenium/webdriver/common/service.rb
@@ -104,6 +104,14 @@ module Selenium
       def env_path
         ENV.fetch(self.class::DRIVER_PATH_ENV_KEY, nil)
       end
+
+      private
+
+      def warn_driver_log_override
+        return unless ENV.key?('SE_DEBUG')
+
+        WebDriver.logger.warn('SE_DEBUG is set; overriding user-specified driver logging settings', id: :se_debug)
+      end
     end # Service
   end # WebDriver
 end # Selenium

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -80,7 +80,15 @@ module Selenium
       def build_process(*command)
         WebDriver.logger.debug("Executing Process #{command}", id: :driver_service)
         @process = ChildProcess.build(*command)
-        @io ||= WebDriver.logger.io if WebDriver.logger.debug?
+        if ENV.key?('SE_DEBUG')
+          if @io && @io != WebDriver.logger.io
+            WebDriver.logger.warn('SE_DEBUG is set; overriding user-specified driver log output to use stderr',
+                                  id: :se_debug)
+          end
+          @io = WebDriver.logger.io
+        elsif WebDriver.logger.debug?
+          @io ||= WebDriver.logger.io
+        end
         @process.io = @io if @io
 
         @process

--- a/rb/lib/selenium/webdriver/common/service_manager.rb
+++ b/rb/lib/selenium/webdriver/common/service_manager.rb
@@ -86,8 +86,6 @@ module Selenium
                                   id: :se_debug)
           end
           @io = WebDriver.logger.io
-        elsif WebDriver.logger.debug?
-          @io ||= WebDriver.logger.io
         end
         @process.io = @io if @io
 

--- a/rb/lib/selenium/webdriver/edge/service.rb
+++ b/rb/lib/selenium/webdriver/edge/service.rb
@@ -25,6 +25,17 @@ module Selenium
         EXECUTABLE = 'msedgedriver'
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_EDGEDRIVER'
+
+        def initialize(path: nil, port: nil, log: nil, args: nil)
+          args ||= []
+          if WebDriver.logger.debug?
+            args.reject! { |arg| arg.start_with?('--log-level') }
+            args << '--verbose'
+          end
+
+          super
+        end
+
         def log
           return @log unless @log.is_a? String
 

--- a/rb/lib/selenium/webdriver/edge/service.rb
+++ b/rb/lib/selenium/webdriver/edge/service.rb
@@ -26,10 +26,10 @@ module Selenium
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_EDGEDRIVER'
 
-        def initialize(path: nil, port: nil, log: nil, args: nil)
-          args ||= []
+        def initialize(args: nil, **)
           if WebDriver.logger.debug?
-            args.reject! { |arg| arg.start_with?('--log-level') }
+            args = Array(args.dup)
+            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'
           end
 

--- a/rb/lib/selenium/webdriver/edge/service.rb
+++ b/rb/lib/selenium/webdriver/edge/service.rb
@@ -29,7 +29,7 @@ module Selenium
         def initialize(args: nil, **)
           if WebDriver.logger.debug?
             args = Array(args.dup)
-            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
+            warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'
           end
 

--- a/rb/lib/selenium/webdriver/edge/service.rb
+++ b/rb/lib/selenium/webdriver/edge/service.rb
@@ -27,7 +27,7 @@ module Selenium
         DRIVER_PATH_ENV_KEY = 'SE_EDGEDRIVER'
 
         def initialize(args: nil, **)
-          if WebDriver.logger.debug?
+          if ENV.key?('SE_DEBUG')
             args = Array(args.dup)
             warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--verbose'

--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -26,8 +26,8 @@ module Selenium
         SHUTDOWN_SUPPORTED = false
         DRIVER_PATH_ENV_KEY = 'SE_GECKODRIVER'
 
-        def initialize(path: nil, port: nil, log: nil, args: nil)
-          args ||= []
+        def initialize(args: nil, **)
+          args = Array(args.dup)
           unless args.any? { |arg| arg.include?('--connect-existing') || arg.include?('--websocket-port') }
             args << '--websocket-port'
             args << '0'
@@ -40,8 +40,7 @@ module Selenium
             elsif (index = args.index { |arg| arg.start_with?('--log=') })
               args.delete_at(index)
             end
-            args << '--log'
-            args << 'debug'
+            args << '-v'
           end
 
           super

--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -33,19 +33,25 @@ module Selenium
             args << '0'
           end
 
-          if WebDriver.logger.debug?
-            if (index = args.index('--log'))
-              args.delete_at(index) # delete '--log'
-              args.delete_at(index) # delete the value (now at same index)
-              warn_driver_log_override
-            elsif (index = args.index { |arg| arg.start_with?('--log=') })
-              args.delete_at(index)
-              warn_driver_log_override
-            end
+          if ENV.key?('SE_DEBUG')
+            remove_log_args(args)
             args << '-v'
           end
 
           super
+        end
+
+        private
+
+        def remove_log_args(args)
+          if (index = args.index('--log'))
+            args.delete_at(index) # delete '--log'
+            args.delete_at(index) if args[index] && !args[index].start_with?('-') # delete value if present
+            warn_driver_log_override
+          elsif (index = args.index { |arg| arg.start_with?('--log=') })
+            args.delete_at(index)
+            warn_driver_log_override
+          end
         end
       end # Service
     end # Firefox

--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -37,8 +37,10 @@ module Selenium
             if (index = args.index('--log'))
               args.delete_at(index) # delete '--log'
               args.delete_at(index) # delete the value (now at same index)
+              warn_driver_log_override
             elsif (index = args.index { |arg| arg.start_with?('--log=') })
               args.delete_at(index)
+              warn_driver_log_override
             end
             args << '-v'
           end

--- a/rb/lib/selenium/webdriver/firefox/service.rb
+++ b/rb/lib/selenium/webdriver/firefox/service.rb
@@ -32,6 +32,18 @@ module Selenium
             args << '--websocket-port'
             args << '0'
           end
+
+          if WebDriver.logger.debug?
+            if (index = args.index('--log'))
+              args.delete_at(index) # delete '--log'
+              args.delete_at(index) # delete the value (now at same index)
+            elsif (index = args.index { |arg| arg.start_with?('--log=') })
+              args.delete_at(index)
+            end
+            args << '--log'
+            args << 'debug'
+          end
+
           super
         end
       end # Service

--- a/rb/lib/selenium/webdriver/ie/service.rb
+++ b/rb/lib/selenium/webdriver/ie/service.rb
@@ -26,10 +26,10 @@ module Selenium
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_IEDRIVER'
 
-        def initialize(path: nil, port: nil, log: nil, args: nil)
-          args ||= []
+        def initialize(args: nil, **)
           if WebDriver.logger.debug?
-            args.reject! { |arg| arg.start_with?('--log-level') }
+            args = Array(args.dup)
+            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--log-level=DEBUG'
           end
 

--- a/rb/lib/selenium/webdriver/ie/service.rb
+++ b/rb/lib/selenium/webdriver/ie/service.rb
@@ -29,7 +29,7 @@ module Selenium
         def initialize(args: nil, **)
           if WebDriver.logger.debug?
             args = Array(args.dup)
-            args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
+            warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--log-level=DEBUG'
           end
 

--- a/rb/lib/selenium/webdriver/ie/service.rb
+++ b/rb/lib/selenium/webdriver/ie/service.rb
@@ -25,6 +25,16 @@ module Selenium
         EXECUTABLE = 'IEDriverServer'
         SHUTDOWN_SUPPORTED = true
         DRIVER_PATH_ENV_KEY = 'SE_IEDRIVER'
+
+        def initialize(path: nil, port: nil, log: nil, args: nil)
+          args ||= []
+          if WebDriver.logger.debug?
+            args.reject! { |arg| arg.start_with?('--log-level') }
+            args << '--log-level=DEBUG'
+          end
+
+          super
+        end
       end # Server
     end # IE
   end # WebDriver

--- a/rb/lib/selenium/webdriver/ie/service.rb
+++ b/rb/lib/selenium/webdriver/ie/service.rb
@@ -27,7 +27,7 @@ module Selenium
         DRIVER_PATH_ENV_KEY = 'SE_IEDRIVER'
 
         def initialize(args: nil, **)
-          if WebDriver.logger.debug?
+          if ENV.key?('SE_DEBUG')
             args = Array(args.dup)
             warn_driver_log_override if args.reject! { |arg| arg.include?('log-level') || arg.include?('silent') }
             args << '--log-level=DEBUG'

--- a/rb/sig/lib/selenium/webdriver/chrome/service.rbs
+++ b/rb/sig/lib/selenium/webdriver/chrome/service.rbs
@@ -12,6 +12,8 @@ module Selenium
 
         SHUTDOWN_SUPPORTED: bool
 
+        def initialize: (?args: Array[String]?, **untyped) -> void
+
         def log: () -> untyped
       end
     end

--- a/rb/sig/lib/selenium/webdriver/common/logger.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/logger.rbs
@@ -4,15 +4,21 @@ module Selenium
 
       @allowed: Array[Symbol]
       @first_warning: bool
+      @level_forced: bool
+      @output_forced: bool
 
       @ignored: Array[Symbol]
       @logger: ::Logger
 
       def initialize: (?::String progname, ?default_level: Symbol? default_level, ?ignored: Array[Symbol]? ignored, ?allowed: Array[Symbol]? allowed) -> void
 
-      def level=: (Symbol level) -> Symbol
+      def debug!: () -> void
 
-      def output=: (String io) -> ::Logger
+      def stderr!: () -> void
+
+      def level=: (Symbol level) -> Symbol?
+
+      def output=: (String io) -> ::Logger?
 
       def io: () -> IO
 

--- a/rb/sig/lib/selenium/webdriver/common/service.rbs
+++ b/rb/sig/lib/selenium/webdriver/common/service.rbs
@@ -60,6 +60,10 @@ module Selenium
       def launch: () -> untyped
 
       def shutdown_supported: () -> untyped
+
+      private
+
+      def warn_driver_log_override: () -> void
     end
   end
 end

--- a/rb/sig/lib/selenium/webdriver/edge/service.rbs
+++ b/rb/sig/lib/selenium/webdriver/edge/service.rbs
@@ -12,6 +12,8 @@ module Selenium
 
         SHUTDOWN_SUPPORTED: bool
 
+        def initialize: (?args: Array[String]?, **untyped) -> void
+
         def log: () -> untyped
       end
     end

--- a/rb/sig/lib/selenium/webdriver/firefox/service.rbs
+++ b/rb/sig/lib/selenium/webdriver/firefox/service.rbs
@@ -10,6 +10,10 @@ module Selenium
         SHUTDOWN_SUPPORTED: false
 
         def initialize: (?path: String?, ?port: Integer?, ?log: untyped?, ?args: Array[String]?) -> void
+
+        private
+
+        def remove_log_args: (Array[String] args) -> void
       end
     end
   end

--- a/rb/sig/lib/selenium/webdriver/ie/service.rbs
+++ b/rb/sig/lib/selenium/webdriver/ie/service.rbs
@@ -8,6 +8,8 @@ module Selenium
         EXECUTABLE: String
 
         SHUTDOWN_SUPPORTED: bool
+
+        def initialize: (?args: Array[String]?, **untyped) -> void
       end
     end
   end

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -82,6 +82,35 @@ module Selenium
 
             expect(service.extra_args).to eq ['--foo', '--bar']
           end
+
+          context 'when SE_DEBUG is set' do
+            around do |example|
+              ENV['SE_DEBUG'] = '1'
+              example.run
+            ensure
+              ENV.delete('SE_DEBUG')
+            end
+
+            it 'adds --verbose flag' do
+              service = described_class.new
+
+              expect(service.extra_args).to include('--verbose')
+            end
+
+            it 'removes conflicting --log-level args' do
+              service = described_class.new(args: ['--log-level=INFO'])
+
+              expect(service.extra_args).to include('--verbose')
+              expect(service.extra_args).not_to include('--log-level=INFO')
+            end
+
+            it 'removes conflicting --silent args' do
+              service = described_class.new(args: ['--silent'])
+
+              expect(service.extra_args).to include('--verbose')
+              expect(service.extra_args).not_to include('--silent')
+            end
+          end
         end
 
         context 'when initializing driver' do

--- a/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/chrome/service_spec.rb
@@ -28,6 +28,7 @@ module Selenium
 
           before do
             allow(Platform).to receive(:assert_executable)
+            allow(WebDriver.logger).to receive(:debug?).and_return(false)
           end
 
           after { described_class.driver_path = nil }

--- a/rb/spec/unit/selenium/webdriver/common/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/common/service_spec.rb
@@ -26,6 +26,7 @@ module Selenium
 
       before do
         allow(Platform).to receive(:assert_executable)
+        allow(WebDriver.logger).to receive(:debug?).and_return(false)
         stub_const('Selenium::WebDriver::Service::DEFAULT_PORT', 1234)
         stub_const('Selenium::WebDriver::Service::EXECUTABLE', 'service')
       end
@@ -48,7 +49,7 @@ module Selenium
         it 'creates Firefox instance' do
           service = described_class.firefox(args: args)
           expect(service).to be_a(Firefox::Service)
-          expect(service.args).to eq args
+          expect(service.args).to eq(args + %w[--websocket-port 0])
         end
 
         it 'creates IE instance' do

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -81,6 +81,35 @@ module Selenium
 
             expect(service.extra_args).to eq ['--foo', '--bar']
           end
+
+          context 'when SE_DEBUG is set' do
+            around do |example|
+              ENV['SE_DEBUG'] = '1'
+              example.run
+            ensure
+              ENV.delete('SE_DEBUG')
+            end
+
+            it 'adds --verbose flag' do
+              service = described_class.new
+
+              expect(service.extra_args).to include('--verbose')
+            end
+
+            it 'removes conflicting --log-level args' do
+              service = described_class.new(args: ['--log-level=INFO'])
+
+              expect(service.extra_args).to include('--verbose')
+              expect(service.extra_args).not_to include('--log-level=INFO')
+            end
+
+            it 'removes conflicting --silent args' do
+              service = described_class.new(args: ['--silent'])
+
+              expect(service.extra_args).to include('--verbose')
+              expect(service.extra_args).not_to include('--silent')
+            end
+          end
         end
 
         context 'when initializing driver' do

--- a/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/edge/service_spec.rb
@@ -28,6 +28,7 @@ module Selenium
 
           before do
             allow(Platform).to receive(:assert_executable)
+            allow(WebDriver.logger).to receive(:debug?).and_return(false)
             described_class.driver_path = nil
           end
 

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -100,6 +100,43 @@ module Selenium
               expect(service.extra_args).to eq(['--websocket-port=1234'])
             end
           end
+
+          context 'when SE_DEBUG is set' do
+            around do |example|
+              ENV['SE_DEBUG'] = '1'
+              example.run
+            ensure
+              ENV.delete('SE_DEBUG')
+            end
+
+            it 'adds -v flag' do
+              service = described_class.new
+
+              expect(service.extra_args).to include('-v')
+            end
+
+            it 'removes conflicting --log args with value' do
+              service = described_class.new(args: ['--log', 'info'])
+
+              expect(service.extra_args).to include('-v')
+              expect(service.extra_args).not_to include('--log')
+              expect(service.extra_args).not_to include('info')
+            end
+
+            it 'removes conflicting --log= args' do
+              service = described_class.new(args: ['--log=info'])
+
+              expect(service.extra_args).to include('-v')
+              expect(service.extra_args).not_to include('--log=info')
+            end
+
+            it 'does not remove next arg if --log has no value' do
+              service = described_class.new(args: ['--log', '--other-flag'])
+
+              expect(service.extra_args).to include('-v')
+              expect(service.extra_args).to include('--other-flag')
+            end
+          end
         end
 
         context 'when initializing driver' do

--- a/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/firefox/service_spec.rb
@@ -28,6 +28,7 @@ module Selenium
 
           before do
             allow(Platform).to receive(:assert_executable)
+            allow(WebDriver.logger).to receive(:debug?).and_return(false)
           end
 
           it 'uses default port and nil path' do
@@ -48,7 +49,7 @@ module Selenium
             expect(service.port).to eq port
           end
 
-          it 'does not create args by default' do
+          it 'creates websocket args by default' do
             service = described_class.new
 
             expect(service.extra_args.count).to eq 2

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -79,6 +79,35 @@ module Selenium
 
             expect(service.extra_args).to eq ['--foo', '--bar']
           end
+
+          context 'when SE_DEBUG is set' do
+            around do |example|
+              ENV['SE_DEBUG'] = '1'
+              example.run
+            ensure
+              ENV.delete('SE_DEBUG')
+            end
+
+            it 'adds --log-level=DEBUG flag' do
+              service = described_class.new
+
+              expect(service.extra_args).to include('--log-level=DEBUG')
+            end
+
+            it 'removes conflicting --log-level args' do
+              service = described_class.new(args: ['--log-level=INFO'])
+
+              expect(service.extra_args).to include('--log-level=DEBUG')
+              expect(service.extra_args).not_to include('--log-level=INFO')
+            end
+
+            it 'removes conflicting --silent args' do
+              service = described_class.new(args: ['--silent'])
+
+              expect(service.extra_args).to include('--log-level=DEBUG')
+              expect(service.extra_args).not_to include('--silent')
+            end
+          end
         end
 
         context 'when initializing driver' do

--- a/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
+++ b/rb/spec/unit/selenium/webdriver/ie/service_spec.rb
@@ -28,6 +28,7 @@ module Selenium
 
           before do
             allow(Platform).to receive(:assert_executable)
+            allow(WebDriver.logger).to receive(:debug?).and_return(false)
           end
 
           it 'uses default port and nil path' do


### PR DESCRIPTION
### **User description**
**Update:** Changed to only trigger on `SE_DEBUG` env var (not `DEBUG`/`$DEBUG`). 
Added Logger force methods, warnings when overriding user settings, and fixed Firefox arg parsing bug.

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Similar to #16900
I actually thought Ruby already did this.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* ~~when `WebDriver.logger.debug?` adds driver log output to logger~~
* *Edit: Only `SE_DEBUG` env var enables driver verbose logging*
* *Edit: Adds `Logger#debug!` and `Logger#stderr!` to force settings*
* *Edit: Warns when overriding user-specified driver logging settings*
* *Edit: Forces driver output to stderr when SE_DEBUG is set*

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* ~~we could have a separate setting for this in logger instead of forcing it on existing debug setups. Or toggle it based on `SE_DEBUG` (the new behavior)~~
* *Edit: Chose SE_DEBUG-only approach for cross-binding consistency*
* *Edit: DEBUG/$DEBUG continues to only affect Selenium's own logging (preserves existing behavior)*
* *Edit: Logger force methods are generic (not SE_DEBUG-aware) to keep Logger reusable*


___

### **PR Type**
Enhancement


___

### **Description**
- Enable verbose driver logging when WebDriver debug mode is active

- Add automatic log level configuration for Chrome, Edge, Firefox, IE

- Remove conflicting log-level arguments before applying debug settings

- Unify debug logging behavior across all supported browser drivers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebDriver.logger.debug?"] -->|enabled| B["Chrome/Edge Service"]
  A -->|enabled| C["Firefox Service"]
  A -->|enabled| D["IE Service"]
  B -->|add --verbose| E["Driver Logs"]
  C -->|set --log debug| E
  D -->|add --log-level=DEBUG| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rb</strong><dd><code>Add verbose logging for Chrome when debug enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/chrome/service.rb

<ul><li>Override <code>initialize</code> method to check WebDriver debug status<br> <li> Remove any existing <code>--log-level</code> arguments from args<br> <li> Add <code>--verbose</code> flag when debug mode is enabled<br> <li> Call parent class initialization with modified arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16901/files#diff-6f75aac92ecf2cf5729b224e082b53f87eb90c59e30e93d626599c04bfbf35e5">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rb</strong><dd><code>Add verbose logging for Edge when debug enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/edge/service.rb

<ul><li>Override <code>initialize</code> method to check WebDriver debug status<br> <li> Remove any existing <code>--log-level</code> arguments from args<br> <li> Add <code>--verbose</code> flag when debug mode is enabled<br> <li> Call parent class initialization with modified arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16901/files#diff-65f982218cda17117bda11beaf5d4e1c975c71da3266c88c311286af22b02532">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rb</strong><dd><code>Add debug logging for Firefox when debug enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/firefox/service.rb

<ul><li>Extend existing <code>initialize</code> method with debug logging logic<br> <li> Remove existing <code>--log</code> arguments and their values if present<br> <li> Add <code>--log debug</code> arguments when debug mode is enabled<br> <li> Preserve existing websocket port configuration logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16901/files#diff-2311788d16c9242f68586a131842f15bd0df08ceccd992c0711042f4c70a51bd">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rb</strong><dd><code>Add debug logging for IE when debug enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rb/lib/selenium/webdriver/ie/service.rb

<ul><li>Override <code>initialize</code> method to check WebDriver debug status<br> <li> Remove any existing <code>--log-level</code> arguments from args<br> <li> Add <code>--log-level=DEBUG</code> flag when debug mode is enabled<br> <li> Call parent class initialization with modified arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16901/files#diff-530e71a224df7dd3fc20e915ac301b0c5a337741584709a4fc98a1c4268cfea8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

