### PR TITLE
[build] add reusable commit-changes.yml workflow

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -53,6 +53,17 @@ jobs:
       run: ./scripts/github-actions/check-format.sh
       artifact-name: format-changes
 
+  fork-format-error:
+    name: Fork format instructions
+    needs: format
+    if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - name: Format instructions
+        run: |
+          echo "::error::Code needs formatting. Run ./scripts/format.sh locally and push changes."
+          exit 1
+
   commit-fixes:
     name: Commit fixes
     needs: format

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -56,40 +56,9 @@ jobs:
   commit-fixes:
     name: Commit fixes
     needs: format
-    if: failure() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      actions: read
-    steps:
-      - name: Check Permissions
-        if: github.event.pull_request.head.repo.fork == true
-        run: |
-          echo "::error::Code needs formatting. Run ./scripts/format.sh locally and push changes."
-          exit 1
-      - name: Checkout PR
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Download format changes
-        uses: actions/download-artifact@v4
-        with:
-          name: format-changes
-      - name: Apply and commit fixes
-        id: apply
-        run: |
-          if [ -s changes.patch ]; then
-            git apply --index changes.patch
-            rm changes.patch
-            git config --local user.name "Selenium CI Bot"
-            git config --local user.email "selenium-ci@users.noreply.github.com"
-            git commit -m "Auto-format code"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::No formatting changes needed."
-          fi
-      - name: Push fixes
-        if: steps.apply.outputs.has_changes == 'true'
-        run: |
-          git push
-          echo "::notice::Auto-formatted and pushed. New CI run will start."
+    if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    uses: ./.github/workflows/commit-changes.yml
+    with:
+      artifact-name: format-changes
+      commit-message: "Auto-format code"
+      ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci-renovate-rbe.yml
+++ b/.github/workflows/ci-renovate-rbe.yml
@@ -42,28 +42,10 @@ jobs:
     name: Commit Repins
     needs: pin
     if: github.event.repository.fork == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download repin patch
-        uses: actions/download-artifact@v4
-        with:
-          name: repin-changes
-        continue-on-error: true
-      - name: Apply patch and commit
-        run: |
-          if [ -f changes.patch ] && [ -s changes.patch ]; then
-            git apply --index changes.patch
-            git config --local user.email "selenium-ci@users.noreply.github.com"
-            git config --local user.name "Selenium CI Bot"
-            git commit -m 'Repin dependencies'
-            git push
-          else
-            echo "No changes to commit"
-          fi
+    uses: ./.github/workflows/commit-changes.yml
+    with:
+      artifact-name: repin-changes
+      commit-message: "Repin dependencies"
 
   check-format:
     needs: commit-repins

--- a/.github/workflows/commit-changes.yml
+++ b/.github/workflows/commit-changes.yml
@@ -51,16 +51,31 @@ jobs:
       - name: Apply and commit
         id: commit
         run: |
-          set -e
           if [ -f changes.patch ] && [ -s changes.patch ]; then
-            git apply --index changes.patch
+            if ! git apply --index changes.patch; then
+              echo "::error::Failed to apply patch"
+              echo "committed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             git config --local user.email "selenium-ci@users.noreply.github.com"
             git config --local user.name "Selenium CI Bot"
-            git commit -m "$COMMIT_MESSAGE"
+            if ! git commit -m "$COMMIT_MESSAGE"; then
+              echo "::error::Failed to commit changes"
+              echo "committed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             if [ -n "$PUSH_BRANCH" ]; then
-              git push origin HEAD:"$PUSH_BRANCH" --force
+              if ! git push origin HEAD:"$PUSH_BRANCH" --force; then
+                echo "::error::Failed to push to $PUSH_BRANCH"
+                echo "committed=false" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
             else
-              git push
+              if ! git push; then
+                echo "::error::Failed to push"
+                echo "committed=false" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
             fi
             echo "::notice::Changes committed and pushed"
             echo "committed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/commit-changes.yml
+++ b/.github/workflows/commit-changes.yml
@@ -37,6 +37,7 @@ jobs:
       committed: ${{ steps.commit.outputs.committed }}
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +45,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.SELENIUM_CI_TOKEN || github.token }}
       - name: Download patch
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
@@ -51,6 +53,11 @@ jobs:
       - name: Apply and commit
         id: commit
         run: |
+          if [ "$DOWNLOAD_OUTCOME" != "success" ]; then
+            echo "::notice::Artifact not found (may not have been uploaded)"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ -f changes.patch ] && [ -s changes.patch ]; then
             if ! git apply --index changes.patch; then
               echo "::error::Failed to apply patch"
