### PR TITLE
[dotnet] Clean nuspec files to exclude pdb

### DIFF
--- a/dotnet/src/support/Selenium.WebDriver.Support.StrongNamed.nuspec
+++ b/dotnet/src/support/Selenium.WebDriver.Support.StrongNamed.nuspec
@@ -4,7 +4,7 @@
     <id>$packageid$</id>
     <version>$version$</version>
     <authors>Selenium Committers</authors>
-    <copyright>Copyright © 2024 Software Freedom Conservancy</copyright>
+    <copyright>Copyright © 2026 Software Freedom Conservancy</copyright>
     <owners>selenium</owners>
     <title>WebDriver Support</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -32,7 +32,6 @@
   </metadata>
   <files>
     <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.dll" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.dll" />
-    <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.pdb" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.pdb" />
     <file src="lib/netstandard2.0/WebDriver.Support.StrongNamed.xml" target="lib/netstandard2.0/WebDriver.Support.StrongNamed.xml" />
 
     <file src="icon.png" />

--- a/dotnet/src/support/Selenium.WebDriver.Support.nuspec
+++ b/dotnet/src/support/Selenium.WebDriver.Support.nuspec
@@ -4,7 +4,7 @@
     <id>$packageid$</id>
     <version>$version$</version>
     <authors>Selenium Committers</authors>
-    <copyright>Copyright © 2024 Software Freedom Conservancy</copyright>
+    <copyright>Copyright © 2026 Software Freedom Conservancy</copyright>
     <owners>selenium</owners>
     <title>WebDriver Support</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -32,7 +32,6 @@
   </metadata>
   <files>
     <file src="lib/netstandard2.0/WebDriver.Support.dll" target="lib/netstandard2.0/WebDriver.Support.dll" />
-    <file src="lib/netstandard2.0/WebDriver.Support.pdb" target="lib/netstandard2.0/WebDriver.Support.pdb" />
     <file src="lib/netstandard2.0/WebDriver.Support.xml" target="lib/netstandard2.0/WebDriver.Support.xml" />
 
     <file src="icon.png" />

--- a/dotnet/src/webdriver/Selenium.WebDriver.StrongNamed.nuspec
+++ b/dotnet/src/webdriver/Selenium.WebDriver.StrongNamed.nuspec
@@ -4,7 +4,7 @@
     <id>$packageid$</id>
     <version>$version$</version>
     <authors>Selenium Committers</authors>
-    <copyright>Copyright © 2024 Software Freedom Conservancy</copyright>
+    <copyright>Copyright © 2026 Software Freedom Conservancy</copyright>
     <owners>selenium</owners>
     <title>Selenium WebDriver</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -41,15 +41,12 @@
   </metadata>
   <files>
     <file src="lib/net462/WebDriver.StrongNamed.dll" target="lib/net462/WebDriver.StrongNamed.dll" />
-    <file src="lib/net462/WebDriver.StrongNamed.pdb" target="lib/net462/WebDriver.StrongNamed.pdb" />
     <file src="lib/net462/WebDriver.StrongNamed.xml" target="lib/net462/WebDriver.StrongNamed.xml" />
 
     <file src="lib/netstandard2.0/WebDriver.StrongNamed.dll" target="lib/netstandard2.0/WebDriver.StrongNamed.dll" />
-    <file src="lib/netstandard2.0/WebDriver.StrongNamed.pdb" target="lib/netstandard2.0/WebDriver.StrongNamed.pdb" />
     <file src="lib/netstandard2.0/WebDriver.StrongNamed.xml" target="lib/netstandard2.0/WebDriver.StrongNamed.xml" />
 
     <file src="lib/net8.0/WebDriver.StrongNamed.dll" target="lib/net8.0/WebDriver.StrongNamed.dll" />
-    <file src="lib/net8.0/WebDriver.StrongNamed.pdb" target="lib/net8.0/WebDriver.StrongNamed.pdb" />
     <file src="lib/net8.0/WebDriver.StrongNamed.xml" target="lib/net8.0/WebDriver.StrongNamed.xml" />
 
     <file src="build/Selenium.WebDriver.StrongNamed.targets" target="build/Selenium.WebDriver.StrongNamed.targets"/>

