### PR TITLE
[bazel] Prevent duplicate directory warnings from python builds

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@py_dev_requirements//:requirements.bzl", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
@@ -401,14 +400,6 @@ py_binary(
     outdir = "selenium/webdriver/common/devtools/{}".format(devtools_version),
     protocol_version = devtools_version,
 ) for devtools_version in BROWSER_VERSIONS]
-
-write_source_files(
-    name = "update-cdp-srcs",
-    files = {
-        "selenium/webdriver/common/devtools/{}".format(devtools_version): ":create-cdp-srcs-{}".format(devtools_version)
-        for devtools_version in BROWSER_VERSIONS
-    },
-)
 
 py_test_suite(
     name = "unit",

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@py_dev_requirements//:requirements.bzl", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
@@ -214,7 +215,10 @@ py_library(
     name = "selenium",
     srcs = glob(
         ["selenium/**/*.py"],
-        exclude = ["generate.py"],
+        exclude = [
+            "generate.py",
+            "selenium/webdriver/common/devtools/v*/**",
+        ],
     ),
     data = [
         "selenium/py.typed",
@@ -397,6 +401,14 @@ py_binary(
     outdir = "selenium/webdriver/common/devtools/{}".format(devtools_version),
     protocol_version = devtools_version,
 ) for devtools_version in BROWSER_VERSIONS]
+
+write_source_files(
+    name = "update-cdp-srcs",
+    files = {
+        "selenium/webdriver/common/devtools/{}".format(devtools_version): ":create-cdp-srcs-{}".format(devtools_version)
+        for devtools_version in BROWSER_VERSIONS
+    },
+)
 
 py_test_suite(
     name = "unit",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Exclude generated devtools directories from Python library sources

- Add write_source_files rule for updating CDP source files

- Prevent duplicate directory warnings in Bazel builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["py/BUILD.bazel"] -->|"add write_source_files load"| B["Bazel configuration"]
  A -->|"exclude devtools v* dirs"| C["selenium library srcs"]
  A -->|"add update-cdp-srcs rule"| D["CDP source file updates"]
  C -->|"prevents duplicates"| E["Clean build output"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Build configuration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add devtools exclusion and CDP source file management</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/BUILD.bazel

<ul><li>Added <code>write_source_files</code> load from <code>aspect_bazel_lib</code> for source file <br>management<br> <li> Excluded generated devtools version directories <br>(<code>selenium/webdriver/common/devtools/v*/**</code>) from <code>selenium</code> library <br>sources to prevent duplicate warnings<br> <li> Added new <code>update-cdp-srcs</code> rule using <code>write_source_files</code> to manage CDP <br>source file generation and updates across all browser versions<br> <li> Maintains existing <code>create-cdp-srcs-*</code> rules for individual version <br>generation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16923/files#diff-3e8ff3a52e8e6c0b195ea328e17c50ba6d90abca1ce1624110607da20691d7a9">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

