### PR TITLE
[build] Java release improvements and build verification tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,14 @@ jobs:
       run: ./go ${{ matrix.language }}:release
     secrets: inherit
 
+  verify:
+    name: Verify Published Packages
+    needs: docs
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Verify packages
+      run: ./go all:verify
+
   docs:
     name: Update ${{ matrix.language }} Documentation
     needs: [stage, publish, github-release]
@@ -150,7 +158,7 @@ jobs:
 
   unrestrict-trunk:
     name: Unrestrict Trunk Branch
-    needs: [github-release]
+    needs: verify
     uses: ./.github/workflows/restrict-trunk.yml
     with:
       restrict: false
@@ -198,7 +206,7 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [stage, publish, docs, github-release, update-version, nightly, mirror]
+    needs: [stage, publish, docs, github-release, update-version, nightly, mirror, verify]
     if: failure()
     steps:
       - uses: actions/checkout@v4
@@ -217,5 +225,6 @@ jobs:
             • Nightly Version Updated: ${{ needs.update-version.result }}
             • Nightly Packages: ${{ needs.nightly.result }}
             • Mirror Updated: ${{ needs.mirror.result }}
+            • Packages Verified: ${{ needs.verify.result }}
           MSG_MINIMAL: actions url
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Rakefile
+++ b/Rakefile
@@ -1232,13 +1232,16 @@ namespace :java do
       when 'VALIDATED', 'PUBLISHED' then break
       when 'FAILED' then raise "Deployment failed: #{status['errors']}"
       end
-      sleep(delay)
+      sleep(delay) unless attempt == max_attempts - 1
     rescue StandardError => e
+      raise if e.message.start_with?('Deployment failed')
+
       warn "API error (attempt #{attempt + 1}/#{max_attempts}): #{e.message}"
       sleep(delay) unless attempt == max_attempts - 1
     end
 
-    return if status['deploymentState'] == 'PUBLISHED'
+    state = status['deploymentState']
+    return if state == 'PUBLISHED'
 
     raise "Timed out after #{(max_attempts * delay) / 60} minutes waiting for validation" unless state == 'VALIDATED'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1242,7 +1242,9 @@ namespace :java do
   desc 'Publish a Sonatype deployment by ID'
   task :publish_deployment, [:deployment_id] do |_task, arguments|
     deployment_id = arguments[:deployment_id] || ENV.fetch('DEPLOYMENT_ID', nil)
-    raise 'Deployment ID required' if deployment_id.nil? || deployment_id.empty?
+    if deployment_id.nil? || deployment_id.empty?
+      raise 'Deployment ID required: ./go java:publish_deployment[ID] or set DEPLOYMENT_ID'
+    end
 
     read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
     token = Base64.strict_encode64("#{ENV.fetch('MAVEN_USER')}:#{ENV.fetch('MAVEN_PASSWORD')}")
@@ -1261,7 +1263,7 @@ namespace :java do
       end
       sleep(5)
     end
-    raise 'Timed out waiting for validation' unless status['deploymentState'] == 'VALIDATED'
+    raise 'Timed out after 5 minutes waiting for validation' unless status['deploymentState'] == 'VALIDATED'
 
     expected = java_release_targets.size
     actual = status['purls']&.size || 0

--- a/Rakefile
+++ b/Rakefile
@@ -1259,8 +1259,7 @@ namespace :java do
       puts "Deployment state: #{state}"
 
       case state
-      when 'VALIDATED' then break
-      when 'PUBLISHED' then return # rubocop:disable Lint/NonLocalExitFromIterator
+      when 'VALIDATED', 'PUBLISHED' then break
       when 'FAILED' then raise "Deployment failed: #{status['errors']}"
       end
       sleep(delay)
@@ -1268,9 +1267,10 @@ namespace :java do
       warn "API error (attempt #{attempt + 1}/#{max_attempts}): #{e.message}"
       sleep(delay) unless attempt == max_attempts - 1
     end
-    unless status['deploymentState'] == 'VALIDATED'
-      raise "Timed out after #{(max_attempts * delay) / 60} minutes waiting for validation"
-    end
+
+    return if status['deploymentState'] == 'PUBLISHED'
+
+    raise "Timed out after #{(max_attempts * delay) / 60} minutes waiting for validation" unless state == 'VALIDATED'
 
     expected = java_release_targets.size
     actual = status['purls']&.size || 0

