### PR TITLE
[build] Fix Bazel NuGet push implementation

### DIFF
--- a/dotnet/private/nuget_push.bzl
+++ b/dotnet/private/nuget_push.bzl
@@ -23,16 +23,27 @@ def _nuget_push_impl(ctx):
         ),
     ]
 
+def _to_runfiles_path(short_path):
+    """Convert a short_path to a runfiles path.
+
+    External repos in bzlmod have paths like ../repo_name/path,
+    which in runfiles becomes repo_name/path.
+    Main repo paths need _main/ prefix.
+    """
+    if short_path.startswith("../"):
+        return short_path[3:]
+    return "_main/" + short_path
+
 def _create_unix_script(ctx, dotnet, nupkg_files):
     """Create bash script for Unix/macOS/Linux."""
     push_commands = []
     for nupkg in nupkg_files:
+        nupkg_runfiles_path = _to_runfiles_path(nupkg.short_path)
         push_commands.append(
-            '"$DOTNET" nuget push "$RUNFILES_DIR/_main/{nupkg}" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" --skip-duplicate --no-symbols'.format(nupkg = nupkg.short_path),
+            '"$DOTNET" nuget push "$RUNFILES_DIR/{nupkg}" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" --skip-duplicate'.format(nupkg = nupkg_runfiles_path),
         )
 
-    # External repos in bzlmod have paths like ../repo_name/path, which in runfiles becomes repo_name/path
-    dotnet_runfiles_path = dotnet.short_path.lstrip("../")
+    dotnet_runfiles_path = _to_runfiles_path(dotnet.short_path)
 
     script_content = """#!/usr/bin/env bash
 set -euo pipefail
@@ -43,7 +54,8 @@ if [[ -d "$0.runfiles/_main" ]]; then
 elif [[ -n "${{RUNFILES_DIR:-}}" ]]; then
     RUNFILES_DIR="$RUNFILES_DIR"
 else
-    RUNFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+    echo "ERROR: Could not locate runfiles directory" >&2
+    exit 1
 fi
 
 DOTNET="$RUNFILES_DIR/{dotnet}"
@@ -65,19 +77,19 @@ def _create_windows_script(ctx, dotnet, nupkg_files):
     """Create batch script for Windows."""
     push_commands = []
     for nupkg in nupkg_files:
-        nupkg_path = nupkg.short_path.replace("/", "\\")
+        nupkg_runfiles_path = _to_runfiles_path(nupkg.short_path).replace("/", "\\")
         push_commands.append(
-            '"%%DOTNET%%" nuget push "%s" --api-key "%%NUGET_API_KEY%%" --source "%%NUGET_SOURCE%%" --skip-duplicate --no-symbols' % nupkg_path,
+            '"%%DOTNET%%" nuget push "%%~dp0%s" --api-key "%%NUGET_API_KEY%%" --source "%%NUGET_SOURCE%%" --skip-duplicate' % nupkg_runfiles_path,
         )
         push_commands.append("if %%ERRORLEVEL%% neq 0 exit /b %%ERRORLEVEL%%")
 
-    dotnet_path = dotnet.short_path.replace("/", "\\")
+    dotnet_runfiles_path = _to_runfiles_path(dotnet.short_path).replace("/", "\\")
 
     script_content = """@echo off
 set DOTNET=%~dp0{dotnet_path}
 {push_commands}
 """.format(
-        dotnet_path = dotnet_path,
+        dotnet_path = dotnet_runfiles_path,
         push_commands = "\n".join(push_commands),
     )
 

--- a/dotnet/private/nuget_push.bzl
+++ b/dotnet/private/nuget_push.bzl
@@ -13,7 +13,8 @@ def _nuget_push_impl(ctx):
     else:
         script = _create_unix_script(ctx, dotnet, nupkg_files)
 
-    runfiles = ctx.runfiles(files = nupkg_files).merge(toolchain.runtime.default_runfiles)
+    runfiles = ctx.runfiles(files = nupkg_files + [dotnet])
+    runfiles = runfiles.merge(toolchain.runtime.default_runfiles)
 
     return [
         DefaultInfo(
@@ -27,15 +28,28 @@ def _create_unix_script(ctx, dotnet, nupkg_files):
     push_commands = []
     for nupkg in nupkg_files:
         push_commands.append(
-            '"$DOTNET" nuget push "%s" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE"' % nupkg.short_path,
+            '"$DOTNET" nuget push "$RUNFILES_DIR/_main/{nupkg}" --api-key "$NUGET_API_KEY" --source "$NUGET_SOURCE" --skip-duplicate --no-symbols'.format(nupkg = nupkg.short_path),
         )
+
+    # External repos in bzlmod have paths like ../repo_name/path, which in runfiles becomes repo_name/path
+    dotnet_runfiles_path = dotnet.short_path.lstrip("../")
 
     script_content = """#!/usr/bin/env bash
 set -euo pipefail
