### PR TITLE
[build] rerun the RBE tests with debugging enabled

### DIFF
--- a/.github/workflows/ci-rbe.yml
+++ b/.github/workflows/ci-rbe.yml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/bazel.yml
     with:
       name: All RBE tests
+      rerun-with-debug: true
       caching: false
       ruby-version: jruby-10.0.0.0
       run: ./scripts/github-actions/ci-build.sh ${{ github.event.inputs.disable_test_cache }}

--- a/py/test/selenium/webdriver/common/quit_tests.py
+++ b/py/test/selenium/webdriver/common/quit_tests.py
@@ -20,16 +20,6 @@ import pytest
 
 @pytest.mark.no_driver_after_test
 def test_quit(driver, pages):
-    # Intentional failure to test rerun-with-debug functionality
-    # Do some WebDriver operations to generate debug log output
-    pages.load("simpleTest.html")
-    driver.current_url
-    driver.title
-    driver.current_window_handle
-    driver.find_element("id", "oneline")
-
-    pytest.fail("Intentional test failure for rerun-with-debug testing")
-
     driver.quit()
     with pytest.raises(Exception):
         pages.load("simpleTest.html")

--- a/py/test/selenium/webdriver/common/quit_tests.py
+++ b/py/test/selenium/webdriver/common/quit_tests.py
@@ -20,6 +20,16 @@ import pytest
 
 @pytest.mark.no_driver_after_test
 def test_quit(driver, pages):
+    # Intentional failure to test rerun-with-debug functionality
+    # Do some WebDriver operations to generate debug log output
+    pages.load("simpleTest.html")
+    driver.current_url
+    driver.title
+    driver.current_window_handle
+    driver.find_element("id", "oneline")
+
+    pytest.fail("Intentional test failure for rerun-with-debug testing")
+
     driver.quit()
     with pytest.raises(Exception):
         pages.load("simpleTest.html")

--- a/scripts/github-actions/rerun-failures.sh
+++ b/scripts/github-actions/rerun-failures.sh
@@ -18,7 +18,11 @@ if [ ! -s build/failures/_run1.txt ]; then
   exit 0
 fi
 
-base_cmd=$(echo "$RUN_CMD" | sed 's| //[^ ]*||g')
+if [[ "$RUN_CMD" == *"/ci-build.sh"* ]]; then
+  base_cmd="bazel test --config=rbe-ci --build_tests_only --keep_going"
+else
+  base_cmd=$(echo "$RUN_CMD" | sed 's| //[^ ]*||g')
+fi
 targets=$(tr '\n' ' ' < build/failures/_run1.txt)
 echo "Rerunning tests: $base_cmd --test_env=SE_DEBUG=true --flaky_test_attempts=1 $targets"
 set +e


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
Similar to the recent PRs for the bindings - https://github.com/SeleniumHQ/selenium/pull/16879

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* if the input to `rerun-failures.sh` is the `ci-build` script reference, then use the standard ci-build settings as the command

I'm honestly not certain we want/need this one, and if it complicates things with RBE.

It works: https://github.com/SeleniumHQ/selenium/actions/runs/20975769113/job/60290021932?pr=16905#step:23:29


___

### **PR Type**
Enhancement


___

### **Description**
- Enable debug output for RBE test reruns via CI workflow

- Add conditional logic to detect ci-build script invocation

- Use standard RBE CI configuration for failed test reruns

- Pass debug flag through rerun-failures script


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI RBE Workflow"] -->|"rerun-with-debug: true"| B["rerun-failures.sh"]
  B -->|"Detect ci-build.sh"| C["Use RBE CI Config"]
  C -->|"Add SE_DEBUG=true"| D["Rerun Failed Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rerun-failures.sh</strong><dd><code>Add RBE CI config detection for test reruns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/github-actions/rerun-failures.sh

<ul><li>Add conditional check to detect if RUN_CMD contains ci-build.sh <br>reference<br> <li> Use standard RBE CI bazel configuration when ci-build.sh is detected<br> <li> Fallback to original sed-based command extraction for other scripts<br> <li> Preserve debug environment variable and flaky test retry logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16905/files#diff-4bda1f90920cfb2f683a46266922dae03db0c9b418266b1a6c58947e95a7ece7">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-rbe.yml</strong><dd><code>Enable debug flag for RBE test reruns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-rbe.yml

<ul><li>Add new <code>rerun-with-debug: true</code> parameter to bazel workflow call<br> <li> Enable debug output for RBE test reruns in CI pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16905/files#diff-9ad6de1290c9f9260ba7c459ff1aa974c7c15aeeaae6f621aeda5dcde357b30e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

