### PR TITLE
[dotnet] [bidi] FileDialogOpened event in Input module

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -54,7 +54,7 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
 
     public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return inputModule.OnFileDialogOpenedAsync((e) =>
+        return inputModule.OnFileDialogOpenedAsync(e =>
         {
             if (context.Equals(e.Context))
             {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -17,6 +17,7 @@
 // under the License.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 using OpenQA.Selenium.BiDi.Input;
 using System.Collections.Generic;
@@ -38,5 +39,27 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
     public Task<SetFilesResult> SetFilesAsync(Script.ISharedReference element, IEnumerable<string> files, SetFilesOptions? options = null)
     {
         return inputModule.SetFilesAsync(context, element, files, options);
+    }
+
+    public Task<Subscription> OnFileDialogOpenedAsync(Func<FileDialogInfo, Task> handler, ContextSubscriptionOptions? options = null)
+    {
+        return inputModule.OnFileDialogOpenedAsync(async e =>
+        {
+            if (context.Equals(e.Context))
+            {
+                await handler(e).ConfigureAwait(false);
+            }
+        }, options.WithContext(context));
+    }
+
+    public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
+    {
+        return inputModule.OnFileDialogOpenedAsync((e) =>
+        {
+            if (context.Equals(e.Context))
+            {
+                handler(e);
+            }
+        }, options.WithContext(context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
@@ -19,5 +19,5 @@
 
 namespace OpenQA.Selenium.BiDi.Input;
 
-public sealed record FileDialogInfo(BrowsingContext.BrowsingContext Context, bool Multiple, Script.ISharedReference? Element)
+public sealed record FileDialogInfo(BrowsingContext.BrowsingContext Context, bool Multiple, Script.SharedReference? Element)
     : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
@@ -1,0 +1,23 @@
+// <copyright file="FileDialogInfo.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+namespace OpenQA.Selenium.BiDi.Input;
+
+public sealed record FileDialogInfo(BrowsingContext.BrowsingContext Context, bool Multiple, Script.ISharedReference? Element)
+    : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Input/InputModule.cs
+++ b/dotnet/src/webdriver/BiDi/Input/InputModule.cs
@@ -18,6 +18,7 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Json.Converters;
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -50,6 +51,16 @@ public sealed class InputModule : Module
         return await Broker.ExecuteCommandAsync(new SetFilesCommand(@params), options, _jsonContext.SetFilesCommand, _jsonContext.SetFilesResult).ConfigureAwait(false);
     }
 
+    public async Task<Subscription> OnFileDialogOpenedAsync(Func<FileDialogInfo, Task> handler, SubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("input.fileDialogOpened", handler, options, _jsonContext.FileDialogInfo).ConfigureAwait(false);
+    }
+
+    public async Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, SubscriptionOptions? options = null)
+    {
+        return await Broker.SubscribeAsync("input.fileDialogOpened", handler, options, _jsonContext.FileDialogInfo).ConfigureAwait(false);
+    }
+
     protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
@@ -65,6 +76,7 @@ public sealed class InputModule : Module
 [JsonSerializable(typeof(ReleaseActionsResult))]
 [JsonSerializable(typeof(SetFilesCommand))]
 [JsonSerializable(typeof(SetFilesResult))]
+[JsonSerializable(typeof(FileDialogInfo))]
 [JsonSerializable(typeof(IEnumerable<IPointerSourceAction>))]
 [JsonSerializable(typeof(IEnumerable<IKeySourceAction>))]
 [JsonSerializable(typeof(IEnumerable<INoneSourceAction>))]

--- a/dotnet/src/webdriver/BiDi/Script/IRemoteReference.cs
+++ b/dotnet/src/webdriver/BiDi/Script/IRemoteReference.cs
@@ -28,6 +28,11 @@ public interface ISharedReference : IRemoteReference
     public Handle? Handle { get; set; }
 }
 
+public sealed record SharedReference(string SharedId) : ISharedReference
+{
+    public Handle? Handle { get; set; }
+}
+
 public interface IRemoteObjectReference : IRemoteReference
 {
     public Handle Handle { get; }

--- a/dotnet/test/common/BiDi/Input/InputEventsTest.cs
+++ b/dotnet/test/common/BiDi/Input/InputEventsTest.cs
@@ -1,0 +1,47 @@
+// <copyright file="InputEventsTest.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using OpenQA.Selenium.BiDi.BrowsingContext;
+
+namespace OpenQA.Selenium.BiDi.Input;
+
+internal class InputEventsTest : BiDiTestFixture
+{
+    [Test]
+    public async Task CanListenToFileDialogOpenedEvent()
+    {
+        TaskCompletionSource<FileDialogInfo> tcs = new();
+
+        await using var subscription = await context.Input.OnFileDialogOpenedAsync(tcs.SetResult);
+
+        await context.NavigateAsync(UrlBuilder.WhereIs("formPage.html"), new() { Wait = ReadinessState.Complete });
+
+        await context.Script.EvaluateAsync("upload.click()", false, new() { UserActivation = true });
+
+        var eventArgs = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(eventArgs, Is.Not.Null);
+        Assert.That(eventArgs.Context, Is.EqualTo(context));
+        Assert.That(eventArgs.Multiple, Is.False);
+        Assert.That(eventArgs.Element, Is.Not.Null);
+    }
+}


### PR DESCRIPTION
### **User description**
https://w3c.github.io/webdriver-bidi/#event-input-fileDialogOpened

### 💥 What does this PR do?
Implements new `FileDialogOpened` event.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Implements `FileDialogOpened` event in Input module per W3C WebDriver BiDi spec

- Adds context-aware event subscription with async and sync handler support

- Creates `FileDialogInfo` record to represent file dialog event data

- Adds concrete `SharedReference` implementation for shared object references

- Includes comprehensive test coverage for file dialog event listening


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InputModule"] -->|"subscribes to"| B["input.fileDialogOpened"]
  B -->|"emits"| C["FileDialogInfo"]
  C -->|"contains"| D["Context, Multiple, Element"]
  E["BrowsingContextInputModule"] -->|"wraps"| A
  E -->|"filters by"| F["Context"]
  G["Test"] -->|"verifies"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileDialogInfo.cs</strong><dd><code>Create FileDialogInfo event data record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs

<ul><li>New sealed record implementing file dialog event data structure<br> <li> Contains browsing context, multiple flag, and optional element <br>reference<br> <li> Inherits from EventArgs for event handling compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16934/files#diff-014ad1730c1278a29edab92301066a72486fa65184aeba3528efd14dae399f50">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InputModule.cs</strong><dd><code>Add file dialog event subscription methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Input/InputModule.cs

<ul><li>Adds two overloads of <code>OnFileDialogOpenedAsync</code> for async and sync <br>handlers<br> <li> Subscribes to "input.fileDialogOpened" event via Broker<br> <li> Registers <code>FileDialogInfo</code> in JSON serializer context<br> <li> Imports System namespace for Func and Action delegates</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16934/files#diff-f98f384929541b30f9b87fb08f96ead9181d6b14a2353f5485ba985ed7cbd672">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextInputModule.cs</strong><dd><code>Add context-aware file dialog event handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs

<ul><li>Adds two context-aware overloads of <code>OnFileDialogOpenedAsync</code><br> <li> Filters events to only trigger for matching browsing context<br> <li> Supports both async and sync handler patterns<br> <li> Imports System namespace for Func delegate</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16934/files#diff-2c553feaa02e7ecc9282581f5507c107d20133e3c1f1104e6ba5d266b0bb756c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IRemoteReference.cs</strong><dd><code>Implement SharedReference concrete class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/IRemoteReference.cs

<ul><li>Implements concrete <code>SharedReference</code> record class<br> <li> Provides default implementation of <code>ISharedReference</code> interface<br> <li> Includes mutable Handle property for reference management</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16934/files#diff-f2b00a71ff30ef4c9bfded7a49ba8f8f772140edf1ba2ca074e6b8eaf91231b7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InputEventsTest.cs</strong><dd><code>Add FileDialogOpened event test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Input/InputEventsTest.cs

<ul><li>New test class for Input module events<br> <li> Tests <code>FileDialogOpened</code> event subscription and event data<br> <li> Verifies context matching, multiple flag, and element reference<br> <li> Uses TaskCompletionSource for async event verification</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16934/files#diff-440cdd3cf3242e5d61b1806d505681dd3a67036be2a0100399105991bc699a6f">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