-DOTNET="$(cd "$(dirname "$0")" && pwd)/{dotnet}"
+
+# Locate runfiles directory
+if [[ -d "$0.runfiles/_main" ]]; then
+    RUNFILES_DIR="$0.runfiles"
+elif [[ -n "${{RUNFILES_DIR:-}}" ]]; then
+    RUNFILES_DIR="$RUNFILES_DIR"
+else
+    RUNFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+DOTNET="$RUNFILES_DIR/{dotnet}"
 {push_commands}
 """.format(
-        dotnet = dotnet.short_path,
+        dotnet = dotnet_runfiles_path,
         push_commands = "\n".join(push_commands),
     )
 
@@ -53,7 +67,7 @@ def _create_windows_script(ctx, dotnet, nupkg_files):
     for nupkg in nupkg_files:
         nupkg_path = nupkg.short_path.replace("/", "\\")
         push_commands.append(
-            '"%%DOTNET%%" nuget push "%s" --api-key "%%NUGET_API_KEY%%" --source "%%NUGET_SOURCE%%"' % nupkg_path,
+            '"%%DOTNET%%" nuget push "%s" --api-key "%%NUGET_API_KEY%%" --source "%%NUGET_SOURCE%%" --skip-duplicate --no-symbols' % nupkg_path,
         )
         push_commands.append("if %%ERRORLEVEL%% neq 0 exit /b %%ERRORLEVEL%%")
 


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
- Fix .NET package publishing via NuGet

### 🔧 Implementation Notes
This fix was verified successful during yesterday's release

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix NuGet package publishing via Bazel by correcting runfiles handling

- Add `dotnet` executable to runfiles dependencies for proper resolution

- Update Unix script to locate runfiles directory dynamically

- Add `--skip-duplicate` and `--no-symbols` flags to push commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nuget_push.bzl"] -->|Add dotnet to runfiles| B["Runfiles Dependencies"]
  A -->|Update Unix script| C["Dynamic Runfiles Detection"]
  A -->|Add CLI flags| D["NuGet Push Command"]
  B --> E["Proper Executable Resolution"]
  C --> E
  D --> F["Improved Push Reliability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nuget_push.bzl</strong><dd><code>Fix NuGet push runfiles and add CLI flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/nuget_push.bzl

<ul><li>Fixed runfiles handling by explicitly adding <code>dotnet</code> executable to <br>runfiles list<br> <li> Refactored Unix script to dynamically locate runfiles directory <br>instead of relying on relative paths<br> <li> Added <code>--skip-duplicate</code> and <code>--no-symbols</code> flags to both Unix and Windows <br>NuGet push commands<br> <li> Improved path handling for external repositories in bzlmod by <br>stripping leading <code>../</code> from dotnet path</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16950/files#diff-ffe47bdf89891536b5daad72314fd0dd78b291420e1c02290f14cea869d6008b">+19/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