--- a/Rakefile
+++ b/Rakefile
@@ -396,35 +396,24 @@ RELEASE_CREDENTIALS = {
   dotnet_nightly: {env: [%w[GITHUB_TOKEN]]}
 }.freeze
 
-def verify_package_published(url, max_attempts: 12, delay: 10)
+def package_published?(url, max_attempts: 12, delay: 10)
   puts "Verifying #{url}..."
-  attempts = 0
-
-  loop do
-    attempts += 1
-    uri = URI(url)
+  uri = URI(url)
+  max_attempts.times do |attempt|
     res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
-                                                  open_timeout: 10, read_timeout: 10) do |http|
-      http.request(Net::HTTP::Get.new(uri))
-    end
-
+                                                  open_timeout: 10, read_timeout: 10) { |http| http.request(Net::HTTP::Get.new(uri)) }
     if res.is_a?(Net::HTTPSuccess)
       puts 'Verified!'
       return true
-    elsif attempts >= max_attempts
-      warn "Not found after #{max_attempts * delay}s"
-      return false
-    else
-      puts "Not yet indexed, waiting... (#{attempts}/#{max_attempts})"
-      sleep(delay)
     end
+    puts "Not yet indexed, waiting... (#{attempt + 1}/#{max_attempts})"
+    sleep(delay)
   rescue StandardError => e
     warn "Error: #{e.message}"
-    return false if attempts >= max_attempts
-
-    sleep(delay)
-    retry
+    sleep(delay) unless attempt == max_attempts - 1
   end
+  warn "Not found after #{max_attempts * delay}s"
+  false
 end
 
 def sonatype_api_post(url, token)
@@ -643,6 +632,15 @@ namespace :node do
 
     puts 'Running Node package release...'
     Bazel.execute('run', ['--config=release'], '//javascript/selenium-webdriver:selenium-webdriver.publish')
+
+    Rake::Task['node:verify'].invoke unless nightly
+  end
+
+  desc 'Verify Node package is published on npm'
+  task :verify do
+    package_published?(
+      "https://registry.npmjs.org/selenium-webdriver/#{node_version}"
+    ) || warn('npm verification failed - package may still be indexing')
   end
 
   task deploy: :release
@@ -708,6 +706,15 @@ namespace :py do
     command = nightly ? '//py:selenium-release-nightly' : '//py:selenium-release'
     puts "Running Python release command: #{command}"
     Bazel.execute('run', ['--config=release'], command)
+
+    Rake::Task['py:verify'].invoke unless nightly
+  end
+
+  desc 'Verify Python package is published on PyPI'
+  task :verify do
+    package_published?(
+      "https://pypi.org/pypi/selenium/#{python_version}/json"
+    ) || warn('PyPI verification failed - package may still be indexing')
   end
 
   desc 'generate and copy files required for local development'
@@ -909,6 +916,22 @@ namespace :rb do
       puts 'Releasing Ruby gems...'
       Bazel.execute('run', ['--config=release'], '//rb:selenium-webdriver-release')
       Bazel.execute('run', ['--config=release'], '//rb:selenium-devtools-release') unless patch_release
+
+      Rake::Task['rb:verify'].invoke
+    end
+  end
+
+  desc 'Verify Ruby packages are published on RubyGems'
+  task :verify do
+    patch_release = ruby_version.split('.').fetch(2, '0').to_i.positive?
+
+    package_published?(
+      "https://rubygems.org/api/v2/rubygems/selenium-webdriver/versions/#{ruby_version}.json"
+    ) || warn('RubyGems verification failed - selenium-webdriver may still be indexing')
+    unless patch_release
+      package_published?(
+        "https://rubygems.org/api/v2/rubygems/selenium-devtools/versions/#{ruby_version}.json"
+      ) || warn('RubyGems verification failed - selenium-devtools may still be indexing')
     end
   end
 
@@ -1067,6 +1090,18 @@ namespace :dotnet do
 
     puts "Pushing .NET packages to #{ENV.fetch('NUGET_SOURCE', nil)}..."
     Bazel.execute('run', ['--config=release'], '//dotnet:publish')
