### PR TITLE
[dotnet] [bidi] AOT safe json converter for `OptionalConverter`

### DIFF
--- a/dotnet/src/webdriver/BiDi/Json/Converters/OptionalConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/OptionalConverter.cs
@@ -33,7 +33,7 @@ public sealed class OptionalConverter<T> : JsonConverter<Optional<T>>
             return new Optional<T>(default!);
         }
 
-        T value = JsonSerializer.Deserialize<T>(ref reader, options)!;
+        T value = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
         return new Optional<T>(value);
     }
 
@@ -41,7 +41,7 @@ public sealed class OptionalConverter<T> : JsonConverter<Optional<T>>
     {
         if (value.TryGetValue(out var optionalValue))
         {
-            JsonSerializer.Serialize(writer, optionalValue, options);
+            JsonSerializer.Serialize(writer, optionalValue, options.GetTypeInfo<T>());
         }
         else
         {

--- a/dotnet/src/webdriver/BiDi/Json/JsonExtensions.cs
+++ b/dotnet/src/webdriver/BiDi/Json/JsonExtensions.cs
@@ -55,6 +55,11 @@ internal static class JsonExtensions
 
     public static JsonTypeInfo<T> GetTypeInfo<T>(this JsonSerializerOptions options)
     {
-        return (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+        if (options.TryGetTypeInfo(typeof(T), out JsonTypeInfo? typeInfo))
+        {
+            return (JsonTypeInfo<T>)typeInfo;
+        }
+
+        throw new JsonException($"Type info for '{typeof(T).FullName}' is not available in the serializer context. Ensure the type is included in the JsonSerializerContext.");
     }
 }


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Resolves AOT trimming warning for OptionalConverter.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace generic `JsonSerializer` calls with AOT-safe type info overloads

- Use `options.GetTypeInfo<T>()` for deserialization and serialization

- Resolves AOT trimming warnings in OptionalConverter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OptionalConverter<br/>Deserialization"] -->|"Replace generic call"| B["GetTypeInfo<T><br/>approach"]
  C["OptionalConverter<br/>Serialization"] -->|"Replace generic call"| B
  B -->|"Result"| D["AOT trimming<br/>warnings resolved"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OptionalConverter.cs</strong><dd><code>Replace generic JSON serializer calls with AOT-safe overloads</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Json/Converters/OptionalConverter.cs

<ul><li>Updated <code>Read()</code> method to use <code>options.GetTypeInfo<T>()</code> instead of generic <br><code>JsonSerializer.Deserialize<T>()</code><br> <li> Updated <code>Write()</code> method to use <code>options.GetTypeInfo<T>()</code> instead of generic <br><code>JsonSerializer.Serialize()</code><br> <li> Eliminates AOT trimming warnings by providing explicit type <br>information to the serializer</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16963/files#diff-70c2765c60f7cbcf0f293bd6bb8cd50fb08bfe5fd95a1811e81f185aa63e21bc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

