### PR TITLE
[dotnet] [bidi] Expose New session command

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -60,11 +60,6 @@ public sealed class BiDi : IAsyncDisposable
 
     public Emulation.EmulationModule Emulation => AsModule<Emulation.EmulationModule>();
 
-    public Task<Session.StatusResult> StatusAsync()
-    {
-        return SessionModule.StatusAsync();
-    }
-
     public static async Task<BiDi> ConnectAsync(string url, BiDiOptions? options = null)
     {
         var bidi = new BiDi(url);
@@ -72,6 +67,16 @@ public sealed class BiDi : IAsyncDisposable
         await bidi.Broker.ConnectAsync(CancellationToken.None).ConfigureAwait(false);
 
         return bidi;
+    }
+
+    public Task<Session.StatusResult> StatusAsync(Session.StatusOptions? options = null)
+    {
+        return SessionModule.StatusAsync(options);
+    }
+
+    public Task<Session.NewResult> NewAsync(Session.CapabilitiesRequest capabilities, Session.NewOptions? options = null)
+    {
+        return SessionModule.NewAsync(capabilities, options);
     }
 
     public Task EndAsync(Session.EndOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
@@ -26,11 +26,13 @@ internal sealed record NewParameters(CapabilitiesRequest Capabilities) : Paramet
 
 public sealed class NewOptions : CommandOptions;
 
-public sealed record NewResult(string SessionId, Capability Capability) : EmptyResult;
+public sealed record NewResult(string SessionId, Capability Capabilities) : EmptyResult;
 
 public sealed record Capability(bool AcceptInsecureCerts, string BrowserName, string BrowserVersion, string PlatformName, bool SetWindowRect, string UserAgent)
 {
     public ProxyConfiguration? Proxy { get; set; }
+
+    public UserPromptHandler? UnhandledPromptBehavior { get; set; }
 
     public string? WebSocketUrl { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
@@ -48,9 +48,9 @@ internal sealed class SessionModule : Module
         return await Broker.ExecuteCommandAsync(new UnsubscribeByIdCommand(@params), options, _jsonContext.UnsubscribeByIdCommand, _jsonContext.UnsubscribeResult).ConfigureAwait(false);
     }
 
-    public async Task<NewResult> NewAsync(CapabilitiesRequest capabilitiesRequest, NewOptions? options = null)
+    public async Task<NewResult> NewAsync(CapabilitiesRequest capabilities, NewOptions? options = null)
     {
-        var @params = new NewParameters(capabilitiesRequest);
+        var @params = new NewParameters(capabilities);
 
         return await Broker.ExecuteCommandAsync(new NewCommand(@params), options, _jsonContext.NewCommand, _jsonContext.NewResult).ConfigureAwait(false);
     }

--- a/dotnet/test/common/BiDi/Session/SessionTest.cs
+++ b/dotnet/test/common/BiDi/Session/SessionTest.cs
@@ -18,7 +18,6 @@
 // </copyright>
 
 using NUnit.Framework;
-using OpenQA.Selenium.BiDi.Session;
 using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.BiDi.Session;
@@ -33,6 +32,4 @@ internal class SessionTest : BiDiTestFixture
         Assert.That(status, Is.Not.Null);
         Assert.That(status.Message, Is.Not.Empty);
     }
-
-    
 }

--- a/dotnet/test/common/BiDi/Session/SessionTest.cs
+++ b/dotnet/test/common/BiDi/Session/SessionTest.cs
@@ -1,0 +1,38 @@
+// <copyright file="SessionTest.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using NUnit.Framework;
+using OpenQA.Selenium.BiDi.Session;
+using System.Threading.Tasks;
+
+namespace OpenQA.Selenium.BiDi.Session;
+
+internal class SessionTest : BiDiTestFixture
+{
+    [Test]
+    public async Task CanGetStatus()
+    {
+        var status = await bidi.StatusAsync();
+
+        Assert.That(status, Is.Not.Null);
+        Assert.That(status.Message, Is.Not.Empty);
+    }
+
+    
+}


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
Make `NewAsync` command publicly available.

### 🔧 Implementation Notes
`Session` module is still exposed via main `BiDi` object.

### 💡 Additional Considerations
I don't know how to use this command in our world, it fails with error `session already exists`. But I successfully use it when launched BiDi mapper (https://github.com/GoogleChromeLabs/chromium-bidi).

### 🔄 Types of changes
- New feature


___

### **PR Type**
Enhancement


___

### **Description**
- Expose `NewAsync` command publicly via BiDi object

- Add `UnhandledPromptBehavior` property to Capability model

- Rename `Capability` field to `Capabilities` in NewResult

- Update `StatusAsync` to accept optional StatusOptions parameter

- Add SessionTest with status verification test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BiDi["BiDi object"]
  NewAsync["NewAsync command"]
  StatusAsync["StatusAsync with options"]
  Capability["Capability model"]
  UnhandledPrompt["UnhandledPromptBehavior property"]
  SessionTest["SessionTest.cs"]
  
  BiDi -- "expose" --> NewAsync
  BiDi -- "enhance" --> StatusAsync
  Capability -- "add" --> UnhandledPrompt
  SessionTest -- "verify" --> StatusAsync
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDi.cs</strong><dd><code>Expose NewAsync and enhance StatusAsync methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BiDi.cs

<ul><li>Remove parameterless <code>StatusAsync()</code> method<br> <li> Add <code>StatusAsync(Session.StatusOptions? options)</code> with optional <br>parameters<br> <li> Add new public <code>NewAsync(CapabilitiesRequest capabilities, </code><br><code>Session.NewOptions? options)</code> method<br> <li> Expose Session module commands at BiDi object level</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16907/files#diff-3f77d71f94e2a47ea90b74f6d37b5a5b94dc83b2f558b30ab070588b9028c2f6">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewCommand.cs</strong><dd><code>Add UnhandledPromptBehavior and fix field naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Session/NewCommand.cs

<ul><li>Rename <code>Capability</code> field to <code>Capabilities</code> in NewResult record<br> <li> Add <code>UnhandledPromptBehavior</code> property to Capability class<br> <li> Maintain existing AcceptInsecureCerts, BrowserName, BrowserVersion, <br>PlatformName, SetWindowRect, UserAgent properties</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16907/files#diff-7f042235ba430d9b49e0bdd605b71d3186d7eb3cad56d9cbf491cf2d62720c3f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SessionModule.cs</strong><dd><code>Rename parameter for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Session/SessionModule.cs

<ul><li>Rename parameter from <code>capabilitiesRequest</code> to <code>capabilities</code> for <br>consistency<br> <li> Update internal parameter assignment to use renamed variable<br> <li> No functional changes to NewAsync method logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16907/files#diff-31b1c3c5b298bcc68ac630c0af2fe9ecd548a737be8b5fa14574317f6eff3ff3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SessionTest.cs</strong><dd><code>Add SessionTest with status verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Session/SessionTest.cs

<ul><li>Create new test class SessionTest extending BiDiTestFixture<br> <li> Add <code>CanGetStatus()</code> test method verifying StatusAsync returns non-null <br>result<br> <li> Verify status message is not empty<br> <li> Include proper copyright and license headers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16907/files#diff-50fb6d18185c11857997dcc4937365ef6fbbe35b52c8296f5a45b9d49749cf1c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

