### PR TITLE
[dotnet] [bidi] Null guard for event handlers

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -145,23 +145,21 @@ public sealed class Broker : IAsyncDisposable
         return (TResult)await tcs.Task.ConfigureAwait(false);
     }
 
-    public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Action<TEventArgs> action, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo)
+    public Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Action<TEventArgs> action, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo)
         where TEventArgs : EventArgs
     {
-        _eventTypesMap[eventName] = jsonTypeInfo;
-
-        var handlers = _eventHandlers.GetOrAdd(eventName, (a) => []);
-
-        var subscribeResult = await _bidi.SessionModule.SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }).ConfigureAwait(false);
-
         var eventHandler = new SyncEventHandler<TEventArgs>(eventName, action);
-
-        handlers.Add(eventHandler);
-
-        return new Subscription(subscribeResult.Subscription, this, eventHandler);
+        return SubscribeAsync(eventName, eventHandler, options, jsonTypeInfo);
     }
 
-    public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Func<TEventArgs, Task> func, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo)
+    public Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Func<TEventArgs, Task> func, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo)
+        where TEventArgs : EventArgs
+    {
+        var eventHandler = new AsyncEventHandler<TEventArgs>(eventName, func);
+        return SubscribeAsync(eventName, eventHandler, options, jsonTypeInfo);
+    }
+
+    private async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo)
         where TEventArgs : EventArgs
     {
         _eventTypesMap[eventName] = jsonTypeInfo;
@@ -169,8 +167,6 @@ public sealed class Broker : IAsyncDisposable
         var handlers = _eventHandlers.GetOrAdd(eventName, (a) => []);
 
         var subscribeResult = await _bidi.SessionModule.SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }).ConfigureAwait(false);
