### PR TITLE
[build] Release workflow improvements

### DIFF
--- a/.github/workflows/mirror-selenium-releases.yml
+++ b/.github/workflows/mirror-selenium-releases.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '0 */12 * * *'
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,18 +87,20 @@ jobs:
           tag: "${{ steps.tag.outputs.tag }}"
           commit: "${{ github.sha }}"
 
-  authorize:
-    name: Authorize Release
+  get-approval:
+    name: Get Approval
     needs: stage
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Approved
-        run: echo "Release ${{ needs.stage.outputs.tag }} approved for publishing"
+    if: needs.stage.result == 'success'
+    uses: ./.github/workflows/get-approval.yml
+    with:
+      title: Release approval required
+      message: Approval is needed to publish ${{ needs.stage.outputs.tag }}.
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   publish:
     name: Publish ${{ matrix.language }}
-    needs: authorize
+    needs: get-approval
     strategy:
       fail-fast: false
       matrix:
@@ -181,7 +183,7 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [stage, authorize, publish, docs, github-release, unrestrict-trunk, update-version]
+    needs: [stage, get-approval, publish, docs, github-release, unrestrict-trunk, update-version]
     if: failure()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
   docs:
     name: Update ${{ matrix.language }} Documentation
-    needs: [stage, publish]
+    needs: [stage, publish, github-release]
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,6 @@ jobs:
   unrestrict-trunk:
     name: Unrestrict Trunk Branch
     needs: [github-release]
-    if: always()
     uses: ./.github/workflows/restrict-trunk.yml
     with:
       restrict: false
@@ -183,7 +182,7 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [stage, get-approval, publish, docs, github-release, unrestrict-trunk, update-version]
+    needs: [stage, publish, docs, github-release, update-version]
     if: failure()
     steps:
       - uses: actions/checkout@v4
@@ -199,7 +198,6 @@ jobs:
             • Selenium Published: ${{ needs.publish.result }}
             • Docs Updated: ${{ needs.docs.result }}
             • GitHub Release Published: ${{ needs.github-release.result }}
-            • Trunk Unlocked: ${{ needs.unrestrict-trunk.result }}
             • Nightly Version Updated: ${{ needs.update-version.result }}
           MSG_MINIMAL: actions url
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,22 @@ jobs:
           git commit -m "[build] Reset versions to nightly after ${{ needs.stage.outputs.tag }} release"
           git push
 
+  nightly:
+    name: Publish Nightly Packages
+    needs: [update-version]
+    uses: ./.github/workflows/nightly.yml
+    secrets: inherit
+
+  mirror:
+    name: Update Release Mirror
+    needs: [nightly]
+    uses: ./.github/workflows/mirror-selenium-releases.yml
+    secrets: inherit
+
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [stage, publish, docs, github-release, update-version]
+    needs: [stage, publish, docs, github-release, update-version, nightly, mirror]
     if: failure()
     steps:
       - uses: actions/checkout@v4
@@ -199,5 +211,7 @@ jobs:
             • Docs Updated: ${{ needs.docs.result }}
             • GitHub Release Published: ${{ needs.github-release.result }}
             • Nightly Version Updated: ${{ needs.update-version.result }}
+            • Nightly Packages: ${{ needs.nightly.result }}
+            • Mirror Updated: ${{ needs.mirror.result }}
           MSG_MINIMAL: actions url
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
 
   update-version:
     name: Reset Versions to Nightly
-    needs: [stage, docs, unrestrict-trunk]
+    needs: [stage, unrestrict-trunk]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,11 +190,11 @@ jobs:
           SLACK_CHANNEL: selenium-tlc
           SLACK_USERNAME: GitHub Workflows
           SLACK_TITLE: Release failed
-          SLACK_MESSAGE: >
-            Selenium Published: ${{ needs.publish.result }},
-            Docs Updated: ${{ needs.docs.result }},
-            GitHub Release Published: ${{ needs.github-release.result }},
-            Trunk Unlocked: ${{ needs.unrestrict-trunk.result }},
-            Nightly Version Updated: ${{ needs.update-version.result }}
+          SLACK_MESSAGE: |
+            • Selenium Published: ${{ needs.publish.result }}
+            • Docs Updated: ${{ needs.docs.result }}
+            • GitHub Release Published: ${{ needs.github-release.result }}
+            • Trunk Unlocked: ${{ needs.unrestrict-trunk.result }}
+            • Nightly Version Updated: ${{ needs.update-version.result }}
           MSG_MINIMAL: actions url
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
         run: |
