### PR TITLE
[java] Stabilize flaky tests related to mouse movement

### DIFF
--- a/common/src/web/mousePositionTracker.html
+++ b/common/src/web/mousePositionTracker.html
@@ -1,33 +1,43 @@
-<html>
+<html lang="en">
   <head>
-    <style type="text/css">
-      div.solidborder
-      {
-        border-style:solid;
-        border-width:1px;
+    <style>
+      #mousetracker {
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 400px;
+        width: 100px;
+        padding: 0;
+        border: 1px solid;
+        box-sizing: border-box;
+      }
+      #display {
+        position: absolute;
+        left: 150px;
+        top: 50px;
       }
     </style>
-
-  <script type="text/javascript" src="js/jquery-3.5.1.min.js"></script>
-  <script type="text/javascript" src="js/jquery-ui-1.12.1.min.js"></script>
-  <script type="text/javascript">
-    jQuery(document).ready(function(){
-        $('#mousetracker').mousemove(function(e){
-          xPos = e.pageX - this.offsetLeft;
-          yPos = e.pageY - this.offsetTop;
-          $('#status').html(xPos + ', ' + yPos);
-          });
-        })
-
-</script>
+    <title>Mouse position tracker</title>
+  </head>
 <body>
-  <b>Div tracking mouse position.</b>
-  <br>
-<div id="mousetracker" class="solidborder" style="position: absolute; left: 10px; top: 80px; height: 400px; width: 100px; padding: 0px;">
-  Move mouse here.
+<div id="mousetracker">
+  <div style="padding: 160px 5px;">Move mouse here</div>
 </div>
-<h2 id="status">
-0, 0
-</h2>
+<div id="display">
+  <b>Div tracking mouse position</b>
+  <h2 id="status">
+  0, 0
+  </h2>
+</div>
+<script>
+  (() => {
+    const mouseTracker = document.getElementById('mousetracker');
+    mouseTracker.addEventListener('mousemove', (e) => {
+      const xPos = e.pageX - mouseTracker.offsetLeft;
+      const yPos = e.pageY - mouseTracker.offsetTop;
+      document.getElementById('status').innerText = `${xPos}, ${yPos}`;
+    });
+  })();
+</script>
 </body>
 </html>

--- a/common/src/web/mouse_interaction.html
+++ b/common/src/web/mouse_interaction.html
@@ -91,5 +91,17 @@
     Move mouse here.
   </div>
   <div id="bottom" style="margin-top: 230px;"></div>
+
+  <script>
+    function describe(el) {
+      return `<${el.tagName.toLowerCase()} id="${el.id}">${el.innerText}</${el.tagName.toLowerCase()}>`;
+    }
+    window.addEventListener('mouseover', e => {
+      document.getElementById('bottom').innerText = `Mouse over (${e.x}, ${e.y}) ${describe(e.target)}`
+    })
+    window.addEventListener('click', e => {
+      document.getElementById('bottom').innerText = `Clicked at (${e.x}, ${e.y}) ${describe(e.target)}`
+    })
+  </script>
   </body>
 </html>

--- a/dotnet/test/common/Interactions/BasicMouseInterfaceTest.cs
+++ b/dotnet/test/common/Interactions/BasicMouseInterfaceTest.cs
@@ -390,7 +390,7 @@ public class BasicMouseInterfaceTest : DriverTestFixture
 
         IWebElement reporter = driver.FindElement(By.Id("status"));
 
-        WaitFor(FuzzyMatchingOfCoordinates(reporter, 40, 20), "Coordinate matching was not within tolerance");
+        WaitFor(FuzzyMatchingOfCoordinates(reporter, 50, 100), "Coordinate matching was not within tolerance");
     }
 
     [Test]

--- a/java/test/org/openqa/selenium/WaitingConditions.java
+++ b/java/test/org/openqa/selenium/WaitingConditions.java
@@ -17,9 +17,14 @@
 
 package org.openqa.selenium;
 
+import static java.lang.Integer.parseInt;
+import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
+
 import java.util.Map;
 import java.util.Set;
+import org.openqa.selenium.support.Colors;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class WaitingConditions {
 
@@ -288,5 +293,38 @@ public class WaitingConditions {
             viewportState.get("viewportHeight"));
       }
     };
