### PR TITLE
[dotnet] [bidi] Simplify context aware command options

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -139,7 +139,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationStartedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -150,7 +150,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -161,7 +161,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -172,7 +172,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Func<HistoryUpdatedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -183,7 +183,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Action<HistoryUpdatedEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -194,7 +194,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -205,7 +205,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -216,7 +216,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnLoadAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -227,7 +227,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnLoadAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -238,7 +238,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -249,7 +249,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -260,7 +260,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -271,7 +271,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -282,7 +282,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -293,7 +293,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -304,7 +304,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -315,7 +315,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -326,7 +326,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
@@ -337,7 +337,7 @@ public sealed record BrowsingContext
             {
                 handler(e);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
@@ -348,7 +348,7 @@ public sealed record BrowsingContext
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(this));
+        }, ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public bool Equals(BrowsingContext? other)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -121,7 +121,7 @@ public sealed record BrowsingContext
         return BiDi.BrowsingContext.HandleUserPromptAsync(this, options);
     }
 
-    public Task<GetTreeResult> GetTreeAsync(BrowsingContextGetTreeOptions? options = null)
+    public Task<GetTreeResult> GetTreeAsync(ContextGetTreeOptions? options = null)
     {
         GetTreeOptions getTreeOptions = new(options)
         {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -123,12 +123,7 @@ public sealed record BrowsingContext
 
     public Task<GetTreeResult> GetTreeAsync(ContextGetTreeOptions? options = null)
     {
-        GetTreeOptions getTreeOptions = new(options)
-        {
-            Root = this
-        };
-
-        return BiDi.BrowsingContext.GetTreeAsync(getTreeOptions);
+        return BiDi.BrowsingContext.GetTreeAsync(ContextGetTreeOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationStartedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -49,7 +49,7 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
@@ -60,6 +60,6 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
@@ -29,7 +29,7 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
     {
         return logModule.OnEntryAddedAsync(async args =>
         {
-            if (args.Source.Context?.Equals(context) is true)
+            if (context.Equals(args.Source.Context))
             {
                 await handler(args).ConfigureAwait(false);
             }
@@ -40,7 +40,7 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
     {
         return logModule.OnEntryAddedAsync(args =>
         {
-            if (args.Source.Context?.Equals(context) is true)
+            if (context.Equals(args.Source.Context))
             {
                 handler(args);
             }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -80,7 +80,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
         return interception;
     }
 
-    public Task<AddDataCollectorResult> AddDataCollectorAsync(IEnumerable<DataType> dataTypes, int maxEncodedDataSize, BrowsingContextAddDataCollectorOptions? options = null)
+    public Task<AddDataCollectorResult> AddDataCollectorAsync(IEnumerable<DataType> dataTypes, int maxEncodedDataSize, ContextAddDataCollectorOptions? options = null)
     {
         AddDataCollectorOptions addDataCollectorOptions = new(options)
         {
@@ -90,7 +90,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
         return networkModule.AddDataCollectorAsync(dataTypes, maxEncodedDataSize, addDataCollectorOptions);
     }
 
-    public Task<SetCacheBehaviorResult> SetCacheBehaviorAsync(CacheBehavior behavior, BrowsingContextSetCacheBehaviorOptions? options = null)
+    public Task<SetCacheBehaviorResult> SetCacheBehaviorAsync(CacheBehavior behavior, ContextSetCacheBehaviorOptions? options = null)
     {
         SetCacheBehaviorOptions setCacheBehaviorOptions = new(options)
         {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -82,22 +82,12 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
 
     public Task<AddDataCollectorResult> AddDataCollectorAsync(IEnumerable<DataType> dataTypes, int maxEncodedDataSize, ContextAddDataCollectorOptions? options = null)
     {
-        AddDataCollectorOptions addDataCollectorOptions = new(options)
-        {
-            Contexts = [context]
-        };
-
-        return networkModule.AddDataCollectorAsync(dataTypes, maxEncodedDataSize, addDataCollectorOptions);
+        return networkModule.AddDataCollectorAsync(dataTypes, maxEncodedDataSize, ContextAddDataCollectorOptions.WithContext(options, context));
     }
 
     public Task<SetCacheBehaviorResult> SetCacheBehaviorAsync(CacheBehavior behavior, ContextSetCacheBehaviorOptions? options = null)
     {
-        SetCacheBehaviorOptions setCacheBehaviorOptions = new(options)
-        {
-            Contexts = [context]
-        };
-
-        return networkModule.SetCacheBehaviorAsync(behavior, setCacheBehaviorOptions);
+        return networkModule.SetCacheBehaviorAsync(behavior, ContextSetCacheBehaviorOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnBeforeRequestSentAsync(Func<BeforeRequestSentEventArgs, Task> handler, ContextSubscriptionOptions? options = null)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -108,7 +108,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnBeforeRequestSentAsync(Action<BeforeRequestSentEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -119,7 +119,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseStartedAsync(Func<ResponseStartedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -130,7 +130,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseStartedAsync(Action<ResponseStartedEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -141,7 +141,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Func<ResponseCompletedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -152,7 +152,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Action<ResponseCompletedEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -163,7 +163,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFetchErrorAsync(Func<FetchErrorEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -174,7 +174,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFetchErrorAsync(Action<FetchErrorEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -185,7 +185,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Func<AuthRequiredEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
@@ -196,7 +196,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Action<AuthRequiredEventArgs> handler, ContextSubscriptionOptions? options = null)
@@ -207,7 +207,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
             {
                 handler(e);
             }
-        }, options.WithContext(context));
+        }, ContextSubscriptionOptions.WithContext(options, context));
     }
 }
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -211,8 +211,8 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
     }
 }
 
-public sealed record InterceptRequestOptions : BrowsingContextAddInterceptOptions;
+public sealed class InterceptRequestOptions : ContextAddInterceptOptions;
 
-public sealed record InterceptResponseOptions : BrowsingContextAddInterceptOptions;
+public sealed class InterceptResponseOptions : ContextAddInterceptOptions;
 
-public sealed record InterceptAuthOptions : BrowsingContextAddInterceptOptions;
+public sealed class InterceptAuthOptions : ContextAddInterceptOptions;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
@@ -25,23 +25,14 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
 public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptModule scriptModule)
 {
-    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, ContextAddPreloadScriptOptions? options = null)
+    public Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, ContextAddPreloadScriptOptions? options = null)
     {
-        AddPreloadScriptOptions addPreloadScriptOptions = new(options)
-        {
-            Contexts = [context]
-        };
-
-        return await scriptModule.AddPreloadScriptAsync(functionDeclaration, addPreloadScriptOptions).ConfigureAwait(false);
+        return scriptModule.AddPreloadScriptAsync(functionDeclaration, ContextAddPreloadScriptOptions.WithContext(options, context));
     }
 
-    public async Task<GetRealmsResult> GetRealmsAsync(GetRealmsOptions? options = null)
+    public Task<GetRealmsResult> GetRealmsAsync(ContextGetRealmsOptions? options = null)
     {
-        options ??= new();
-
-        options.Context = context;
-
-        return await scriptModule.GetRealmsAsync(options).ConfigureAwait(false);
+        return scriptModule.GetRealmsAsync(ContextGetRealmsOptions.WithContext(options, context));
     }
 
     public Task<EvaluateResult> EvaluateAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
 public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptModule scriptModule)
 {
-    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, BrowsingContextAddPreloadScriptOptions? options = null)
+    public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, ContextAddPreloadScriptOptions? options = null)
     {
         AddPreloadScriptOptions addPreloadScriptOptions = new(options)
         {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextStorageModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextStorageModule.cs
@@ -24,34 +24,18 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
 public sealed class BrowsingContextStorageModule(BrowsingContext context, StorageModule storageModule)
 {
-    public Task<GetCookiesResult> GetCookiesAsync(GetCookiesOptions? options = null)
+    public Task<GetCookiesResult> GetCookiesAsync(ContextGetCookiesOptions? options = null)
     {
-        options ??= new();
-
-        options.Partition = new ContextPartitionDescriptor(context);
-
-        return storageModule.GetCookiesAsync(options);
+        return storageModule.GetCookiesAsync(ContextGetCookiesOptions.WithContext(options, context));
     }
 
-    public async Task<PartitionKey> DeleteCookiesAsync(DeleteCookiesOptions? options = null)
+    public Task<DeleteCookiesResult> DeleteCookiesAsync(ContextDeleteCookiesOptions? options = null)
     {
-        options ??= new();
-
-        options.Partition = new ContextPartitionDescriptor(context);
-
-        var res = await storageModule.DeleteCookiesAsync(options).ConfigureAwait(false);
-
-        return res.PartitionKey;
+        return storageModule.DeleteCookiesAsync(ContextDeleteCookiesOptions.WithContext(options, context));
     }
 
-    public async Task<PartitionKey> SetCookieAsync(PartialCookie cookie, SetCookieOptions? options = null)
+    public Task<SetCookieResult> SetCookieAsync(PartialCookie cookie, ContextSetCookieOptions? options = null)
     {
-        options ??= new();
-
-        options.Partition = new ContextPartitionDescriptor(context);
-
-        var res = await storageModule.SetCookieAsync(cookie, options).ConfigureAwait(false);
-
-        return res.PartitionKey;
+        return storageModule.SetCookieAsync(cookie, ContextSetCookieOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
@@ -26,15 +26,8 @@ internal sealed class GetTreeCommand(GetTreeParameters @params)
 
 internal sealed record GetTreeParameters(long? MaxDepth, BrowsingContext? Root) : Parameters;
 
-public sealed class GetTreeOptions() : CommandOptions
+public sealed class GetTreeOptions : CommandOptions
 {
-    internal GetTreeOptions(ContextGetTreeOptions? options)
-        : this()
-    {
-        MaxDepth = options?.MaxDepth;
-        Timeout = options?.Timeout;
-    }
-
     public long? MaxDepth { get; set; }
 
     public BrowsingContext? Root { get; set; }
@@ -43,6 +36,13 @@ public sealed class GetTreeOptions() : CommandOptions
 public sealed class ContextGetTreeOptions : CommandOptions
 {
     public long? MaxDepth { get; set; }
+
+    internal static GetTreeOptions WithContext(ContextGetTreeOptions? options, BrowsingContext context) => new()
+    {
+        Root = context,
+        MaxDepth = options?.MaxDepth,
+        Timeout = options?.Timeout
+    };
 }
 
 public sealed record GetTreeResult(IReadOnlyList<BrowsingContextInfo> Contexts) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
@@ -26,13 +26,13 @@ internal sealed class GetTreeCommand(GetTreeParameters @params)
 
 internal sealed record GetTreeParameters(long? MaxDepth, BrowsingContext? Root) : Parameters;
 
-public sealed class GetTreeOptions : CommandOptions
+public sealed class GetTreeOptions() : CommandOptions
 {
-    public GetTreeOptions() { }
-
-    internal GetTreeOptions(BrowsingContextGetTreeOptions? options)
+    internal GetTreeOptions(ContextGetTreeOptions? options)
+        : this()
     {
         MaxDepth = options?.MaxDepth;
+        Timeout = options?.Timeout;
     }
 
     public long? MaxDepth { get; set; }
@@ -40,7 +40,7 @@ public sealed class GetTreeOptions : CommandOptions
     public BrowsingContext? Root { get; set; }
 }
 
-public sealed record BrowsingContextGetTreeOptions
+public sealed class ContextGetTreeOptions : CommandOptions
 {
     public long? MaxDepth { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -28,15 +28,8 @@ internal sealed class AddDataCollectorCommand(AddDataCollectorParameters @params
 
 internal sealed record AddDataCollectorParameters(IEnumerable<DataType> DataTypes, int MaxEncodedDataSize, CollectorType? CollectorType, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class AddDataCollectorOptions() : CommandOptions
+public sealed class AddDataCollectorOptions : CommandOptions
 {
-    internal AddDataCollectorOptions(ContextAddDataCollectorOptions? options) : this()
-    {
-        CollectorType = options?.CollectorType;
-        UserContexts = options?.UserContexts;
-        Timeout = options?.Timeout;
-    }
-
     public CollectorType? CollectorType { get; set; }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
@@ -49,6 +42,14 @@ public sealed class ContextAddDataCollectorOptions : CommandOptions
     public CollectorType? CollectorType { get; set; }
 
     public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+
+    internal static AddDataCollectorOptions WithContext(ContextAddDataCollectorOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Contexts = [context],
+        CollectorType = options?.CollectorType,
+        UserContexts = options?.UserContexts,
+        Timeout = options?.Timeout
+    };
 }
 
 public sealed record AddDataCollectorResult(Collector Collector) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -28,12 +28,13 @@ internal sealed class AddDataCollectorCommand(AddDataCollectorParameters @params
 
 internal sealed record AddDataCollectorParameters(IEnumerable<DataType> DataTypes, int MaxEncodedDataSize, CollectorType? CollectorType, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public class AddDataCollectorOptions() : CommandOptions
+public sealed class AddDataCollectorOptions() : CommandOptions
 {
-    internal AddDataCollectorOptions(BrowsingContextAddDataCollectorOptions? options) : this()
+    internal AddDataCollectorOptions(ContextAddDataCollectorOptions? options) : this()
     {
         CollectorType = options?.CollectorType;
         UserContexts = options?.UserContexts;
+        Timeout = options?.Timeout;
     }
 
     public CollectorType? CollectorType { get; set; }
@@ -43,7 +44,7 @@ public class AddDataCollectorOptions() : CommandOptions
     public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
 }
 
-public class BrowsingContextAddDataCollectorOptions
+public sealed class ContextAddDataCollectorOptions : CommandOptions
 {
     public CollectorType? CollectorType { get; set; }
 

--- a/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
@@ -28,13 +28,14 @@ internal sealed class AddInterceptCommand(AddInterceptParameters @params)
 
 internal sealed record AddInterceptParameters(IEnumerable<InterceptPhase> Phases, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<UrlPattern>? UrlPatterns) : Parameters;
 
-public class AddInterceptOptions : CommandOptions
+public sealed class AddInterceptOptions : CommandOptions
 {
     public AddInterceptOptions() { }
 
-    internal AddInterceptOptions(BrowsingContextAddInterceptOptions? options)
+    internal AddInterceptOptions(ContextAddInterceptOptions? options)
     {
         UrlPatterns = options?.UrlPatterns;
+        Timeout = options?.Timeout;
     }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
@@ -42,7 +43,7 @@ public class AddInterceptOptions : CommandOptions
     public IEnumerable<UrlPattern>? UrlPatterns { get; set; }
 }
 
-public record BrowsingContextAddInterceptOptions
+public class ContextAddInterceptOptions : CommandOptions
 {
     public IEnumerable<UrlPattern>? UrlPatterns { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
@@ -28,11 +28,9 @@ internal sealed class AddInterceptCommand(AddInterceptParameters @params)
 
 internal sealed record AddInterceptParameters(IEnumerable<InterceptPhase> Phases, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<UrlPattern>? UrlPatterns) : Parameters;
 
-public sealed class AddInterceptOptions : CommandOptions
+public class AddInterceptOptions() : CommandOptions
 {
-    public AddInterceptOptions() { }
-
-    internal AddInterceptOptions(ContextAddInterceptOptions? options)
+    internal AddInterceptOptions(ContextAddInterceptOptions? options) : this()
     {
         UrlPatterns = options?.UrlPatterns;
         Timeout = options?.Timeout;

--- a/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
@@ -30,15 +30,15 @@ internal sealed record SetCacheBehaviorParameters(CacheBehavior CacheBehavior, I
 
 public sealed class SetCacheBehaviorOptions() : CommandOptions
 {
-    internal SetCacheBehaviorOptions(BrowsingContextSetCacheBehaviorOptions? options) : this()
+    internal SetCacheBehaviorOptions(ContextSetCacheBehaviorOptions? options) : this()
     {
-
+        Timeout = options?.Timeout;
     }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
 }
 
-public sealed record BrowsingContextSetCacheBehaviorOptions;
+public sealed class ContextSetCacheBehaviorOptions : CommandOptions;
 
 [JsonConverter(typeof(CamelCaseEnumConverter<CacheBehavior>))]
 public enum CacheBehavior

--- a/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
@@ -28,17 +28,19 @@ internal sealed class SetCacheBehaviorCommand(SetCacheBehaviorParameters @params
 
 internal sealed record SetCacheBehaviorParameters(CacheBehavior CacheBehavior, IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 
-public sealed class SetCacheBehaviorOptions() : CommandOptions
+public sealed class SetCacheBehaviorOptions : CommandOptions
 {
-    internal SetCacheBehaviorOptions(ContextSetCacheBehaviorOptions? options) : this()
-    {
-        Timeout = options?.Timeout;
-    }
-
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
 }
 
-public sealed class ContextSetCacheBehaviorOptions : CommandOptions;
+public sealed class ContextSetCacheBehaviorOptions : CommandOptions
+{
+    internal static SetCacheBehaviorOptions WithContext(ContextSetCacheBehaviorOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Contexts = [context],
+        Timeout = options?.Timeout
+    };
+}
 
 [JsonConverter(typeof(CamelCaseEnumConverter<CacheBehavior>))]
 public enum CacheBehavior

--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -27,14 +27,14 @@ internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params
 
 internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : Parameters;
 
-public sealed class AddPreloadScriptOptions : CommandOptions
+public sealed class AddPreloadScriptOptions() : CommandOptions
 {
-    public AddPreloadScriptOptions() { }
-
-    internal AddPreloadScriptOptions(BrowsingContextAddPreloadScriptOptions? options)
+    internal AddPreloadScriptOptions(ContextAddPreloadScriptOptions? options)
+        : this()
     {
         Arguments = options?.Arguments;
         Sandbox = options?.Sandbox;
+        Timeout = options?.Timeout;
     }
 
     public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
@@ -44,7 +44,7 @@ public sealed class AddPreloadScriptOptions : CommandOptions
     public string? Sandbox { get; set; }
 }
 
-public sealed record BrowsingContextAddPreloadScriptOptions
+public sealed class ContextAddPreloadScriptOptions : CommandOptions
 {
     public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 

--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -27,16 +27,8 @@ internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params
 
 internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : Parameters;
 
-public sealed class AddPreloadScriptOptions() : CommandOptions
+public sealed class AddPreloadScriptOptions : CommandOptions
 {
-    internal AddPreloadScriptOptions(ContextAddPreloadScriptOptions? options)
-        : this()
-    {
-        Arguments = options?.Arguments;
-        Sandbox = options?.Sandbox;
-        Timeout = options?.Timeout;
-    }
-
     public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
@@ -49,6 +41,14 @@ public sealed class ContextAddPreloadScriptOptions : CommandOptions
     public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 
     public string? Sandbox { get; set; }
+
+    internal static AddPreloadScriptOptions WithContext(ContextAddPreloadScriptOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Contexts = [context],
+        Arguments = options?.Arguments,
+        Sandbox = options?.Sandbox,
+        Timeout = options?.Timeout
+    };
 }
 
 public sealed record AddPreloadScriptResult(PreloadScript Script) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
@@ -33,4 +33,16 @@ public sealed class GetRealmsOptions : CommandOptions
     public RealmType? Type { get; set; }
 }
 
+public sealed class ContextGetRealmsOptions : CommandOptions
+{
+    public RealmType? Type { get; set; }
+
+    internal static GetRealmsOptions WithContext(ContextGetRealmsOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Context = context,
+        Type = options?.Type,
+        Timeout = options?.Timeout
+    };
+}
+
 public sealed record GetRealmsResult(IReadOnlyList<RealmInfo> Realms) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
@@ -31,4 +31,16 @@ public sealed class DeleteCookiesOptions : CommandOptions
     public PartitionDescriptor? Partition { get; set; }
 }
 
+public sealed class ContextDeleteCookiesOptions : CommandOptions
+{
+    public CookieFilter? Filter { get; set; }
+
+    internal static DeleteCookiesOptions WithContext(ContextDeleteCookiesOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Partition = new ContextPartitionDescriptor(context),
+        Filter = options?.Filter,
+        Timeout = options?.Timeout
+    };
+}
+
 public sealed record DeleteCookiesResult(PartitionKey PartitionKey) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
@@ -35,6 +35,18 @@ public sealed class GetCookiesOptions : CommandOptions
     public PartitionDescriptor? Partition { get; set; }
 }
 
+public sealed class ContextGetCookiesOptions : CommandOptions
+{
+    public CookieFilter? Filter { get; set; }
+
+    internal static GetCookiesOptions WithContext(ContextGetCookiesOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Filter = options?.Filter,
+        Partition = new ContextPartitionDescriptor(context),
+        Timeout = options?.Timeout
+    };
+}
+
 public sealed record GetCookiesResult(IReadOnlyList<Network.Cookie> Cookies, PartitionKey PartitionKey) : EmptyResult;
 
 public sealed record CookieFilter

--- a/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
@@ -47,4 +47,13 @@ public sealed class SetCookieOptions : CommandOptions
     public PartitionDescriptor? Partition { get; set; }
 }
 
+public sealed class ContextSetCookieOptions : CommandOptions
+{
+    internal static SetCookieOptions WithContext(ContextSetCookieOptions? options, BrowsingContext.BrowsingContext context) => new()
+    {
+        Partition = new ContextPartitionDescriptor(context),
+        Timeout = options?.Timeout
+    };
+}
+
 public sealed record SetCookieResult(PartitionKey PartitionKey) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Subscription.cs
+++ b/dotnet/src/webdriver/BiDi/Subscription.cs
@@ -61,13 +61,8 @@ public class SubscriptionOptions
 public class ContextSubscriptionOptions
 {
     public TimeSpan? Timeout { get; set; }
-}
 
-internal static class ContextSubscriptionOptionsExtensions
-{
-    // Converts ContextSubscriptionOptions to SubscriptionOptions with the specified context.
-    // Deeply copying other properties as needed.
-    public static SubscriptionOptions WithContext(this ContextSubscriptionOptions? options, BrowsingContext.BrowsingContext context) => new()
+    internal static SubscriptionOptions WithContext(ContextSubscriptionOptions? options, BrowsingContext.BrowsingContext context) => new()
     {
         Contexts = [context],
         Timeout = options?.Timeout


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
- Rename `BrowsingContext*Options` to `Context*Options`
- Propagate `Timeout` command property
- Align context options with its parent (class instead of record)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Rename `BrowsingContext*Options` to `Context*Options` for consistency

- Convert context options from records to classes inheriting `CommandOptions`

- Propagate `Timeout` property from context options to command options

- Align context-aware command options with parent class structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BrowsingContext*Options<br/>records"] -- "rename to" --> B["Context*Options<br/>classes"]
  B -- "inherit from" --> C["CommandOptions"]
  C -- "provides" --> D["Timeout property"]
  B -- "propagate to" --> E["Command Options"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Update GetTreeAsync method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Update method signature to use <code>ContextGetTreeOptions</code> instead of <br><code>BrowsingContextGetTreeOptions</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextNetworkModule.cs</strong><dd><code>Update network module method signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs

<ul><li>Update <code>AddDataCollectorAsync</code> method to use <br><code>ContextAddDataCollectorOptions</code><br> <li> Update <code>SetCacheBehaviorAsync</code> method to use <br><code>ContextSetCacheBehaviorOptions</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-1d8c6478b9d4994a87119245a8ae49fdfe54d287d45087f5acff51e9c04dc3cf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextScriptModule.cs</strong><dd><code>Update script module method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs

<ul><li>Update <code>AddPreloadScriptAsync</code> method to use <br><code>ContextAddPreloadScriptOptions</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-aa602ac791163e69e232a5c6676709905f92d894a8da7ff46ab6d3450512b61c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GetTreeCommand.cs</strong><dd><code>Refactor GetTreeOptions and ContextGetTreeOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs

<ul><li>Convert <code>GetTreeOptions</code> to use primary constructor<br> <li> Rename <code>BrowsingContextGetTreeOptions</code> to <code>ContextGetTreeOptions</code> and <br>change from record to class inheriting <code>CommandOptions</code><br> <li> Add <code>Timeout</code> property propagation from context options</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-af620e59fd946547606bfa939dfd78078129c6ebd737e8b24d958fcf0ff738a9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddDataCollectorCommand.cs</strong><dd><code>Refactor AddDataCollectorOptions and ContextAddDataCollectorOptions</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs

<ul><li>Add <code>sealed</code> modifier to <code>AddDataCollectorOptions</code><br> <li> Rename <code>BrowsingContextAddDataCollectorOptions</code> to <br><code>ContextAddDataCollectorOptions</code> and change from class to sealed class <br>inheriting <code>CommandOptions</code><br> <li> Add <code>Timeout</code> property propagation from context options</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-01a09e20bf279de7afbb5833ae2a4371db79c96f85e036c2b976ea460ae993ad">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddInterceptCommand.cs</strong><dd><code>Refactor AddInterceptOptions and ContextAddInterceptOptions</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs

<ul><li>Add <code>sealed</code> modifier to <code>AddInterceptOptions</code><br> <li> Rename <code>BrowsingContextAddInterceptOptions</code> to <br><code>ContextAddInterceptOptions</code> and change from record to class inheriting <br><code>CommandOptions</code><br> <li> Add <code>Timeout</code> property propagation from context options</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-4f788e5020bb6b13134e22847235f1f6a09f8f4d61358946b4faf828428567f0">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SetCacheBehaviorCommand.cs</strong><dd><code>Refactor SetCacheBehaviorOptions and ContextSetCacheBehaviorOptions</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs

<ul><li>Rename <code>BrowsingContextSetCacheBehaviorOptions</code> to <br><code>ContextSetCacheBehaviorOptions</code> and change from record to sealed class <br>inheriting <code>CommandOptions</code><br> <li> Add <code>Timeout</code> property propagation from context options</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-7a0b314b6d25a0cb64b4413acab656a82af713d893d6c2408181cc3d2238ecd9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddPreloadScriptCommand.cs</strong><dd><code>Refactor AddPreloadScriptOptions and ContextAddPreloadScriptOptions</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs

<ul><li>Convert <code>AddPreloadScriptOptions</code> to use primary constructor<br> <li> Rename <code>BrowsingContextAddPreloadScriptOptions</code> to <br><code>ContextAddPreloadScriptOptions</code> and change from record to sealed class <br>inheriting <code>CommandOptions</code><br> <li> Add <code>Timeout</code> property propagation from context options</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16954/files#diff-9b0ba21d638ed69dac4b05032dada1694f6a5a2eaab71e9be255866ea47216bb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

