### PR TITLE
[dotnet] [bidi] AOT safe json converter for `Input.Origin` class

### DIFF
--- a/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
@@ -46,9 +46,9 @@ internal class InputOriginConverter : JsonConverter<Origin>
             writer.WriteStartObject();
             writer.WriteString("type", "element");
             writer.WritePropertyName("element");
-            
+
             JsonSerializer.Serialize(writer, element.Element, options.GetTypeInfo<Script.ISharedReference>());
-            
+
             writer.WriteEndObject();
         }
     }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
@@ -47,8 +47,7 @@ internal class InputOriginConverter : JsonConverter<Origin>
             writer.WriteString("type", "element");
             writer.WritePropertyName("element");
             
-            var sharedReferenceTypeInfo = options.GetTypeInfo<Script.ISharedReference>();
-            JsonSerializer.Serialize(writer, element.Element, sharedReferenceTypeInfo);
+            JsonSerializer.Serialize(writer, element.Element, options.GetTypeInfo<Script.ISharedReference>());
             
             writer.WriteEndObject();
         }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs
@@ -19,14 +19,11 @@
 
 using OpenQA.Selenium.BiDi.Input;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Json.Converters;
 
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Json serializer options should have AOT-safe type resolution")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Json serializer options should have AOT-safe type resolution")]
 internal class InputOriginConverter : JsonConverter<Origin>
 {
     public override Origin Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -49,7 +46,10 @@ internal class InputOriginConverter : JsonConverter<Origin>
             writer.WriteStartObject();
             writer.WriteString("type", "element");
             writer.WritePropertyName("element");
-            JsonSerializer.Serialize(writer, element.Element, options);
+            
+            var sharedReferenceTypeInfo = options.GetTypeInfo<Script.ISharedReference>();
+            JsonSerializer.Serialize(writer, element.Element, sharedReferenceTypeInfo);
+            
             writer.WriteEndObject();
         }
     }


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Resolves aot trimming warning.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Removes suppression attributes and implements AOT-safe serialization

- Uses explicit type info for ISharedReference serialization

- Eliminates IL2026 and IL3050 trimming warnings properly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InputOriginConverter"] -->|"Remove suppression attributes"| B["Clean code"]
  A -->|"Use GetTypeInfo for serialization"| C["AOT-safe implementation"]
  C -->|"Explicit type resolution"| D["No trimming warnings"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InputOriginConverter.cs</strong><dd><code>AOT-safe JSON serialization for Origin class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Json/Converters/InputOriginConverter.cs

<ul><li>Removed <code>System.Diagnostics.CodeAnalysis</code> using statement<br> <li> Removed two <code>UnconditionalSuppressMessage</code> attributes for IL2026 and <br>IL3050 warnings<br> <li> Replaced generic <code>JsonSerializer.Serialize</code> call with explicit type info <br>using <code>options.GetTypeInfo<Script.ISharedReference>()</code><br> <li> This approach properly handles AOT compilation without suppressing <br>warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16962/files#diff-c0d773d3f8f349123913432f9cb99ce7bb6f59c182333ff8e9b58dd7b8c896c3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

