### PR TITLE
[rust] Replace fs::rename by file::move_file for Grid artifacts

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -45,6 +45,8 @@ use crate::shell::{
 use crate::stats::{Props, send_stats_to_plausible};
 use anyhow::Error;
 use anyhow::anyhow;
+use fs_extra::file;
+use fs_extra::file::CopyOptions;
 use reqwest::{Client, Proxy};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -222,7 +224,7 @@ pub trait SeleniumManager {
 
         if self.is_grid() {
             let driver_path_in_cache = self.get_driver_path_in_cache()?;
-            fs::rename(driver_zip_file, driver_path_in_cache)?;
+            file::move_file(driver_zip_file, driver_path_in_cache, &CopyOptions::new())?;
         } else {
             uncompress(
                 &driver_zip_file,


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
This PR replace the use `fs::rename` by `file::move_file` for Grid artifacts, since rename isn't allowed across filesystems.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `fs::rename` with `file::move_file` for Grid artifacts

- Enables cross-filesystem driver file movement in Grid environments

- Adds `fs_extra` crate dependency for improved file operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fs::rename<br/>limited to same filesystem"] -- "replaced by" --> B["file::move_file<br/>supports cross-filesystem moves"]
  B --> C["Grid artifact handling<br/>now works across filesystems"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Replace fs::rename with file::move_file for Grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/src/lib.rs

<ul><li>Added imports for <code>fs_extra::file</code> module and <code>CopyOptions</code><br> <li> Replaced <code>fs::rename</code> call with <code>file::move_file</code> for Grid driver <br>artifacts<br> <li> Uses <code>CopyOptions::new()</code> to configure the move operation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16911/files#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

