### PR TITLE
[dotnet] have SE_DEBUG output driver logs to stderr

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -120,23 +120,29 @@ public abstract class ChromiumDriverService : DriverService
 
             if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
             {
-                if (this.SuppressInitialDiagnosticInformation || this.LogLevel != ChromiumDriverLogLevel.Default)
+                if (this.SuppressInitialDiagnosticInformation ||
+                    (this.LogLevel != ChromiumDriverLogLevel.Default && this.LogLevel != ChromiumDriverLogLevel.All))
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing ChromiumDriver --verbose and overriding --silent/--log-level settings.");
                 }
                 argsBuilder.Append(" --verbose");
             }
-            else if (this.EnableVerboseLogging)
+            else
             {
-                argsBuilder.Append(" --verbose");
-            }
-            else if (this.SuppressInitialDiagnosticInformation)
-            {
-                argsBuilder.Append(" --silent");
-            }
-            else if (this.LogLevel != ChromiumDriverLogLevel.Default)
-            {
-                argsBuilder.Append($" --log-level={this.LogLevel.ToString().ToUpperInvariant()}");
+                if (this.EnableVerboseLogging)
+                {
+                    argsBuilder.Append(" --verbose");
+                }
+
+                if (this.SuppressInitialDiagnosticInformation)
+                {
+                    argsBuilder.Append(" --silent");
+                }
+
+                if (this.LogLevel != ChromiumDriverLogLevel.Default)
+                {
+                    argsBuilder.Append($" --log-level={this.LogLevel.ToString().ToUpperInvariant()}");
+                }
             }
 
             if (this.EnableAppendLog)

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -113,19 +113,30 @@ public abstract class ChromiumDriverService : DriverService
                 argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --adb-port={0}", adb);
             }
 
-            if (this.SuppressInitialDiagnosticInformation)
-            {
-                argsBuilder.Append(" --silent");
-            }
-
             if (this.DisableBuildCheck)
             {
                 argsBuilder.Append(" --disable-build-check");
             }
 
-            if (this.EnableVerboseLogging)
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
+            {
+                if (this.SuppressInitialDiagnosticInformation || this.LogLevel != ChromiumDriverLogLevel.Default)
+                {
+                    Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing ChromiumDriver --verbose and overriding --silent/--log-level settings.");
+                }
+            }
+
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.EnableVerboseLogging)
             {
                 argsBuilder.Append(" --verbose");
+            }
+            else if (this.SuppressInitialDiagnosticInformation)
+            {
+                argsBuilder.Append(" --silent");
+            }
+            else if (this.LogLevel != ChromiumDriverLogLevel.Default)
+            {
+                argsBuilder.Append($" --log-level={this.LogLevel.ToString().ToUpperInvariant()}");
             }
 
             if (this.EnableAppendLog)
@@ -155,12 +166,7 @@ public abstract class ChromiumDriverService : DriverService
 
             if (!string.IsNullOrEmpty(this.AllowedIPAddresses))
             {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -allowed-ips={0}", this.AllowedIPAddresses));
-            }
-
-            if (this.LogLevel != ChromiumDriverLogLevel.Default)
-            {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log-level={0}", this.LogLevel.ToString().ToUpperInvariant()));
+                argsBuilder.Append($" -allowed-ips={this.AllowedIPAddresses}");
             }
 
             // Unconditionally redirect browser logs to the same log as the driver

--- a/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriverService.cs
@@ -124,9 +124,9 @@ public abstract class ChromiumDriverService : DriverService
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing ChromiumDriver --verbose and overriding --silent/--log-level settings.");
                 }
+                argsBuilder.Append(" --verbose");
             }
-
-            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.EnableVerboseLogging)
+            else if (this.EnableVerboseLogging)
             {
                 argsBuilder.Append(" --verbose");
             }

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -176,7 +176,8 @@ public abstract class DriverService : ICommandServer
     /// <remarks>Set this property to <see langword="true"/> to force all process output and error streams to
     /// be redirected, even if redirection is not required by default behavior. This can be useful in scenarios where
     /// capturing process output is necessary for logging or analysis.</remarks>
