### PR TITLE
[build] Create config files from environment variables for publishing

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -86,7 +86,6 @@ jobs:
       SEL_M2_USER: ${{ secrets.SEL_M2_USER }}
       SEL_M2_PASS: ${{ secrets.SEL_M2_PASS }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/Rakefile
+++ b/Rakefile
@@ -392,18 +392,6 @@ RELEASE_CREDENTIALS = {
     file: -> { File.exist?("#{Dir.home}/.m2/settings.xml") && File.read("#{Dir.home}/.m2/settings.xml").include?('<id>central</id>') }
   },
   java_gpg: {cmd: 'gpg'},
-  python: {
-    env: [%w[TWINE_USERNAME], %w[TWINE_PASSWORD]],
-    file: -> { File.exist?("#{Dir.home}/.pypirc") }
-  },
-  ruby: {
-    env: [%w[GEM_HOST_API_KEY]],
-    file: -> { File.exist?("#{Dir.home}/.gem/credentials") }
-  },
-  node: {
-    env: [%w[NODE_AUTH_TOKEN]],
-    file: -> { File.exist?("#{Dir.home}/.npmrc") && File.read("#{Dir.home}/.npmrc").include?('//registry.npmjs.org/:_authToken') }
-  },
   dotnet: {env: [%w[NUGET_API_KEY]]},
   dotnet_nightly: {env: [%w[GITHUB_TOKEN]]}
 }.freeze
@@ -413,6 +401,61 @@ def credential_valid?(cred)
   has_file = cred[:file]&.call
   has_cmd = cred[:cmd] && (system('which', cred[:cmd], out: File::NULL, err: File::NULL) || system('where', cred[:cmd], out: File::NULL, err: File::NULL))
   has_env || has_file || has_cmd
+end
+
+def setup_npm_auth
+  npmrc = File.join(Dir.home, '.npmrc')
+  return if File.exist?(npmrc) && File.read(npmrc).include?('//registry.npmjs.org/:_authToken=')
+
+  token = ENV.fetch('NODE_AUTH_TOKEN', nil)
+  raise 'Missing npm credentials: set NODE_AUTH_TOKEN or configure ~/.npmrc' if token.nil? || token.empty?
+
+  auth_line = "//registry.npmjs.org/:_authToken=#{token}"
+  if File.exist?(npmrc)
+    File.open(npmrc, 'a') { |f| f.puts(auth_line) }
+  else
+    File.write(npmrc, "#{auth_line}\n")
+  end
+end
+
+def setup_gem_credentials
+  gem_dir = File.join(Dir.home, '.gem')
+  credentials = File.join(gem_dir, 'credentials')
+  return if File.exist?(credentials) && File.read(credentials).include?(':rubygems_api_key:')
+
+  token = ENV.fetch('GEM_HOST_API_KEY', nil)
+  if token.nil? || token.empty?
+    raise 'Missing RubyGems credentials: set GEM_HOST_API_KEY or configure ~/.gem/credentials'
+  end
+
+  FileUtils.mkdir_p(gem_dir)
+  if File.exist?(credentials)
+    File.open(credentials, 'a') { |f| f.puts(":rubygems_api_key: #{token}") }
+  else
+    File.write(credentials, ":rubygems_api_key: #{token}\n")
+  end
+  File.chmod(0o600, credentials)
+end
+
+def setup_pypirc
+  pypirc = File.join(Dir.home, '.pypirc')
+  return if File.exist?(pypirc) && File.read(pypirc).match?(/^\[pypi\]/m)
+
+  token = ENV.fetch('TWINE_PASSWORD', nil)
+  raise 'Missing PyPI credentials: set TWINE_PASSWORD or configure ~/.pypirc' if token.nil? || token.empty?
+
+  pypi_section = <<~PYPIRC
+    [pypi]
+    username = __token__
+    password = #{token}
+  PYPIRC
+
+  if File.exist?(pypirc)
+    File.open(pypirc, 'a') { |f| f.puts("\n#{pypi_section}") }
+  else
+    File.write(pypirc, pypi_section)
+  end
+  File.chmod(0o600, pypirc)
 end
 
 def check_credentials(langs)