+  }
+
+  public static ExpectedCondition<Boolean> fuzzyMatchingOfCoordinates(
+      final WebElement element, final int x, final int y) {
+    return new ExpectedCondition<>() {
+      private static final int ALLOWED_DEVIATION_PIXELS = 10;
+
+      @Override
+      public Boolean apply(WebDriver ignored) {
+        return fuzzyPositionMatching(x, y, element.getText());
+      }
+
+      private boolean fuzzyPositionMatching(int expectedX, int expectedY, String locationTuple) {
+        String[] splitString = locationTuple.split("[,\\s]+", 2);
+        int gotX = parseInt(splitString[0]);
+        int gotY = parseInt(splitString[1]);
+
+        return Math.abs(expectedX - gotX) < ALLOWED_DEVIATION_PIXELS
+            && Math.abs(expectedY - gotY) < ALLOWED_DEVIATION_PIXELS;
+      }
+
+      @Override
+      public String toString() {
+        return String.format("Coordinates: (%s, %s), but was: (%s)", x, y, element.getText());
+      }
+    };
+  }
+
+  public static ExpectedCondition<Boolean> color(
+      final WebElement element, final String cssPropertyName, final Colors expectedColor) {
+    return ExpectedConditions.or(
+        attributeToBe(element, cssPropertyName, expectedColor.getColorValue().asRgb()),
+        attributeToBe(element, cssPropertyName, expectedColor.getColorValue().asRgba()));
   }
 }

--- a/java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java
@@ -18,21 +18,20 @@
 package org.openqa.selenium.bidi.input;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.WaitingConditions.color;
 import static org.openqa.selenium.WaitingConditions.elementTextToEqual;
 import static org.openqa.selenium.WaitingConditions.elementValueToEqual;
+import static org.openqa.selenium.WaitingConditions.fuzzyMatchingOfCoordinates;
 import static org.openqa.selenium.support.Colors.GREEN;
 import static org.openqa.selenium.support.Colors.RED;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
+import static org.openqa.selenium.support.ui.ExpectedConditions.urlContains;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.openqa.selenium.testing.drivers.Browser.CHROME;
-import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,26 +49,23 @@ import org.openqa.selenium.bidi.script.EvaluateResultSuccess;
 import org.openqa.selenium.bidi.script.LocalValue;
 import org.openqa.selenium.bidi.script.WindowProxyProperties;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.Color;
