### PR TITLE
[build] implement bazel rule for pushing nuget packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -908,35 +908,23 @@ namespace :dotnet do
     FileUtils.chmod(0o666, "build/dist/selenium-dotnet-strongnamed-#{dotnet_version}.zip")
   end
 
-  desc 'Upload nupkg files to Nuget'
+  desc 'Build, package, and push nupkg files to NuGet'
   task :release do |_task, arguments|
     nightly = arguments.to_a.include?('nightly')
     if nightly
       puts 'Updating .NET version to nightly...'
       Rake::Task['dotnet:version'].invoke('nightly')
+      ENV['NUGET_API_KEY'] = ENV.fetch('GITHUB_TOKEN', nil)
+      ENV['NUGET_SOURCE'] = 'https://nuget.pkg.github.com/seleniumhq/index.json'
+    else
+      ENV['NUGET_SOURCE'] = 'https://api.nuget.org/v3/index.json'
     end
 
-    puts 'Packaging .NET release artifacts...'
+    puts 'Building and packaging .NET artifacts...'
     Rake::Task['dotnet:package'].invoke('--config=release')
 
-    api_key = ENV.fetch('NUGET_API_KEY', nil)
-    push_destination = 'https://api.nuget.org/v3/index.json'
-
-    if nightly
-      puts 'Setting up NuGet GitHub source for nightly release...'
-      api_key = ENV.fetch('GITHUB_TOKEN', nil)
-      github_push_url = 'https://nuget.pkg.github.com/seleniumhq/index.json'
-      push_destination = 'github'
-      flags = ['--username', 'seleniumhq', '--password', api_key, '--store-password-in-clear-text', '--name',
-               push_destination, github_push_url]
-      sh "dotnet nuget add source #{flags.join(' ')}"
-    end
-
-    puts 'Pushing packages to NuGet'
-    ["./bazel-bin/dotnet/src/webdriver/Selenium.WebDriver.#{dotnet_version}.nupkg",
-     "./bazel-bin/dotnet/src/support/Selenium.Support.#{dotnet_version}.nupkg"].each do |asset|
-      sh "dotnet nuget push #{asset} --api-key #{api_key} --source #{push_destination}"
-    end
+    puts "Pushing .NET packages to #{ENV.fetch('NUGET_SOURCE', nil)}..."
+    Bazel.execute('run', ['--config=release'], '//dotnet:publish')
   end
 
   desc 'Generate .NET documentation'

