### PR TITLE
[dotnet] [bidi] Unignore some internal tests

### DIFF
--- a/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
+++ b/dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs
@@ -26,7 +26,6 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 internal class BrowsingContextEventsTest : BiDiTestFixture
 {
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanListenDownloadWillBeginEvent()
     {
         await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });
@@ -42,11 +41,10 @@ internal class BrowsingContextEventsTest : BiDiTestFixture
         Assert.That(eventArgs, Is.Not.Null);
         Assert.That(eventArgs.Context, Is.EqualTo(context));
         Assert.That(eventArgs.Url, Does.EndWith("downloads/file_1.txt"));
-        Assert.That(eventArgs.SuggestedFilename, Is.EqualTo("file_1.txt"));
+        Assert.That(eventArgs.SuggestedFilename, Does.Contain("file_1")); // Avoid incremental prefix
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanListenDownloadEndEvent()
     {
         await context.NavigateAsync(UrlBuilder.WhereIs("downloads/download.html"), new() { Wait = ReadinessState.Complete });

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -24,7 +24,6 @@ namespace OpenQA.Selenium.BiDi.Emulation;
 internal class EmulationTest : BiDiTestFixture
 {
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetTimezoneOverride()
     {
         Assert.That(async () =>
@@ -35,7 +34,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetTimezoneOverrideToDefault()
     {
         Assert.That(async () =>
@@ -46,9 +44,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetUserAgentOverride()
     {
         Assert.That(async () =>
@@ -59,9 +54,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetUserAgentOverrideToDefault()
     {
         Assert.That(async () =>
@@ -118,8 +110,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
     [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetScriptingEnabled()
     {
@@ -131,8 +121,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
     [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetScriptingEnabledToDefault()
     {
@@ -144,7 +132,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetScreenOrientationOverride()
     {
         var orientation = new ScreenOrientation(ScreenOrientationNatural.Portrait, ScreenOrientationType.PortraitPrimary);
@@ -157,7 +144,6 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetScreenOrientationOverrideToDefault()
     {
         Assert.That(async () =>
@@ -170,7 +156,6 @@ internal class EmulationTest : BiDiTestFixture
     [Test]
     [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
     [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetScreenSettingsOverride()
     {
         var screenArea = new ScreenArea(300, 200);

--- a/dotnet/test/common/BiDi/Network/NetworkTest.cs
+++ b/dotnet/test/common/BiDi/Network/NetworkTest.cs
@@ -260,9 +260,6 @@ internal class NetworkTest : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanSetExtraHeaders()
     {
         var result = await bidi.Network.SetExtraHeadersAsync([new Header("x-test-header", "test-value")]);


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Include some tests into regular CI run.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Tests


___

### **Description**
- Remove browser ignore attributes from BiDi tests

- Tests now run on Firefox, Chrome, and Edge

- Update assertion to handle filename variations

- Enable previously skipped test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BiDi Tests<br/>with IgnoreBrowser"] -- "Remove ignore<br/>attributes" --> B["Tests enabled<br/>on all browsers"]
  C["Assertion<br/>exact match"] -- "Update to<br/>flexible match" --> D["Assertion handles<br/>filename variations"]
  B --> E["Expanded test<br/>coverage"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrowsingContextEventsTest.cs</strong><dd><code>Enable Firefox tests with flexible assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/BrowsingContext/BrowsingContextEventsTest.cs

<ul><li>Remove <code>[IgnoreBrowser(Selenium.Browser.Firefox)]</code> attributes from two <br>test methods<br> <li> Update assertion for <code>SuggestedFilename</code> to use <code>Does.Contain()</code> instead <br>of exact equality<br> <li> Allows tests to run on Firefox with flexible filename matching</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16968/files#diff-b3cb443c2ac9387e7845183a2e112c73e864707e2656d2029269970c4f0714a3">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EmulationTest.cs</strong><dd><code>Enable emulation tests on Firefox and other browsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Emulation/EmulationTest.cs

<ul><li>Remove <code>[IgnoreBrowser]</code> attributes from 6 test methods across multiple <br>browsers<br> <li> Tests <code>CanSetTimezoneOverride</code>, <code>CanSetTimezoneOverrideToDefault</code>, <br><code>CanSetUserAgentOverride</code>, <code>CanSetUserAgentOverrideToDefault</code>, <br><code>CanSetScreenOrientationOverride</code>, and <br><code>CanSetScreenOrientationOverrideToDefault</code> now run on all browsers<br> <li> Keep Firefox ignore only for <code>CanSetScriptingEnabled</code> and <br><code>CanSetScriptingEnabledToDefault</code> tests<br> <li> Remove Chrome and Edge ignores from <code>CanSetScreenSettingsOverride</code> test</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16968/files#diff-33ef1ac6efefab8202da67be679d33d4ca9d7e6460fd265468aaddce41026938">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkTest.cs</strong><dd><code>Enable network extra headers test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/BiDi/Network/NetworkTest.cs

<ul><li>Remove <code>[IgnoreBrowser]</code> attributes for Chrome, Edge, and Firefox from <br><code>CanSetExtraHeaders</code> test<br> <li> Enables network extra headers test across all supported browsers</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16968/files#diff-6e4fab225f6b53775948caadd4c88fda1f84c06dc51cc76412ca2a93e07dceb7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