-          gh release delete nightly --yes || true
-          git push origin --delete refs/tags/nightly || true
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release delete nightly --yes
+          fi
+          if git ls-remote --tags origin refs/tags/nightly | grep -q nightly; then
+            git push origin --delete refs/tags/nightly
+          fi
       - name: Draft GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SELENIUM_CI_TOKEN }}
       - name: Extract tag and version
         id: tag
         env:
@@ -66,11 +68,12 @@ jobs:
           bazelrc: common --color=yes
       - name: Build Java & .NET packages
         run: ./go all:package --config=release
-      - name: Delete nightly tag
+      - name: Delete nightly release and tag
+        env:
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/nightly"; then
-            git push origin --delete refs/tags/nightly || true
-          fi
+          gh release delete nightly --yes || true
+          git push origin --delete refs/tags/nightly || true
       - name: Draft GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues
~#16946 should be merged first~

### 💥 What does this PR do?
- Make failure Slack message stand out better
- During release delete nightly release as well as tag
- Release workflow to use the get-approval workflow
- Docs must wait for GitHub release to create the tag
- Can update version on trunk before docs have been updated since it is a different branch
- If release build breaks, do not try to unlock trunk (which waits for approval) — ensure slack notification sent
- Run nightly and mirror workflows after release

### 🔧 Implementation Notes
Uses the `get-approval.yml` workflow created for pre-release PR.

### 💡 Additional Considerations
I'd like to make this so we aren't building and releasing in separate jobs, but this works

### 🔄 Types of changes
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace manual approval job with reusable `get-approval` workflow

- Delete nightly GitHub release alongside tag during release process

- Add authentication token to checkout step for secure operations

- Improve Slack failure notification formatting with bullet points

- Run nightly and mirror workflows after successful release completion

- Decouple docs update from publish job, allow version update before docs

- Remove unnecessary approval wait on release build failure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  stage["Stage Release"]
  approval["Get Approval<br/>Reusable Workflow"]
  publish["Publish Packages"]
  docs["Update Docs"]
  release["GitHub Release"]
  unrestrict["Unrestrict Trunk"]
  version["Update Version"]
  nightly["Publish Nightly"]
  mirror["Mirror Releases"]
  failure["Failure Notification"]
  
  stage -- "success" --> approval
  approval -- "approved" --> publish
  stage -- "success" --> release
  publish --> docs
  release --> unrestrict
  unrestrict --> version
  version --> nightly
  nightly --> mirror
  
  stage -.-> failure
  publish -.-> failure
  docs -.-> failure
  release -.-> failure
  version -.-> failure
  nightly -.-> failure
  mirror -.-> failure
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mirror-selenium-releases.yml</strong><dd><code>Enable mirror workflow as reusable workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mirror-selenium-releases.yml

<ul><li>Add <code>workflow_call</code> trigger to enable reuse as called workflow<br> <li> Allows mirror workflow to be invoked from release workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16947/files#diff-09af8e9f2d0267b1778e969beb999aa35ddec12a5d9a50019440aefddb1c1fed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Refactor release workflow with approval reuse and post-release </code><br><code>automation</code></dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Add <code>SELENIUM_CI_TOKEN</code> to checkout step for authenticated operations<br> <li> Replace manual approval job with <code>get-approval</code> reusable workflow<br> <li> Change nightly deletion to use <code>gh release delete</code> command alongside tag <br>deletion<br> <li> Decouple docs job from publish dependency, only require stage and <br>publish<br> <li> Remove unnecessary <code>always()</code> condition from unrestrict-trunk job<br> <li> Remove docs dependency from update-version job for earlier version <br>updates<br> <li> Add nightly and mirror workflow calls after version update<br> <li> Improve Slack failure message formatting with bullet points and add <br>nightly/mirror status<br> <li> Update on-release-failure job dependencies to include new nightly and <br>mirror jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16947/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+39/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