@@ -84,5 +91,6 @@ jobs:
             echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
         env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
           COMMIT_MESSAGE: ${{ inputs.commit-message }}
           PUSH_BRANCH: ${{ inputs.push-branch }}

--- a/.github/workflows/commit-changes.yml
+++ b/.github/workflows/commit-changes.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Apply and commit
         id: commit
         run: |
+          set -e
           if [ -f changes.patch ] && [ -s changes.patch ]; then
             git apply --index changes.patch
             git config --local user.email "selenium-ci@users.noreply.github.com"

--- a/.github/workflows/commit-changes.yml
+++ b/.github/workflows/commit-changes.yml
@@ -1,0 +1,72 @@
+name: Commit Changes
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: Name of artifact containing changes.patch
+        required: true
+        type: string
+      commit-message:
+        description: Commit message
+        required: true
+        type: string
+      ref:
+        description: Git ref to checkout
+        required: false
+        type: string
+        default: ''
+      push-branch:
+        description: Branch to push to (defaults to current branch, uses force push)
+        required: false
+        type: string
+        default: ''
+    outputs:
+      changes-committed:
+        description: Whether changes were committed and pushed
+        value: ${{ jobs.commit.outputs.committed }}
+    secrets:
+      SELENIUM_CI_TOKEN:
+        required: false
+
+jobs:
+  commit:
+    name: Commit Changes
+    runs-on: ubuntu-latest
+    outputs:
+      committed: ${{ steps.commit.outputs.committed }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.SELENIUM_CI_TOKEN || github.token }}
+      - name: Download patch
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+        continue-on-error: true
+      - name: Apply and commit
+        id: commit
+        run: |
+          if [ -f changes.patch ] && [ -s changes.patch ]; then
+            git apply --index changes.patch
+            git config --local user.email "selenium-ci@users.noreply.github.com"
+            git config --local user.name "Selenium CI Bot"
+            git commit -m "$COMMIT_MESSAGE"
+            if [ -n "$PUSH_BRANCH" ]; then
+              git push origin HEAD:"$PUSH_BRANCH" --force
+            else
+              git push
+            fi
+            echo "::notice::Changes committed and pushed"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No changes to commit"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          COMMIT_MESSAGE: ${{ inputs.commit-message }}
+          PUSH_BRANCH: ${{ inputs.push-branch }}

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
         run: |
-          existing=$(gh pr list --head pinned-browser-updates --json number --jq '.[0].number')
+          existing=$(gh pr list --head pinned-browser-updates --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             echo "::notice::PR #$existing already exists"
           else

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -48,10 +48,5 @@ jobs:
               --head pinned-browser-updates \
               --base trunk \
               --title "[dotnet][rb][java][js][py] Automated Browser Version Update" \
-              --body "$(cat <<'EOF'
-This is an automated pull request to update pinned browsers and drivers
-
-Merge after verify the new browser versions properly passing the tests and no bugs need to be filed
-EOF
-)"
+              --body $'This is an automated pull request to update pinned browsers and drivers\n\nMerge after verify the new browser versions properly passing the tests and no bugs need to be filed'
           fi

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -50,5 +50,5 @@ jobs:
               --title "[dotnet][rb][java][js][py] Automated Browser Version Update" \
               --body "This is an automated pull request to update pinned browsers and drivers
 
-          Merge after verify the new browser versions properly passing the tests and no bugs need to be filed"
+Merge after verify the new browser versions properly passing the tests and no bugs need to be filed"
           fi

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -48,7 +48,10 @@ jobs:
               --head pinned-browser-updates \
               --base trunk \
               --title "[dotnet][rb][java][js][py] Automated Browser Version Update" \
-              --body "This is an automated pull request to update pinned browsers and drivers
+              --body "$(cat <<'EOF'
+This is an automated pull request to update pinned browsers and drivers
 
-Merge after verify the new browser versions properly passing the tests and no bugs need to be filed"
+Merge after verify the new browser versions properly passing the tests and no bugs need to be filed
+EOF
+)"
           fi

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -16,38 +16,39 @@ jobs:
       run: bazel run //scripts:pinned_browsers
       artifact-name: pinned-browsers
 
