### PR TITLE
[grid] Improve race conditions in Grid session distribution

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -441,27 +441,34 @@ public class LocalDistributor extends Distributor implements Closeable {
   }
 
   private SlotId reserveSlot(RequestId requestId, Capabilities caps) {
-    Lock writeLock = lock.writeLock();
-    writeLock.lock();
+    // Use read lock for slot selection to allow concurrent reads
+    // This reduces contention compared to using write lock for the entire operation
+    Set<SlotId> slotIds;
+    Lock readLock = lock.readLock();
+    readLock.lock();
     try {
-      Set<SlotId> slotIds = slotSelector.selectSlot(caps, getAvailableNodes(), slotMatcher);
-      if (slotIds.isEmpty()) {
-        LOG.log(
-            getDebugLogLevel(),
-            String.format("No slots found for request %s and capabilities %s", requestId, caps));
-        return null;
-      }
-
-      for (SlotId slotId : slotIds) {
-        if (reserve(slotId)) {
-          return slotId;
-        }
-      }
-
-      return null;
+      slotIds = slotSelector.selectSlot(caps, getAvailableNodes(), slotMatcher);
     } finally {
-      writeLock.unlock();
+      readLock.unlock();
     }
+
+    if (slotIds.isEmpty()) {
+      LOG.log(
+          getDebugLogLevel(),
+          String.format("No slots found for request %s and capabilities %s", requestId, caps));
+      return null;
+    }
+
+    // Try to reserve each candidate slot
+    // The reserve() method uses write lock briefly and atomic operations ensure thread safety
+    // Multiple threads may select the same slot but only one will successfully reserve it
+    for (SlotId slotId : slotIds) {
+      if (reserve(slotId)) {
+        return slotId;
+      }
+    }
+
+    return null;
   }
 
   private boolean isNotSupported(Capabilities caps) {

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalGridModel.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalGridModel.java
@@ -337,13 +337,16 @@ public class LocalGridModel extends GridModel {
       }
 
       Optional<Slot> maybeSlot =
-          node.getSlots().stream().filter(slot -> slotId.equals(slot.getId())).findFirst();
+          node.getSlots().stream()
+              .filter(slot -> slotId.equals(slot.getId()))
+              .filter(slot -> slot.getSession() == null)
+              .findFirst();
 
       if (maybeSlot.isEmpty()) {
-        LOG.warning(
+        LOG.fine(
             String.format(
-                "Asked to reserve slot on node %s, but no slot with id %s found",
-                node.getNodeId(), slotId));
+                "Asked to reserve slot %s on node %s, but slot not found or already reserved",
+                slotId, node.getNodeId()));
         return false;
       }
 

--- a/java/src/org/openqa/selenium/grid/node/local/SessionSlot.java
+++ b/java/src/org/openqa/selenium/grid/node/local/SessionSlot.java
@@ -62,7 +62,8 @@ public class SessionSlot
   private final boolean supportingCdp;
   private final boolean supportingBiDi;
   private final AtomicLong connectionCounter;
-  private ActiveSession currentSession;
+  // volatile ensures memory visibility across threads when session is set after reservation
+  private volatile ActiveSession currentSession;
 
   public SessionSlot(EventBus bus, Capabilities stereotype, SessionFactory factory) {
     this.bus = Require.nonNull("Event bus", bus);
@@ -131,16 +132,17 @@ public class SessionSlot
     }
 
     SessionId id = currentSession.getId();
+    LOG.info(String.format("Stopping session %s (reason: %s)", id, reason));
     try {
       currentSession.stop();
+      LOG.info(String.format("Session stopped successfully: %s", id));
     } catch (Exception e) {
-      LOG.log(Level.WARNING, "Unable to cleanly close session", e);
+      LOG.log(Level.WARNING, String.format("Unable to cleanly close session %s", id), e);
     }
     currentSession = null;
     connectionCounter.set(0);
     release();
     bus.fire(new SessionClosedEvent(id, reason));
