### PR TITLE
build js docs with bazel

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -75,11 +75,6 @@ jobs:
               rules_ruby++ruby+ruby: rb/.ruby-version
           repository-cache: true
           bazelrc: common --color=yes
-      - name: Install npm dependencies
-        if: ${{ inputs.language == 'node' || inputs.language == 'all' }}
-        run: |
-          npm install
-          npm install --prefix javascript/selenium-webdriver
       - name: Generate Documentation for selected langauges
         run: ./go ${{ inputs.language }}:docs ${{ inputs.force }}
       - name: Documentation Pull Request

--- a/Rakefile
+++ b/Rakefile
@@ -518,14 +518,7 @@ namespace :node do
 
     puts 'Generating Node documentation'
     FileUtils.rm_rf('build/docs/api/javascript/')
-    begin
-      Dir.chdir('javascript/selenium-webdriver') do
-        sh 'pnpm install', verbose: true
-        sh 'pnpm run generate-docs', verbose: true
-      end
-    rescue StandardError => e
-      puts "Node documentation generation contains errors; continuing... #{e.message}"
-    end
+    Bazel.execute('run', [], '//javascript/selenium-webdriver:docs')
 
     update_gh_pages unless arguments.to_a.include?('skip_update')
   end

--- a/javascript/private/jsdoc.bzl
+++ b/javascript/private/jsdoc.bzl
@@ -1,0 +1,48 @@
+"""Rule for running jsdoc using Bazel-managed Node.js."""
+
+def _jsdoc_impl(ctx):
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+
+    if is_windows:
+        script = ctx.actions.declare_file(ctx.label.name + ".bat")
+        ctx.actions.write(script, _WINDOWS_TEMPLATE.format(
+            config = ctx.file.config.basename,
+        ), is_executable = True)
+    else:
+        script = ctx.actions.declare_file(ctx.label.name + ".sh")
+        ctx.actions.write(script, _UNIX_TEMPLATE.format(
+            config = ctx.file.config.basename,
+        ), is_executable = True)
+
+    runfiles = ctx.runfiles(files = ctx.files.data + [ctx.file.config])
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+_UNIX_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+cd "$BUILD_WORKSPACE_DIRECTORY/javascript/selenium-webdriver"
+exec "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/javascript/selenium-webdriver/node_modules/.bin/jsdoc" \\
+    --configure {config} "$@"
+"""
+
+_WINDOWS_TEMPLATE = """@echo off
+cd /d "%BUILD_WORKSPACE_DIRECTORY%\\javascript\\selenium-webdriver"
+"%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\javascript\\selenium-webdriver\\node_modules\\.bin\\jsdoc" ^
+    --configure {config} %*
+"""
+
+jsdoc = rule(
+    implementation = _jsdoc_impl,
+    executable = True,
+    attrs = {
+        "config": attr.label(
+            mandatory = True,
+            allow_single_file = [".json"],
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
+    },
+)

--- a/javascript/selenium-webdriver/BUILD.bazel
+++ b/javascript/selenium-webdriver/BUILD.bazel
@@ -8,6 +8,7 @@ load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("//common:defs.bzl", "copy_file")
 load("//javascript:defs.bzl", "mocha_test")
 load("//javascript/private:browsers.bzl", "BROWSERS")
+load("//javascript/private:jsdoc.bzl", "jsdoc")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -283,4 +284,13 @@ copy_to_bin(
 copy_to_bin(
     name = "prettier-ignore",
     srcs = [".prettierignore"],
+)
+
+jsdoc(
+    name = "docs",
+    config = "jsdoc_conf.json",
+    data = [
+        ":node_modules/clean-jsdoc-theme",
+        ":prod-src-files",
+    ],
 )


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->
remove the need for npm when generating documentation

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* creates jsdoc rule
* simplifies rake task

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->
Ensured the rule is cross platform


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Creates Bazel-based jsdoc rule for cross-platform documentation generation

- Removes npm/pnpm dependency from documentation build workflow

- Simplifies Rakefile by replacing shell commands with Bazel execution

- Updates CI workflow to use Bazel instead of npm for setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["npm/pnpm<br/>dependencies"] -->|removed| B["Bazel jsdoc rule"]
  C["Rakefile<br/>shell commands"] -->|replaced| B
  D["CI workflow<br/>npm setup"] -->|replaced| E["Bazel setup"]
  B -->|generates| F["JavaScript docs"]
  E -->|executes| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jsdoc.bzl</strong><dd><code>New jsdoc Bazel rule for documentation generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/private/jsdoc.bzl

<ul><li>New Bazel rule implementation for running jsdoc with Bazel-managed <br>Node.js<br> <li> Supports cross-platform execution with separate Windows batch and Unix <br>shell templates<br> <li> Handles platform detection using Bazel constraints<br> <li> Manages runfiles and executable script generation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16922/files#diff-4eb9af5f00d5bee10d998f86a4a1e5b539a4a7ce8dda6c74a9599432cc8677a6">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-documentation.yml</strong><dd><code>Update CI workflow to use Bazel for setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-documentation.yml

<ul><li>Replaces npm install steps with Bazel setup action<br> <li> Removes separate npm dependency installation for Node.js<br> <li> Adds bazelisk-cache configuration for improved CI performance<br> <li> Simplifies workflow by delegating to Bazel for dependency management</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16922/files#diff-762373f28dabfb9bf0baf6a4fb9d5ca47a3ff3a5c16c908e74b52d2eb81ddbc9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add jsdoc target to BUILD configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/BUILD.bazel

<ul><li>Imports new jsdoc rule from javascript/private/jsdoc.bzl<br> <li> Adds docs target using jsdoc rule with jsdoc_conf.json configuration<br> <li> Includes node_modules and prod-src-files as data dependencies<br> <li> Enables Bazel-based documentation generation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16922/files#diff-929781d2a6493d8b5cef8e48c29d8c3430df0e548b4ed20829588d79e5fa57a7">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Simplify Rakefile documentation task with Bazel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Removes pnpm install and generate-docs shell commands<br> <li> Replaces with single Bazel execution call<br> <li> Eliminates error handling try-catch block<br> <li> Simplifies documentation generation task</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16922/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

