### PR TITLE
[java] preserve original file's modification time when uploading to Grid

### DIFF
--- a/java/src/org/openqa/selenium/io/BUILD.bazel
+++ b/java/src/org/openqa/selenium/io/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//java:defs.bzl", "java_library")
 
 java_library(
@@ -9,5 +10,8 @@ java_library(
         "//java/src/org/openqa/selenium:__pkg__",
         "//java/src/org/openqa/selenium/os:__pkg__",
         "//java/test/org/openqa/selenium/io:__pkg__",
+    ],
+    deps = [
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/io/MultiOutputStream.java
+++ b/java/src/org/openqa/selenium/io/MultiOutputStream.java
@@ -19,14 +19,16 @@ package org.openqa.selenium.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import org.jspecify.annotations.Nullable;
 
 /** Output stream demultiplexer */
 public class MultiOutputStream extends OutputStream {
 
   private final OutputStream mandatory;
-  private final OutputStream optional;
 
-  public MultiOutputStream(OutputStream mandatory, OutputStream optional) {
+  @Nullable private final OutputStream optional;
+
+  public MultiOutputStream(OutputStream mandatory, @Nullable OutputStream optional) {
     this.mandatory = mandatory;
     this.optional = optional;
   }

--- a/java/src/org/openqa/selenium/io/Zip.java
+++ b/java/src/org/openqa/selenium/io/Zip.java
@@ -26,12 +26,17 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.attribute.FileTime;
 import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+import org.jspecify.annotations.Nullable;
 
 public class Zip {
+  private static final Logger LOG = Logger.getLogger(Zip.class.getName());
   private static final int BUF_SIZE = 16384; // "big"
 
   public static String zip(File input) throws IOException {
@@ -61,6 +66,8 @@ public class Zip {
         String name = toAdd.getAbsolutePath().substring(basePath.length() + 1);
 
         ZipEntry entry = new ZipEntry(name.replace('\\', '/'));
+        entry.setTime(toAdd.lastModified());
+        entry.setLastModifiedTime(FileTime.fromMillis(toAdd.lastModified()));
         zos.putNextEntry(entry);
 
         int len;
@@ -107,6 +114,18 @@ public class Zip {
         }
 
         unzipFile(outputDir, zis, entry.getName());
+        setLastModified(file, entry.getLastModifiedTime());
+      }
+    }
+  }
+
+  private static void setLastModified(File file, @Nullable FileTime time) {
+    if (time != null) {
+      boolean ok = file.setLastModified(time.toMillis());
+      if (!ok) {
+        LOG.log(
+            Level.WARNING,
+            () -> String.format("Failed to set last modified %s for file %s", time, file));
       }
     }
   }

--- a/java/src/org/openqa/selenium/io/package-info.java
+++ b/java/src/org/openqa/selenium/io/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.io;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/os/BUILD.bazel
+++ b/java/src/org/openqa/selenium/os/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//java:defs.bzl", "java_export")
 load("//java:version.bzl", "SE_VERSION")
 
@@ -13,5 +14,6 @@ java_export(
     deps = [
         "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/io",
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/os/ExecutableFinder.java
+++ b/java/src/org/openqa/selenium/os/ExecutableFinder.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Platform;
 
 public class ExecutableFinder {
@@ -42,6 +43,7 @@ public class ExecutableFinder {
    * @param named The name of the executable to find
    * @return The absolute path to the executable, or null if no match is made.
    */
+  @Nullable
   public String find(String named) {
     File file = new File(named);
     if (canExecute(file)) {

--- a/java/src/org/openqa/selenium/os/ExternalProcess.java
+++ b/java/src/org/openqa/selenium/os/ExternalProcess.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.io.CircularOutputStream;
 import org.openqa.selenium.io.MultiOutputStream;
@@ -43,8 +44,8 @@ public class ExternalProcess {
 
   public static class Builder {
 
-    private ProcessBuilder builder;
-    private OutputStream copyOutputTo;
+    private final ProcessBuilder builder;
+    private @Nullable OutputStream copyOutputTo;
     private int bufferSize = 32768;
 
     Builder() {

--- a/java/src/org/openqa/selenium/os/package-info.java
+++ b/java/src/org/openqa/selenium/os/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.os;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/test/org/openqa/selenium/io/ZipTest.java
+++ b/java/test/org/openqa/selenium/io/ZipTest.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.io;
 
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -24,6 +25,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -59,6 +62,7 @@ class ZipTest {
     File unwanted = new File(inputDir, "nay.txt");
     writeTestFile(input);
     writeTestFile(unwanted);
+    input.setLastModified(100_000L);
 
     String zipped = Zip.zip(input);
 
@@ -67,6 +71,7 @@ class ZipTest {
     File notThere = new File(outputDir, "nay.txt");
 
     assertThat(unzipped).exists();
+    assertThat(unzipped.lastModified()).isEqualTo(100_000L);
     assertThat(notThere).doesNotExist();
   }
 
@@ -90,25 +95,29 @@ class ZipTest {
   @Test
   void testCanUnzip() throws IOException {
     File testZip = File.createTempFile("testUnzip", "zip");
-    writeTestZip(testZip, 25);
+    writeTestZip(testZip, 5, 10_000L);
     File out = Zip.unzipToTempDir(new FileInputStream(testZip), "unzip", "stream");
-    assertThat(out.list()).hasSize(25);
+    assertThat(out.list()).hasSize(5);
+
+    assertThat(Arrays.stream(out.listFiles()).map(File::lastModified).collect(toSet()))
+        .as("Preserves original file's modification time when unzipping")
+        .containsExactlyInAnyOrder(0L, 10_000L, 20_000L, 30_000L, 40_000L);
   }
 
-  private File writeTestZip(File file, int files) throws IOException {
-    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file));
-    for (int i = 0; i < files; i++) {
-      writeTestZipEntry(out);
+  private void writeTestZip(File file, int files, long lastModifiedStep) throws IOException {
+    try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file))) {
+      for (int i = 0; i < files; i++) {
+        writeTestZipEntry(out, i * lastModifiedStep);
+      }
     }
-    out.close();
     file.deleteOnExit();
-    return file;
   }
 
-  private void writeTestZipEntry(ZipOutputStream out) throws IOException {
+  private void writeTestZipEntry(ZipOutputStream out, long lastModified) throws IOException {
     File testFile = File.createTempFile("testZip", "file");
     writeTestFile(testFile);
     ZipEntry entry = new ZipEntry(testFile.getName());
+    entry.setLastModifiedTime(FileTime.fromMillis(lastModified));
     out.putNextEntry(entry);
     try (FileInputStream in = new FileInputStream(testFile)) {
       byte[] buffer = new byte[16384];

--- a/javascript/selenium-webdriver/io/zip.js
+++ b/javascript/selenium-webdriver/io/zip.js
@@ -19,7 +19,7 @@
 
 const jszip = require('jszip')
 const path = require('node:path')
-
+const fs = require('fs/promises')
 const io = require('./index')
 const { InvalidArgumentError } = require('../lib/error')
 
@@ -44,9 +44,11 @@ class Zip {
    * @return {!Promise<?>} a promise that will resolve when added.
    */
   addFile(filePath, zipPath = path.basename(filePath)) {
-    let add = io
-      .read(filePath)
-      .then((buffer) => this.z_.file(/** @type {string} */ (zipPath.replace(/\\/g, '/')), buffer))
+    let add = Promise.all([io.read(filePath), fs.stat(filePath)]).then(([buffer, stats]) =>
+      this.z_.file(/** @type {string} */ (zipPath.replace(/\\/g, '/')), buffer, {
+        date: stats.mtime, // preserve file's "last modified" value
+      }),
+    )
     this.pendingAdds_.add(add)
     return add.then(
       () => this.pendingAdds_.delete(add),


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
Fixes #16927

### 💥 What does this PR do?
When uploading a file remotely, the uploaded file is packed to ZIP, and unpacked on the server side. 
This PR fixes ZIP algorithm, so that it preserves the files' "lastModified" value when zipping/unzipping.

### 🔧 Implementation Notes
I touched only Java (tested myself) and JS (don't know how to test it).
Other bindings didn't have this problem (according to https://github.com/SeleniumHQ/selenium/issues/16927).


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve file modification time when zipping/unzipping in Java and JavaScript

- Add `FileTime` handling to `ZipEntry` during compression and decompression

- Update tests to verify modification time preservation across zip operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original File<br/>with lastModified"] -->|zip with FileTime| B["ZipEntry<br/>with lastModifiedTime"]
  B -->|unzip and restore| C["Extracted File<br/>with original lastModified"]
  D["Test Verification"] -->|assert lastModified| E["Matches Original Value"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Zip.java</strong><dd><code>Add FileTime preservation to zip/unzip operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/io/Zip.java

<ul><li>Import <code>FileTime</code> from <code>java.nio.file.attribute</code> package<br> <li> Set <code>lastModifiedTime</code> on <code>ZipEntry</code> when adding files to preserve <br>original modification time<br> <li> Restore file modification time from <code>ZipEntry</code> when extracting files <br>during unzip operation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16935/files#diff-3e596a9120e7662c9a57ecd465b4b000f7334902bda6060447332370cb2b1498">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zip.js</strong><dd><code>Preserve file modification time in JavaScript zip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/io/zip.js

<ul><li>Import <code>fs/promises</code> module for file stat operations<br> <li> Modify <code>addFile</code> method to retrieve file stats and preserve <code>mtime</code> in zip <br>options<br> <li> Pass <code>date</code> parameter to jszip's <code>file()</code> method to maintain original <br>modification time</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16935/files#diff-2cce4b5845f42ac415c77a7f121cd0f262225acba1686a3d1abed5470560e501">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ZipTest.java</strong><dd><code>Add modification time preservation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/io/ZipTest.java

<ul><li>Import <code>FileTime</code> and stream utilities for test assertions<br> <li> Add explicit modification time (100_000L) to test file in <br><code>testCanZipASingleFile</code><br> <li> Verify unzipped file preserves original modification time with <br>assertion<br> <li> Refactor <code>writeTestZip</code> to accept <code>lastModifiedStep</code> parameter for varied <br>timestamps<br> <li> Update <code>writeTestZipEntry</code> to set <code>lastModifiedTime</code> on <code>ZipEntry</code> with <br>calculated values<br> <li> Enhance <code>testCanUnzip</code> to verify multiple files preserve different <br>modification times</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16935/files#diff-e137ceed4a9fe41beda57fe056ea74c412d57557869555f52cc4ce3f7a233035">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