--- a/dotnet/src/webdriver/Selenium.WebDriver.nuspec
+++ b/dotnet/src/webdriver/Selenium.WebDriver.nuspec
@@ -4,7 +4,7 @@
     <id>$packageid$</id>
     <version>$version$</version>
     <authors>Selenium Committers</authors>
-    <copyright>Copyright © 2024 Software Freedom Conservancy</copyright>
+    <copyright>Copyright © 2026 Software Freedom Conservancy</copyright>
     <owners>selenium</owners>
     <title>Selenium WebDriver</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -41,15 +41,12 @@
   </metadata>
   <files>
     <file src="lib/net462/WebDriver.dll" target="lib/net462/WebDriver.dll" />
-    <file src="lib/net462/WebDriver.pdb" target="lib/net462/WebDriver.pdb" />
     <file src="lib/net462/WebDriver.xml" target="lib/net462/WebDriver.xml" />
 
     <file src="lib/netstandard2.0/WebDriver.dll" target="lib/netstandard2.0/WebDriver.dll" />
-    <file src="lib/netstandard2.0/WebDriver.pdb" target="lib/netstandard2.0/WebDriver.pdb" />
     <file src="lib/netstandard2.0/WebDriver.xml" target="lib/netstandard2.0/WebDriver.xml" />
 
     <file src="lib/net8.0/WebDriver.dll" target="lib/net8.0/WebDriver.dll" />
-    <file src="lib/net8.0/WebDriver.pdb" target="lib/net8.0/WebDriver.pdb" />
     <file src="lib/net8.0/WebDriver.xml" target="lib/net8.0/WebDriver.xml" />
 
     <file src="build/Selenium.WebDriver.targets" target="build/Selenium.WebDriver.targets"/>


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
- remove mentions of pdb, it is obsolete
- update year

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Other


___

### **Description**
- Remove PDB file references from all nuspec files

- Update copyright year from 2024 to 2026

- Clean up obsolete debug symbol packaging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  nuspec["NuGet Spec Files"]
  pdb["PDB References"]
  copyright["Copyright Year"]
  nuspec -- "Remove" --> pdb
  nuspec -- "Update" --> copyright
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.Support.StrongNamed.nuspec</strong><dd><code>Remove PDB and update copyright year</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/support/Selenium.WebDriver.Support.StrongNamed.nuspec

<ul><li>Removed PDB file reference for WebDriver.Support.StrongNamed<br> <li> Updated copyright year from 2024 to 2026</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16964/files#diff-8db68da91606cd04636b872426bb9557adc9ce8b9b610eab9ec29764ba6f9351">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.Support.nuspec</strong><dd><code>Remove PDB and update copyright year</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/support/Selenium.WebDriver.Support.nuspec

<ul><li>Removed PDB file reference for WebDriver.Support<br> <li> Updated copyright year from 2024 to 2026</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16964/files#diff-de53636142823d8d583290f71d6227a4dfbba90e91f32f3a97c0e5effa7e4ef0">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.StrongNamed.nuspec</strong><dd><code>Remove PDB files across multiple frameworks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Selenium.WebDriver.StrongNamed.nuspec

<ul><li>Removed PDB file references for net462, netstandard2.0, and net8.0 <br>frameworks<br> <li> Updated copyright year from 2024 to 2026</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16964/files#diff-0ff4e0f438661fe7ba423064ce4448d3eff8af945aba633385e745a1633fd2ce">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Selenium.WebDriver.nuspec</strong><dd><code>Remove PDB files across multiple frameworks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/Selenium.WebDriver.nuspec

<ul><li>Removed PDB file references for net462, netstandard2.0, and net8.0 <br>frameworks<br> <li> Updated copyright year from 2024 to 2026</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16964/files#diff-21ff096eb5f83fd731541d547b54c33e66e7ed3c78050a9af5a4a8b105b84c80">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