-
-        var eventHandler = new AsyncEventHandler<TEventArgs>(eventName, func);
 
         handlers.Add(eventHandler);
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -128,6 +128,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationStartedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationStartedAsync(
             e => HandleNavigationStartedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -135,6 +137,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationStartedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationStartedAsync(
             e => HandleNavigationStarted(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -142,6 +146,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnFragmentNavigatedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnFragmentNavigatedAsync(
             e => HandleFragmentNavigatedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -149,6 +155,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnFragmentNavigatedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnFragmentNavigatedAsync(
             e => HandleFragmentNavigated(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -156,6 +164,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnHistoryUpdatedAsync(Func<HistoryUpdatedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnHistoryUpdatedAsync(
             e => HandleHistoryUpdatedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -163,6 +173,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnHistoryUpdatedAsync(Action<HistoryUpdatedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnHistoryUpdatedAsync(
             e => HandleHistoryUpdated(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -170,6 +182,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDomContentLoadedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDomContentLoadedAsync(
             e => HandleDomContentLoadedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -177,6 +191,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDomContentLoadedAsync(
             e => HandleDomContentLoaded(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -184,6 +200,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnLoadAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnLoadAsync(
             e => HandleLoad(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -191,6 +209,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnLoadAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnLoadAsync(
             e => HandleLoadAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -198,6 +218,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(
             e => HandleDownloadWillBegin(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -205,6 +227,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDownloadWillBeginAsync(
             e => HandleDownloadWillBeginAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -212,6 +236,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDownloadEndAsync(
             e => HandleDownloadEnd(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -219,6 +245,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnDownloadEndAsync(
             e => HandleDownloadEndAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -226,6 +254,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationAbortedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationAbortedAsync(
             e => HandleNavigationAborted(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -233,6 +263,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationAbortedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationAbortedAsync(
             e => HandleNavigationAbortedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -240,6 +272,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationFailedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationFailedAsync(
             e => HandleNavigationFailed(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -247,6 +281,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationFailedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationFailedAsync(
             e => HandleNavigationFailedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -254,6 +290,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationCommittedAsync(
             e => HandleNavigationCommitted(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));
@@ -261,6 +299,8 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
         return BiDi.BrowsingContext.OnNavigationCommittedAsync(
             e => HandleNavigationCommittedAsync(e, handler),
             ContextSubscriptionOptions.WithContext(options, this));

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -128,222 +128,302 @@ public sealed record BrowsingContext
 
     public Task<Subscription> OnNavigationStartedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationStartedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationStartedAsync(
+            e => HandleNavigationStartedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationStartedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationStartedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationStartedAsync(
+            e => HandleNavigationStarted(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(
+            e => HandleFragmentNavigatedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnFragmentNavigatedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnFragmentNavigatedAsync(
+            e => HandleFragmentNavigated(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Func<HistoryUpdatedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(
+            e => HandleHistoryUpdatedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnHistoryUpdatedAsync(Action<HistoryUpdatedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnHistoryUpdatedAsync(
+            e => HandleHistoryUpdated(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDomContentLoadedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDomContentLoadedAsync(
+            e => HandleDomContentLoadedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDomContentLoadedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDomContentLoadedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDomContentLoadedAsync(
+            e => HandleDomContentLoaded(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnLoadAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnLoadAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnLoadAsync(
+            e => HandleLoad(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnLoadAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnLoadAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnLoadAsync(
+            e => HandleLoadAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Action<DownloadWillBeginEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(
+            e => HandleDownloadWillBegin(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadWillBeginAsync(Func<DownloadWillBeginEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDownloadWillBeginAsync(
+            e => HandleDownloadWillBeginAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Action<DownloadEndEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadEndAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDownloadEndAsync(
+            e => HandleDownloadEnd(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnDownloadEndAsync(Func<DownloadEndEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnDownloadEndAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnDownloadEndAsync(
+            e => HandleDownloadEndAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationAbortedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationAbortedAsync(
+            e => HandleNavigationAborted(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationAbortedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationAbortedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationAbortedAsync(
+            e => HandleNavigationAbortedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationFailedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationFailedAsync(
+            e => HandleNavigationFailed(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationFailedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationFailedAsync(async e =>
-        {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationFailedAsync(
+            e => HandleNavigationFailedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Action<NavigationInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationCommittedAsync(e =>
-        {
-            if (Equals(e.Context))
-            {
-                handler(e);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(
+            e => HandleNavigationCommitted(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
     }
 
     public Task<Subscription> OnNavigationCommittedAsync(Func<NavigationInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return BiDi.BrowsingContext.OnNavigationCommittedAsync(async e =>
+        return BiDi.BrowsingContext.OnNavigationCommittedAsync(
+            e => HandleNavigationCommittedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, this));
+    }
+
+    private async Task HandleNavigationStartedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
         {
-            if (Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }, ContextSubscriptionOptions.WithContext(options, this));
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleNavigationStarted(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleFragmentNavigatedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleFragmentNavigated(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleHistoryUpdatedAsync(HistoryUpdatedEventArgs e, Func<HistoryUpdatedEventArgs, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleHistoryUpdated(HistoryUpdatedEventArgs e, Action<HistoryUpdatedEventArgs> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleDomContentLoadedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleDomContentLoaded(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private void HandleLoad(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleLoadAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleDownloadWillBegin(DownloadWillBeginEventArgs e, Action<DownloadWillBeginEventArgs> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleDownloadWillBeginAsync(DownloadWillBeginEventArgs e, Func<DownloadWillBeginEventArgs, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleDownloadEnd(DownloadEndEventArgs e, Action<DownloadEndEventArgs> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleDownloadEndAsync(DownloadEndEventArgs e, Func<DownloadEndEventArgs, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleNavigationAborted(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleNavigationAbortedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleNavigationFailed(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleNavigationFailedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleNavigationCommitted(NavigationInfo e, Action<NavigationInfo> handler)
+    {
+        if (Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleNavigationCommittedAsync(NavigationInfo e, Func<NavigationInfo, Task> handler)
+    {
+        if (Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
     }
 
     public bool Equals(BrowsingContext? other)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -45,29 +45,33 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(FileDialogInfo e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return inputModule.OnFileDialogOpenedAsync(
+            e => HandleFileDialogOpenedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+        return inputModule.OnFileDialogOpenedAsync(
+            e => HandleFileDialogOpened(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
+    }
 
-        void OnContextMatch(FileDialogInfo e)
+    private async Task HandleFileDialogOpenedAsync(FileDialogInfo e, Func<FileDialogInfo, Task> handler)
+    {
+        if (context.Equals(e.Context))
         {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleFileDialogOpened(FileDialogInfo e, Action<FileDialogInfo> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
         }
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -45,6 +45,8 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
+        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
         async Task OnContextMatch(FileDialogInfo e)
         {
             if (context.Equals(e.Context))
@@ -52,13 +54,13 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
                 await handler(e).ConfigureAwait(false);
             }
         }
-
-        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
 
         void OnContextMatch(FileDialogInfo e)
         {
@@ -67,7 +69,5 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
                 handler(e);
             }
         }
-
-        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs
@@ -43,23 +43,31 @@ public sealed class BrowsingContextInputModule(BrowsingContext context, InputMod
 
     public Task<Subscription> OnFileDialogOpenedAsync(Func<FileDialogInfo, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return inputModule.OnFileDialogOpenedAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        async Task OnContextMatch(FileDialogInfo e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
+
+        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFileDialogOpenedAsync(Action<FileDialogInfo> handler, ContextSubscriptionOptions? options = null)
     {
-        return inputModule.OnFileDialogOpenedAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        void OnContextMatch(FileDialogInfo e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
+
+        return inputModule.OnFileDialogOpenedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
@@ -29,6 +29,8 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
+        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
         async Task OnContextMatch(Log.LogEntry args)
         {
             if (context.Equals(args.Source.Context))
@@ -36,13 +38,13 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
                 await handler(args).ConfigureAwait(false);
             }
         }
-
-        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnEntryAddedAsync(Action<Log.LogEntry> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
 
         void OnContextMatch(Log.LogEntry args)
         {
@@ -51,7 +53,5 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
                 handler(args);
             }
         }
-
-        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
@@ -27,23 +27,31 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
 {
     public Task<Subscription> OnEntryAddedAsync(Func<Log.LogEntry, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return logModule.OnEntryAddedAsync(async args =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        async Task OnContextMatch(Log.LogEntry args)
         {
             if (context.Equals(args.Source.Context))
             {
                 await handler(args).ConfigureAwait(false);
             }
-        }, new SubscriptionOptions() { Timeout = options?.Timeout }); // special case, don't scope to context, awaiting https://github.com/w3c/webdriver-bidi/issues/1032
+        }
+
+        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnEntryAddedAsync(Action<Log.LogEntry> handler, ContextSubscriptionOptions? options = null)
     {
-        return logModule.OnEntryAddedAsync(args =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        void OnContextMatch(Log.LogEntry args)
         {
             if (context.Equals(args.Source.Context))
             {
                 handler(args);
             }
-        }, new SubscriptionOptions() { Timeout = options?.Timeout }); // special case, don't scope to context, awaiting https://github.com/w3c/webdriver-bidi/issues/1032
+        }
+
+        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs
@@ -29,29 +29,33 @@ public sealed class BrowsingContextLogModule(BrowsingContext context, LogModule 
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(Log.LogEntry args)
-        {
-            if (context.Equals(args.Source.Context))
-            {
-                await handler(args).ConfigureAwait(false);
-            }
-        }
+        return logModule.OnEntryAddedAsync(
+            e => HandleEntryAddedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnEntryAddedAsync(Action<Log.LogEntry> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return logModule.OnEntryAddedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+        return logModule.OnEntryAddedAsync(
+            e => HandleEntryAdded(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
+    }
 
-        void OnContextMatch(Log.LogEntry args)
+    private async Task HandleEntryAddedAsync(Log.LogEntry e, Func<Log.LogEntry, Task> handler)
+    {
+        if (context.Equals(e.Source.Context))
         {
-            if (context.Equals(args.Source.Context))
-            {
-                handler(args);
-            }
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleEntryAdded(Log.LogEntry e, Action<Log.LogEntry> handler)
+    {
+        if (context.Equals(e.Source.Context))
+        {
+            handler(e);
         }
     }
 }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -92,112 +92,152 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
 
     public Task<Subscription> OnBeforeRequestSentAsync(Func<BeforeRequestSentEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnBeforeRequestSentAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnBeforeRequestSentAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        async Task OnContextMatch(BeforeRequestSentEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnBeforeRequestSentAsync(Action<BeforeRequestSentEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnBeforeRequestSentAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnBeforeRequestSentAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        void OnContextMatch(BeforeRequestSentEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnResponseStartedAsync(Func<ResponseStartedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnResponseStartedAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnResponseStartedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        async Task OnContextMatch(ResponseStartedEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnResponseStartedAsync(Action<ResponseStartedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnResponseStartedAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnResponseStartedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        void OnContextMatch(ResponseStartedEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Func<ResponseCompletedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnResponseCompletedAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnResponseCompletedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        async Task OnContextMatch(ResponseCompletedEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Action<ResponseCompletedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnResponseCompletedAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnResponseCompletedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        void OnContextMatch(ResponseCompletedEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnFetchErrorAsync(Func<FetchErrorEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnFetchErrorAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnFetchErrorAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        async Task OnContextMatch(FetchErrorEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnFetchErrorAsync(Action<FetchErrorEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnFetchErrorAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnFetchErrorAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        void OnContextMatch(FetchErrorEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Func<AuthRequiredEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnAuthRequiredAsync(async e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnAuthRequiredAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        async Task OnContextMatch(AuthRequiredEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 await handler(e).ConfigureAwait(false);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Action<AuthRequiredEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
-        return networkModule.OnAuthRequiredAsync(e =>
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        return networkModule.OnAuthRequiredAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+
+        void OnContextMatch(AuthRequiredEventArgs e)
         {
             if (context.Equals(e.Context))
             {
                 handler(e);
             }
-        }, ContextSubscriptionOptions.WithContext(options, context));
+        }
     }
 }
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -94,149 +94,169 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnBeforeRequestSentAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(BeforeRequestSentEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return networkModule.OnBeforeRequestSentAsync(
+            e => HandleBeforeRequestSentAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnBeforeRequestSentAsync(Action<BeforeRequestSentEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnBeforeRequestSentAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        void OnContextMatch(BeforeRequestSentEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
-        }
+        return networkModule.OnBeforeRequestSentAsync(
+            e => HandleBeforeRequestSent(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseStartedAsync(Func<ResponseStartedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnResponseStartedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(ResponseStartedEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return networkModule.OnResponseStartedAsync(e
+         => HandleResponseStartedAsync(e, handler),
+         ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseStartedAsync(Action<ResponseStartedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnResponseStartedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        void OnContextMatch(ResponseStartedEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
-        }
+        return networkModule.OnResponseStartedAsync(
+            e => HandleResponseStarted(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Func<ResponseCompletedEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnResponseCompletedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(ResponseCompletedEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return networkModule.OnResponseCompletedAsync(
+            e => HandleResponseCompletedAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnResponseCompletedAsync(Action<ResponseCompletedEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnResponseCompletedAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        void OnContextMatch(ResponseCompletedEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
-        }
+        return networkModule.OnResponseCompletedAsync(
+            e => HandleResponseCompleted(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFetchErrorAsync(Func<FetchErrorEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnFetchErrorAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(FetchErrorEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return networkModule.OnFetchErrorAsync(
+            e => HandleFetchErrorAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnFetchErrorAsync(Action<FetchErrorEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnFetchErrorAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        void OnContextMatch(FetchErrorEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
-        }
+        return networkModule.OnFetchErrorAsync(
+            e => HandleFetchError(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Func<AuthRequiredEventArgs, Task> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnAuthRequiredAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
-
-        async Task OnContextMatch(AuthRequiredEventArgs e)
-        {
-            if (context.Equals(e.Context))
-            {
-                await handler(e).ConfigureAwait(false);
-            }
-        }
+        return networkModule.OnAuthRequiredAsync(
+            e => HandleAuthRequiredAsync(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
     }
 
     public Task<Subscription> OnAuthRequiredAsync(Action<AuthRequiredEventArgs> handler, ContextSubscriptionOptions? options = null)
     {
         if (handler is null) throw new ArgumentNullException(nameof(handler));
 
-        return networkModule.OnAuthRequiredAsync(OnContextMatch, ContextSubscriptionOptions.WithContext(options, context));
+        return networkModule.OnAuthRequiredAsync(
+            e => HandleAuthRequired(e, handler),
+            ContextSubscriptionOptions.WithContext(options, context));
+    }
 
-        void OnContextMatch(AuthRequiredEventArgs e)
+    private async Task HandleBeforeRequestSentAsync(BeforeRequestSentEventArgs e, Func<BeforeRequestSentEventArgs, Task> handler)
+    {
+        if (context.Equals(e.Context))
         {
-            if (context.Equals(e.Context))
-            {
-                handler(e);
-            }
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleBeforeRequestSent(BeforeRequestSentEventArgs e, Action<BeforeRequestSentEventArgs> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleResponseStartedAsync(ResponseStartedEventArgs e, Func<ResponseStartedEventArgs, Task> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleResponseStarted(ResponseStartedEventArgs e, Action<ResponseStartedEventArgs> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleResponseCompletedAsync(ResponseCompletedEventArgs e, Func<ResponseCompletedEventArgs, Task> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleResponseCompleted(ResponseCompletedEventArgs e, Action<ResponseCompletedEventArgs> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleFetchErrorAsync(FetchErrorEventArgs e, Func<FetchErrorEventArgs, Task> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleFetchError(FetchErrorEventArgs e, Action<FetchErrorEventArgs> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
+        }
+    }
+
+    private async Task HandleAuthRequiredAsync(AuthRequiredEventArgs e, Func<AuthRequiredEventArgs, Task> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            await handler(e).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleAuthRequired(AuthRequiredEventArgs e, Action<AuthRequiredEventArgs> handler)
+    {
+        if (context.Equals(e.Context))
+        {
+            handler(e);
         }
     }
 }

--- a/dotnet/src/webdriver/BiDi/EventHandler.cs
+++ b/dotnet/src/webdriver/BiDi/EventHandler.cs
@@ -32,7 +32,7 @@ internal abstract class EventHandler(string eventName)
 internal class AsyncEventHandler<TEventArgs>(string eventName, Func<TEventArgs, Task> func)
     : EventHandler(eventName) where TEventArgs : EventArgs
 {
-    private readonly Func<TEventArgs, Task> _func = func;
+    private readonly Func<TEventArgs, Task> _func = func ?? throw new ArgumentNullException(nameof(func));
 
     public override async ValueTask InvokeAsync(EventArgs args)
     {
@@ -43,7 +43,7 @@ internal class AsyncEventHandler<TEventArgs>(string eventName, Func<TEventArgs, 
 internal class SyncEventHandler<TEventArgs>(string eventName, Action<TEventArgs> action)
     : EventHandler(eventName) where TEventArgs : EventArgs
 {
-    private readonly Action<TEventArgs> _action = action;
+    private readonly Action<TEventArgs> _action = action ?? throw new ArgumentNullException(nameof(action));
 
     public override ValueTask InvokeAsync(EventArgs args)
     {

--- a/dotnet/src/webdriver/BiDi/EventHandler.cs
+++ b/dotnet/src/webdriver/BiDi/EventHandler.cs
@@ -32,7 +32,7 @@ internal abstract class EventHandler(string eventName)
 internal class AsyncEventHandler<TEventArgs>(string eventName, Func<TEventArgs, Task> func)
     : EventHandler(eventName) where TEventArgs : EventArgs
 {
-    private readonly Func<TEventArgs, Task> _func = func ?? throw new ArgumentNullException(nameof(func));
+    private readonly Func<TEventArgs, Task> _func = func ?? throw new ArgumentNullException(nameof(func), "Async event handler function cannot be null.");
 
     public override async ValueTask InvokeAsync(EventArgs args)
     {
@@ -43,7 +43,7 @@ internal class AsyncEventHandler<TEventArgs>(string eventName, Func<TEventArgs, 
 internal class SyncEventHandler<TEventArgs>(string eventName, Action<TEventArgs> action)
     : EventHandler(eventName) where TEventArgs : EventArgs
 {
-    private readonly Action<TEventArgs> _action = action ?? throw new ArgumentNullException(nameof(action));
+    private readonly Action<TEventArgs> _action = action ?? throw new ArgumentNullException(nameof(action), "Sync event handler action cannot be null.");
 
     public override ValueTask InvokeAsync(EventArgs args)
     {


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Fail fast with `NullArgumentException` if provided event handler is `null`.

### 🔧 Implementation Notes
Also translated inline lambda expression to private method for better stacktrace.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add null guard checks for event handlers with ArgumentNullException

- Extract inline lambda expressions to private named methods for better stacktraces

- Refactor Broker.SubscribeAsync to consolidate duplicate logic

- Improve code maintainability across BiDi event subscription modules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Handler Methods"] -->|"Add null checks"| B["ArgumentNullException"]
  A -->|"Extract lambdas"| C["Private Named Methods"]
  C -->|"Improve"| D["Stack Traces"]
  E["Broker.SubscribeAsync"] -->|"Consolidate"| F["Single Implementation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Broker.cs</strong><dd><code>Consolidate SubscribeAsync implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Broker.cs

<ul><li>Refactored SubscribeAsync methods to eliminate code duplication<br> <li> Created single private implementation handling both sync and async <br>handlers<br> <li> Removed redundant event registration logic from public overloads<br> <li> Changed public methods from async to sync, delegating to private async <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08b">+9/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContext.cs</strong><dd><code>Extract event handlers to private methods with null guards</code></dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs

<ul><li>Added null guard checks for all event handler parameters<br> <li> Extracted 24 inline lambda expressions to private named methods<br> <li> Improved stack trace clarity for debugging event handler issues<br> <li> Maintained context filtering logic in dedicated handler methods</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-e72b719bd0bbb2a35be2b9acaaff6e7d9ad914658bd3069ac10a90e0f1057e39">+259/-139</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextInputModule.cs</strong><dd><code>Add null guards and extract input module handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextInputModule.cs

<ul><li>Added null guard checks for FileDialogOpened event handlers<br> <li> Extracted inline lambdas to HandleFileDialogOpenedAsync and <br>HandleFileDialogOpened methods<br> <li> Improved error reporting with ArgumentNullException</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-2c553feaa02e7ecc9282581f5507c107d20133e3c1f1104e6ba5d266b0bb756c">+25/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextLogModule.cs</strong><dd><code>Add null guards and extract log module handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextLogModule.cs

<ul><li>Added null guard checks for EntryAdded event handlers<br> <li> Extracted inline lambdas to HandleEntryAddedAsync and HandleEntryAdded <br>methods<br> <li> Simplified subscription options handling with <br>ContextSubscriptionOptions.WithContext</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-e85e9d7658b3ea46968f17bedb59ca0706699d2a1a32603feb76bf6b165b8197">+25/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextNetworkModule.cs</strong><dd><code>Add null guards and extract network module handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs

<ul><li>Added null guard checks for all 8 network event handler methods<br> <li> Extracted 16 inline lambda expressions to private named handler <br>methods<br> <li> Improved code readability and stack trace quality for network events<br> <li> Maintained context filtering in dedicated handler implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-1d8c6478b9d4994a87119245a8ae49fdfe54d287d45087f5acff51e9c04dc3cf">+129/-69</a></td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EventHandler.cs</strong><dd><code>Add null guards to EventHandler constructors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/EventHandler.cs

<ul><li>Added null guard checks in AsyncEventHandler constructor for func <br>parameter<br> <li> Added null guard checks in SyncEventHandler constructor for action <br>parameter<br> <li> Throws ArgumentNullException with descriptive messages for null <br>handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16967/files#diff-a334013e8aa9ccff955dbadd755ce149a7c3b65d6b8bb00d1ae06b5388fe3ee6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

