### PR TITLE
[build] Use symlinks in local_dev

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -577,8 +577,6 @@ namespace :py do
 
   desc 'generate and copy files required for local development'
   task :local_dev do
-    Bazel.execute('build', [], '//py:selenium')
-    Rake::Task['grid'].invoke
     dirs = ['devtools', 'linux', 'macos', 'windows']
     dirs.each do |dir|
       target = "../../../../bazel-bin/py/selenium/webdriver/common/#{dir}"  # relative path from symlink location

--- a/Rakefile
+++ b/Rakefile
@@ -579,9 +579,13 @@ namespace :py do
   task :local_dev do
     Bazel.execute('build', [], '//py:selenium')
     Rake::Task['grid'].invoke
-
-    FileUtils.rm_rf('py/selenium/webdriver/common/devtools/')
-    FileUtils.cp_r('bazel-bin/py/selenium/webdriver/.', 'py/selenium/webdriver', remove_destination: true)
+    dirs = ['devtools', 'linux', 'macos', 'windows']
+    dirs.each do |dir|
+      target = "../../../../bazel-bin/py/selenium/webdriver/common/#{dir}"  # relative path from symlink location
+      link = "py/selenium/webdriver/common/#{dir}"
+      FileUtils.rm_rf(link)
+      FileUtils.symlink(target, link)
+    end
   end
 
   desc 'Update generated Python files for local development'

--- a/Rakefile
+++ b/Rakefile
@@ -577,9 +577,9 @@ namespace :py do
 
   desc 'generate and copy files required for local development'
   task :local_dev do
-    dirs = ['devtools', 'linux', 'macos', 'windows']
+    dirs = %w[devtools linux macos windows]
     dirs.each do |dir|
-      target = "../../../../bazel-bin/py/selenium/webdriver/common/#{dir}"  # relative path from symlink location
+      target = "../../../../bazel-bin/py/selenium/webdriver/common/#{dir}" # relative path from symlink location
       link = "py/selenium/webdriver/common/#{dir}"
       FileUtils.rm_rf(link)
       FileUtils.symlink(target, link)

--- a/Rakefile
+++ b/Rakefile
@@ -575,7 +575,7 @@ namespace :py do
     Bazel.execute('run', ['--config=release'], command)
   end
 
-  desc 'generate and copy files required for local development'
+  desc 'Generate and copy files required for local development'
   task :local_dev do
     dirs = %w[devtools linux macos windows]
     dirs.each do |dir|


### PR DESCRIPTION
### 💥 What does this PR do?

This PR removes the build step from the `local_dev` rake task in the `go` wrapper.

When you invoke bazel through a rake task and build python, it creates bytecode files in some of the output directories when running the `generate.py` script to generate CDP files, and bazel doesn't like running after that.

To do local Python development, NEVER build using `go`.

instead, do:

```
bazel build //py/...
./go py:local_dev
```

This PR also changes the task to symlink the necessary files into your local source tree instead of copying them.. this gives us a single source of truth for all files.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Dev/Build