### PR TITLE
[java] Change BiDi "internalId" type from Long to String

### DIFF
--- a/java/src/org/openqa/selenium/bidi/script/RemoteValue.java
+++ b/java/src/org/openqa/selenium/bidi/script/RemoteValue.java
@@ -90,7 +90,7 @@ public class RemoteValue {
 
   private final Optional<String> handle;
 
-  private final Optional<Long> internalId;
+  private final Optional<String> internalId;
 
   private final Optional<Object> value;
 
@@ -99,7 +99,7 @@ public class RemoteValue {
   public RemoteValue(
       Type type,
       Optional<String> handle,
-      Optional<Long> internalId,
+      Optional<String> internalId,
       Optional<Object> value,
       Optional<String> sharedId) {
     this.type = type;
@@ -114,7 +114,7 @@ public class RemoteValue {
 
     Optional<String> handle = Optional.empty();
 
-    Optional<Long> internalId = Optional.empty();
+    Optional<String> internalId = Optional.empty();
 
     Optional<Object> value = Optional.empty();
 
@@ -133,7 +133,7 @@ public class RemoteValue {
           break;
 
         case "internalId":
-          internalId = Optional.ofNullable(input.read(Long.class));
+          internalId = Optional.ofNullable(input.read(String.class));
           break;
 
         case "value":
@@ -168,7 +168,7 @@ public class RemoteValue {
     return handle;
   }
 
-  public Optional<Long> getInternalId() {
+  public Optional<String> getInternalId() {
     return internalId;
   }
 


### PR DESCRIPTION
@diemol @titusfortner We need to **get this fix to 4.40.0 release**.

### **User description**
In BiDi spec, its type is "TEXT".

Latest FireFox 147.0 returns UUID in field "internalId":

```json
{
  "type" : "node",
  "sharedId" : "5dd958fd-0033-4b3a-b06a-f9eec9db2c85",
  "value" : { ... },
  "internalId" : "df8e0744-b1db-49b2-96df-45bd0d70dcd3"
}
```

### Stack trace:

```java
Exception in thread "BiDi Connection" org.openqa.selenium.bidi.BiDiException: Unable to process: {"type":"event","method":"log.entryAdded","params":{"type":"console","method":"log","source":{"realm":"9df00687-aa19-411c-a53f-bdb338b7abd8","context":"c6cc0a2e-8ba7-4c54-b58a-3615367747d7"},"args":[{"type":"object","value":[["originalEvent",{"type":"object"}],["type",{"type":"string","value":"keyup"}],["isDefaultPrevented",{"type":"function"}],["timeStamp",{"type":"number","value":339}],["jQuery183020487445442839158",{"type":"boolean","value":true}],["keyCode",{"type":"number","value":67}],["key",{"type":"string","value":"c"}],["charCode",{"type":"number","value":0}],["char",{"type":"undefined"}],["which",{"type":"number","value":67}],["view",{"type":"window","value":{"context":"10","isTopBrowsingContext":true}}],["target",{"type":"node","sharedId":"e5d288b2-6404-455b-aac1-9150c047bd08","value":{"nodeType":1,"localName":"input","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":0,"attributes":{"id":"tags","class":"ui-autocomplete-input","autocomplete":"off"},"shadowRoot":null},"internalId":"a7f2ac11-981a-4b84-ac22-7cb6d3c152ab"}],["shiftKey",{"type":"boolean","value":false}],["relatedTarget",{"type":"undefined"}],["metaKey",{"type":"boolean","value":false}],["eventPhase",{"type":"number","value":2}],["currentTarget",{"type":"node","sharedId":"e5d288b2-6404-455b-aac1-9150c047bd08","internalId":"a7f2ac11-981a-4b84-ac22-7cb6d3c152ab","value":{"nodeType":1,"localName":"input","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":0,"attributes":{"id":"tags","class":"ui-autocomplete-input","autocomplete":"off"},"shadowRoot":null}}],["ctrlKey",{"type":"boolean","value":false}],["cancelable",{"type":"boolean","value":true}],["bubbles",{"type":"boolean","value":true}],["altKey",{"type":"boolean","value":false}],["srcElement",{"type":"node","sharedId":"e5d288b2-6404-455b-aac1-9150c047bd08","internalId":"a7f2ac11-981a-4b84-ac22-7cb6d3c152ab","value":{"nodeType":1,"localName":"input","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":0,"attributes":{"id":"tags","class":"ui-autocomplete-input","autocomplete":"off"},"shadowRoot":null}}],["relatedNode",{"type":"undefined"}],["attrName",{"type":"undefined"}],["attrChange",{"type":"undefined"}],["delegateTarget",{"type":"node","sharedId":"e5d288b2-6404-455b-aac1-9150c047bd08","internalId":"a7f2ac11-981a-4b84-ac22-7cb6d3c152ab","value":{"nodeType":1,"localName":"input","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":0,"attributes":{"id":"tags","class":"ui-autocomplete-input","autocomplete":"off"},"shadowRoot":null}}],["data",{"type":"undefined"}],["handleObj",{"type":"object","value":[["type",{"type":"string","value":"keyup"}],["origType",{"type":"string","value":"keyup"}],["data",{"type":"undefined"}],["handler",{"type":"function"}],["guid",{"type":"number","value":7}],["selector",{"type":"undefined"}],["needsContext",{"type":"undefined"}],["namespace",{"type":"string","value":""}]]}]]}],"level":"info","text":"[object Object]","timestamp":1768573719871}}
	at org.openqa.selenium.bidi.Connection$Listener.lambda$onText$0(Connection.java:279)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.openqa.selenium.json.JsonException: Unable to create instance of class org.openqa.selenium.bidi.log.ConsoleLogEntry
Build info: version: '4.40.0-SNAPSHOT', revision: '048a50178d*'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.2', java.version: '17.0.17'
Driver info: driver.version: unknown
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:61)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.JsonInput.read(JsonInput.java:428)
	at org.openqa.selenium.bidi.log.Log.lambda$entryAdded$0(Log.java:49)
	at org.openqa.selenium.bidi.Connection.lambda$handleEventResponse$7(Connection.java:372)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1850)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.openqa.selenium.bidi.Connection.handleEventResponse(Connection.java:367)
	at org.openqa.selenium.bidi.Connection.handle(Connection.java:304)
	at org.openqa.selenium.bidi.Connection$Listener.lambda$onText$0(Connection.java:277)
	... 3 more
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:59)
	... 20 more
Caused by: org.openqa.selenium.json.JsonException: Unable to create instance of class org.openqa.selenium.bidi.script.RemoteValue
Build info: version: '4.40.0-SNAPSHOT', revision: '048a50178d*'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.2', java.version: '17.0.17'
Driver info: driver.version: unknown
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:61)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.CollectionCoercer.lambda$apply$0(CollectionCoercer.java:63)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.openqa.selenium.json.CollectionCoercer.lambda$apply$1(CollectionCoercer.java:64)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.JsonInput.read(JsonInput.java:428)
	at org.openqa.selenium.bidi.log.ConsoleLogEntry.fromJson(ConsoleLogEntry.java:98)
	... 24 more
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:59)
	... 40 more
Caused by: org.openqa.selenium.json.JsonException: Unable to create instance of class org.openqa.selenium.bidi.script.RemoteValue
Build info: version: '4.40.0-SNAPSHOT', revision: '048a50178d*'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.2', java.version: '17.0.17'
Driver info: driver.version: unknown
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:61)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.JsonInput.read(JsonInput.java:428)
	at org.openqa.selenium.bidi.script.RemoteValue.deserializeValue(RemoteValue.java:223)
	at org.openqa.selenium.bidi.script.RemoteValue.fromJson(RemoteValue.java:157)
	... 44 more
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.openqa.selenium.json.StaticInitializerCoercer.lambda$apply$0(StaticInitializerCoercer.java:59)
	... 49 more
Caused by: org.openqa.selenium.json.JsonException: java.lang.NumberFormatException: Character array is missing "e" notation exponential mark.
Build info: version: '4.40.0-SNAPSHOT', revision: '048a50178d*'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.2', java.version: '17.0.17'
Driver info: driver.version: unknown
	at org.openqa.selenium.json.NumberCoercer.lambda$apply$0(NumberCoercer.java:68)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.JsonInput.read(JsonInput.java:428)
	at org.openqa.selenium.bidi.script.RemoteValue.fromJson(RemoteValue.java:136)
	... 53 more
Caused by: java.lang.NumberFormatException: Character array is missing "e" notation exponential mark.
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:645)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:471)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:900)
	at org.openqa.selenium.json.NumberCoercer.lambda$apply$0(NumberCoercer.java:66)
	... 57 more
```
### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Change BiDi `internalId` field type from `Long` to `String`

- Align with BiDi specification where type is TEXT

- Support Firefox 147.0+ UUID format for `internalId`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RemoteValue class"] -- "internalId field type change" --> B["Long to String"]
  B -- "affects" --> C["Constructor parameter"]
  B -- "affects" --> D["fromJson deserialization"]
  B -- "affects" --> E["getInternalId getter"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoteValue.java</strong><dd><code>Update internalId field type to String</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/bidi/script/RemoteValue.java

<ul><li>Changed <code>internalId</code> field type from <code>Optional<Long></code> to <code>Optional<String></code><br> <li> Updated constructor parameter type for <code>internalId</code><br> <li> Modified <code>fromJson()</code> method to deserialize <code>internalId</code> as <code>String</code> instead <br>of <code>Long</code><br> <li> Updated <code>getInternalId()</code> getter return type to <code>Optional<String></code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16918/files#diff-b14a4430fbdc0b574940d5c7b90269d0c19274a3b126f467c42a0f0da50e0e9b">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

