### PR TITLE
[build] Fix Bazel JSDocs implementation

### DIFF
--- a/javascript/private/jsdoc.bzl
+++ b/javascript/private/jsdoc.bzl
@@ -1,33 +1,70 @@
-"""Rule for running jsdoc using Bazel-managed Node.js."""
+"""Rule for running jsdoc using Bazel-managed Node.js.
+
+This rule creates a wrapper script that:
+1. Runs jsdoc from the bazel-managed npm package
+2. Outputs to the workspace build directory
+3. Ignores jsdoc exit code (it exits 1 on type warnings) but verifies output was generated
+"""
 
 def _jsdoc_impl(ctx):
+    jsdoc_bin = ctx.attr.jsdoc_binary[DefaultInfo].files_to_run.executable
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
 
     if is_windows:
         script = ctx.actions.declare_file(ctx.label.name + ".bat")
         ctx.actions.write(script, _WINDOWS_TEMPLATE.format(
             config = ctx.file.config.basename,
+            jsdoc_bin = jsdoc_bin.short_path.replace("/", "\\\\"),
         ), is_executable = True)
     else:
         script = ctx.actions.declare_file(ctx.label.name + ".sh")
         ctx.actions.write(script, _UNIX_TEMPLATE.format(
             config = ctx.file.config.basename,
+            jsdoc_bin = jsdoc_bin.short_path,
         ), is_executable = True)
 
     runfiles = ctx.runfiles(files = ctx.files.data + [ctx.file.config])
+    runfiles = runfiles.merge(ctx.attr.jsdoc_binary[DefaultInfo].default_runfiles)
     return [DefaultInfo(executable = script, runfiles = runfiles)]
 
 _UNIX_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 cd "$BUILD_WORKSPACE_DIRECTORY/javascript/selenium-webdriver"
-exec "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/javascript/selenium-webdriver/node_modules/.bin/jsdoc" \\
-    --configure {config} "$@"
+DEST="$BUILD_WORKSPACE_DIRECTORY/build/docs/api/javascript"
+TEMPLATE="$0.runfiles/_main/javascript/selenium-webdriver/node_modules/clean-jsdoc-theme"
+
+# Set BAZEL_BINDIR to suppress rules_js error for non-build actions
+export BAZEL_BINDIR="."
+
+# Run jsdoc - ignore exit code since it fails on type warnings
+"$0.runfiles/_main/{jsdoc_bin}" --configure {config} --destination "$DEST" --template "$TEMPLATE" "$@" || true
+
+# Verify docs were generated
+if [[ -d "$DEST" ]] && [[ -n "$(ls -A "$DEST" 2>/dev/null)" ]]; then
+    echo "Documentation generated successfully at $DEST"
+else
+    echo "ERROR: Documentation was not generated"
+    exit 1
+fi
 """
 
 _WINDOWS_TEMPLATE = """@echo off
 cd /d "%BUILD_WORKSPACE_DIRECTORY%\\javascript\\selenium-webdriver"