-    protected virtual internal bool EnableProcessRedirection { get; } = false;
+    protected virtual internal bool EnableProcessRedirection =>
+        Environment.GetEnvironmentVariable("SE_DEBUG") is not null;
 
     /// <summary>
     /// Gets a value indicating whether the service is responding to HTTP requests.
@@ -347,7 +348,10 @@ public abstract class DriverService : ICommandServer
     /// <param name="args">The data received event arguments.</param>
     protected virtual void OnDriverProcessDataReceived(object sender, DataReceivedEventArgs args)
     {
-
+        if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null && !string.IsNullOrEmpty(args.Data))
+        {
+            Console.Error.WriteLine(args.Data);
+        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -199,9 +199,9 @@ public sealed class FirefoxDriverService : DriverService
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing GeckoDriver log level to DEBUG and overriding configured log level.");
                 }
+                argsBuilder.Append(" --log debug");
             }
-
-            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.LogLevel == FirefoxDriverLogLevel.Debug)
+            else if (this.LogLevel == FirefoxDriverLogLevel.Debug)
             {
                 argsBuilder.Append(" --log debug");
             }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -193,9 +193,25 @@ public sealed class FirefoxDriverService : DriverService
                 argsBuilder.AppendFormat(CultureInfo.InvariantCulture, " --host \"{0}\"", this.Host);
             }
 
-            if (this.LogLevel != FirefoxDriverLogLevel.Default)
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
             {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " --log {0}", this.LogLevel.ToString().ToLowerInvariant()));
+                if (this.SuppressInitialDiagnosticInformation || this.LogLevel != FirefoxDriverLogLevel.Default)
+                {
+                    Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing GeckoDriver log level to DEBUG and overriding configured log level.");
+                }
+            }
+
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.LogLevel == FirefoxDriverLogLevel.Debug)
+            {
+                argsBuilder.Append(" --log debug");
+            }
+            else if (this.SuppressInitialDiagnosticInformation)
+            {
+                argsBuilder.Append(" --log fatal");
+            }
+            else if (this.LogLevel != FirefoxDriverLogLevel.Default)
+            {
+                argsBuilder.Append($" --log {this.LogLevel.ToString().ToLowerInvariant()}");
             }
 
             if (this.OpenBrowserToolbox)
@@ -225,7 +241,7 @@ public sealed class FirefoxDriverService : DriverService
     /// <summary>
     /// Gets a value indicating whether process output redirection is required.
     /// </summary>
-    protected internal override bool EnableProcessRedirection => LogPath is not null;
+    protected internal override bool EnableProcessRedirection => base.EnableProcessRedirection || LogPath is not null;
 
     /// <summary>
     /// Called when the driver process is starting. This method sets up log file writing if a log path is specified.

--- a/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriverService.cs
@@ -195,7 +195,8 @@ public sealed class FirefoxDriverService : DriverService
 
             if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
             {
-                if (this.SuppressInitialDiagnosticInformation || this.LogLevel != FirefoxDriverLogLevel.Default)
+                if (this.SuppressInitialDiagnosticInformation ||
+                    (this.LogLevel != FirefoxDriverLogLevel.Default && this.LogLevel != FirefoxDriverLogLevel.Debug))
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing GeckoDriver log level to DEBUG and overriding configured log level.");
                 }

--- a/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
@@ -106,7 +106,8 @@ public sealed class InternetExplorerDriverService : DriverService
 
             if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
             {
-                if (this.SuppressInitialDiagnosticInformation || this.LoggingLevel != InternetExplorerDriverLogLevel.Fatal)
+                if (this.SuppressInitialDiagnosticInformation ||
+                    (this.LoggingLevel != InternetExplorerDriverLogLevel.Fatal && this.LoggingLevel != InternetExplorerDriverLogLevel.Debug))
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing IEDriver log level to DEBUG and overriding configured log level.");
                 }