+
+    Rake::Task['dotnet:verify'].invoke unless nightly
+  end
+
+  desc 'Verify .NET packages are published on NuGet'
+  task :verify do
+    package_published?(
+      "https://api.nuget.org/v3/registration5-semver1/selenium.webdriver/#{dotnet_version}.json"
+    ) || warn('NuGet verification failed - Selenium.WebDriver may still be indexing')
+    package_published?(
+      "https://api.nuget.org/v3/registration5-semver1/selenium.support/#{dotnet_version}.json"
+    ) || warn('NuGet verification failed - Selenium.Support may still be indexing')
   end
 
   desc 'Generate .NET documentation'
@@ -1165,7 +1200,7 @@ namespace :java do
   end
 
   desc 'Publish to sonatype'
-  task :publish do |_task|
+  task :publish do
     read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
     user = ENV.fetch('MAVEN_USER')
     pass = ENV.fetch('MAVEN_PASSWORD')
@@ -1206,7 +1241,7 @@ namespace :java do
 
   desc 'Publish a Sonatype deployment by ID'
   task :publish_deployment, [:deployment_id] do |_task, arguments|
-    deployment_id = arguments[:deployment_id] || ENV['DEPLOYMENT_ID']
+    deployment_id = arguments[:deployment_id] || ENV.fetch('DEPLOYMENT_ID', nil)
     raise 'Deployment ID required' if deployment_id.nil? || deployment_id.empty?
 
     read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
@@ -1239,7 +1274,7 @@ namespace :java do
 
   desc 'Verify Java packages are published on Maven Central'
   task :verify do
-    verify_package_published(
+    package_published?(
       "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/#{java_version}/selenium-java-#{java_version}.pom",
       max_attempts: 30, delay: 60
     ) || warn('Maven Central verification failed - may still be syncing')
@@ -1432,8 +1467,24 @@ namespace :all do
   desc 'Validate release credentials for all languages without releasing'
   task :check_credentials do |_task, arguments|
     nightly = arguments.to_a.include?('nightly')
-    langs = nightly ? %i[java dotnet_nightly] : %i[java java_gpg python ruby node dotnet]
-    check_credentials(langs)
+
+    if nightly
+      check_credentials(%i[java dotnet_nightly])
+    else
+      check_credentials(%i[java java_gpg dotnet])
+      setup_pypirc
+      setup_gem_credentials
+      setup_npm_auth
+    end
+  end
+
+  desc 'Verify all packages are published to their registries'
+  task :verify do
+    Rake::Task['java:verify'].invoke
+    Rake::Task['py:verify'].invoke
+    Rake::Task['rb:verify'].invoke
+    Rake::Task['dotnet:verify'].invoke
+    Rake::Task['node:verify'].invoke
   end
 
   desc 'Release all artifacts for all language bindings'

--- a/Rakefile
+++ b/Rakefile
@@ -1251,19 +1251,26 @@ namespace :java do
 
     encoded_id = URI.encode_www_form_component(deployment_id.strip)
     status = {}
-    60.times do
+    max_attempts = 60
+    delay = 5
+    max_attempts.times do |attempt|
       status = sonatype_api_post("https://central.sonatype.com/api/v1/publisher/status?id=#{encoded_id}", token)
       state = status['deploymentState']
       puts "Deployment state: #{state}"
 
       case state
       when 'VALIDATED' then break
-      when 'PUBLISHED' then return
+      when 'PUBLISHED' then return # rubocop:disable Lint/NonLocalExitFromIterator
       when 'FAILED' then raise "Deployment failed: #{status['errors']}"
       end
-      sleep(5)
+      sleep(delay)
+    rescue StandardError => e
+      warn "API error (attempt #{attempt + 1}/#{max_attempts}): #{e.message}"
+      sleep(delay) unless attempt == max_attempts - 1
     end
-    raise 'Timed out after 5 minutes waiting for validation' unless status['deploymentState'] == 'VALIDATED'
+    unless status['deploymentState'] == 'VALIDATED'
+      raise "Timed out after #{(max_attempts * delay) / 60} minutes waiting for validation"
+    end
 
     expected = java_release_targets.size
     actual = status['purls']&.size || 0

--- a/Rakefile
+++ b/Rakefile
@@ -396,6 +396,48 @@ RELEASE_CREDENTIALS = {
   dotnet_nightly: {env: [%w[GITHUB_TOKEN]]}
 }.freeze
 
+def verify_package_published(url, max_attempts: 12, delay: 10)
+  puts "Verifying #{url}..."
+  attempts = 0
+
+  loop do
+    attempts += 1
+    uri = URI(url)
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
+                                                  open_timeout: 10, read_timeout: 10) do |http|
+      http.request(Net::HTTP::Get.new(uri))
+    end
+
+    if res.is_a?(Net::HTTPSuccess)
+      puts 'Verified!'
+      return true
+    elsif attempts >= max_attempts
+      warn "Not found after #{max_attempts * delay}s"
+      return false
+    else
+      puts "Not yet indexed, waiting... (#{attempts}/#{max_attempts})"
+      sleep(delay)
+    end
+  rescue StandardError => e
+    warn "Error: #{e.message}"
+    return false if attempts >= max_attempts
+
+    sleep(delay)
+    retry
+  end
+end
+
+def sonatype_api_post(url, token)
+  uri = URI(url)
+  req = Net::HTTP::Post.new(uri)
+  req['Authorization'] = "Bearer #{token}"
+
+  res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+  raise "Sonatype API error (#{res.code}): #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+  res.body.empty? ? {} : JSON.parse(res.body)
+end
+
 def credential_valid?(cred)
   has_env = cred[:env]&.all? { |vars| vars.any? { |v| ENV.fetch(v, nil) } }
   has_file = cred[:file]&.call
