### PR TITLE
[build] Prevent nightly releases during release window

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,8 +33,24 @@ permissions:
   packages: write
 
 jobs:
+  check-release:
+    name: Check Release Window
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+    outputs:
+      release-in-progress: ${{ steps.check.outputs.releasing }}
+    steps:
+      - name: Check if release ruleset is active
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ENFORCEMENT=$(gh api /repos/${{ github.repository }}/rulesets/11911909 --jq '.enforcement')
+          echo "releasing=$([[ "$ENFORCEMENT" == "active" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
   ruby:
-    if: (github.event.repository.fork == false) && (inputs.language == 'ruby' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'ruby' || inputs.language == 'all' || github.event_name == 'schedule')
     name: Ruby
     uses: ./.github/workflows/bazel.yml
     strategy:
@@ -66,7 +82,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   python:
-    if: (github.event.repository.fork == false) && (inputs.language == 'python' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'python' || inputs.language == 'all' || github.event_name == 'schedule')
     name: Python
     uses: ./.github/workflows/bazel.yml
     with:
@@ -92,7 +109,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   java:
-    if: (github.event.repository.fork == false) && (inputs.language == 'java' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'java' || inputs.language == 'all' || github.event_name == 'schedule')
     name: Java
     uses: ./.github/workflows/bazel.yml
     with:
@@ -118,7 +136,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   dotnet:
-    if: (github.event.repository.fork == false) && (inputs.language == 'dotnet' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'dotnet' || inputs.language == 'all' || github.event_name == 'schedule')
     name: DotNet
     uses: ./.github/workflows/bazel.yml
     with:
@@ -145,7 +164,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   grid:
-    if: (github.event.repository.fork == false) && (inputs.language == 'grid' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'grid' || inputs.language == 'all' || github.event_name == 'schedule')
     name: Grid
     permissions:
       contents: write  # for creating nightly GitHub release
@@ -173,7 +193,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   javascript:
-    if: (github.event.repository.fork == false) && (inputs.language == 'javascript' || inputs.language == 'all' || github.event_name == 'schedule')
+    needs: check-release
+    if: (github.event.repository.fork == false) && (needs.check-release.outputs.release-in-progress != 'true') && (inputs.language == 'javascript' || inputs.language == 'all' || github.event_name == 'schedule')
     name: JavaScript
     uses: ./.github/workflows/bazel.yml
     with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,15 +38,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     outputs:
-      release-in-progress: ${{ steps.check.outputs.releasing }}
+      release-in-progress: ${{ steps.check.outputs.release-in-progress }}
     steps:
       - name: Check if release ruleset is active
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          ENFORCEMENT=$(gh api /repos/${{ github.repository }}/rulesets/11911909 --jq '.enforcement')
-          echo "releasing=$([[ "$ENFORCEMENT" == "active" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # Ruleset 11911909 is "Release In Progress Access" - see restrict-trunk.yml
+          if ! ENFORCEMENT=$(gh api /repos/${{ github.repository }}/rulesets/11911909 --jq '.enforcement' 2>/dev/null); then
+            echo "::warning::Failed to check release ruleset, assuming release in progress"
+            echo "release-in-progress=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release-in-progress=$([[ "$ENFORCEMENT" == "active" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
 
   ruby:
     needs: check-release


### PR DESCRIPTION
### **User description**
Nightly job ran mid-release yesterday and it was suboptimal. This will prevent that.
Plan in #16947 is to run nightly at the end of the release anyway since things expect a nightly tag.

### 💥 What does this PR do?
- Prevent nightly releases while a release is in progress

### 🔧 Implementation Notes
Checks whether release ruleset is active before proceeding with nightly build.

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent nightly releases during active release windows

- Add check-release job to detect active release ruleset

- Update all language jobs to depend on release check

- Skip nightly builds when release is in progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["check-release job"] -- "outputs release-in-progress" --> B["ruby job"]
  A -- "outputs release-in-progress" --> C["python job"]
  A -- "outputs release-in-progress" --> D["java job"]
  A -- "outputs release-in-progress" --> E["dotnet job"]
  A -- "outputs release-in-progress" --> F["grid job"]
  A -- "outputs release-in-progress" --> G["javascript job"]
  B -- "skipped if releasing" --> H["nightly workflow"]
  C -- "skipped if releasing" --> H
  D -- "skipped if releasing" --> H
  E -- "skipped if releasing" --> H
  F -- "skipped if releasing" --> H
  G -- "skipped if releasing" --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nightly.yml</strong><dd><code>Add release window detection to nightly workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/nightly.yml

<ul><li>Added new <code>check-release</code> job that queries GitHub API to detect if <br>release ruleset is active<br> <li> Updated all language-specific jobs (ruby, python, java, dotnet, grid, <br>javascript) to depend on <code>check-release</code><br> <li> Modified conditional logic in all jobs to skip execution when <br><code>release-in-progress</code> output is true<br> <li> Prevents nightly releases from running concurrently with active <br>release processes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16948/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6">+27/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