-import org.openqa.selenium.support.Colors;
-import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.SwitchToTopAfterTest;
 
 /** Tests operations that involve mouse and keyboard. */
 class DefaultMouseTest extends JupiterTestBase {
-  private Input inputModule;
+  private static final Dimension MOUSE_TRACKER = new Dimension(100, 400);
 
+  private Input inputModule;
   private String windowHandle;
 
   @BeforeEach
   public void setUp() {
     windowHandle = driver.getWindowHandle();
     inputModule = new Input(driver);
+    resetMousePointer();
   }
 
   private Actions getBuilder(WebDriver driver) {
@@ -177,19 +173,19 @@ class DefaultMouseTest extends JupiterTestBase {
     assertThat(toContextClick.getAttribute("value")).isEqualTo("ContextClicked");
   }
 
-  @NeedsFreshDriver
   @Test
-  @Ignore(value = FIREFOX, gitHubActions = true)
-  @Ignore(value = CHROME, gitHubActions = true)
-  @Ignore(value = EDGE, gitHubActions = true)
   void testMoveToLocation() {
     driver.get(pages.mouseInteractionPage);
+
+    inputModule.perform(windowHandle, getBuilder(driver).moveToLocation(70, 60).getSequences());
+    assertThat(driver.findElement(By.id("bottom")).getText()).contains("Click for Results Page");
 
     inputModule.perform(
         windowHandle, getBuilder(driver).moveToLocation(70, 60).click().getSequences());
 
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("greeting")));
+    wait.until(urlContains("/resultPage.html"));
+    wait.until(visibilityOfElementLocated(By.id("greeting")));
 
     WebElement element = driver.findElement(By.id("greeting"));
 
@@ -314,11 +310,10 @@ class DefaultMouseTest extends JupiterTestBase {
     driver.get(pages.mouseTrackerPage);
 
     WebElement trackerDiv = driver.findElement(By.id("mousetracker"));
-    Dimension size = trackerDiv.getSize();
     inputModule.perform(
         windowHandle,
         getBuilder(driver)
-            .moveToElement(trackerDiv, 95 - size.getWidth() / 2, 195 - size.getHeight() / 2)
+            .moveToElement(trackerDiv, 95 - MOUSE_TRACKER.width / 2, 195 - MOUSE_TRACKER.height / 2)
             .getSequences());
 
     WebElement reporter = driver.findElement(By.id("status"));
@@ -336,30 +331,24 @@ class DefaultMouseTest extends JupiterTestBase {
 
     WebElement reporter = driver.findElement(By.id("status"));
 
-    Dimension size = trackerDiv.getSize();
-    wait.until(fuzzyMatchingOfCoordinates(reporter, size.getWidth() / 2, size.getHeight() / 2));
+    wait.until(
+        fuzzyMatchingOfCoordinates(reporter, MOUSE_TRACKER.width / 2, MOUSE_TRACKER.height / 2));
   }
 
-  @NeedsFreshDriver({IE, CHROME, FIREFOX, EDGE})
   @Test
   public void testMoveRelativeToBody() {
-    try {
-      driver.get(pages.mouseTrackerPage);
+    driver.get(pages.mouseTrackerPage);
 
-      inputModule.perform(
-          driver.getWindowHandle(), getBuilder(driver).moveByOffset(50, 100).getSequences());
+    WebElement reporter = driver.findElement(By.id("status"));
+    wait.until(fuzzyMatchingOfCoordinates(reporter, 0, 0));
 
-      WebElement reporter = driver.findElement(By.id("status"));
+    inputModule.perform(
+        driver.getWindowHandle(), getBuilder(driver).moveByOffset(50, 100).getSequences());
 
-      wait.until(fuzzyMatchingOfCoordinates(reporter, 40, 20));
-    } finally {
-      inputModule.perform(
-          driver.getWindowHandle(), getBuilder(driver).moveByOffset(-50, -100).getSequences());
-    }
+    shortWait.until(fuzzyMatchingOfCoordinates(reporter, 50, 100));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   public void testMoveMouseByOffsetOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
 
@@ -377,8 +366,7 @@ class DefaultMouseTest extends JupiterTestBase {
     inputModule.perform(
         windowHandle, getBuilder(driver).moveToElement(greenbox, xOffset, yOffset).getSequences());
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
 
     inputModule.perform(
         windowHandle,
@@ -386,7 +374,7 @@ class DefaultMouseTest extends JupiterTestBase {
             .moveToElement(greenbox, xOffset, yOffset)
             .moveByOffset(shiftX, shiftY)
             .getSequences());
-    shortWait.until(attributeToBe(redbox, "background-color", Colors.RED.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", RED));
 
     inputModule.perform(
         windowHandle,
@@ -396,12 +384,10 @@ class DefaultMouseTest extends JupiterTestBase {
             .moveByOffset(-shiftX, -shiftY)
             .getSequences());
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   public void testCanMoveOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
 
@@ -416,12 +402,10 @@ class DefaultMouseTest extends JupiterTestBase {
             .moveToElement(greenbox, 1 - greenSize.getWidth() / 2, 1 - greenSize.getHeight() / 2)
             .getSequences());
 
-    assertThat(Color.fromString(redbox.getCssValue("background-color")))
-        .isEqualTo(GREEN.getColorValue());
+    shortWait.until(color(redbox, "background-color", GREEN));
 
     inputModule.perform(windowHandle, getBuilder(driver).moveToElement(redbox).getSequences());
-    assertThat(Color.fromString(redbox.getCssValue("background-color")))
-        .isEqualTo(RED.getColorValue());
+    shortWait.until(color(redbox, "background-color", RED));
 
     inputModule.perform(
         windowHandle,
@@ -429,32 +413,14 @@ class DefaultMouseTest extends JupiterTestBase {
             .moveToElement(redbox, redSize.getWidth() + 1, redSize.getHeight() + 1)
             .getSequences());
 
-    wait.until(attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    wait.until(color(redbox, "background-color", GREEN));
   }
 
-  private boolean fuzzyPositionMatching(int expectedX, int expectedY, String locationTuple) {
-    String[] splitString = locationTuple.split(",");
-    int gotX = Integer.parseInt(splitString[0].trim());
-    int gotY = Integer.parseInt(splitString[1].trim());
-
-    // Everything within 5 pixels range is OK
-    final int ALLOWED_DEVIATION = 5;
-    return Math.abs(expectedX - gotX) < ALLOWED_DEVIATION
-        && Math.abs(expectedY - gotY) < ALLOWED_DEVIATION;
-  }
-
-  private ExpectedCondition<Boolean> fuzzyMatchingOfCoordinates(
-      final WebElement element, final int x, final int y) {
-    return new ExpectedCondition<>() {
-      @Override
-      public Boolean apply(WebDriver ignored) {
-        return fuzzyPositionMatching(x, y, element.getText());
-      }
-
-      @Override
-      public String toString() {
-        return "Coordinates: " + element.getText() + " but expected: " + x + ", " + y;
-      }
-    };
+  private void resetMousePointer() {
+    WebElement body = driver.findElement(By.tagName("body"));
+    Dimension size = body.getSize();
+    Collection<Sequence> moveToLeftUpperCorner =
+        getBuilder(driver).moveToElement(body, -size.width / 2, -size.height / 2).getSequences();
+    inputModule.perform(windowHandle, moveToLeftUpperCorner);
   }
 }

--- a/java/test/org/openqa/selenium/interactions/DefaultMouseTest.java
+++ b/java/test/org/openqa/selenium/interactions/DefaultMouseTest.java
@@ -19,20 +19,19 @@ package org.openqa.selenium.interactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.openqa.selenium.WaitingConditions.color;
 import static org.openqa.selenium.WaitingConditions.elementTextToEqual;
 import static org.openqa.selenium.WaitingConditions.elementValueToEqual;
+import static org.openqa.selenium.WaitingConditions.fuzzyMatchingOfCoordinates;
 import static org.openqa.selenium.support.Colors.GREEN;
 import static org.openqa.selenium.support.Colors.RED;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
+import static org.openqa.selenium.support.ui.ExpectedConditions.urlContains;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.openqa.selenium.testing.drivers.Browser.CHROME;
-import static org.openqa.selenium.testing.drivers.Browser.EDGE;
-import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
@@ -41,16 +40,19 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.Color;
-import org.openqa.selenium.support.Colors;
-import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.SwitchToTopAfterTest;
 
 /** Tests operations that involve mouse and keyboard. */
 class DefaultMouseTest extends JupiterTestBase {
+
+  @BeforeEach
+  void resetMousePointer() {
+    WebElement body = driver.findElement(By.tagName("body"));
+    Dimension size = body.getSize();
+    getBuilder(driver).moveToElement(body, -size.width / 2, -size.height / 2).perform();
+  }
 
   private Actions getBuilder(WebDriver driver) {
     return new Actions(driver);
@@ -164,14 +166,17 @@ class DefaultMouseTest extends JupiterTestBase {
   }
 
   @Test
-  @Ignore(value = CHROME, issue = "Timeout in RBE, works locally.")
   void testMoveToLocation() {
     driver.get(pages.mouseInteractionPage);
+
+    getBuilder(driver).moveToLocation(70, 60).build().perform();
+    assertThat(driver.findElement(By.id("bottom")).getText()).contains("Click for Results Page");
 
     Action moveAndClick = getBuilder(driver).moveToLocation(70, 60).click().build();
 
     moveAndClick.perform();
 
+    shortWait.until(urlContains("/resultPage.html"));
     WebElement element = driver.findElement(By.id("greeting"));
 
     assertThat(element.getText()).isEqualTo("Success!");
@@ -309,25 +314,20 @@ class DefaultMouseTest extends JupiterTestBase {
     wait.until(fuzzyMatchingOfCoordinates(reporter, size.getWidth() / 2, size.getHeight() / 2));
   }
 
-  @NeedsFreshDriver({IE, CHROME, FIREFOX, EDGE})
   @Test
   @NotYetImplemented(SAFARI)
   public void testMoveRelativeToBody() {
-    try {
-      driver.get(pages.mouseTrackerPage);
+    driver.get(pages.mouseTrackerPage);
+    WebElement reporter = driver.findElement(By.id("status"));
 
-      getBuilder(driver).moveByOffset(50, 100).perform();
+    wait.until(fuzzyMatchingOfCoordinates(reporter, 0, 0));
 
-      WebElement reporter = driver.findElement(By.id("status"));
+    getBuilder(driver).moveByOffset(50, 100).perform();
 
-      wait.until(fuzzyMatchingOfCoordinates(reporter, 40, 20));
-    } finally {
-      getBuilder(driver).moveByOffset(-50, -100).perform();
-    }
+    wait.until(fuzzyMatchingOfCoordinates(reporter, 50, 100));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   @NotYetImplemented(SAFARI)
   public void testMoveMouseByOffsetOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
@@ -345,14 +345,13 @@ class DefaultMouseTest extends JupiterTestBase {
 
     getBuilder(driver).moveToElement(greenbox, xOffset, yOffset).perform();
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
 
     getBuilder(driver)
         .moveToElement(greenbox, xOffset, yOffset)
         .moveByOffset(shiftX, shiftY)
         .perform();
-    shortWait.until(attributeToBe(redbox, "background-color", Colors.RED.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", RED));
 
     getBuilder(driver)
         .moveToElement(greenbox, xOffset, yOffset)
@@ -360,12 +359,10 @@ class DefaultMouseTest extends JupiterTestBase {
         .moveByOffset(-shiftX, -shiftY)
         .perform();
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   @NotYetImplemented(SAFARI)
   public void testCanMoveOverAndOutOfAnElement() {
     driver.get(pages.mouseOverPage);
@@ -390,32 +387,6 @@ class DefaultMouseTest extends JupiterTestBase {
         .moveToElement(redbox, redSize.getWidth() + 1, redSize.getHeight() + 1)
         .perform();
 
-    wait.until(attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
-  }
-
-  private boolean fuzzyPositionMatching(int expectedX, int expectedY, String locationTuple) {
-    String[] splitString = locationTuple.split(",");
-    int gotX = Integer.parseInt(splitString[0].trim());
-    int gotY = Integer.parseInt(splitString[1].trim());
-
-    // Everything within 5 pixels range is OK
-    final int ALLOWED_DEVIATION = 5;
-    return Math.abs(expectedX - gotX) < ALLOWED_DEVIATION
-        && Math.abs(expectedY - gotY) < ALLOWED_DEVIATION;
-  }
-
-  private ExpectedCondition<Boolean> fuzzyMatchingOfCoordinates(
-      final WebElement element, final int x, final int y) {
-    return new ExpectedCondition<Boolean>() {
-      @Override
-      public Boolean apply(WebDriver ignored) {
-        return fuzzyPositionMatching(x, y, element.getText());
-      }
-
-      @Override
-      public String toString() {
-        return "Coordinates: " + element.getText() + " but expected: " + x + ", " + y;
-      }
-    };
+    wait.until(color(redbox, "background-color", GREEN));
   }
 }

--- a/java/test/org/openqa/selenium/interactions/PenPointerTest.java
+++ b/java/test/org/openqa/selenium/interactions/PenPointerTest.java
@@ -17,54 +17,50 @@
 
 package org.openqa.selenium.interactions;
 
+import static java.time.Duration.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.openqa.selenium.WaitingConditions.color;
 import static org.openqa.selenium.WaitingConditions.elementTextToEqual;
 import static org.openqa.selenium.WaitingConditions.elementValueToEqual;
+import static org.openqa.selenium.WaitingConditions.fuzzyMatchingOfCoordinates;
+import static org.openqa.selenium.interactions.PointerInput.Kind.PEN;
 import static org.openqa.selenium.support.Colors.GREEN;
 import static org.openqa.selenium.support.Colors.RED;
-import static org.openqa.selenium.support.ui.ExpectedConditions.attributeToBe;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.openqa.selenium.testing.drivers.Browser.CHROME;
-import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
-import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.support.Color;
-import org.openqa.selenium.support.Colors;
-import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.testing.Ignore;
 import org.openqa.selenium.testing.JupiterTestBase;
-import org.openqa.selenium.testing.NeedsFreshDriver;
 import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.SwitchToTopAfterTest;
 
 /** Tests operations that involve pen input device. */
 class PenPointerTest extends JupiterTestBase {
-  private final PointerInput defaultPen = new PointerInput(PointerInput.Kind.PEN, "default pen");
+  private void resetMousePointer() {
+    WebElement body = driver.findElement(By.tagName("body"));
+    Dimension size = body.getSize();
+    setDefaultPen(driver).moveToElement(body, -size.width / 2, -size.height / 2).click().perform();
+  }
 
   private Actions setDefaultPen(WebDriver driver) {
-    return new Actions(driver).setActivePointer(PointerInput.Kind.PEN, "default pen");
+    return new Actions(driver).setActivePointer(PEN, "default pen");
   }
 
   private void performDragAndDropWithPen() {
@@ -116,19 +112,10 @@ class PenPointerTest extends JupiterTestBase {
     assertThat(text).matches("Nothing happened. (?:DragOut *)+DropIn RightItem 3");
   }
 
-  private boolean isElementAvailable(WebDriver driver, By locator) {
-    try {
-      driver.findElement(locator);
-      return true;
-    } catch (NoSuchElementException e) {
-      return false;
-    }
-  }
-
   @Test
   @NotYetImplemented(SAFARI)
   @NotYetImplemented(FIREFOX)
-  public void testDragAndDrop() throws InterruptedException {
+  public void testDragAndDrop() {
     driver.get(pages.droppableItems);
 
     WebElement toDrag = wait.until(visibilityOfElementLocated(By.id("draggable")));
@@ -161,17 +148,24 @@ class PenPointerTest extends JupiterTestBase {
   }
 
   @Test
+  @SuppressWarnings("DataFlowIssue")
   void testCannotMoveToANullLocator() {
     driver.get(pages.javascriptPage);
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> setDefaultPen(driver).moveToElement(null).build());
+    assertThatThrownBy(() -> setDefaultPen(driver).moveToElement(null).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Element must be set");
   }
 
   @Test
   @NotYetImplemented(SAFARI)
   public void testMovingPastViewPortThrowsException() {
-    assertThatExceptionOfType(MoveTargetOutOfBoundsException.class)
-        .isThrownBy(() -> setDefaultPen(driver).moveByOffset(-1000, -1000).perform());
+    assertThatThrownBy(() -> setDefaultPen(driver).moveByOffset(-1000, -1000).perform())
+        .isInstanceOf(MoveTargetOutOfBoundsException.class)
+        .satisfiesAnyOf(
+            ex ->
+                assertThat(ex)
+                    .hasMessageStartingWith("Move target (-1000, -1000) is out of bounds"),
+            ex -> assertThat(ex).hasMessageStartingWith("move target out of bounds"));
   }
 
   @SwitchToTopAfterTest
@@ -287,31 +281,25 @@ class PenPointerTest extends JupiterTestBase {
     wait.until(fuzzyMatchingOfCoordinates(reporter, size.getWidth() / 2, size.getHeight() / 2));
   }
 
-  @NeedsFreshDriver({IE, CHROME, FIREFOX, EDGE})
   @Test
   @NotYetImplemented(SAFARI)
   @NotYetImplemented(FIREFOX)
   public void testMoveRelativeToBody() {
+    resetMousePointer();
     try {
       driver.get(pages.mouseTrackerPage);
 
-      setDefaultPen(driver).moveByOffset(50, 100).perform();
+      setDefaultPen(driver).moveByOffset(70, 180).perform();
 
       WebElement reporter = driver.findElement(By.id("status"));
 
-      wait.until(fuzzyMatchingOfCoordinates(reporter, 40, 20));
+      wait.until(fuzzyMatchingOfCoordinates(reporter, 70, 180));
     } finally {
-      Sequence actionList =
-          new Sequence(defaultPen, 0)
-              .addAction(
-                  defaultPen.createPointerMove(
-                      Duration.ZERO, PointerInput.Origin.pointer(), new Point(-50, -100)));
-      ((RemoteWebDriver) driver).perform(Collections.singletonList(actionList));
+      resetMousePointer();
     }
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   @NotYetImplemented(SAFARI)
   @NotYetImplemented(FIREFOX)
   public void testMovePenByOffsetOverAndOutOfAnElement() {
@@ -330,14 +318,13 @@ class PenPointerTest extends JupiterTestBase {
 
     setDefaultPen(driver).moveToElement(greenbox, xOffset, yOffset).perform();
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
 
     setDefaultPen(driver)
         .moveToElement(greenbox, xOffset, yOffset)
         .moveByOffset(shiftX, shiftY)
         .perform();
-    shortWait.until(attributeToBe(redbox, "background-color", Colors.RED.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", RED));
 
     setDefaultPen(driver)
         .moveToElement(greenbox, xOffset, yOffset)
@@ -345,12 +332,10 @@ class PenPointerTest extends JupiterTestBase {
         .moveByOffset(-shiftX, -shiftY)
         .perform();
 
-    shortWait.until(
-        attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   @NotYetImplemented(SAFARI)
   @NotYetImplemented(FIREFOX)
   public void testCanMoveOverAndOutOfAnElement() {
@@ -365,36 +350,33 @@ class PenPointerTest extends JupiterTestBase {
         .moveToElement(greenbox, 1 - greenSize.getWidth() / 2, 1 - greenSize.getHeight() / 2)
         .perform();
 
-    assertThat(Color.fromString(redbox.getCssValue("background-color")))
-        .isEqualTo(GREEN.getColorValue());
+    shortWait.until(color(redbox, "background-color", GREEN));
 
     setDefaultPen(driver).moveToElement(redbox).perform();
-    assertThat(Color.fromString(redbox.getCssValue("background-color")))
-        .isEqualTo(RED.getColorValue());
+    shortWait.until(color(redbox, "background-color", RED));
 
     setDefaultPen(driver)
         .moveToElement(redbox, redSize.getWidth() + 1, redSize.getHeight() + 1)
         .perform();
 
-    wait.until(attributeToBe(redbox, "background-color", Colors.GREEN.getColorValue().asRgba()));
+    shortWait.until(color(redbox, "background-color", GREEN));
   }
 
   @Test
-  @Ignore(value = FIREFOX, issue = "https://github.com/mozilla/geckodriver/issues/789")
   @NotYetImplemented(FIREFOX)
   public void setPointerEventProperties() {
     driver.get(pages.pointerActionsPage);
     long start = System.currentTimeMillis();
 
     WebElement pointerArea = driver.findElement(By.id("pointerArea"));
-    PointerInput pen = new PointerInput(PointerInput.Kind.PEN, "default pen");
+    PointerInput pen = new PointerInput(PEN, "default pen");
     PointerInput.PointerEventProperties eventProperties =
         PointerInput.eventProperties().setTiltX(-72).setTiltY(9).setTwist(86);
     PointerInput.Origin origin = PointerInput.Origin.fromElement(pointerArea);
 
     Sequence actionListPen =
         new Sequence(pen, 0)
-            .addAction(pen.createPointerMove(Duration.ZERO, origin, 0, 0))
+            .addAction(pen.createPointerMove(ZERO, origin, 0, 0))
             .addAction(pen.createPointerDown(0))
             .addAction(
                 pen.createPointerMove(
@@ -404,7 +386,7 @@ class PenPointerTest extends JupiterTestBase {
     ((RemoteWebDriver) driver).perform(List.of(actionListPen));
 
     long duration = System.currentTimeMillis() - start;
-    Assertions.assertThat(duration).isGreaterThan(2);
+    assertThat(duration).isGreaterThan(2);
 
     List<WebElement> moves = driver.findElements(By.className("pointermove"));
     Map<String, String> moveTo = properties(moves.get(0));
@@ -416,21 +398,21 @@ class PenPointerTest extends JupiterTestBase {
 
     int centerX = rect.width / 2 + rect.getX();
     int centerY = rect.height / 2 + rect.getY();
-    Assertions.assertThat(moveTo.get("button")).isEqualTo("-1");
-    Assertions.assertThat(moveTo.get("pageX")).isEqualTo("" + centerX);
-    Assertions.assertThat(moveTo.get("pageY")).isEqualTo("" + centerY);
-    Assertions.assertThat(down.get("button")).isEqualTo("0");
-    Assertions.assertThat(down.get("pageX")).isEqualTo("" + centerX);
-    Assertions.assertThat(down.get("pageY")).isEqualTo("" + centerY);
-    Assertions.assertThat(moveBy.get("button")).isEqualTo("-1");
-    Assertions.assertThat(moveBy.get("pageX")).isEqualTo("" + (centerX + 2));
-    Assertions.assertThat(moveBy.get("pageY")).isEqualTo("" + (centerY + 2));
-    Assertions.assertThat(moveBy.get("tiltX")).isEqualTo("-72");
-    Assertions.assertThat(moveBy.get("tiltY")).isEqualTo("9");
-    Assertions.assertThat(moveBy.get("twist")).isEqualTo("86");
-    Assertions.assertThat(up.get("button")).isEqualTo("0");
-    Assertions.assertThat(up.get("pageX")).isEqualTo("" + (centerX + 2));
-    Assertions.assertThat(up.get("pageY")).isEqualTo("" + (centerY + 2));
+    assertThat(moveTo.get("button")).isEqualTo("-1");
+    assertThat(moveTo.get("pageX")).isEqualTo("" + centerX);
+    assertThat(moveTo.get("pageY")).isEqualTo("" + centerY);
+    assertThat(down.get("button")).isEqualTo("0");
+    assertThat(down.get("pageX")).isEqualTo("" + centerX);
+    assertThat(down.get("pageY")).isEqualTo("" + centerY);
+    assertThat(moveBy.get("button")).isEqualTo("-1");
+    assertThat(moveBy.get("pageX")).isEqualTo("" + (centerX + 2));
+    assertThat(moveBy.get("pageY")).isEqualTo("" + (centerY + 2));
+    assertThat(moveBy.get("tiltX")).isEqualTo("-72");
+    assertThat(moveBy.get("tiltY")).isEqualTo("9");
+    assertThat(moveBy.get("twist")).isEqualTo("86");
+    assertThat(up.get("button")).isEqualTo("0");
+    assertThat(up.get("pageX")).isEqualTo("" + (centerX + 2));
+    assertThat(up.get("pageY")).isEqualTo("" + (centerY + 2));
   }
 
   private Map<String, String> properties(WebElement element) {
@@ -444,31 +426,5 @@ class PenPointerTest extends JupiterTestBase {
                 a -> a[0], // key
                 a -> a[1] // value
                 ));
-  }
-
-  private boolean fuzzyPositionMatching(int expectedX, int expectedY, String locationTuple) {
-    String[] splitString = locationTuple.split(",");
-    int gotX = Integer.parseInt(splitString[0].trim());
-    int gotY = Integer.parseInt(splitString[1].trim());
-
-    // Everything within 5 pixels range is OK
-    final int ALLOWED_DEVIATION = 5;
-    return Math.abs(expectedX - gotX) < ALLOWED_DEVIATION
-        && Math.abs(expectedY - gotY) < ALLOWED_DEVIATION;
-  }
-
-  private ExpectedCondition<Boolean> fuzzyMatchingOfCoordinates(
-      final WebElement element, final int x, final int y) {
-    return new ExpectedCondition<Boolean>() {
-      @Override
-      public Boolean apply(WebDriver ignored) {
-        return fuzzyPositionMatching(x, y, element.getText());
-      }
-
-      @Override
-      public String toString() {
-        return "Coordinates: " + element.getText() + " but expected: " + x + ", " + y;
-      }
-    };
   }
 }


### PR DESCRIPTION
### **User description**
1. Reset mouse pointer to (0,0) before each test
2. Wait until the next page gets loaded after click
3. Extract a reusable method for checking background color which is tolerant to browsers ("rgb in Chrome" vs "rgbs in Firefox").


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reset mouse pointer to (0,0) before each test to eliminate flakiness

- Extract reusable `fuzzyMatchingOfCoordinates()` and `color()` methods to `WaitingConditions`

- Replace browser-specific color assertions with tolerance-aware `color()` method

- Remove flaky test annotations and improve mouse tracker HTML page structure

- Update coordinate assertions to match actual mouse positions after reset


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] -->|resetMousePointer| B["Mouse at 0,0"]
  B -->|fuzzyMatchingOfCoordinates| C["Coordinate Matching"]
  B -->|color method| D["Color Assertions"]
  C -->|tolerance 10px| E["Stable Tests"]
  D -->|rgb/rgba support| E
  F["WaitingConditions"] -->|new methods| G["Reusable Utilities"]
  G -->|used by| H["DefaultMouseTest<br/>PenPointerTest"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WaitingConditions.java</strong><dd><code>Add reusable fuzzy coordinate and color matching conditions</code></dd></summary>
<hr>

java/test/org/openqa/selenium/WaitingConditions.java

<ul><li>Added <code>fuzzyMatchingOfCoordinates()</code> method with 10-pixel tolerance for <br>coordinate matching<br> <li> Added <code>color()</code> method supporting both RGB and RGBA color formats for <br>cross-browser compatibility<br> <li> Imported <code>Colors</code> and <code>ExpectedConditions</code> utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-7316b743189146f201933b51996505c7df3ca57cf0a2abb83055230c5634c3c2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mouse_interaction.html</strong><dd><code>Add mouse tracking and click event logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/web/mouse_interaction.html

<ul><li>Added JavaScript event listeners to track mouse position and clicks<br> <li> Displays mouse coordinates and target element information in <code>#bottom</code> <br>div<br> <li> Supports test verification of mouse movement and click events</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-583e386213e52b36b52570c050280ec9c5258864b1a8fdbe06180e542a550ce5">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultMouseTest.java</strong><dd><code>Stabilize mouse tests with pointer reset and reusable conditions</code></dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/input/DefaultMouseTest.java

<ul><li>Added <code>resetMousePointer()</code> method called in <code>@BeforeEach</code> to position <br>mouse at (0,0)<br> <li> Extracted <code>fuzzyMatchingOfCoordinates()</code> and <code>color()</code> calls from <br><code>WaitingConditions</code><br> <li> Removed <code>@NeedsFreshDriver</code> and <code>@Ignore</code> annotations from flaky tests<br> <li> Updated <code>testMoveToLocation()</code> to wait for page load before assertions<br> <li> Fixed <code>testMoveRelativeToBody()</code> to expect correct coordinates after <br>reset<br> <li> Replaced direct color assertions with <code>color()</code> method for browser <br>tolerance<br> <li> Added static <code>MOUSE_TRACKER</code> dimension constant</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-73693f52d08caad34072a0088cf7e5e3d6ad8809138e1b1a655c3f67c624ddc2">+34/-68</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultMouseTest.java</strong><dd><code>Stabilize mouse tests with pointer reset and reusable conditions</code></dd></summary>
<hr>

java/test/org/openqa/selenium/interactions/DefaultMouseTest.java

<ul><li>Added <code>resetMousePointer()</code> method in <code>@BeforeEach</code> to position mouse at <br>(0,0)<br> <li> Replaced local <code>fuzzyMatchingOfCoordinates()</code> implementation with <br><code>WaitingConditions</code> version<br> <li> Removed <code>@NeedsFreshDriver</code> and <code>@Ignore</code> annotations from flaky tests<br> <li> Updated <code>testMoveToLocation()</code> to wait for page load before assertions<br> <li> Fixed <code>testMoveRelativeToBody()</code> to expect correct coordinates after <br>reset<br> <li> Replaced direct color assertions with <code>color()</code> method for browser <br>tolerance</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-2286706b02531fd3c0f3d217b9d4c77f24788366a2c14ab6c183c68b99ac2d76">+24/-53</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PenPointerTest.java</strong><dd><code>Stabilize pen pointer tests with reset and reusable conditions</code></dd></summary>
<hr>

java/test/org/openqa/selenium/interactions/PenPointerTest.java

<ul><li>Added <code>resetMousePointer()</code> method to position pen pointer at (0,0)<br> <li> Extracted <code>fuzzyMatchingOfCoordinates()</code> to <code>WaitingConditions</code><br> <li> Replaced local <code>fuzzyPositionMatching()</code> with reusable <code>color()</code> method<br> <li> Removed <code>@NeedsFreshDriver</code> and <code>@Ignore</code> annotations from flaky tests<br> <li> Updated <code>testMoveRelativeToBody()</code> to use reset and expect correct <br>coordinates<br> <li> Replaced <code>assertThatExceptionOfType()</code> with <code>assertThatThrownBy()</code> for <br>modern assertions<br> <li> Simplified exception assertions with fluent API<br> <li> Removed unused imports and cleaned up test code</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-5c76841c952c66827ad2ba834af670e491c18973314132b87b79be7d34e49601">+51/-95</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BasicMouseInterfaceTest.cs</strong><dd><code>Update expected coordinates after mouse reset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/Interactions/BasicMouseInterfaceTest.cs

<ul><li>Updated <code>MoveRelativeToBody()</code> test to expect coordinates (50, 100) <br>instead of (40, 20)<br> <li> Aligns with mouse pointer reset behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-159c0a3a023649cfc21c60522225e7fb5cd451ef1eb1c2814f67e0b2653e51a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mousePositionTracker.html</strong><dd><code>Refactor mouse tracker page for reliable coordinate tracking</code></dd></summary>
<hr>

common/src/web/mousePositionTracker.html

<ul><li>Refactored HTML structure with proper semantic layout and CSS <br>positioning<br> <li> Replaced jQuery with vanilla JavaScript for mouse tracking<br> <li> Fixed mouse tracker positioning to start at (0,0) with absolute <br>positioning<br> <li> Added <code>lang="en"</code> attribute and <code><title></code> element<br> <li> Improved CSS with <code>box-sizing: border-box</code> for consistent dimensions<br> <li> Separated display area from tracker area for better test reliability</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16906/files#diff-ae59f72f0e1f413ac21c0af987758982153399293343a5b57c34209195266a0f">+36/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