@@ -1127,28 +1169,80 @@ namespace :java do
     read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
     user = ENV.fetch('MAVEN_USER')
     pass = ENV.fetch('MAVEN_PASSWORD')
+    token = Base64.strict_encode64("#{user}:#{pass}")
 
+    puts 'Triggering Sonatype validation...'
     uri = URI('https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/org.seleniumhq')
-    encoded = Base64.strict_encode64("#{user}:#{pass}")
 
-    puts 'Triggering validation POST to Central Portal...'
     req = Net::HTTP::Post.new(uri)
-    req['Authorization'] = "Basic #{encoded}"
+    req['Authorization'] = "Basic #{token}"
     req['Accept'] = '*/*'
     req['Content-Length'] = '0'
 
-    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true,
-                                                  open_timeout: 10, read_timeout: 60) do |http|
-      http.request(req)
+    begin
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true,
+                                                    open_timeout: 10, read_timeout: 180) do |http|
+        http.request(req)
+      end
+    rescue Net::ReadTimeout, Net::OpenTimeout => e
+      warn <<~MSG
+        Request timed out waiting for deployment ID.
+        The deployment may still have been created on the server.
+        Check https://central.sonatype.com/publishing/deployments for pending deployments,
+        then run: ./go java:publish_deployment <deployment_id>
+      MSG
+      raise e
     end
 
     if res.is_a?(Net::HTTPSuccess)
-      puts "Manual upload triggered successfully (HTTP #{res.code})"
+      deployment_id = res.body.strip
+      puts "Got deployment ID: #{deployment_id}"
+      Rake::Task['java:publish_deployment'].invoke(deployment_id)
     else
-      warn "Manual upload failed (HTTP #{res.code}): #{res.code} #{res.message}"
-      warn res.body if res.body && !res.body.empty?
+      warn "Failed to get deployment ID (HTTP #{res.code}): #{res.body}"
       exit(1)
     end
