### PR TITLE
[java] fix logging in Selenium own tests

### DIFF
--- a/java/test/org/openqa/selenium/testing/CaptureLoggingRule.java
+++ b/java/test/org/openqa/selenium/testing/CaptureLoggingRule.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.testing;
 
+import static java.util.Collections.synchronizedList;
 import static java.util.stream.Collectors.toList;
 import static org.openqa.selenium.internal.Debug.isDebugging;
 
@@ -32,65 +33,59 @@ import java.util.List;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 class CaptureLoggingRule {
 
-  List<Handler> handlers;
+  private final Logger logger = rootLogger();
 
-  public CaptureLoggingRule() {
+  public void startLogCapture() {
     if (isDebugging()) {
       return;
     }
 
-    Logger logger = LogManager.getLogManager().getLogger("");
-
     // Capture the original log handlers
-    handlers =
-        Arrays.stream(logger.getHandlers())
-            .filter(handler -> handler instanceof ConsoleHandler)
-            .collect(toList());
+    List<ConsoleHandler> handlers = handlers(ConsoleHandler.class);
 
     // Remove them from the logger
     handlers.forEach(logger::removeHandler);
 
     // Replace them with log handlers that record messages
-    logger.addHandler(new RecordingHandler());
+    logger.addHandler(new RecordingHandler(handlers));
   }
 
-  public void writeCapturedLogs() {
-    if (isDebugging()) {
-      return;
-    }
-
-    Logger logger = LogManager.getLogManager().getLogger("");
-    Arrays.stream(logger.getHandlers())
-        .filter(handler -> handler instanceof RecordingHandler)
-        .map(handler -> (RecordingHandler) handler)
-        .forEach(RecordingHandler::write);
+  private void writeCapturedLogs(Level writeLogsHigherThan) {
+    handlers(RecordingHandler.class)
+        .forEach(recordingHandler -> recordingHandler.write(writeLogsHigherThan));
   }
 
-  public void endLogCapture() {
+  public void endLogCapture(Level writeLogsHigherThan) {
+    writeCapturedLogs(writeLogsHigherThan);
+
     if (isDebugging()) {
       return;
     }
 
     // Find our recording handler
-    Logger logger = LogManager.getLogManager().getLogger("");
-    List<RecordingHandler> recordingHandlers =
-        Arrays.stream(logger.getHandlers())
-            .filter(handler -> handler instanceof RecordingHandler)
-            .map(handler -> (RecordingHandler) handler)
-            .collect(toList());
+    List<RecordingHandler> recordingHandlers = handlers(RecordingHandler.class);
 
-    recordingHandlers.forEach(logger::removeHandler);
+    // Restore the original handlers
+    for (RecordingHandler recordingHandler : recordingHandlers) {
+      logger.removeHandler(recordingHandler);
+      recordingHandler.originalHandlers.forEach(logger::addHandler);
+    }
   }
 
   private static class RecordingHandler extends Handler {
+    private final List<? extends Handler> originalHandlers;
+    private final List<LogRecord> records = synchronizedList(new ArrayList<>());
 
-    private final List<LogRecord> records = new ArrayList<>();
+    private RecordingHandler(List<? extends Handler> originalHandlers) {
+      this.originalHandlers = originalHandlers;
+    }
 
     @Override
     public void publish(LogRecord record) {
@@ -107,9 +102,11 @@ class CaptureLoggingRule {
       // no-op
     }
 
-    public void write() {
+    public void write(Level writeLogsHigherThan) {
       Formatter formatter = new OurFormatter();
-      records.forEach(record -> System.out.print(formatter.format(record)));
+      records.stream()
+          .filter(record -> record.getLevel().intValue() >= writeLogsHigherThan.intValue())
+          .forEach(record -> System.out.print(formatter.format(record)));
     }
   }
 
@@ -144,5 +141,17 @@ class CaptureLoggingRule {
 
       return buffer.toString();
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> List<T> handlers(Class<T> klass) {
+    return Arrays.stream(logger.getHandlers())
+        .filter(handler -> klass.isAssignableFrom(handler.getClass()))
+        .map(handler -> (T) handler)
+        .collect(toList());
+  }
+
+  private static Logger rootLogger() {
+    return LogManager.getLogManager().getLogger("");
   }
 }

--- a/java/test/org/openqa/selenium/testing/JupiterTestBase.java
+++ b/java/test/org/openqa/selenium/testing/JupiterTestBase.java
@@ -43,7 +43,8 @@ public abstract class JupiterTestBase {
 
   private static final Logger LOG = Logger.getLogger(JupiterTestBase.class.getName());
 
-  @RegisterExtension protected static SeleniumExtension seleniumExtension = new SeleniumExtension();
+  @RegisterExtension
+  protected static final SeleniumExtension seleniumExtension = new SeleniumExtension();
 
   protected TestEnvironment environment;
   protected AppServer appServer;

--- a/java/test/org/openqa/selenium/testing/SeleniumExtension.java
+++ b/java/test/org/openqa/selenium/testing/SeleniumExtension.java
@@ -56,19 +56,13 @@ public class SeleniumExtension
         TestExecutionExceptionHandler {
 
   private static final ThreadLocal<SeleniumExtension.Instances> instances = new ThreadLocal<>();
-
   private static final Logger LOG = Logger.getLogger(SeleniumExtension.class.getName());
 
   private final Duration regularWait;
-
   private final Duration shortWait;
-
   private boolean nullDriver = false;
-
   private final TestIgnorance ignorance;
-
-  private final CaptureLoggingRule captureLoggingRule;
-
+  private final CaptureLoggingRule captureLoggingRule = new CaptureLoggingRule();
   private boolean failedWithNotYetImplemented = false;
   private boolean failedWithRemoteBuild = false;
 
@@ -82,11 +76,11 @@ public class SeleniumExtension
 
     this.ignorance =
         new TestIgnorance(Optional.ofNullable(Browser.detect()).orElse(Browser.CHROME));
-    this.captureLoggingRule = new CaptureLoggingRule();
   }
 
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
+    captureLoggingRule.startLogCapture();
     nullDriver = false;
 
     // ManageDriverRule.starting
@@ -138,11 +132,11 @@ public class SeleniumExtension
     SwitchToTopRule switchToTopRule = new SwitchToTopRule(context);
     switchToTopRule.apply();
 
-    // TraceMethodNameRule.finished
-    LOG.info(() -> "<<< Finished  " + displayName(context));
+    Level logLevel =
+        context.getExecutionException().map(testFailed -> Level.ALL).orElse(Level.WARNING);
+    captureLoggingRule.endLogCapture(logLevel);
 
-    // CaptureLoggingRule
-    captureLoggingRule.endLogCapture();
+    LOG.info(() -> "<<< Finished  " + displayName(context));
 
     // NotYetImplementedRule
     NotYetImplementedRule notYetImplementedRule = new NotYetImplementedRule(context);
@@ -211,8 +205,7 @@ public class SeleniumExtension
       }
     }
 
-    // CaptureLoggingRule
-    captureLoggingRule.writeCapturedLogs();
+    captureLoggingRule.endLogCapture(Level.ALL);
   }
 
   @Override
@@ -346,7 +339,7 @@ public class SeleniumExtension
       return nyi.anyMatch(driver -> current.matches(driver.value()));
     }
 
-    public boolean check() throws Exception {
+    public boolean check() {
       Optional<AnnotatedElement> element = context.getElement();
       Optional<NotYetImplementedList> notYetImplementedList =
           findAnnotation(element, NotYetImplementedList.class);


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #16932

### 💥 What does this PR do?
This PR fixes `SeleniumExtension`, so that Selenium logs are written again when running Selenium own tests.

### 🔧 Implementation Notes
Now `SeleniumExtension` works as follows:
1. Replace ConsoleHandlers by RecordingHandler before each test
2. Restore original ConsoleHandlers after each test
3. For failed tests - write down ALL logs
4. For succeeded tests - write down WARN and ERROR logs (they might be also useful)

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix logging capture in Selenium tests by refactoring `CaptureLoggingRule`

- Replace console handlers with recording handler before each test

- Restore original handlers after each test completion

- Write all logs for failed tests, warn/error logs for passed tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] -->|beforeEach| B["Start Log Capture"]
  B -->|Remove ConsoleHandlers| C["Add RecordingHandler"]
  C -->|Test Runs| D["Logs Recorded"]
  D -->|afterEach| E["End Log Capture"]
  E -->|Check Test Status| F{Test Failed?}
  F -->|Yes| G["Write ALL Logs"]
  F -->|No| H["Write WARN/ERROR Logs"]
  G -->|Restore Handlers| I["Original Handlers"]
  H -->|Restore Handlers| I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaptureLoggingRule.java</strong><dd><code>Refactor logging capture with selective level-based output</code></dd></summary>
<hr>

java/test/org/openqa/selenium/testing/CaptureLoggingRule.java

<ul><li>Refactored to use instance logger instead of repeated lookups<br> <li> Changed constructor to <code>startLogCapture()</code> method for lifecycle <br>management<br> <li> Added <code>Level</code> parameter to <code>writeCapturedLogs()</code> and <code>endLogCapture()</code> for <br>selective logging<br> <li> <code>RecordingHandler</code> now stores original handlers to restore them after <br>test<br> <li> Added generic <code>handlers()</code> helper method to filter handlers by type<br> <li> Modified <code>write()</code> method to filter logs by level before output</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16933/files#diff-eac85baa1e6247c0d4980e231400e53bfdb0cd1fb19c2253e9684467611cb485">+39/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SeleniumExtension.java</strong><dd><code>Integrate selective log capture based on test outcome</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/SeleniumExtension.java

<ul><li>Initialize <code>captureLoggingRule</code> as instance field instead of in <br>constructor<br> <li> Call <code>startLogCapture()</code> in <code>beforeEach()</code> to capture logs before test <br>execution<br> <li> Modified <code>afterEach()</code> to determine log level based on test failure <br>status<br> <li> Pass appropriate log level to <code>endLogCapture()</code> - <code>Level.ALL</code> for failed <br>tests, <code>Level.WARNING</code> for passed tests<br> <li> Removed redundant <code>writeCapturedLogs()</code> call from <code>testFailed()</code> method<br> <li> Removed unnecessary blank lines for code cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16933/files#diff-cfa0965ea8e2e8fca6e9c501cb0b8a16f16a251f7771a7e5fc973ff40513ebaf">+8/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JupiterTestBase.java</strong><dd><code>Make SeleniumExtension field final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/testing/JupiterTestBase.java

<ul><li>Made <code>seleniumExtension</code> field <code>final</code> for immutability<br> <li> Reformatted <code>@RegisterExtension</code> annotation placement</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16933/files#diff-b63297bc768ca812e8b803878284f87c82fb681cdda15ec93bf4190195f3f814">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

