### PR TITLE
[py] make bazel test target names consistent with other languages

### DIFF
--- a/py/private/suite.bzl
+++ b/py/private/suite.bzl
@@ -8,8 +8,6 @@ def _suite_suffix(name):
     return name[len("test-"):] if name.startswith("test-") else name
 
 def _strip_test_prefixes(path):
-    if path.startswith("test/"):
-        path = path[len("test/"):]
     if path.endswith(".py"):
         path = path[:-len(".py")]
     filename = path.rsplit("/", 1)[-1]

--- a/py/private/suite.bzl
+++ b/py/private/suite.bzl
@@ -14,7 +14,7 @@ def _strip_test_prefixes(path):
     if filename.startswith("test_"):
         path = path[:-len(filename)] + filename[len("test_"):]
     if path.endswith("_tests"):
-        path = path[:-len("_tests")]
+        path = path[:-1]  # Convert _tests to _test
     return path
 
 def py_test_suite(name, srcs, size = None, deps = None, python_version = None, imports = None, visibility = None, **kwargs):

--- a/py/private/suite.bzl
+++ b/py/private/suite.bzl
@@ -13,8 +13,6 @@ def _strip_test_prefixes(path):
     filename = path.rsplit("/", 1)[-1]
     if filename.startswith("test_"):
         path = path[:-len(filename)] + filename[len("test_"):]
-    if path.endswith("_tests"):
-        path = path[:-1]  # Convert _tests to _test
     return path
 
 def py_test_suite(name, srcs, size = None, deps = None, python_version = None, imports = None, visibility = None, **kwargs):

--- a/py/private/suite.bzl
+++ b/py/private/suite.bzl
@@ -4,6 +4,21 @@ load("//py/private:pytest.bzl", "pytest_test")
 def _is_test(file):
     return file.startswith("test_") or file.endswith("_tests.py")
 
+def _suite_suffix(name):
+    return name[len("test-"):] if name.startswith("test-") else name
+
+def _strip_test_prefixes(path):
+    if path.startswith("test/"):
+        path = path[len("test/"):]
+    if path.endswith(".py"):
+        path = path[:-len(".py")]
+    filename = path.rsplit("/", 1)[-1]
+    if filename.startswith("test_"):
+        path = path[:-len(filename)] + filename[len("test_"):]
+    if path.endswith("_tests"):
+        path = path[:-len("_tests")]
+    return path
+
 def py_test_suite(name, srcs, size = None, deps = None, python_version = None, imports = None, visibility = None, **kwargs):
     library_name = "%s-test-lib" % name
 
@@ -19,7 +34,7 @@ def py_test_suite(name, srcs, size = None, deps = None, python_version = None, i
     tests = []
     for src in srcs:
         if _is_test(src):
-            test_name = "%s-%s" % (name, src)
+            test_name = "%s-%s" % (_strip_test_prefixes(src), _suite_suffix(name))
 
             tests.append(test_name)
 


### PR DESCRIPTION
### **User description**
Python is the only language that puts the config pieces before the test name. @cgoldberg / @navin772 any objection to just renaming them so it doesn't make my eyes twitch?

Before:
```
//py:test-firefox-remote-test/selenium/webdriver/support/event_firing_webdriver_tests.py
```
After:
```
//py:test/selenium/webdriver/support/event_firing_webdriver-firefox-remote
```

Eventually we move to more granular build files (colon further to the right), but that's low priority
```
//py/selenium/webdriver/support:event_firing_webdriver-firefox-remote
```

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Reorganizes Python test target naming convention

- Moves config pieces after test name for consistency

- Implements helper functions to strip test prefixes

- Aligns Python naming with other language patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old naming:<br/>test-firefox-remote-test/path"] -->|"_suite_suffix()<br/>_strip_test_prefixes()"| B["New naming:<br/>path-test-firefox-remote"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>suite.bzl</strong><dd><code>Refactor test target naming with helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/private/suite.bzl

<ul><li>Added <code>_suite_suffix()</code> function to extract config suffix from test <br>suite name<br> <li> Added <code>_strip_test_prefixes()</code> function to normalize file paths by <br>removing test prefixes and extensions<br> <li> Modified test name generation to use new helper functions, reversing <br>the order of path and config components<br> <li> Changed from <code>name-src</code> pattern to <code>src-name</code> pattern for consistency with <br>other languages</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16969/files#diff-723411286c42e476a2f1605f4b7bcbd257dabb02aba4882e5345c3d549470076">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