@@ -533,7 +576,7 @@ namespace :node do
   desc 'Release Node npm package'
   task :release do |_task, arguments|
     nightly = arguments.to_a.include?('nightly')
-    check_credentials(%i[node]) unless nightly
+    setup_npm_auth unless nightly
 
     if nightly
       puts 'Updating Node version to nightly...'
@@ -597,9 +640,7 @@ namespace :py do
   desc 'Release Python wheel and sdist to pypi'
   task :release do |_task, arguments|
     nightly = arguments.to_a.include?('nightly')
-    check_credentials(%i[python]) unless nightly
-
-    ENV['TWINE_USERNAME'] = '__token__'
+    setup_pypirc unless nightly
 
     if nightly
       puts 'Updating Python version to nightly...'
@@ -804,7 +845,7 @@ namespace :rb do
       puts 'Releasing nightly WebDriver gem...'
       Bazel.execute('run', ['--config=release'], '//rb:selenium-webdriver-release-nightly')
     else
-      check_credentials(%i[ruby])
+      setup_gem_credentials
       patch_release = ruby_version.split('.').fetch(2, '0').to_i.positive?
 
       puts 'Releasing Ruby gems...'

--- a/Rakefile
+++ b/Rakefile
@@ -599,6 +599,8 @@ namespace :py do
     nightly = arguments.to_a.include?('nightly')
     check_credentials(%i[python]) unless nightly
 
+    ENV['TWINE_USERNAME'] = '__token__'
+
     if nightly
       puts 'Updating Python version to nightly...'
       Rake::Task['py:version'].invoke('nightly')

--- a/Rakefile
+++ b/Rakefile
@@ -416,6 +416,7 @@ def setup_npm_auth
   else
     File.write(npmrc, "#{auth_line}\n")
   end
+  File.chmod(0o600, npmrc)
 end
 
 def setup_gem_credentials


### PR DESCRIPTION
### **User description**
Ruby, Python & JS all failed automated release process yesterday on CI, but passed with same code when run locally.
I think it was probably environment variable related?

### 💥 What does this PR do?
- TWINE_USERNAME is always __token__
- Create config files from environment variables for publishing

### 🔧 Implementation Notes
Does not override existing credentials when found if you're running locally with your own

### 💡 Additional Considerations
We can't know if this will work until next release, unfortunately

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Create config files from environment variables for publishing

- Replace credential validation with dynamic setup functions

- Set TWINE_USERNAME to __token__ for PyPI authentication

- Skip credential checks for nightly releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] -->|setup_npm_auth| B[".npmrc"]
  A -->|setup_gem_credentials| C[".gem/credentials"]
  A -->|setup_pypirc| D[".pypirc"]
  B --> E["Node Release"]
  C --> F["Ruby Release"]
  D --> G["Python Release"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bazel.yml</strong><dd><code>Remove TWINE_USERNAME from workflow secrets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bazel.yml

<ul><li>Removed TWINE_USERNAME from GitHub Actions environment variables<br> <li> TWINE_USERNAME will now be hardcoded as __token__ in the Rakefile <br>setup</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16951/files#diff-85e6e6bfc3047eb4fe69bf0f06238ddd442edf74266ad3a964ebfba26f46923c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Replace credential validation with dynamic config file setup</code></dd></summary>
<hr>

Rakefile

<ul><li>Removed python, ruby, and node credential validation entries from <br>RELEASE_CREDENTIALS<br> <li> Added setup_npm_auth function to create .npmrc from NODE_AUTH_TOKEN <br>environment variable<br> <li> Added setup_gem_credentials function to create .gem/credentials from <br>GEM_HOST_API_KEY<br> <li> Added setup_pypirc function to create .pypirc with __token__ username <br>from TWINE_PASSWORD<br> <li> Updated node:release, py:release, and rb:release tasks to call setup <br>functions instead of credential validation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16951/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+58/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

