### PR TITLE
[py] have SE_DEBUG output driver logs as well

### DIFF
--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -55,7 +55,9 @@ class ChromiumService(service.Service):
             self.log_output = log_output
 
         if os.environ.get("SE_DEBUG"):
-            self._service_args = [arg for arg in self._service_args if "--log-level" not in arg and arg != "--silent"]
+            self._service_args = [
+                arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-path", "silent"))
+            ]
             self._service_args.append("--verbose")
             self.log_output = sys.stderr
 

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
+import sys
 from collections.abc import Mapping, Sequence
 from typing import IO, Any
 
@@ -51,6 +53,12 @@ class ChromiumService(service.Service):
             self.log_output = None
         else:
             self.log_output = log_output
+
+        if os.environ.get("SE_DEBUG"):
+            # --verbose, --silent, and --log-level are mutually exclusive
+            self._service_args = [arg for arg in self._service_args if "--log-level" not in arg and arg != "--silent"]
+            self._service_args.append("--verbose")
+            self.log_output = sys.stderr
 
         super().__init__(
             executable_path=executable_path,

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -55,7 +55,6 @@ class ChromiumService(service.Service):
             self.log_output = log_output
 
         if os.environ.get("SE_DEBUG"):
-            # --verbose, --silent, and --log-level are mutually exclusive
             self._service_args = [arg for arg in self._service_args if "--log-level" not in arg and arg != "--silent"]
             self._service_args.append("--verbose")
             self.log_output = sys.stderr

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
+import sys
 from collections.abc import Mapping, Sequence
 from typing import IO, Any
 
@@ -45,6 +47,16 @@ class Service(service.Service):
     ) -> None:
         self._service_args = list(service_args or [])
         driver_path_env_key = driver_path_env_key or "SE_GECKODRIVER"
+
+        if os.environ.get("SE_DEBUG"):
+            if "--log" in self._service_args:
+                idx = self._service_args.index("--log")
+                del self._service_args[idx : idx + 2]
+            else:
+                self._service_args = [arg for arg in self._service_args if not arg.startswith("--log=")]
+            self._service_args.append("--log")
+            self._service_args.append("debug")
+            log_output = sys.stderr
 
         super().__init__(
             executable_path=executable_path,

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -58,7 +58,9 @@ class Service(service.Service):
             self._service_args.append(f"--log-level={log_level}")
 
         if os.environ.get("SE_DEBUG"):
-            self._service_args = [arg for arg in self._service_args if "--log-level" not in arg]
+            self._service_args = [
+                arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-file"))
+            ]
             self._service_args.append("--log-level=DEBUG")
             log_output = sys.stderr
 

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
+import sys
 from collections.abc import Sequence
 from typing import IO, Any
 
@@ -54,6 +56,11 @@ class Service(service.Service):
             self._service_args.append(f"--host={host}")
         if log_level:
             self._service_args.append(f"--log-level={log_level}")
+
+        if os.environ.get("SE_DEBUG"):
+            self._service_args = [arg for arg in self._service_args if "--log-level" not in arg]
+            self._service_args.append("--log-level=DEBUG")
+            log_output = sys.stderr
 
         super().__init__(
             executable_path=executable_path,

--- a/py/test/selenium/webdriver/common/window_switching_tests.py
+++ b/py/test/selenium/webdriver/common/window_switching_tests.py
@@ -52,7 +52,7 @@ def test_should_switch_focus_to_anew_window_when_it_is_opened_and_not_stop_futur
     handles = driver.window_handles
     handles.remove(current)
     driver.switch_to.window(handles[0])
-    assert driver.title == "We Arrive Here"
+    WebDriverWait(driver, 3).until(EC.title_is("We Arrive Here"))
 
     pages.load("iframes.html")
     handle = driver.current_window_handle


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
Python version of #16900

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* SE_DEBUG environment variable forces driver logs to stderr (as well as the selenium logging)

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
--verbose, --silent, and --log-level are mutually exclusive, so need to remove the others if forcing verbose

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Add SE_DEBUG environment variable support to output driver logs to stderr

- Implement debug logging for Chromium-based browsers with --verbose flag

- Implement debug logging for Firefox with --log debug flag

- Implement debug logging for Internet Explorer with --log-level=DEBUG flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SE_DEBUG env var set"] --> B["Chromium Service"]
  A --> C["Firefox Service"]
  A --> D["IE Service"]
  B --> E["--verbose flag + stderr"]
  C --> F["--log debug flag + stderr"]
  D --> G["--log-level=DEBUG flag + stderr"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Add SE_DEBUG support for Chromium driver logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/chromium/service.py

<ul><li>Import <code>os</code> and <code>sys</code> modules<br> <li> Add SE_DEBUG environment variable check in <code>__init__</code> method<br> <li> Remove conflicting <code>--log-level</code> and <code>--silent</code> arguments when SE_DEBUG is <br>set<br> <li> Append <code>--verbose</code> flag and redirect log output to <code>sys.stderr</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16902/files#diff-062c917a35158860c8065910187232dbab480ac982cc48bb293c8e808d29818e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Add SE_DEBUG support for Firefox driver logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/firefox/service.py

<ul><li>Import <code>os</code> and <code>sys</code> modules<br> <li> Add SE_DEBUG environment variable check in <code>__init__</code> method<br> <li> Remove existing <code>--log</code> arguments and replace with <code>--log debug</code><br> <li> Redirect log output to <code>sys.stderr</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16902/files#diff-1e444af73ad0e1c989ee6c2b0e03dd257071fe4a165e450a23bd86bea7d26323">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Add SE_DEBUG support for IE driver logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/ie/service.py

<ul><li>Import <code>os</code> and <code>sys</code> modules<br> <li> Add SE_DEBUG environment variable check in <code>__init__</code> method<br> <li> Remove conflicting <code>--log-level</code> arguments and set to <code>--log-level=DEBUG</code><br> <li> Redirect log output to <code>sys.stderr</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16902/files#diff-a13e626edcc84bf396cd60c854a31afd904cdeac659b8ab0b04ff98d9def7b02">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

