### PR TITLE
[build] simplify release.yml: remove draft, build once during publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          persist-credentials: true
       - name: Download release packages
         uses: actions/download-artifact@v4
         with:
           pattern: release-packages-*
-          path: build/dist
           merge-multiple: true
       - name: Delete nightly release and tag
         env:
@@ -98,7 +100,7 @@ jobs:
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          allowUpdates: true
+          allowUpdates: ${{ github.run_attempt > 1 }}
           artifacts: "build/dist/*.*"
           bodyFile: "scripts/github-actions/release_header.md"
           generateReleaseNotes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
   prepare:
     name: Prepare Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     if: >
       github.event.repository.fork == false &&
       ((startsWith(github.event.pull_request.head.ref, 'release-preparation-') &&
@@ -30,10 +28,6 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.SELENIUM_CI_TOKEN }}
       - name: Extract tag and version
         id: tag
         env:
@@ -50,56 +44,9 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$(echo "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
-  build:
-    name: Build Packages
-    needs: prepare
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Build Packages
-      run: ./go all:package --config=release
-      artifact-name: release-packages
-      artifact-path: build/dist/*.*
-
-  create-release:
-    name: Create Draft Release
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Download release packages
-        uses: actions/download-artifact@v4
-        with:
-          name: release-packages
-      - name: Delete nightly release and tag
-        env:
-          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
-        run: |
-          if gh release view nightly >/dev/null 2>&1; then
-            gh release delete nightly --yes
-          fi
-          if git ls-remote --tags origin refs/tags/nightly | grep -q nightly; then
-            git push origin --delete refs/tags/nightly
-          fi
-      - name: Draft GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "build/dist/*.*"
-          bodyFile: "scripts/github-actions/release_header.md"
-          draft: true
-          generateReleaseNotes: true
-          name: "Selenium ${{ needs.prepare.outputs.version }}"
-          prerelease: false
-          skipIfReleaseExists: true
-          tag: "${{ needs.prepare.outputs.tag }}"
-          commit: "${{ github.sha }}"
-
   get-approval:
     name: Get Approval
-    needs: [prepare, create-release]
-    if: needs.create-release.result == 'success'
+    needs: prepare
     uses: ./.github/workflows/get-approval.yml
     with:
       title: Release approval required
@@ -108,7 +55,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   publish:
-    name: Publish ${{ matrix.language }}
+    name: Build and Publish ${{ matrix.language }}
     needs: get-approval
     strategy:
       fail-fast: false
@@ -119,7 +66,47 @@ jobs:
       name: Publish ${{ matrix.language }}
       gpg-sign: ${{ matrix.language == 'java' }}
       run: ./go ${{ matrix.language }}:release
+      artifact-name: release-packages-${{ matrix.language }}
+      artifact-path: build/dist/*.*
     secrets: inherit
+
+  github-release:
+    name: GitHub Release
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Download Java packages
+        uses: actions/download-artifact@v4
+        with:
+          name: release-packages-java
+      - name: Download .NET packages
+        uses: actions/download-artifact@v4
+        with:
+          name: release-packages-dotnet
+          path: build/dist
+      - name: Delete nightly release and tag
+        env:
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
+        run: |
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release delete nightly --yes
+          fi
+          if git ls-remote --tags origin refs/tags/nightly | grep -q nightly; then
+            git push origin --delete refs/tags/nightly
+          fi
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build/dist/*.*"
+          bodyFile: "scripts/github-actions/release_header.md"
+          generateReleaseNotes: true
+          name: "Selenium ${{ needs.prepare.outputs.version }}"
+          tag: "${{ needs.prepare.outputs.tag }}"
+          commit: "${{ github.sha }}"
 
   verify:
     name: Verify Published Packages
@@ -145,22 +132,6 @@ jobs:
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
-  github-release:
-    name: GitHub Release
-    needs: [prepare, publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "${{ needs.prepare.outputs.tag }}"
-          draft: false
-          allowUpdates: true
-          omitBodyDuringUpdate: true
-          omitNameDuringUpdate: true
-
   unrestrict-trunk:
     name: Unrestrict Trunk Branch
     needs: verify
@@ -170,7 +141,7 @@ jobs:
     secrets: inherit
 
   reset-version:
-    name: Generate Version Reset
+    name: Generate Nightly Versions
     needs: docs
     uses: ./.github/workflows/bazel.yml
     with:
@@ -179,7 +150,7 @@ jobs:
       artifact-name: version-reset
 
   update-version:
-    name: Push Version Reset
+    name: Push Nightly Versions
     needs: [prepare, reset-version, unrestrict-trunk]
     runs-on: ubuntu-latest
     permissions:
@@ -220,7 +191,7 @@ jobs:
   on-release-failure:
     name: On Release Failure
     runs-on: ubuntu-latest
-    needs: [build, publish, docs, github-release, update-version, nightly, mirror, verify]
+    needs: [publish, docs, github-release, update-version, nightly, mirror, verify]
     if: failure()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SELENIUM_CI_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
       - name: Download release packages
         uses: actions/download-artifact@v4
         with:
@@ -95,18 +94,18 @@ jobs:
             gh release delete nightly --yes
           fi
           if git ls-remote --tags origin refs/tags/nightly | grep -q nightly; then
-            git push origin --delete refs/tags/nightly
+            gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/nightly
           fi
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          allowUpdates: ${{ github.run_attempt > 1 }}
+          allowUpdates: true
           artifacts: "build/dist/*.*"
           bodyFile: "scripts/github-actions/release_header.md"
           generateReleaseNotes: true
           name: "Selenium ${{ needs.prepare.outputs.version }}"
           tag: "${{ needs.prepare.outputs.tag }}"
-          commit: "${{ github.sha }}"
+          commit: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
   verify:
     name: Verify Published Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,15 +79,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Download Java packages
+      - name: Download release packages
         uses: actions/download-artifact@v4
         with:
-          name: release-packages-java
-      - name: Download .NET packages
-        uses: actions/download-artifact@v4
-        with:
-          name: release-packages-dotnet
+          pattern: release-packages-*
           path: build/dist
+          merge-multiple: true
       - name: Delete nightly release and tag
         env:
           GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -101,6 +98,7 @@ jobs:
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
+          allowUpdates: true
           artifacts: "build/dist/*.*"
           bodyFile: "scripts/github-actions/release_header.md"
           generateReleaseNotes: true


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

Changes in #16955 allow us to simplify release process. Currently building twice once for upload and once for release.

### 💥 What does this PR do?

* Move approval to the beginning, so nothing happens until approval
* Build and publish in one bazel job
* Do not need a draft github release, just download generated assets and do the release

**Old flow:**
```
prepare → build (all) → create-draft-release → get-approval → publish (each) → finalize-release → ...
```

**New flow:**
```
prepare → get-approval → publish (each, includes build) → github-release → ...
```

### 🔧 Implementation Notes

Also removed unnecessary checkouts
Not differentiating between build and publish, but step names and logging info will tell us where problems are

### 💡 Additional Considerations

- Won't be able to test this until the next actual release

### 🔄 Types of changes

- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Reorganize workflow to build and publish in single job

- Move approval step before build to gate release process

- Remove draft release creation, create final release directly

- Eliminate unnecessary checkout and duplicate build steps

- Download language-specific artifacts for final release


___

### Diagram Walkthrough


```mermaid
flowchart LR
  prepare["Prepare Release"]
  approval["Get Approval"]
  publish["Publish (Build + Release)"]
  github["GitHub Release"]
  verify["Verify"]
  docs["Update Docs"]
  
  prepare -- "tag, version" --> approval
  approval -- "approved" --> publish
  publish -- "artifacts" --> github
  github --> verify
  docs --> verify
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Consolidate build and publish, streamline approval workflow</code></dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Reorganized job dependencies: moved <code>get-approval</code> before <code>publish</code> to <br>gate the release process<br> <li> Consolidated <code>build</code> and <code>publish</code> jobs into single <code>publish</code> job that <br>builds and releases per language<br> <li> Removed <code>create-release</code> draft job; <code>github-release</code> now creates final <br>release directly<br> <li> Removed unnecessary checkout from <code>prepare</code> job and unused permissions<br> <li> Updated <code>github-release</code> to download language-specific artifacts and <br>removed draft/update flags<br> <li> Renamed version reset jobs for clarity: "Generate Version Reset" → <br>"Generate Nightly Versions"<br> <li> Removed duplicate <code>github-release</code> finalization job that was updating <br>draft to release</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16960/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+35/-64</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

