### PR TITLE
[build] generate dotnet docs with bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -101,6 +101,9 @@ use_repo(dotnet, "dotnet_toolchains")
 selenium_paket = use_extension("//dotnet:paket.nuget_extension.bzl", "nuget_extension")
 use_repo(selenium_paket, "paket.nuget")
 
+docfx_ext = use_extension("//dotnet/private:docfx_repo.bzl", "docfx_extension")
+use_repo(docfx_ext, "docfx")
+
 register_toolchains("@dotnet_toolchains//:all")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/Rakefile
+++ b/Rakefile
@@ -882,28 +882,7 @@ namespace :dotnet do
 
     puts 'Generating .NET documentation'
     FileUtils.rm_rf('build/docs/api/dotnet/')
-    begin
-      # Pinning to 2.78.2 to avoid breaking changes in newer versions
-      sh 'dotnet tool uninstall --global docfx || true'
-      sh 'dotnet tool install --global --version 2.78.2 docfx'
-      # sh 'dotnet tool update -g docfx'
-    rescue StandardError
-      puts 'Please ensure that .NET SDK is installed.'
-      raise
-    end
-
-    begin
-      sh 'docfx dotnet/docs/docfx.json'
-    rescue StandardError
-      case $CHILD_STATUS.exitstatus
-      when 133
-        raise 'Ensure the dotnet/tools directory is added to your PATH environment variable (e.g., `~/.dotnet/tools`)'
-      when 255
-        puts '.NET documentation build failed, likely because of DevTools namespacing. This is ok; continuing'
-      else
-        raise
-      end
-    end
+    Bazel.execute('run', [], '//dotnet:docs')
 
     update_gh_pages unless arguments.to_a.include?('skip_update')
   end