+  end
+
+  desc 'Publish a Sonatype deployment by ID'
+  task :publish_deployment, [:deployment_id] do |_task, arguments|
+    deployment_id = arguments[:deployment_id] || ENV['DEPLOYMENT_ID']
+    raise 'Deployment ID required' if deployment_id.nil? || deployment_id.empty?
+
+    read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
+    token = Base64.strict_encode64("#{ENV.fetch('MAVEN_USER')}:#{ENV.fetch('MAVEN_PASSWORD')}")
+
+    60.times do
+      status = sonatype_api_post("https://central.sonatype.com/api/v1/publisher/status?id=#{deployment_id}", token)
+      state = status['deploymentState']
+      puts "Deployment state: #{state}"
+
+      case state
+      when 'VALIDATED' then break
+      when 'PUBLISHED' then exit(0)
+      when 'FAILED' then raise "Deployment failed: #{status['errors']}"
+      end
+      sleep(5)
+    end
+    raise 'Timed out waiting for validation' unless status['deploymentState'] == 'VALIDATED'
+
+    expected = java_release_targets.size
+    actual = status['purls']&.size || 0
+    raise "Expected #{expected} packages but found #{actual}" if actual != expected
+
+    puts 'Publishing deployed packages...'
+    sonatype_api_post("https://central.sonatype.com/api/v1/publisher/deployment/#{deployment_id}", token)
+    puts "Published! Deployment ID: #{deployment_id}"
+
+    Rake::Task['java:verify'].invoke
+  end
+
+  desc 'Verify Java packages are published on Maven Central'
+  task :verify do
+    verify_package_published(
+      "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/#{java_version}/selenium-java-#{java_version}.pom",
+      max_attempts: 30, delay: 60
+    ) || warn('Maven Central verification failed - may still be syncing')
   end
 
   desc 'Install jars to local m2 directory'

--- a/Rakefile
+++ b/Rakefile
@@ -419,12 +419,12 @@ end
 def sonatype_api_post(url, token)
   uri = URI(url)
   req = Net::HTTP::Post.new(uri)
-  req['Authorization'] = "Bearer #{token}"
+  req['Authorization'] = "Basic #{token}"
 
   res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
   raise "Sonatype API error (#{res.code}): #{res.body}" unless res.is_a?(Net::HTTPSuccess)
 
-  res.body.empty? ? {} : JSON.parse(res.body)
+  res.body.to_s.empty? ? {} : JSON.parse(res.body)
 end
 
 def credential_valid?(cred)
@@ -1247,14 +1247,16 @@ namespace :java do
     read_m2_user_pass unless ENV['MAVEN_PASSWORD'] && ENV['MAVEN_USER']
     token = Base64.strict_encode64("#{ENV.fetch('MAVEN_USER')}:#{ENV.fetch('MAVEN_PASSWORD')}")
 
+    encoded_id = URI.encode_www_form_component(deployment_id.strip)
+    status = {}
     60.times do
-      status = sonatype_api_post("https://central.sonatype.com/api/v1/publisher/status?id=#{deployment_id}", token)
+      status = sonatype_api_post("https://central.sonatype.com/api/v1/publisher/status?id=#{encoded_id}", token)
       state = status['deploymentState']
       puts "Deployment state: #{state}"
 
       case state
       when 'VALIDATED' then break
-      when 'PUBLISHED' then exit(0)
+      when 'PUBLISHED' then return
       when 'FAILED' then raise "Deployment failed: #{status['errors']}"
       end
       sleep(5)
@@ -1263,10 +1265,13 @@ namespace :java do
 
     expected = java_release_targets.size
     actual = status['purls']&.size || 0
-    raise "Expected #{expected} packages but found #{actual}" if actual != expected
+    if actual != expected
+      raise "Expected #{expected} packages but found #{actual}. " \
+            'Drop the deployment at https://central.sonatype.com/publishing/deployments and redeploy.'
+    end
 
     puts 'Publishing deployed packages...'
-    sonatype_api_post("https://central.sonatype.com/api/v1/publisher/deployment/#{deployment_id}", token)
+    sonatype_api_post("https://central.sonatype.com/api/v1/publisher/deployment/#{encoded_id}", token)
     puts "Published! Deployment ID: #{deployment_id}"
 
     Rake::Task['java:verify'].invoke

--- a/Rakefile
+++ b/Rakefile
@@ -399,8 +399,7 @@ RELEASE_CREDENTIALS = {
 def verify_package_published(url)
   puts "Verifying #{url}..."
   uri = URI(url)
-  res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
-                                                open_timeout: 10, read_timeout: 10) { |http| http.request(Net::HTTP::Get.new(uri)) }
+  res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http| http.request(Net::HTTP::Get.new(uri)) }
   raise "Package not published: #{url}" unless res.is_a?(Net::HTTPSuccess)
 
   puts 'Verified!'
@@ -1462,11 +1461,13 @@ namespace :all do
 
   desc 'Verify all packages are published to their registries'
   task :verify do
