### PR TITLE
Replace hardcoded bazel-selenium references with dynamic path resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,11 +128,7 @@ rust/target
 rust/.idea
 
 # Bazel stuff
-bazel-bin
-bazel-genfiles
-bazel-out
-bazel-selenium
-bazel-testlogs
+/bazel-*
 MODULE.bazel.lock
 
 /.vscode/

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you want to debug code, you can do it via [`debug`](https://github.com/ruby/d
 3. When debugger starts, run the following in a separate terminal to connect to debugger:
 
 ```shell
-bazel-selenium/external/bundle/bin/rdbg -A
+bazel-bin/external/bundle/bin/rdbg -A
 ```
 
 If you want to use [RubyMine](https://www.jetbrains.com/ruby/) for development,
@@ -279,7 +279,7 @@ you can configure it use Bazel artifacts:
 
 1. Open `rb/` as a main project directory.
 2. From the `selenium` (parent) directory, run `./go rb:local_dev` to create up-to-date artifacts.
-3. In <kbd>Settings / Languages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-selenium/external/rules_ruby++ruby+ruby/dist/bin/ruby`.
+3. In <kbd>Settings / Languages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-bin/external/rules_ruby++ruby+ruby/dist/bin/ruby`.
 4. You should now be able to run and debug any spec. It uses Chrome by default, but you can alter it using environment variables specified in [Ruby Testing](#ruby-2) section below.
 
 ### Rust

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you want to debug code, you can do it via [`debug`](https://github.com/ruby/d
 3. When debugger starts, run the following in a separate terminal to connect to debugger:
 
 ```shell
-bazel-bin/external/bundle/bin/rdbg -A
+bazel-selenium/external/bundle/bin/rdbg -A
 ```
 
 If you want to use [RubyMine](https://www.jetbrains.com/ruby/) for development,
@@ -279,7 +279,7 @@ you can configure it use Bazel artifacts:
 
 1. Open `rb/` as a main project directory.
 2. From the `selenium` (parent) directory, run `./go rb:local_dev` to create up-to-date artifacts.
-3. In <kbd>Settings / Languages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-bin/external/rules_ruby++ruby+ruby/dist/bin/ruby`.
+3. In <kbd>Settings / Languages & Frameworks / Ruby SDK and Gems</kbd> add new <kbd>Interpreter</kbd> pointing to `../bazel-selenium/external/rules_ruby++ruby+ruby/dist/bin/ruby`.
 4. You should now be able to run and debug any spec. It uses Chrome by default, but you can alter it using environment variables specified in [Ruby Testing](#ruby-2) section below.
 
 ### Rust

--- a/dotnet/private/docfx.bzl
+++ b/dotnet/private/docfx.bzl
@@ -35,14 +35,21 @@ def _docfx_impl(ctx):
 _UNIX_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 cd "$BUILD_WORKSPACE_DIRECTORY"
-exec "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/{dotnet}" exec \
-     "$BUILD_WORKSPACE_DIRECTORY/bazel-selenium/{docfx}" {config} "$@"
+# Resolve execution root from bazel-bin symlink (bin -> config -> bazel-out -> exec_root)
+EXEC_ROOT=$(cd "$BUILD_WORKSPACE_DIRECTORY/bazel-bin/../../.." && pwd -P)
+exec "$EXEC_ROOT/{dotnet}" exec \
+     "$EXEC_ROOT/{docfx}" {config} "$@"
 """
 
 _WINDOWS_TEMPLATE = """@echo off
+setlocal
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
-"%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\{dotnet}" exec ^
-    "%BUILD_WORKSPACE_DIRECTORY%\\bazel-selenium\\{docfx}" {config} %*
+rem Resolve execution root from bazel-bin junction (bin -> config -> bazel-out -> exec_root)
+cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin\\..\\..\.."
+set EXEC_ROOT=%CD%
+cd /d "%BUILD_WORKSPACE_DIRECTORY%"
+"%EXEC_ROOT%\\{dotnet}" exec ^
+    "%EXEC_ROOT%\\{docfx}" {config} %*
 """
 
 docfx = rule(

--- a/dotnet/private/docfx.bzl
+++ b/dotnet/private/docfx.bzl
@@ -36,7 +36,7 @@ _UNIX_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 cd "$BUILD_WORKSPACE_DIRECTORY"
 # Resolve execution root from bazel-bin symlink (bin -> config -> bazel-out -> exec_root)
-EXEC_ROOT=$(cd "$BUILD_WORKSPACE_DIRECTORY/bazel-bin/../../.." && pwd -P)
+EXEC_ROOT=$(cd "$BUILD_WORKSPACE_DIRECTORY/bazel-bin" && cd ../../.. && pwd -P)
 exec "$EXEC_ROOT/{dotnet}" exec \
      "$EXEC_ROOT/{docfx}" {config} "$@"
 """
@@ -45,7 +45,8 @@ _WINDOWS_TEMPLATE = """@echo off
 setlocal
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
 rem Resolve execution root from bazel-bin junction (bin -> config -> bazel-out -> exec_root)
-cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin\\..\\..\\.."
+cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin"
+cd ..\\..\\..
 set EXEC_ROOT=%CD%
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
 "%EXEC_ROOT%\\{dotnet}" exec ^

--- a/dotnet/private/docfx.bzl
+++ b/dotnet/private/docfx.bzl
@@ -45,7 +45,7 @@ _WINDOWS_TEMPLATE = """@echo off
 setlocal
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
 rem Resolve execution root from bazel-bin junction (bin -> config -> bazel-out -> exec_root)
-cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin\\..\\..\.."
+cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin\\..\\..\\.."
 set EXEC_ROOT=%CD%
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
 "%EXEC_ROOT%\\{dotnet}" exec ^

--- a/dotnet/private/docfx.bzl
+++ b/dotnet/private/docfx.bzl
@@ -35,8 +35,7 @@ def _docfx_impl(ctx):
 _UNIX_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 cd "$BUILD_WORKSPACE_DIRECTORY"
-# Resolve execution root from bazel-bin symlink (bin -> config -> bazel-out -> exec_root)
-EXEC_ROOT=$(cd "$BUILD_WORKSPACE_DIRECTORY/bazel-bin" && cd ../../.. && pwd -P)
+EXEC_ROOT=$(bazel info execution_root)
 exec "$EXEC_ROOT/{dotnet}" exec \
      "$EXEC_ROOT/{docfx}" {config} "$@"
 """
@@ -44,13 +43,10 @@ exec "$EXEC_ROOT/{dotnet}" exec \
 _WINDOWS_TEMPLATE = """@echo off
 setlocal
 cd /d "%BUILD_WORKSPACE_DIRECTORY%"
-rem Resolve execution root from bazel-bin junction (bin -> config -> bazel-out -> exec_root)
-cd /d "%BUILD_WORKSPACE_DIRECTORY%\\bazel-bin"
-cd ..\\..\\..
-set EXEC_ROOT=%CD%
-cd /d "%BUILD_WORKSPACE_DIRECTORY%"
+for /f "tokens=*" %%i in ('bazel info execution_root') do set "EXEC_ROOT=%%i"
 "%EXEC_ROOT%\\{dotnet}" exec ^
     "%EXEC_ROOT%\\{docfx}" {config} %*
+endlocal
 """
 
 docfx = rule(

--- a/dotnet/update-deps.sh
+++ b/dotnet/update-deps.sh
@@ -3,8 +3,9 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT="$SCRIPT_DIR/.."
 
-if [[ -d "$REPO_ROOT/bazel-selenium/external" ]]; then
-    DOTNET_DIR=$(find "$REPO_ROOT/bazel-selenium/external" -maxdepth 1 -name "rules_dotnet++dotnet+dotnet_*" -type d | head -1)
+EXTERNAL_DIR=$(cd "$REPO_ROOT" && bazel info output_base 2>/dev/null)/external
+if [[ -d "$EXTERNAL_DIR" ]]; then
+    DOTNET_DIR=$(find "$EXTERNAL_DIR" -maxdepth 1 -name "rules_dotnet++dotnet+dotnet_*" -type d 2>/dev/null | head -1)
     if [[ -n "$DOTNET_DIR" && -x "$DOTNET_DIR/dotnet" ]]; then
         DOTNET="$DOTNET_DIR/dotnet"
         echo "Using bazel-managed dotnet: $DOTNET"

--- a/dotnet/update-deps.sh
+++ b/dotnet/update-deps.sh
@@ -3,8 +3,9 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT="$SCRIPT_DIR/.."
 
-EXTERNAL_DIR=$(cd "$REPO_ROOT" && bazel info output_base 2>/dev/null)/external
-if [[ -d "$EXTERNAL_DIR" ]]; then
+OUTPUT_BASE=$(cd "$REPO_ROOT" && bazel info output_base 2>/dev/null)
+if [[ -n "$OUTPUT_BASE" && -d "$OUTPUT_BASE/external" ]]; then
+    EXTERNAL_DIR="$OUTPUT_BASE/external"
     DOTNET_DIR=$(find "$EXTERNAL_DIR" -maxdepth 1 -name "rules_dotnet++dotnet+dotnet_*" -type d 2>/dev/null | head -1)
     if [[ -n "$DOTNET_DIR" && -x "$DOTNET_DIR/dotnet" ]]; then
         DOTNET="$DOTNET_DIR/dotnet"

--- a/dotnet/update-deps.sh
+++ b/dotnet/update-deps.sh
@@ -11,6 +11,8 @@ if [[ -n "$OUTPUT_BASE" && -d "$OUTPUT_BASE/external" ]]; then
         DOTNET="$DOTNET_DIR/dotnet"
         echo "Using bazel-managed dotnet: $DOTNET"
     fi
+else
+    echo "Warning: bazel info output_base failed; falling back to system dotnet" >&2
 fi
 DOTNET="${DOTNET:-dotnet}"
 


### PR DESCRIPTION
### **User description**
### 🔗 Related Issues

None - discovered while working in a git worktree

### 💥 What does this PR do?

Removes hardcoded `bazel-selenium` references that break in git worktrees or differently-named checkouts.

- `.gitignore`: Replace individual `bazel-*` entries with `/bazel-*` glob pattern
- `README.md`: Update Ruby paths to use `bazel-bin/external/...` instead of `bazel-selenium/external/...`
- `dotnet/private/docfx.bzl`: Resolve execution root dynamically via `bazel-bin` symlink
- `dotnet/update-deps.sh`: Use `bazel info output_base` to find external dependencies

### 🔧 Implementation Notes

The `bazel-selenium` symlink name is derived from the workspace name and doesn't exist in worktrees or renamed checkouts. The fixes use stable Bazel paths:

- `bazel-bin` symlink always exists and points to `<exec_root>/bazel-out/<config>/bin`
- `bazel info output_base` returns the correct path regardless of workspace name
- `/bazel-*` in gitignore catches all Bazel convenience symlinks at the repo root

### 💡 Additional Considerations

None

### 🔄 Types of changes

- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace hardcoded `bazel-selenium` references with dynamic path resolution

- Use `bazel-bin` symlink to resolve execution root in docfx scripts

- Use `bazel info output_base` for external dependencies in update-deps.sh

- Update Ruby documentation paths to use `bazel-bin` instead of `bazel-selenium`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded bazel-selenium paths"] -->|docfx.bzl| B["Resolve via bazel-bin symlink"]
  A -->|update-deps.sh| C["Resolve via bazel info output_base"]
  A -->|README.md| D["Update to bazel-bin paths"]
  B --> E["Unix/Windows scripts work in worktrees"]
  C --> F["External deps found correctly"]
  D --> G["Documentation accurate"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docfx.bzl</strong><dd><code>Dynamic execution root resolution for docfx scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/docfx.bzl

<ul><li>Replace hardcoded <code>bazel-selenium</code> paths with dynamic <code>EXEC_ROOT</code> <br>resolution<br> <li> Unix template: resolve execution root by traversing from <code>bazel-bin</code> <br>symlink<br> <li> Windows template: resolve execution root via <code>bazel-bin</code> junction with <br><code>setlocal</code> scope<br> <li> Use resolved <code>EXEC_ROOT</code> for both dotnet and docfx tool paths</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16976/files#diff-f1834764181bf7fe701bc71b1799c97ae36f9faf50078ad87f97aef96097bf43">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-deps.sh</strong><dd><code>Dynamic external dependencies resolution via bazel info</code>&nbsp; &nbsp; </dd></summary>
<hr>

dotnet/update-deps.sh

<ul><li>Replace hardcoded <code>bazel-selenium/external</code> with dynamic <code>bazel info </code><br><code>output_base</code><br> <li> Validate <code>OUTPUT_BASE</code> exists before constructing external directory <br>path<br> <li> Use <code>EXTERNAL_DIR</code> variable for cleaner path construction<br> <li> Add error suppression for <code>bazel info</code> and <code>find</code> commands</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16976/files#diff-b556838ee6ea58b37d10ccd6be0d1d7e00d72262995abbc9a1e64d27f441fda2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Ruby development paths to use bazel-bin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update Ruby debugger path from <code>bazel-selenium/external/bundle/bin/rdbg</code> <br>to <code>bazel-bin/external/bundle/bin/rdbg</code><br> <li> Update RubyMine interpreter path from <br><code>bazel-selenium/external/rules_ruby++ruby+ruby/dist/bin/ruby</code> to <br><code>bazel-bin/external/rules_ruby++ruby+ruby/dist/bin/ruby</code><br> <li> Maintain consistency with dynamic path resolution approach</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16976/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

