### PR TITLE
[dotnet] [bidi] Expose Input module in root BiDi class

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -48,7 +48,7 @@ public sealed class BiDi : IAsyncDisposable
 
     public Network.NetworkModule Network => AsModule<Network.NetworkModule>();
 
-    internal Input.InputModule InputModule => AsModule<Input.InputModule>();
+    public Input.InputModule Input => AsModule<Input.InputModule>();
 
     public Script.ScriptModule Script => AsModule<Script.ScriptModule>();
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -69,7 +69,7 @@ public sealed record BrowsingContext
     public BrowsingContextStorageModule Storage => _storageModule ?? Interlocked.CompareExchange(ref _storageModule, new BrowsingContextStorageModule(this, BiDi.Storage), null) ?? _storageModule;
 
     [JsonIgnore]
-    public BrowsingContextInputModule Input => _inputModule ?? Interlocked.CompareExchange(ref _inputModule, new BrowsingContextInputModule(this, BiDi.InputModule), null) ?? _inputModule;
+    public BrowsingContextInputModule Input => _inputModule ?? Interlocked.CompareExchange(ref _inputModule, new BrowsingContextInputModule(this, BiDi.Input), null) ?? _inputModule;
 
     public Task<NavigateResult> NavigateAsync(string url, NavigateOptions? options = null)
     {


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Make `Input` module publicly available. Continue to expose everything what the specification defines.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Expose `Input` module as public property in root `BiDi` class

- Rename `InputModule` property to `Input` for consistency

- Update `BrowsingContext` to reference public `Input` property


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BiDi["BiDi class"]
  InputModule["InputModule property"]
  PublicInput["Public Input property"]
  BrowsingContext["BrowsingContext class"]
  BiDi -- "change internal to public" --> PublicInput
  PublicInput -- "referenced by" --> BrowsingContext
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BiDi.cs</strong><dd><code>Make Input module publicly accessible</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BiDi.cs

<ul><li>Changed <code>InputModule</code> property from <code>internal</code> to <code>public</code><br> <li> Renamed property from <code>InputModule</code> to <code>Input</code> for API consistency<br> <li> Aligns with other public module properties like <code>Browser</code>, <code>Network</code>, <br><code>Script</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16940/files#diff-3f77d71f94e2a47ea90b74f6d37b5a5b94dc83b2f558b30ab070588b9028c2f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Update Input module reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Updated reference from <code>BiDi.InputModule</code> to <code>BiDi.Input</code><br> <li> Maintains consistency with the renamed public property</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16940/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