--- a/dotnet/BUILD.bazel
+++ b/dotnet/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//dotnet:defs.bzl", "nuget_push")
 load("//dotnet/private:docfx.bzl", "docfx")
 
 exports_files([
@@ -41,4 +42,12 @@ docfx(
     name = "docs",
     docfx_dll = "@docfx//:docfx_dll",
     docfx_json = "docs/docfx.json",
+)
+
+nuget_push(
+    name = "publish",
+    packages = [
+        "//dotnet/src/support:support-pack",
+        "//dotnet/src/webdriver:webdriver-pack",
+    ],
 )

--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -6,6 +6,7 @@ load("//dotnet/private:generate_resources.bzl", _generated_resource_utilities = 
 load("//dotnet/private:generated_assembly_info.bzl", _generated_assembly_info = "generated_assembly_info")
 load("//dotnet/private:nuget_pack.bzl", _nuget_pack = "nuget_pack")
 load("//dotnet/private:nuget_package.bzl", _nuget_package = "nuget_package")
+load("//dotnet/private:nuget_push.bzl", _nuget_push = "nuget_push")
 load("//dotnet/private:nunit_test.bzl", _nunit_test = "nunit_test")
 
 def devtools_version_targets():
@@ -23,4 +24,5 @@ generated_resource_utilities = _generated_resource_utilities
 generated_assembly_info = _generated_assembly_info
 nuget_pack = _nuget_pack
 nuget_package = _nuget_package
+nuget_push = _nuget_push
 nunit_test = _nunit_test

--- a/dotnet/private/nuget_push.bzl
+++ b/dotnet/private/nuget_push.bzl
@@ -1,0 +1,92 @@
+"""Rule for pushing NuGet packages using the Bazel-managed dotnet toolchain."""
+
+def _nuget_push_impl(ctx):
+    toolchain = ctx.toolchains["@rules_dotnet//dotnet:toolchain_type"]
+    dotnet = toolchain.runtime.files_to_run.executable
+
+    nupkg_files = ctx.files.packages
+
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
+    if is_windows:
+        script = _create_windows_script(ctx, dotnet, nupkg_files)
+    else:
+        script = _create_unix_script(ctx, dotnet, nupkg_files)
+
+    runfiles = ctx.runfiles(files = nupkg_files).merge(toolchain.runtime.default_runfiles)
+
+    return [
+        DefaultInfo(
+            executable = script,
+            runfiles = runfiles,
+        ),
+    ]
+
+def _create_unix_script(ctx, dotnet, nupkg_files):
+    """Create bash script for Unix/macOS/Linux."""
+    push_commands = []
+    for nupkg in nupkg_files:
+        push_commands.append(
+            '"$DOTNET" nuget push "%s" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE"' % nupkg.short_path,
+        )
+
+    script_content = """#!/usr/bin/env bash
+set -euo pipefail
+DOTNET="$(cd "$(dirname "$0")" && pwd)/{dotnet}"
+{push_commands}
+""".format(
+        dotnet = dotnet.short_path,
+        push_commands = "\n".join(push_commands),
+    )
+
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+        is_executable = True,
+    )
+    return script
+
+def _create_windows_script(ctx, dotnet, nupkg_files):
+    """Create batch script for Windows."""
+    push_commands = []
+    for nupkg in nupkg_files:
+        nupkg_path = nupkg.short_path.replace("/", "\\")
+        push_commands.append(
+            '"%DOTNET%" nuget push "%s" --api-key "%NUGET_API_KEY%" --source "%NUGET_SOURCE%"' % nupkg_path,
+        )
+        push_commands.append("if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%")
+
+    dotnet_path = dotnet.short_path.replace("/", "\\")
+
+    script_content = """@echo off
+set DOTNET=%~dp0{dotnet_path}
+{push_commands}
+""".format(
+        dotnet_path = dotnet_path,
+        push_commands = "\n".join(push_commands),
+    )
+
+    script = ctx.actions.declare_file(ctx.label.name + ".bat")
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+        is_executable = True,
+    )
+    return script
+
+nuget_push = rule(
+    implementation = _nuget_push_impl,
+    attrs = {
+        "packages": attr.label_list(
+            doc = "The nupkg files to push",
+            mandatory = True,
+            allow_files = [".nupkg"],
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
+    },
+    executable = True,
+    toolchains = ["@rules_dotnet//dotnet:toolchain_type"],
+)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
Use bazel dotnet to push packages to nuget so do not need local installation

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* creates `nuget_push` rule
* simplifies release setp

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
* Cross platform script used in rule
* Expects `NUGET_API_KEY` to be set

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
* Might be good to have an explicit check for the environment variable
* Looking to add this to CI workflow soon


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements new `nuget_push` Bazel rule for cross-platform NuGet package publishing

- Eliminates local dotnet installation requirement for release workflow

- Simplifies Rakefile release task by delegating to Bazel-managed toolchain

- Supports both Windows batch and Unix/Linux/macOS bash scripts automatically


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rakefile release task"] -->|invokes| B["Bazel nuget_push rule"]
  B -->|detects platform| C["Windows batch script"]
  B -->|detects platform| D["Unix bash script"]
  C -->|uses| E["Bazel dotnet toolchain"]
  D -->|uses| E
  E -->|pushes packages| F["NuGet registry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nuget_push.bzl</strong><dd><code>New nuget_push Bazel rule implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/nuget_push.bzl

<ul><li>Creates new <code>nuget_push</code> Bazel rule for pushing NuGet packages<br> <li> Implements platform detection to generate Windows batch or Unix bash <br>scripts<br> <li> Handles cross-platform path conversion and error handling<br> <li> Integrates with Bazel-managed dotnet toolchain for executable <br>resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16920/files#diff-ffe47bdf89891536b5daad72314fd0dd78b291420e1c02290f14cea869d6008b">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defs.bzl</strong><dd><code>Export nuget_push rule definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/defs.bzl

<ul><li>Loads new <code>nuget_push</code> rule from private module<br> <li> Exports <code>nuget_push</code> as public API for use in BUILD files</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16920/files#diff-0846f178a64aa8555e4c6ce6fe66d46f5eb388fd67747724e590fdafdf199b80">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add publish target using nuget_push rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/BUILD.bazel

<ul><li>Loads <code>nuget_push</code> rule from defs module<br> <li> Creates <code>publish</code> target that packages and pushes WebDriver and Support <br>NuGet packages</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16920/files#diff-8e75219e968f5da47dee9789ba5f72083b23b96495163c10dac06ecb93464115">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Simplify dotnet release task with Bazel integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Simplifies release task by delegating to Bazel <code>nuget_push</code> rule<br> <li> Removes manual dotnet CLI invocations and source configuration logic<br> <li> Sets environment variables for NuGet API key and source URL based on <br>release type<br> <li> Reduces complexity from 30+ lines to 5 lines of push logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16920/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+8/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