-    Rake::Task['java:verify'].invoke
-    Rake::Task['py:verify'].invoke
-    Rake::Task['rb:verify'].invoke
-    Rake::Task['dotnet:verify'].invoke
-    Rake::Task['node:verify'].invoke
+    failures = []
+    %w[java py rb dotnet node].each do |lang|
+      Rake::Task["#{lang}:verify"].invoke
+    rescue StandardError => e
+      failures << "#{lang}: #{e.message}"
+    end
+    raise "Verification failed:\n#{failures.join("\n")}" unless failures.empty?
   end
 
   desc 'Release all artifacts for all language bindings'

--- a/Rakefile
+++ b/Rakefile
@@ -396,24 +396,14 @@ RELEASE_CREDENTIALS = {
   dotnet_nightly: {env: [%w[GITHUB_TOKEN]]}
 }.freeze
 
-def package_published?(url, max_attempts: 12, delay: 10)
+def verify_package_published(url)
   puts "Verifying #{url}..."
   uri = URI(url)
-  max_attempts.times do |attempt|
-    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
-                                                  open_timeout: 10, read_timeout: 10) { |http| http.request(Net::HTTP::Get.new(uri)) }
-    if res.is_a?(Net::HTTPSuccess)
-      puts 'Verified!'
-      return true
-    end
-    puts "Not yet indexed, waiting... (#{attempt + 1}/#{max_attempts})"
-    sleep(delay)
-  rescue StandardError => e
-    warn "Error: #{e.message}"
-    sleep(delay) unless attempt == max_attempts - 1
-  end
-  warn "Not found after #{max_attempts * delay}s"
-  false
+  res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
+                                                open_timeout: 10, read_timeout: 10) { |http| http.request(Net::HTTP::Get.new(uri)) }
+  raise "Package not published: #{url}" unless res.is_a?(Net::HTTPSuccess)
+
+  puts 'Verified!'
 end
 
 def sonatype_api_post(url, token)
@@ -632,15 +622,11 @@ namespace :node do
 
     puts 'Running Node package release...'
     Bazel.execute('run', ['--config=release'], '//javascript/selenium-webdriver:selenium-webdriver.publish')
-
-    Rake::Task['node:verify'].invoke unless nightly
   end
 
   desc 'Verify Node package is published on npm'
   task :verify do
-    package_published?(
-      "https://registry.npmjs.org/selenium-webdriver/#{node_version}"
-    ) || warn('npm verification failed - package may still be indexing')
+    verify_package_published("https://registry.npmjs.org/selenium-webdriver/#{node_version}")
   end
 
   task deploy: :release
@@ -706,15 +692,11 @@ namespace :py do
     command = nightly ? '//py:selenium-release-nightly' : '//py:selenium-release'
     puts "Running Python release command: #{command}"
     Bazel.execute('run', ['--config=release'], command)
-
-    Rake::Task['py:verify'].invoke unless nightly
   end
 
   desc 'Verify Python package is published on PyPI'
   task :verify do
-    package_published?(
-      "https://pypi.org/pypi/selenium/#{python_version}/json"
-    ) || warn('PyPI verification failed - package may still be indexing')
+    verify_package_published("https://pypi.org/pypi/selenium/#{python_version}/json")
   end
 
   desc 'generate and copy files required for local development'
@@ -916,8 +898,6 @@ namespace :rb do
       puts 'Releasing Ruby gems...'
       Bazel.execute('run', ['--config=release'], '//rb:selenium-webdriver-release')
       Bazel.execute('run', ['--config=release'], '//rb:selenium-devtools-release') unless patch_release
-
-      Rake::Task['rb:verify'].invoke
     end
   end
 
@@ -925,13 +905,9 @@ namespace :rb do
   task :verify do
     patch_release = ruby_version.split('.').fetch(2, '0').to_i.positive?
 
-    package_published?(
-      "https://rubygems.org/api/v2/rubygems/selenium-webdriver/versions/#{ruby_version}.json"
-    ) || warn('RubyGems verification failed - selenium-webdriver may still be indexing')
+    verify_package_published("https://rubygems.org/api/v2/rubygems/selenium-webdriver/versions/#{ruby_version}.json")
     unless patch_release