-  pull-request:
-    if: github.event.repository.fork == false
-    runs-on: ubuntu-latest
+  push-changes:
+    name: Push Changes
     needs: update
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Download patch
-        uses: actions/download-artifact@v4
-        with:
-          name: pinned-browsers
-      - name: Apply Patch
-        run: |
-          git apply changes.patch
-          rm changes.patch
-      - name: Check Changes
-        run: |
-          if [[ -n $(git status --porcelain common/repositories.bzl) ]]; then
-            echo "CHANGES_FOUND=true" >> "$GITHUB_ENV"
-          fi
-      - name: Create Pull Request
-        if: env.CHANGES_FOUND == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.SELENIUM_CI_TOKEN }}
-          add-paths: common/repositories.bzl
-          commit-message: "Update pinned browser versions"
-          committer: Selenium CI Bot <selenium-ci@users.noreply.github.com>
-          author: Selenium CI Bot <selenium-ci@users.noreply.github.com>
-          title: "[dotnet][rb][java][js][py] Automated Browser Version Update"
-          body: |
-            This is an automated pull request to update pinned browsers and drivers
+    if: github.event.repository.fork == false
+    uses: ./.github/workflows/commit-changes.yml
+    with:
+      artifact-name: pinned-browsers
+      commit-message: "Update pinned browser versions"
+      push-branch: pinned-browser-updates
+    secrets:
+      SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
-            Merge after verify the new browser versions properly passing the tests and no bugs need to be filed
-          branch: "pinned-browser-updates"
+  create-pr:
+    name: Create Pull Request
+    needs: push-changes
+    if: github.event.repository.fork == false && needs.push-changes.outputs.changes-committed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
+        run: |
+          existing=$(gh pr list --head pinned-browser-updates --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "::notice::PR #$existing already exists"
+          else
+            gh pr create \
+              --head pinned-browser-updates \
+              --base trunk \
+              --title "[dotnet][rb][java][js][py] Automated Browser Version Update" \
+              --body "This is an automated pull request to update pinned browsers and drivers
+
+          Merge after verify the new browser versions properly passing the tests and no bugs need to be filed"
+          fi

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # Rust jobs run in parallel with approval since work is not on trunk
+  # Run rust jobs run in parallel with approval since work is not on trunk
   generate-rust-version:
     name: Generate Rust Version
     if: github.event.repository.fork == false
@@ -43,29 +43,13 @@ jobs:
   push-rust-version:
     name: Push Rust Version
     needs: generate-rust-version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.SELENIUM_CI_TOKEN }}
-          fetch-depth: 0
-      - name: Download rust version patch
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-version
-      - name: Apply and push
-        run: |
-          if [ -f changes.patch ] && [ -s changes.patch ]; then
-            git apply --index changes.patch
-            git config --local user.email "selenium-ci@users.noreply.github.com"
-            git config --local user.name "Selenium CI Bot"
-            git commit -m "update selenium manager version and rust changelog"
-            git push origin HEAD:rust-release-${{ inputs.version }} --force
-          else
-            echo "::error::No changes to apply for rust version update"
-            exit 1
-          fi
+    uses: ./.github/workflows/commit-changes.yml
+    with:
+      artifact-name: rust-version
+      commit-message: "update selenium manager version and rust changelog"
+      push-branch: rust-release-${{ inputs.version }}
+    secrets:
+      SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
   selenium-manager:
     name: Release Selenium Manager

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # Run rust jobs run in parallel with approval since work is not on trunk
+  # Run rust jobs in parallel with approval since work is not on trunk
   generate-rust-version:
     name: Generate Rust Version
     if: github.event.repository.fork == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,29 +151,12 @@ jobs:
   update-version:
     name: Push Nightly Versions
     needs: [prepare, reset-version, unrestrict-trunk]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.SELENIUM_CI_TOKEN }}
-      - name: Download version reset patch
-        uses: actions/download-artifact@v4
-        with:
-          name: version-reset
-      - name: Apply and push
-        run: |
-          if [ -f changes.patch ] && [ -s changes.patch ]; then
-            git apply --index changes.patch
-            git config --local user.email "selenium-ci@users.noreply.github.com"
-            git config --local user.name "Selenium CI Bot"
-            git commit -m "[build] Reset versions to nightly after ${{ needs.prepare.outputs.tag }} release"
-            git push
-          else
-            echo "::notice::No version changes to apply"
-          fi
+    uses: ./.github/workflows/commit-changes.yml
+    with:
+      artifact-name: version-reset
+      commit-message: "[build] Reset versions to nightly after ${{ needs.prepare.outputs.tag }} release"
+    secrets:
+      SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
   nightly:
     name: Publish Nightly Packages


### PR DESCRIPTION
### **User description**
Repeated pattern with our bazel.yml approach. Bazel workflow generates a patch, then calling workflow does:
* checkout
* download patch
* apply patch
* commit change
* push commit

### 💥 What does this PR do?
Adds a reusable `commit-changes.yml` workflow to manage this flow