-    LOG.info(String.format("Stopping session %s (reason: %s)", id, reason));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/router/HandleSession.java
+++ b/java/src/org/openqa/selenium/grid/router/HandleSession.java
@@ -118,31 +118,28 @@ class HandleSession implements HttpHandler, Closeable {
         () -> {
           Instant staleBefore = Instant.now().minus(2, ChronoUnit.MINUTES);
 
-          // Use computeIfPresent for atomic check-and-remove to avoid TOCTOU race condition
-          // where inUse could be incremented between check and removal
-          httpClients.forEach(
-              (uri, entry) -> {
-                httpClients.computeIfPresent(
-                    uri,
-                    (key, currentEntry) -> {
-                      // Atomically check conditions and remove if stale
-                      if (currentEntry.inUse.get() != 0) {
-                        // the client is currently in use
-                        return currentEntry;
-                      } else if (!currentEntry.lastUse.isBefore(staleBefore)) {
-                        // the client was recently used
-                        return currentEntry;
-                      } else {
-                        // the client has not been used for a while, remove it from the cache
-                        try {
-                          currentEntry.httpClient.close();
-                        } catch (Exception ex) {
-                          LOG.log(Level.WARNING, "failed to close a stale httpclient", ex);
-                        }
-                        return null; // removes entry from map
-                      }
-                    });
-              });
+          // Use removeIf for safe and efficient removal from ConcurrentHashMap
+          httpClients
+              .entrySet()
+              .removeIf(
+                  entry -> {
+                    CacheEntry cacheEntry = entry.getValue();
+                    if (cacheEntry.inUse.get() != 0) {
+                      // the client is currently in use
+                      return false;
+                    }
+                    if (!cacheEntry.lastUse.isBefore(staleBefore)) {
+                      // the client was recently used
+                      return false;
+                    }
+                    // the client has not been used for a while, close and remove it
+                    try {
+                      cacheEntry.httpClient.close();
+                    } catch (Exception ex) {
+                      LOG.log(Level.WARNING, "failed to close a stale httpclient", ex);
+                    }
+                    return true;
+                  });
         };
 
     this.cleanUpHttpClientsCacheService =

--- a/java/src/org/openqa/selenium/grid/router/HandleSession.java
+++ b/java/src/org/openqa/selenium/grid/router/HandleSession.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -118,28 +117,32 @@ class HandleSession implements HttpHandler, Closeable {
     Runnable cleanUpHttpClients =
         () -> {
           Instant staleBefore = Instant.now().minus(2, ChronoUnit.MINUTES);
-          Iterator<CacheEntry> iterator = httpClients.values().iterator();
 
-          while (iterator.hasNext()) {
-            CacheEntry entry = iterator.next();
-
-            if (entry.inUse.get() != 0) {
-              // the client is currently in use
-              return;
-            } else if (!entry.lastUse.isBefore(staleBefore)) {
-              // the client was recently used
-              return;
-            } else {
-              // the client has not been used for a while, remove it from the cache
-              iterator.remove();
-
-              try {
-                entry.httpClient.close();
-              } catch (Exception ex) {
-                LOG.log(Level.WARNING, "failed to close a stale httpclient", ex);
-              }
-            }
-          }
+          // Use computeIfPresent for atomic check-and-remove to avoid TOCTOU race condition
+          // where inUse could be incremented between check and removal
+          httpClients.forEach(
+              (uri, entry) -> {
+                httpClients.computeIfPresent(
+                    uri,
+                    (key, currentEntry) -> {
+                      // Atomically check conditions and remove if stale
+                      if (currentEntry.inUse.get() != 0) {
+                        // the client is currently in use
+                        return currentEntry;
+                      } else if (!currentEntry.lastUse.isBefore(staleBefore)) {
+                        // the client was recently used
+                        return currentEntry;
+                      } else {
+                        // the client has not been used for a while, remove it from the cache
+                        try {
+                          currentEntry.httpClient.close();
+                        } catch (Exception ex) {
+                          LOG.log(Level.WARNING, "failed to close a stale httpclient", ex);
+                        }
+                        return null; // removes entry from map
+                      }
+                    });
+              });
         };
 
     this.cleanUpHttpClientsCacheService =


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
`reserveSlot()` with write lock is exclusive - only one thread can hold it. All other threads must wait, even though selectSlot() is just reading data. Now, use read lock for slot selection (allows concurrent reads), write lock only for actual reservation (brief, atomic). The procedure would be
  1. selectSlot() is a read-only operation - it queries the snapshot, doesn't modify it                                                                                                                                                             
  2. Multiple threads can select slots in parallel - they may pick the same slot, but that's OK                                                                                                                                                     
  3. reserve() uses write lock briefly - only during the actual reservation                                                                                                                                                                         
  4. LocalGridModel.reserve() now validates slot is free - so only one thread succeeds per slot                                                                                                                                                     
  5. Failed reservations try next slot - from their pre-selected list                                                                                                                                                                               
                                                                                                                                                                                                                                                    
  Improve                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  - Higher throughput - concurrent session requests don't block each other during selection                                                                                                                                                         
  - Lower latency - threads spend less time waiting for locks                      

When multiple concurrent session requests arrive, the Grid can send multiple requests to the same Node slot, causing the Node to reject with "Max session count reached" even when slots should be available. (point 2 - they may pick the same slot).                                                                                                                                                                                                    
Few reasons: The Distributor maintains a snapshot of slot states, but multiple threads could:                                                                                                                                                      
  1. Select the same slot during concurrent reads                                                                                                                                                                                                   
  2. All successfully "reserved" the slot (no validation of current slot state)                                                                                                                                                                           
  3. All send requests to the Node, overwhelming it 

- LocalGridModel.java - Prevent Double Reservation 
   Only the first thread to acquire write lock can reserve a slot. Subsequent threads see session != null and try the next slot.
- SessionSlot.java - Thread Safety & Logging
   `volatile` ensures visibility across threads. Logging moved before stop for better debugging.
- HandleSession.java - Fix TOCTOU Race in HTTP Client Cleanup
   `computeIfPresent` provides atomic check-and-remove, preventing race where inUse could be incremented between check and removal.


### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix


___

### **Description**
- Optimize locking strategy in slot selection using read locks for concurrent reads

- Prevent double reservation by filtering already-reserved slots during selection

- Add volatile modifier to ensure thread-safe visibility of session state

- Fix TOCTOU race condition in HTTP client cleanup using atomic operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Concurrent Session Requests"] -->|"Read Lock"| B["Slot Selection"]
  B -->|"Write Lock"| C["Atomic Reservation"]
  C -->|"Check Session == null"| D["Reserve Slot"]
  D -->|"Success"| E["Session Created"]
  D -->|"Already Reserved"| F["Try Next Slot"]
  G["HTTP Client Cleanup"] -->|"computeIfPresent"| H["Atomic Check-Remove"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalDistributor.java</strong><dd><code>Optimize locking strategy for concurrent slot selection</code>&nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java

<ul><li>Split locking strategy: use read lock for slot selection, write lock <br>only for reservation<br> <li> Reduces contention by allowing concurrent reads of available slots<br> <li> Slot selection now happens outside write lock critical section<br> <li> Multiple threads can select same slot but only one reserves it <br>successfully</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16939/files#diff-024d7dccb0a4ff87c444dc3549032e7c6b2595f582f4f267cdf48c7f8c2f87c1">+24/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalGridModel.java</strong><dd><code>Prevent double reservation with session state check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/distributor/local/LocalGridModel.java

<ul><li>Add filter to check slot.getSession() == null during reservation<br> <li> Prevents reserving already-occupied slots when multiple threads race<br> <li> Change log level from WARNING to FINE for expected race condition case<br> <li> Improve log message clarity to indicate slot already reserved</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16939/files#diff-bda8b0e720d20df1cbe5f5860ea7ee820d406a45e0153fa6d240dd89835508f1">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionSlot.java</strong><dd><code>Add volatile modifier and improve logging in SessionSlot</code>&nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/grid/node/local/SessionSlot.java

<ul><li>Add volatile modifier to currentSession field for thread-safe <br>visibility<br> <li> Reorder logging in stop() method to log before session stops for <br>better debugging<br> <li> Improve log messages with session ID for better traceability<br> <li> Ensure memory visibility across threads when session state changes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16939/files#diff-f6f6aa2f002118f5a983cd076f893c5a56c2f5f5d4c0d09d6f296c45b8b3ef30">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HandleSession.java</strong><dd><code>Fix TOCTOU race in HTTP client cleanup with atomic operations</code></dd></summary>
<hr>

java/src/org/openqa/selenium/grid/router/HandleSession.java

<ul><li>Replace iterator-based cleanup with computeIfPresent for atomic <br>operations<br> <li> Fix TOCTOU race condition where inUse could be incremented between <br>check and removal<br> <li> Simplify logic using functional approach with forEach and <br>computeIfPresent<br> <li> Remove unused Iterator import</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16939/files#diff-3f58425b642a490159052d431ed753fa75cf79a4d5e756ed37dc26039983c59a">+26/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