-      package_published?(
-        "https://rubygems.org/api/v2/rubygems/selenium-devtools/versions/#{ruby_version}.json"
-      ) || warn('RubyGems verification failed - selenium-devtools may still be indexing')
+      verify_package_published("https://rubygems.org/api/v2/rubygems/selenium-devtools/versions/#{ruby_version}.json")
     end
   end
 
@@ -1090,18 +1066,12 @@ namespace :dotnet do
 
     puts "Pushing .NET packages to #{ENV.fetch('NUGET_SOURCE', nil)}..."
     Bazel.execute('run', ['--config=release'], '//dotnet:publish')
-
-    Rake::Task['dotnet:verify'].invoke unless nightly
   end
 
   desc 'Verify .NET packages are published on NuGet'
   task :verify do
-    package_published?(
-      "https://api.nuget.org/v3/registration5-semver1/selenium.webdriver/#{dotnet_version}.json"
-    ) || warn('NuGet verification failed - Selenium.WebDriver may still be indexing')
-    package_published?(
-      "https://api.nuget.org/v3/registration5-semver1/selenium.support/#{dotnet_version}.json"
-    ) || warn('NuGet verification failed - Selenium.Support may still be indexing')
+    verify_package_published("https://api.nuget.org/v3/registration5-semver1/selenium.webdriver/#{dotnet_version}.json")
+    verify_package_published("https://api.nuget.org/v3/registration5-semver1/selenium.support/#{dotnet_version}.json")
   end
 
   desc 'Generate .NET documentation'
@@ -1282,16 +1252,11 @@ namespace :java do
     puts 'Publishing deployed packages...'
     sonatype_api_post("https://central.sonatype.com/api/v1/publisher/deployment/#{encoded_id}", token)
     puts "Published! Deployment ID: #{deployment_id}"
-
-    Rake::Task['java:verify'].invoke
   end
 
   desc 'Verify Java packages are published on Maven Central'
   task :verify do
-    package_published?(
-      "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/#{java_version}/selenium-java-#{java_version}.pom",
-      max_attempts: 30, delay: 60
-    ) || warn('Maven Central verification failed - may still be syncing')
+    verify_package_published("https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/#{java_version}/selenium-java-#{java_version}.pom")
   end
 
   desc 'Install jars to local m2 directory'


### PR DESCRIPTION
### **User description**
Java release worked yesterday, but the new Sonatype validation step timed out

### 💥 What does this PR do?
- Increase sonatype validation timeout
- Verify that all assets uploaded at the end of the release workflow 
- Automatically publish the deployment
- Add publication verification for each language

### 🔧 Implementation Notes
- Added a lot of comments to make it clear where things are
~~- Verification tasks can be run separately / manually~~

**UPDATES:**
- Verifications Integrated later in the release workflow instead of in the release task
- Verification tasks raise on failure instead of warning

### 💡 Additional Considerations
We can't know if the Java improvements will fix the problem I had yesterday until next release, unfortunately

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add package verification tasks for all language bindings

- Improve Java release robustness with deployment validation

- Increase Sonatype API timeout and add error handling

- Support manual deployment publishing by ID


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Release["Language Release Tasks"]
  Verify["Verification Tasks"]
  JavaDeploy["Java Deployment Publishing"]
  
  Release -->|invoke| Verify
  Release -->|java| JavaDeploy
  JavaDeploy -->|validate| Verify
  Verify -->|check registries| Status["Package Status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Add verification tasks and improve Java release workflow</code>&nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Added <code>package_published?</code> helper to verify package availability on <br>registries with retry logic<br> <li> Added <code>sonatype_api_post</code> helper for Sonatype API interactions with <br>Bearer token auth<br> <li> Added <code>:verify</code> tasks for Node, Python, Ruby, .NET, and Java language <br>bindings<br> <li> Enhanced Java <code>:publish</code> task with improved timeout handling and <br>deployment ID extraction<br> <li> Added new <code>:publish_deployment</code> task to manually publish validated <br>Sonatype deployments<br> <li> Updated <code>:check_credentials</code> task to conditionally validate credentials <br>based on release type<br> <li> Added <code>:verify</code> task to <code>all</code> namespace to run verification for all <br>languages</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16952/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+157/-12</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