--- a/dotnet/BUILD.bazel
+++ b/dotnet/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//dotnet/private:docfx.bzl", "docfx")
 
 exports_files([
     "AssemblyInfo.cs.template",
@@ -34,4 +35,10 @@ filegroup(
         "//dotnet/src/webdriver:Properties/StringSyntaxConstants.cs",
     ],
     visibility = ["__subpackages__"],
+)
+
+docfx(
+    name = "docs",
+    docfx_dll = "@docfx//:docfx_dll",
+    docfx_json = "docs/docfx.json",
 )

--- a/dotnet/private/docfx.bzl
+++ b/dotnet/private/docfx.bzl
@@ -1,0 +1,65 @@
+"""Rule for running docfx using the Bazel-managed dotnet toolchain."""
+
+def _to_manifest_path(file):
+    """Convert short_path to manifest path (external repos need 'external/' prefix)."""
+    if file.short_path.startswith("../"):
+        return "external/" + file.short_path[3:]
+    return file.short_path
+
+def _docfx_impl(ctx):
+    toolchain = ctx.toolchains["@rules_dotnet//dotnet:toolchain_type"]
+    dotnet = toolchain.runtime.files_to_run.executable
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
+    dotnet_path = _to_manifest_path(dotnet)
+    docfx_path = _to_manifest_path(ctx.file.docfx_dll)
+    config_path = ctx.file.docfx_json.short_path
+
+    if is_windows:
+        script = ctx.actions.declare_file(ctx.label.name + ".bat")
+        ctx.actions.write(script, _WINDOWS_TEMPLATE.format(
+            dotnet = dotnet_path.replace("/", "\\"),
+            docfx = docfx_path.replace("/", "\\"),
+            config = config_path.replace("/", "\\"),
+        ), is_executable = True)
+    else:
+        script = ctx.actions.declare_file(ctx.label.name + ".sh")
+        ctx.actions.write(script, _UNIX_TEMPLATE.format(
+            dotnet = dotnet_path,
+            docfx = docfx_path,
+            config = config_path,
+        ), is_executable = True)
+
+    return [DefaultInfo(executable = script)]
+
+_UNIX_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+cd "$BUILD_WORKSPACE_DIRECTORY"
+exec "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/{dotnet}" exec \
+     "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/{docfx}" {config} "$@"
+"""
+
+_WINDOWS_TEMPLATE = """@echo off
+cd /d "%BUILD_WORKSPACE_DIRECTORY%"
+"%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\{dotnet}" exec ^
+    "%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\{docfx}" {config} %*
+"""
+
+docfx = rule(
+    implementation = _docfx_impl,
+    executable = True,
+    toolchains = ["@rules_dotnet//dotnet:toolchain_type"],
+    attrs = {
+        "docfx_dll": attr.label(
+            mandatory = True,
+            allow_single_file = [".dll"],
+        ),
+        "docfx_json": attr.label(
+            mandatory = True,
+            allow_single_file = [".json"],
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
+    },
+)

--- a/dotnet/private/docfx_repo.bzl
+++ b/dotnet/private/docfx_repo.bzl
@@ -1,0 +1,33 @@
+"""Repository rule to download the docfx NuGet package."""
+
+_BUILD = """
+package(default_visibility = ["//visibility:public"])
+exports_files(glob(["**/*"]))
+filegroup(name = "docfx_dll", srcs = ["tools/net8.0/any/docfx.dll"])
+"""
+
+def _docfx_repo_impl(ctx):
+    ctx.download_and_extract(
+        url = "https://api.nuget.org/v3-flatcontainer/docfx/{0}/docfx.{0}.nupkg".format(ctx.attr.version),
+        sha256 = ctx.attr.sha256,
+        type = "zip",
+    )
+    ctx.file("BUILD.bazel", _BUILD)
+
+docfx_repo = repository_rule(
+    implementation = _docfx_repo_impl,
+    attrs = {
+        "version": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
+    },
+)
+
+def _docfx_extension_impl(module_ctx):
+    docfx_repo(
+        name = "docfx",
+        version = "2.78.2",
+        sha256 = "68b70b5e3e3f0df0dd858b228131fec40ca45493bb5b93f77b9ab3a38b21f7fb",
+    )
+    return module_ctx.extension_metadata(reproducible = True)
+
+docfx_extension = module_extension(implementation = _docfx_extension_impl)


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
remove need for local dotnet installation to generate docs

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* defines the bazel repo for getting docfx
* creates bazel rule  for using it
* simplifies the command to generate docs


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement Bazel-based docfx integration for .NET documentation generation

- Remove dependency on local dotnet installation for docs

- Create repository rule to download docfx NuGet package automatically

- Simplify documentation generation command in Rakefile


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docfx_repo.bzl<br/>Repository Rule"] -->|"downloads docfx<br/>NuGet package"| B["@docfx repo<br/>External Dependency"]
  C["docfx.bzl<br/>Bazel Rule"] -->|"uses docfx_dll"| B
  D["MODULE.bazel"] -->|"registers<br/>docfx_extension"| A
  E["dotnet/BUILD.bazel"] -->|"defines docs<br/>target"| C
  F["Rakefile"] -->|"calls bazel run<br/>docs target"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docfx.bzl</strong><dd><code>Bazel rule for docfx execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/docfx.bzl

<ul><li>Creates new Bazel rule <code>docfx</code> for executing docfx documentation <br>generation<br> <li> Implements platform-specific script generation (Windows .bat and Unix <br>.sh)<br> <li> Handles manifest path conversion for external repository dependencies<br> <li> Integrates with rules_dotnet toolchain for dotnet executable access</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16921/files#diff-f1834764181bf7fe701bc71b1799c97ae36f9faf50078ad87f97aef96097bf43">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docfx_repo.bzl</strong><dd><code>Repository rule for docfx NuGet package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/docfx_repo.bzl

<ul><li>Defines repository rule to download docfx NuGet package from nuget.org<br> <li> Creates module extension for Bazel 7+ dependency management<br> <li> Pins docfx version to 2.78.2 with SHA256 verification<br> <li> Exports docfx.dll filegroup for use in other targets</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16921/files#diff-bf0b94f5661e0a654dff3a8afea6ac1e44621c13b57d8130244f94b62e3bade1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Define docs target with docfx rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/BUILD.bazel

<ul><li>Imports docfx rule from dotnet/private/docfx.bzl<br> <li> Defines new <code>docs</code> target using docfx rule<br> <li> Specifies docfx_dll from @docfx repository and docfx.json <br>configuration file</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16921/files#diff-8e75219e968f5da47dee9789ba5f72083b23b96495163c10dac06ecb93464115">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Register docfx module extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Registers docfx_extension module for automatic docfx dependency <br>management<br> <li> Adds use_repo directive to make @docfx repository available<br> <li> Integrates docfx into Bazel's module system alongside other <br>dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16921/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Simplify docs task with Bazel integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Removes manual dotnet tool installation and uninstallation logic<br> <li> Eliminates error handling for missing .NET SDK and PATH configuration<br> <li> Replaces complex docfx invocation with single <code>Bazel.execute('run', [], </code><br><code>'//dotnet:docs')</code> call<br> <li> Simplifies documentation generation workflow significantly</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16921/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+1/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