-"%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\javascript\\selenium-webdriver\\node_modules\\.bin\\jsdoc" ^
-    --configure {config} %*
+set DEST=%BUILD_WORKSPACE_DIRECTORY%\\build\\docs\\api\\javascript
+set TEMPLATE=%~dp0.runfiles\\_main\\javascript\\selenium-webdriver\\node_modules\\clean-jsdoc-theme
+set BAZEL_BINDIR=.
+
+"%~dp0.runfiles\\_main\\{jsdoc_bin}" --configure {config} --destination "%DEST%" --template "%TEMPLATE%" %*
+if %ERRORLEVEL% neq 0 (
+    echo jsdoc exited with warnings, checking output...
+)
+
+if exist "%DEST%\\index.html" (
+    echo Documentation generated successfully at %DEST%
+) else (
+    echo ERROR: Documentation was not generated
+    exit /b 1
+)
 """
 
 jsdoc = rule(
@@ -40,6 +77,12 @@ jsdoc = rule(
         ),
         "data": attr.label_list(
             allow_files = True,
+        ),
+        "jsdoc_binary": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "target",
+            doc = "The jsdoc binary target from npm",
         ),
         "_windows_constraint": attr.label(
             default = "@platforms//os:windows",

--- a/javascript/private/jsdoc.bzl
+++ b/javascript/private/jsdoc.bzl
@@ -36,6 +36,10 @@ TEMPLATE="$0.runfiles/_main/javascript/selenium-webdriver/node_modules/clean-jsd
 # Set BAZEL_BINDIR to suppress rules_js error for non-build actions
 export BAZEL_BINDIR="."
 
+# Clean destination to prevent stale files
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
 # Run jsdoc - ignore exit code since it fails on type warnings
 "$0.runfiles/_main/{jsdoc_bin}" --configure {config} --destination "$DEST" --template "$TEMPLATE" "$@" || true
 
@@ -53,6 +57,9 @@ cd /d "%BUILD_WORKSPACE_DIRECTORY%\\javascript\\selenium-webdriver"
 set DEST=%BUILD_WORKSPACE_DIRECTORY%\\build\\docs\\api\\javascript
 set TEMPLATE=%~dp0.runfiles\\_main\\javascript\\selenium-webdriver\\node_modules\\clean-jsdoc-theme
 set BAZEL_BINDIR=.
+
+if exist "%DEST%" rmdir /s /q "%DEST%"
+mkdir "%DEST%"
 
 "%~dp0.runfiles\\_main\\{jsdoc_bin}" --configure {config} --destination "%DEST%" --template "%TEMPLATE%" %*
 if %ERRORLEVEL% neq 0 (

--- a/javascript/private/jsdoc.bzl
+++ b/javascript/private/jsdoc.bzl
@@ -44,7 +44,7 @@ mkdir -p "$DEST"
 "$0.runfiles/_main/{jsdoc_bin}" --configure {config} --destination "$DEST" --template "$TEMPLATE" "$@" || true
 
 # Verify docs were generated
-if [[ -d "$DEST" ]] && [[ -n "$(ls -A "$DEST" 2>/dev/null)" ]]; then
+if [[ -f "$DEST/index.html" ]]; then
     echo "Documentation generated successfully at $DEST"
 else
     echo "ERROR: Documentation was not generated"

--- a/javascript/selenium-webdriver/BUILD.bazel
+++ b/javascript/selenium-webdriver/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//javascript/selenium-webdriver:eslint/package_json.bzl", eslint_bin = "bin")
+load("@npm//javascript/selenium-webdriver:jsdoc/package_json.bzl", jsdoc_bin = "bin")
 load("@npm//javascript/selenium-webdriver:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("//common:defs.bzl", "copy_file")
@@ -286,6 +287,15 @@ copy_to_bin(
     srcs = [".prettierignore"],
 )
 
+# Internal jsdoc binary from npm - used by the docs rule
+jsdoc_bin.jsdoc_binary(
+    name = "jsdoc_bin",
+    visibility = ["//visibility:private"],
+)
+
+# Documentation generator that wraps jsdoc and handles:
+# - Output to workspace build directory
+# - Ignoring jsdoc type warning exit codes
 jsdoc(
     name = "docs",
     config = "jsdoc_conf.json",
@@ -293,4 +303,5 @@ jsdoc(
         ":node_modules/clean-jsdoc-theme",
         ":prod-src-files",
     ],
+    jsdoc_binary = ":jsdoc_bin",
 )

--- a/javascript/selenium-webdriver/bidi/storage.js
+++ b/javascript/selenium-webdriver/bidi/storage.js
@@ -44,7 +44,7 @@ class Storage {
    *
    * @param {CookieFilter} [filter] - The filter to apply to the cookies.
    * @param {(BrowsingContextPartitionDescriptor|StorageKeyPartitionDescriptor)} [partition] - The partition to retrieve cookies from.
-   * @returns {Promise<{ cookies: Cookie[], partitionKey?: PartitionKey }>} - A promise that resolves to an object containing the retrieved cookies and an optional partition key.
+   * @returns {Promise<{ cookies: Cookie[], partitionKey: (PartitionKey|undefined) }>} - A promise that resolves to an object containing the retrieved cookies and an optional partition key.
    * @throws {Error} If the filter parameter is provided but is not an instance of CookieFilter.
    * @throws {Error} If the partition parameter is provided but is not an instance of BrowsingContextPartitionDescriptor or StorageKeyPartitionDescriptor.
    */


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
- Fix JavaScript documentation generation in Bazel

### 🔧 Implementation Notes
This fix was verified successful during yesterday's release

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Bazel jsdoc rule to properly reference npm-managed jsdoc binary

- Update jsdoc templates to output to workspace build directory

- Add verification that documentation was successfully generated

- Correct JSDoc type annotation for optional partition key property


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["jsdoc rule"] -->|"uses npm binary"| B["jsdoc_binary attribute"]
  B -->|"references"| C["npm jsdoc package"]
  A -->|"executes"| D["Unix/Windows template"]
  D -->|"outputs to"| E["build/docs/api/javascript"]
  D -->|"verifies"| F["docs generated successfully"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jsdoc.bzl</strong><dd><code>Refactor jsdoc rule templates and add binary attribute</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/private/jsdoc.bzl

<ul><li>Add <code>jsdoc_binary</code> attribute to rule definition for npm-managed jsdoc <br>binary<br> <li> Update Unix template to use proper runfiles path and output to <br>workspace build directory<br> <li> Update Windows template with equivalent path handling and output <br>directory<br> <li> Add verification logic to check if documentation was successfully <br>generated<br> <li> Set <code>BAZEL_BINDIR</code> environment variable to suppress rules_js errors<br> <li> Handle jsdoc exit code gracefully since it exits 1 on type warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16949/files#diff-4eb9af5f00d5bee10d998f86a4a1e5b539a4a7ce8dda6c74a9599432cc8677a6">+48/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Wire npm jsdoc binary to docs rule target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/BUILD.bazel

<ul><li>Load jsdoc binary from npm package using <code>package_json.bzl</code><br> <li> Create internal <code>jsdoc_bin</code> target wrapping the npm jsdoc binary<br> <li> Pass <code>jsdoc_binary</code> attribute to jsdoc rule invocation<br> <li> Add documentation comments explaining the docs rule behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16949/files#diff-929781d2a6493d8b5cef8e48c29d8c3430df0e548b4ed20829588d79e5fa57a7">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.js</strong><dd><code>Fix JSDoc type annotation for optional property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

javascript/selenium-webdriver/bidi/storage.js

<ul><li>Update JSDoc <code>@returns</code> type annotation for <code>getCookies</code> method<br> <li> Change <code>partitionKey?: PartitionKey</code> to <code>partitionKey: </code><br><code>(PartitionKey|undefined)</code> for proper type documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16949/files#diff-e501e64dd763ab26a28bf7adff203399d918d2475d08aa85e28d5947c71454e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