Refactors the following workflows to use it:
- ci-lint.yml (commit-fixes job)
- ci-renovate-rbe.yml
- pin-browsers.yml
- pre-release.yml (push-rust-version job)
- release.yml (update-version job)

### 🔧 Implementation Notes
This pattern was duplicated across 5 workflows with minor variations. The reusable workflow supports:
- Custom artifact name and commit message
- Optional target ref to checkout
- Optional push-branch for force-pushing to a different branch (selenium manager job)

### 💡 Additional Considerations
More tweaks to simplify incoming

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces reusable `commit-changes.yml` workflow for standardized patch application

- Refactors 5 workflows to use centralized commit-changes workflow

- Supports custom artifact names, commit messages, and optional branch pushing

- Eliminates duplicated patch-apply-commit-push logic across workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Artifact Generation<br/>bazel.yml"] -- "artifact-name" --> B["commit-changes.yml<br/>Reusable Workflow"]
  B -- "applies patch" --> C["Git Commit<br/>& Push"]
  D["ci-lint.yml"] -- "uses" --> B
  E["ci-renovate-rbe.yml"] -- "uses" --> B
  F["pin-browsers.yml"] -- "uses" --> B
  G["pre-release.yml"] -- "uses" --> B
  H["release.yml"] -- "uses" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit-changes.yml</strong><dd><code>New reusable workflow for patch management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/commit-changes.yml

<ul><li>New reusable workflow that handles patch application, git <br>configuration, and commit/push operations<br> <li> Accepts inputs for artifact name, commit message, optional ref, and <br>optional push-branch<br> <li> Supports force-push to alternate branches via <code>push-branch</code> parameter<br> <li> Outputs <code>changes-committed</code> flag to indicate success/failure<br> <li> Supports optional <code>SELENIUM_CI_TOKEN</code> secret for authenticated <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-76a65136019a3accefa26a30b69fe35810c8ab872671c7763b1a74bdccb373b0">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pin-browsers.yml</strong><dd><code>Refactor to use commit-changes and gh CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pin-browsers.yml

<ul><li>Refactors <code>pull-request</code> job into two separate jobs: <code>push-changes</code> and <br><code>create-pr</code><br> <li> <code>push-changes</code> job now uses <code>commit-changes.yml</code> with force-push to <br><code>pinned-browser-updates</code> branch<br> <li> <code>create-pr</code> job uses GitHub CLI to create PR, checking for existing PRs <br>to avoid duplicates<br> <li> Replaces <code>peter-evans/create-pull-request</code> action with native <code>gh pr </code><br><code>create</code> command</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-4cdb71ed282d9e7b522ed730c4fe1cd13cc17dd5d0bf665f4416e9646215a2c5">+30/-29</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-lint.yml</strong><dd><code>Refactor to use commit-changes workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-lint.yml

<ul><li>Replaces 31 lines of inline patch-apply-commit-push logic with call to <br><code>commit-changes.yml</code><br> <li> Simplifies <code>commit-fixes</code> job to use reusable workflow with <br>artifact-name and commit-message inputs<br> <li> Moves fork check to job-level condition instead of step-level check</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-57157b14b324e35015a6c3e7dcacbca988efb53e3441e11e4ab4a07cbba16161">+6/-37</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-renovate-rbe.yml</strong><dd><code>Refactor to use commit-changes workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-renovate-rbe.yml

<ul><li>Replaces 18 lines of inline patch-apply-commit-push logic with <br><code>commit-changes.yml</code> call<br> <li> Simplifies <code>commit-repins</code> job configuration<br> <li> Removes manual git configuration and error handling steps</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-3c36acad7162c66d69ced5efdd84650ec36e90e0c8fad0fccf42f4553851b623">+4/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Refactor to use commit-changes workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Replaces 27 lines of inline patch-apply-commit-push logic in <br><code>push-rust-version</code> job with <code>commit-changes.yml</code> call<br> <li> Adds force-push to <code>rust-release-${{ inputs.version }}</code> branch via <br><code>push-branch</code> parameter<br> <li> Passes <code>SELENIUM_CI_TOKEN</code> secret to reusable workflow<br> <li> Minor comment fix: "Run rust jobs" instead of "Rust jobs"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+8/-24</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Refactor to use commit-changes workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replaces 27 lines of inline patch-apply-commit-push logic in <br><code>update-version</code> job with <code>commit-changes.yml</code> call<br> <li> Simplifies version reset workflow by delegating to reusable workflow<br> <li> Passes <code>SELENIUM_CI_TOKEN</code> secret for authenticated git operations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16965/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-23</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

