### PR TITLE
[build] use rulesets to restrict and unrestrict trunk during release window

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,6 +22,7 @@ jobs:
   update-rust:
     name: Update Rust Version
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,18 @@ jobs:
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
 
+  unrestrict-trunk:
+    name: Unrestrict Trunk Branch
+    needs: [github-release]
+    if: always()
+    uses: ./.github/workflows/restrict-trunk.yml
+    with:
+      enforcement: disabled
+    secrets: inherit
+
   update-version:
     name: Reset Versions to Nightly
-    needs: [stage, docs]
+    needs: [stage, docs, unrestrict-trunk]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [publish, docs, github-release, unrestrict-trunk, update-version]
+    needs: [stage, authorize, publish, docs, github-release, unrestrict-trunk, update-version]
     if: failure()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,3 +174,31 @@ jobs:
         run: |
           git commit -m "[build] Reset versions to nightly after ${{ needs.stage.outputs.tag }} release"
           git push
+
+  on-release-failure:
+    name: On Release Failure
+    runs-on: ubuntu-latest
+    needs: [publish, github-release, unrestrict-trunk, update-version]
+    if: >
+      always() &&
+      (needs.publish.result == 'failure' ||
+       needs.github-release.result == 'failure' ||
+       needs.unrestrict-trunk.result == 'failure' ||
+       needs.update-version.result == 'failure')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_ICON_EMOJI: ":rotating_light:"
+          SLACK_COLOR: failure
+          SLACK_CHANNEL: selenium-tlc
+          SLACK_USERNAME: GitHub Workflows
+          SLACK_TITLE: Release failed
+          SLACK_MESSAGE: >
+            Selenium Published: ${{ needs.publish.result }},
+            GitHub Release Published: ${{ needs.github-release.result }},
+            Trunk Unlocked: ${{ needs.unrestrict-trunk.result }},
+            Nightly Version Updated: ${{ needs.update-version.result }}
+          MSG_MINIMAL: actions url
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     if: always()
     uses: ./.github/workflows/restrict-trunk.yml
     with:
-      enforcement: disabled
+      restrict: false
     secrets: inherit
 
   update-version:
@@ -178,13 +178,8 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [publish, github-release, unrestrict-trunk, update-version]
-    if: >
-      always() &&
-      (needs.publish.result == 'failure' ||
-       needs.github-release.result == 'failure' ||
-       needs.unrestrict-trunk.result == 'failure' ||
-       needs.update-version.result == 'failure')
+    needs: [publish, docs, github-release, unrestrict-trunk, update-version]
+    if: failure()
     steps:
       - uses: actions/checkout@v4
       - name: Slack Notification
@@ -197,6 +192,7 @@ jobs:
           SLACK_TITLE: Release failed
           SLACK_MESSAGE: >
             Selenium Published: ${{ needs.publish.result }},
+            Docs Updated: ${{ needs.docs.result }},
             GitHub Release Published: ${{ needs.github-release.result }},
             Trunk Unlocked: ${{ needs.unrestrict-trunk.result }},
             Nightly Version Updated: ${{ needs.update-version.result }}

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -1,5 +1,7 @@
 name: Manage Trunk Restrictions
 
+permissions: {}
+
 on:
   pull_request:
     types: [ready_for_review, closed]

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -13,19 +13,16 @@ on:
       - trunk
   workflow_dispatch:
     inputs:
-      enforcement:
-        description: 'Ruleset enforcement level'
+      restrict:
+        description: 'Restrict trunk branch'
         required: true
-        type: choice
-        options:
-          - active
-          - disabled
+        type: boolean
   workflow_call:
     inputs:
-      enforcement:
-        description: 'Ruleset enforcement level'
+      restrict:
+        description: 'Restrict trunk branch'
         required: true
-        type: string
+        type: boolean
 
 jobs:
   manage-trunk:
@@ -33,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
-      (inputs.enforcement ||
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' ||
        (startsWith(github.event.pull_request.head.ref, 'release-preparation-') &&
         (github.event.action == 'ready_for_review' ||
          (github.event.action == 'closed' && github.event.pull_request.merged == false))))
@@ -43,7 +40,7 @@ jobs:
           - 11911909  # Release In Progress Access (restrict updates to trunk to release managers)
           - 11912022  # Release In Progress Flow (requires branches to be up to date before merging)
     env:
-      ENFORCEMENT: ${{ inputs.enforcement || (github.event.action == 'ready_for_review' && 'active') || 'disabled' }}
+      TRUNK_RESTRICTED: ${{ inputs.restrict || github.event.action == 'ready_for_review' }}
     steps:
       - name: Update ruleset enforcement
         uses: octokit/request-action@v2.4.0
@@ -52,6 +49,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           ruleset_id: ${{ matrix.ruleset_id }}
-          enforcement: ${{ env.ENFORCEMENT }}
+          enforcement: ${{ env.TRUNK_RESTRICTED == 'true' && 'active' || 'disabled' }}
         env:
           GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -2,6 +2,10 @@ name: Manage Trunk Restrictions
 
 permissions: {}
 
+concurrency:
+  group: manage-trunk-restrictions
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [ready_for_review, closed]
@@ -35,7 +39,9 @@ jobs:
          (github.event.action == 'closed' && github.event.pull_request.merged == false))))
     strategy:
       matrix:
