### PR TITLE
[build] combine pre-release dependency updates

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -131,10 +131,8 @@ jobs:
             run: ./go all:update_cdp ${{ inputs.chrome_channel }}
           - name: manager
             run: ./go update_manager
-          - name: maven
-            run: ./go java:update
-          - name: node
-            run: ./go node:update
+          - name: dependencies
+            run: ./go update_dependencies
           - name: authors
             run: ./go authors
     uses: ./.github/workflows/bazel.yml
@@ -201,8 +199,7 @@ jobs:
           apply_patch browsers "update pinned browser versions"
           apply_patch devtools "update devtools versions"
           apply_patch manager "update selenium manager versions"
-          apply_patch maven "update maven dependency versions"
-          apply_patch node "update node dependency versions"
+          apply_patch dependencies "update dependency versions"
           apply_patch authors "update authors file"
           apply_patch versions "bump versions in preparation for release"
           apply_patch changelogs "changelogs updated"
@@ -223,8 +220,7 @@ jobs:
             | Browser and driver versions | ${{ steps.apply.outputs.browsers == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | CDP version | ${{ steps.apply.outputs.devtools == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Selenium Manager version | ${{ steps.apply.outputs.manager == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Maven dependencies | ${{ steps.apply.outputs.maven == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Node dependencies | ${{ steps.apply.outputs.node == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Update dependencies | ${{ steps.apply.outputs.dependencies == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Update Authors | ${{ steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Bump Versions | ${{ steps.apply.outputs.versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Draft Changelogs | ${{ steps.apply.outputs.changelogs == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -132,7 +132,7 @@ jobs:
           - name: manager
             run: ./go update_manager
           - name: dependencies
-            run: ./go update_dependencies
+            run: ./go release_update
           - name: authors
             run: ./go authors
     uses: ./.github/workflows/bazel.yml

--- a/Rakefile
+++ b/Rakefile
@@ -174,6 +174,21 @@ task :update_manager do |_task, _arguments|
   @git.add('common/selenium_manager.bzl')
 end
 
+# Ruby and Rust are automatically updated as part of version bumps in a separate step
+desc 'Update dependencies for the release'
+task :release_update do |_task, _arguments|
+  Rake::Task[:update_multitool].invoke
+  Rake::Task['java:update'].invoke
+  Rake::Task['node:update'].invoke
+end
+
+desc 'Update multitool binaries to latest releases'
+task :update_multitool do |_task, _arguments|
+  puts 'Updating multitool binary versions'
+  Bazel.execute('run', [], '//scripts:update_multitool_binaries')
+  @git.add('multitool.lock.json')
+end
+
 task all: [
   :'selenium-java',
   '//java/test/org/openqa/selenium/environment:webserver'
@@ -601,6 +616,7 @@ namespace :node do
     args << '--latest' if arguments[:latest] == 'latest'
     args += ['--dir', Dir.pwd]
     Bazel.execute('run', args, '@pnpm//:pnpm')
+    @git.add('javascript/selenium-webdriver/package.json')
     Rake::Task['node:pin'].invoke
   end
 
@@ -1346,6 +1362,8 @@ namespace :rust do
     puts 'pinning cargo versions'
     ENV['CARGO_BAZEL_REPIN'] = 'true'
     Bazel.execute('fetch', [], '@crates//:all')
+    @git.add('rust/Cargo.Bazel.lock')
+    @git.add('rust/Cargo.lock')
   end
 
   desc 'Pin Rust dependencies'

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -33,6 +33,11 @@ py_binary(
     srcs = ["update_copyright.py"],
 )
 
+py_binary(
+    name = "update_multitool_binaries",
+    srcs = ["update_multitool_binaries.py"],
+)
+
 java_binary(
     name = "google-java-format",
     jvm_flags = [


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Combines pre-release dependency updates into a single workflow step and centralizes the update logic in the Rakefile.
 Also ensures the dependency update tasks stage the files they modify (notably Node package.json and Rust lockfiles).

### 🔧 Implementation Notes
- Swapped separate Maven/Node workflow steps for `update_dependencies`, backed by a new `release_update` task.
- Moved multitool updates into a Bazel target for hermeticity.
- Added staging in `node:update` and `rust:update` for the files those tasks actually modify.

### 🔄 Types of changes
- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidates Maven and Node dependency updates into single `update_dependencies` task

- Adds file staging for modified lockfiles and package.json files

- Moves multitool binary updates to dedicated Bazel target for hermeticity

- Simplifies pre-release workflow by reducing separate matrix steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Separate Maven/Node steps"] -->|Consolidate| B["update_dependencies task"]
  B -->|Invokes| C["release_update"]
  C -->|Calls| D["java:update"]
  C -->|Calls| E["node:update"]
  C -->|Calls| F["update_multitool"]
  D -->|Stages| G["Modified files"]
  E -->|Stages| G
  F -->|Stages| G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Consolidate workflow matrix steps for dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Replaces separate <code>maven</code> and <code>node</code> matrix steps with single <code>dependencies</code> <br>step<br> <li> Updates patch application logic to use combined <code>dependencies</code> output <br>variable<br> <li> Simplifies PR body table to show unified dependency update status</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16973/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Add release_update task and file staging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Adds new <code>release_update</code> task that orchestrates Maven, Node, and <br>multitool updates<br> <li> Introduces <code>update_multitool</code> task as dedicated Bazel target for binary <br>updates<br> <li> Adds <code>@git.add()</code> calls to stage modified files in <code>node:update</code> and <br><code>rust:update</code> tasks<br> <li> Stages <code>javascript/selenium-webdriver/package.json</code>, <br><code>rust/Cargo.Bazel.lock</code>, and <code>rust/Cargo.lock</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16973/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

