### PR TITLE
[java] fix JSON parsing of numbers with exponent

### DIFF
--- a/java/src/org/openqa/selenium/json/JsonInput.java
+++ b/java/src/org/openqa/selenium/json/JsonInput.java
@@ -220,31 +220,43 @@ public class JsonInput implements Closeable {
    */
   public Number nextNumber() {
     expect(JsonType.NUMBER);
+    boolean decimal = false;
     StringBuilder builder = new StringBuilder();
     // We know it's safe to use a do/while loop since the first character was a number
-    boolean fractionalPart = false;
+    boolean read = true;
     do {
-      char read = input.peek();
-      if (Character.isDigit(read)
-          || read == '+'
-          || read == '-'
-          || read == 'e'
-          || read == 'E'
-          || read == '.') {
-        builder.append(input.read());
-      } else {
-        break;
+      switch (input.peek()) {
+        case '-':
+        case '+':
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+          builder.append(input.read());
+          break;
+        case '.':
+        case 'e':
+        case 'E':
+          decimal = true;
+          builder.append(input.read());
+          break;
+        default:
+          read = false;
       }
-
-      fractionalPart |= (read == '.');
-    } while (true);
+    } while (read);
 
     try {
-      Number number = new BigDecimal(builder.toString());
-      if (fractionalPart) {
-        return number.doubleValue();
+      if (!decimal) {
+        return Long.valueOf(builder.toString());
       }
-      return number.longValue();
+
+      return new BigDecimal(builder.toString()).doubleValue();
     } catch (NumberFormatException e) {
       throw new JsonException("Unable to parse to a number: " + builder + ". " + input);
     }

--- a/java/test/org/openqa/selenium/json/JsonTest.java
+++ b/java/test/org/openqa/selenium/json/JsonTest.java
@@ -63,6 +63,10 @@ class JsonTest {
     assertThat((Number) new Json().toType("42", Number.class)).isEqualTo(42L);
     assertThat((Integer) new Json().toType("42", Integer.class)).isEqualTo(42);
     assertThat((Double) new Json().toType("42", Double.class)).isEqualTo(42.0);
+    assertThat((Double) new Json().toType("4.2e+1", Double.class)).isEqualTo(42.0);
+    assertThat((Double) new Json().toType("42e+1", Double.class)).isEqualTo(420.0);
+    assertThat((Double) new Json().toType("42e-1", Double.class)).isEqualTo(4.2);
+    assertThat((Double) new Json().toType("4.2e-1", Double.class)).isEqualTo(0.42);
   }
 
   @Test


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
I noticed this when reading the z-index of an element via Javascript.
All numbers with exponent and no fraction part are broken.
e.g. `42e-1` should be parsed as `double 4.2` but instead was parsed as `long 4`

### 💥 What does this PR do?
Fix the JSON parsing of numbers with exponent and no fraction part.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix JSON parsing of numbers with exponent notation

- Correctly parse exponents without fractional parts as doubles

- Refactor number parsing logic using switch statement

- Add test cases for exponent notation variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON Number Input"] --> B["Check for decimal point or exponent"]
  B --> C{Contains decimal or exponent?}
  C -->|Yes| D["Parse as Double via BigDecimal"]
  C -->|No| E["Parse as Long"]
  D --> F["Return Number"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonInput.java</strong><dd><code>Refactor number parsing with exponent support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/JsonInput.java

<ul><li>Refactored number parsing logic from character-by-character checks to <br>switch statement<br> <li> Changed tracking from <code>fractionalPart</code> boolean to <code>decimal</code> boolean to <br>detect both decimal points and exponents<br> <li> Fixed bug where numbers with exponents but no fractional part were <br>incorrectly parsed as Long instead of Double<br> <li> Simplified parsing logic to return Long for integers and Double for <br>numbers with decimal or exponent notation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16961/files#diff-162d1e84f8475ebea31dd037e38d700e07beacf189da303f454b1b62ad7b8483">+30/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonTest.java</strong><dd><code>Add exponent notation test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/json/JsonTest.java

<ul><li>Added test case for exponent with decimal fraction: <code>4.2e+1</code> should <br>parse as <code>42.0</code><br> <li> Added test case for positive exponent without fraction: <code>42e+1</code> should <br>parse as <code>420.0</code><br> <li> Added test case for negative exponent without fraction: <code>42e-1</code> should <br>parse as <code>4.2</code><br> <li> Added test case for negative exponent with fraction: <code>4.2e-1</code> should <br>parse as <code>0.42</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16961/files#diff-ca8b46815d2ed84d1c82776cf430ab11d8b9cdb91a4c904338c96dc482147623">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