-        ruleset_id: [11911909, 11912022]
+        ruleset_id:
+          - 11911909  # Release In Progress Access (restrict updates to trunk to release managers)
+          - 11912022  # Release In Progress Flow (requires branches to be up to date before merging)
     env:
       ENFORCEMENT: ${{ inputs.enforcement || (github.event.action == 'ready_for_review' && 'active') || 'disabled' }}
     steps:

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -46,7 +46,7 @@ jobs:
       ENFORCEMENT: ${{ inputs.enforcement || (github.event.action == 'ready_for_review' && 'active') || 'disabled' }}
     steps:
       - name: Update ruleset enforcement
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v2.4.0
         with:
           route: PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -1,0 +1,49 @@
+name: Manage Trunk Restrictions
+
+on:
+  pull_request:
+    types: [ready_for_review, closed]
+    branches:
+      - trunk
+  workflow_dispatch:
+    inputs:
+      enforcement:
+        description: 'Ruleset enforcement level'
+        required: true
+        type: choice
+        options:
+          - active
+          - disabled
+  workflow_call:
+    inputs:
+      enforcement:
+        description: 'Ruleset enforcement level'
+        required: true
+        type: string
+
+jobs:
+  manage-trunk:
+    name: Manage Trunk Branch
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      (inputs.enforcement ||
+       (startsWith(github.event.pull_request.head.ref, 'release-preparation-') &&
+        (github.event.action == 'ready_for_review' ||
+         (github.event.action == 'closed' && github.event.pull_request.merged == false))))
+    strategy:
+      matrix:
+        ruleset_id: [11911909, 11912022]
+    env:
+      ENFORCEMENT: ${{ inputs.enforcement || (github.event.action == 'ready_for_review' && 'active') || 'disabled' }}
+    steps:
+      - name: Update ruleset enforcement
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          ruleset_id: ${{ matrix.ruleset_id }}
+          enforcement: ${{ env.ENFORCEMENT }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}

--- a/.github/workflows/restrict-trunk.yml
+++ b/.github/workflows/restrict-trunk.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 concurrency:
   group: manage-trunk-restrictions
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   pull_request:


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Addition to #16937 to prevent commits accidentally being added to release

### 💥 What does this PR do?

We want to make sure the PR that kicks off the automated release process was tested against trunk
instead of getting squash merged on top of it. It's also nice to be able to enforce no
changes to trunk when actively working on the release.

I've created 2 rulesets as part of this:
1. Only Release Managers (currently TLC) can merge PRs or commit to trunk during the release process window
2. No one can merge a PR that isn't up to date with trunk

The rulesets are automatically enabled when the release preparation PR comes out of Draft
and is marked "Ready for Review". They are automatically disabled when the release workflow
completes, or if the release preparation PR is closed without merging (abandoned release).

This can be manually toggled via the "Manage Trunk Restrictions" workflow with
`production` environment approval (currently TLC members) or directly in repo settings:
https://github.com/SeleniumHQ/selenium/settings/rules

### 🔧 Implementation Notes

A single consolidated `manage-trunk` job dynamically determines enforcement level:
- Uses `inputs.enforcement` when manually triggered or called as reusable workflow
- Uses `active` for `ready_for_review` PR events
- Uses `disabled` for closed (unmerged) PR events
- ~Unrestrict in `release.yml` runs with `if: always()` to ensure cleanup even on failure~ Unrestrict only runs if release is successful and version updates need to happen. If it is not successful, release managers will need to manually fix and run the unrestrict job. I'm adding a slack notification if it fails and needs to be fixed.

### 💡 Additional Considerations

- Hardcoded ruleset IDs (`11911909`, `11912022`) are specific to this repo - update if
  rulesets are recreated
- All workflows skip on forks (no secrets, no rulesets)

### 🔄 Types of changes

- New feature (non-breaking change which adds functionality)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement GitHub rulesets to restrict trunk during release window

- Automatically enable restrictions when release PR marked ready

- Automatically disable restrictions when release completes

- Add manual workflow to toggle trunk restrictions via approval

- Skip workflows on forked repositories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Prep PR"] -->|ready_for_review| B["Enable Rulesets"]
  B -->|restrict trunk| C["Only Release Managers can merge"]
  D["Release Workflow"] -->|completes| E["Disable Rulesets"]
  F["Manual Trigger"] -->|with approval| E
  G["PR Closed Unmerged"] -->|abandoned| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>restrict-trunk.yml</strong><dd><code>New workflow to manage trunk restrictions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/restrict-trunk.yml

<ul><li>New workflow to manage trunk branch rulesets enforcement<br> <li> Triggered on release-preparation PR ready_for_review and closed events<br> <li> Supports manual workflow_dispatch and reusable workflow_call <br>invocations<br> <li> Dynamically determines enforcement level (active/disabled) based on <br>event type<br> <li> Updates two hardcoded rulesets (11911909, 11912022) via GitHub API</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16941/files#diff-f44145b933a9de712cde8f0bb7fe7533b53b985deabdbb8109d9abd851d79f41">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Add fork check to pre-release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Add fork check to skip workflow on forked repositories<br> <li> Prevents execution of update-rust job on non-official forks</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16941/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Add unrestrict-trunk job to release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Add new unrestrict-trunk job that calls restrict-trunk workflow<br> <li> Job runs with if: always() to ensure cleanup even on failure<br> <li> Disables rulesets after github-release job completes<br> <li> Update update-version job dependency to include unrestrict-trunk</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16941/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