--- a/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using OpenQA.Selenium.Internal;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -103,19 +104,30 @@ public sealed class InternetExplorerDriverService : DriverService
                 argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -extract-path=\"{0}\"", this.LibraryExtractionPath));
             }
 
-            if (this.LoggingLevel != InternetExplorerDriverLogLevel.Fatal)
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null)
             {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -log-level={0}", this.LoggingLevel.ToString().ToUpperInvariant()));
+                if (this.SuppressInitialDiagnosticInformation || this.LoggingLevel != InternetExplorerDriverLogLevel.Fatal)
+                {
+                    Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing IEDriver log level to DEBUG and overriding configured log level.");
+                }
+            }
+
+            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.LoggingLevel == InternetExplorerDriverLogLevel.Debug)
+            {
+                argsBuilder.Append(" -log-level=DEBUG");
+            }
+            else if (this.SuppressInitialDiagnosticInformation)
+            {
+                argsBuilder.Append(" -silent");
+            }
+            else if (this.LoggingLevel != InternetExplorerDriverLogLevel.Fatal)
+            {
+                argsBuilder.Append($" -log-level={this.LoggingLevel.ToString().ToUpperInvariant()}");
             }
 
             if (!string.IsNullOrEmpty(this.WhitelistedIPAddresses))
             {
-                argsBuilder.Append(string.Format(CultureInfo.InvariantCulture, " -whitelisted-ips={0}", this.WhitelistedIPAddresses));
-            }
-
-            if (this.SuppressInitialDiagnosticInformation)
-            {
-                argsBuilder.Append(" -silent");
+                argsBuilder.Append($" -whitelisted-ips={this.WhitelistedIPAddresses}");
             }
 
             return argsBuilder.ToString();

--- a/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriverService.cs
@@ -110,9 +110,9 @@ public sealed class InternetExplorerDriverService : DriverService
                 {
                     Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; forcing IEDriver log level to DEBUG and overriding configured log level.");
                 }
+                argsBuilder.Append(" -log-level=DEBUG");
             }
-
-            if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null || this.LoggingLevel == InternetExplorerDriverLogLevel.Debug)
+            else if (this.LoggingLevel == InternetExplorerDriverLogLevel.Debug)
             {
                 argsBuilder.Append(" -log-level=DEBUG");
             }

--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -19,24 +19,29 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 
 namespace OpenQA.Selenium.Internal.Logging;
 
 internal class LogContextManager
 {
+    private static bool _seDebugWarned;
     private readonly AsyncLocal<ILogContext?> _currentAmbientLogContext = new();
 
     public LogContextManager()
     {
-        var defaulLogHandler = new TextWriterHandler(Console.Error);
+        var defaultLogHandler = new TextWriterHandler(Console.Error);
 
         // Enable debug logging if SE_DEBUG environment variable is set
+        if (Environment.GetEnvironmentVariable("SE_DEBUG") is not null && !_seDebugWarned)
+        {
+            _seDebugWarned = true;
+            Console.Error.WriteLine("WARNING: Environment Variable `SE_DEBUG` is set; Selenium is forcing verbose logging which may override user-specified settings.");
+        }
         var level = Environment.GetEnvironmentVariable("SE_DEBUG") is not null
             ? LogEventLevel.Debug
             : LogEventLevel.Warn;
 
-        GlobalContext = new LogContext(level, null, null, [defaulLogHandler]);
+        GlobalContext = new LogContext(level, null, null, [defaultLogHandler]);
     }
 
     public ILogContext GlobalContext { get; }

--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace OpenQA.Selenium.Internal.Logging;
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->
.NET implementation of #16900

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* When `SE_DEBUG` is set, driver logs are output to stderr just like selenium logs
* ~Silent/Verbose/Log Level are mutually exclusive, so updated all driver classes to use conditionals for these 3.~
*  Update: keeping original logic where users who pass in more than one setting get failing response
* `SuppressInitialDiagnosticInformation` was in superclass but Firefox was ignoring it, now it won't 

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
~Could change the order of verbose then silent, then log level but that seems best.~

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement SE_DEBUG environment variable to output driver logs to stderr

- Make verbose, silent, and log level settings mutually exclusive

- Ensure Firefox respects SuppressInitialDiagnosticInformation setting

- Enable process redirection when SE_DEBUG is set across all drivers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SE_DEBUG["SE_DEBUG env var set"]
  SE_DEBUG -->|"Check in all drivers"| Verbose["Enable verbose/debug logging"]
  SE_DEBUG -->|"Enable redirection"| Redirect["Redirect process output to stderr"]
  Verbose -->|"Mutually exclusive"| Silent["Silent mode"]
  Silent -->|"Fallback to"| LogLevel["Custom log level"]
  Redirect -->|"Output via"| Stderr["Console.Error.WriteLine"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromiumDriverService.cs</strong><dd><code>Implement SE_DEBUG and mutually exclusive logging options</code></dd></summary>
<hr>

dotnet/src/webdriver/Chromium/ChromiumDriverService.cs

<ul><li>Check SE_DEBUG environment variable to enable verbose logging<br> <li> Restructure logging options as mutually exclusive (verbose > silent > <br>log level)<br> <li> Move log level argument handling into conditional chain<br> <li> Modernize string formatting from string.Format to string interpolation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16903/files#diff-7b7a876beec5c5bbf8892cfef44f5d3cc18a1ced78506de3f69ea119d6b80b50">+10/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DriverService.cs</strong><dd><code>Enable process redirection and stderr logging for SE_DEBUG</code></dd></summary>
<hr>

dotnet/src/webdriver/DriverService.cs

<ul><li>Change EnableProcessRedirection to check SE_DEBUG environment variable<br> <li> Implement OnDriverProcessDataReceived to output logs to stderr when <br>SE_DEBUG is set<br> <li> Convert property from auto-property to computed property</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16903/files#diff-c38089621d41671b4719164b262303e275d4a4a442125fd9d4ea61eeca855c2b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirefoxDriverService.cs</strong><dd><code>Add SE_DEBUG support and respect suppress flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Firefox/FirefoxDriverService.cs

<ul><li>Check SE_DEBUG to set log level to debug<br> <li> Implement SuppressInitialDiagnosticInformation by setting log level to <br>fatal<br> <li> Restructure logging as mutually exclusive chain (SE_DEBUG > suppress > <br>log level)<br> <li> Update EnableProcessRedirection to include base class check</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16903/files#diff-8a02c4932a0154eb11aafcbf7e736968b70fe5d69dac3df52ac67fa8c8a7c965">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InternetExplorerDriverService.cs</strong><dd><code>Add SE_DEBUG support and mutually exclusive logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/IE/InternetExplorerDriverService.cs

<ul><li>Add System namespace import<br> <li> Check SE_DEBUG to set log level to DEBUG<br> <li> Implement SuppressInitialDiagnosticInformation with silent flag<br> <li> Restructure logging as mutually exclusive chain (SE_DEBUG > suppress > <br>log level)<br> <li> Modernize string formatting to string interpolation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16903/files#diff-b5bc14c6fe80476d83f529175715431b5a04ac8b0bdffd4d39f1d32f9c865615">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>I-cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogContextManager.cs</strong><dd><code>Fix variable naming typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Internal/Logging/LogContextManager.cs

<ul><li>Fix typo in variable name from defaulLogHandler to defaultLogHandler</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16903/files#diff-259c2c4f3567044d233aa46147d492b89964cbe4bc5e45fd976a03c88674007f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

