### PR TITLE
[build] Remove update_gh_pages in favor of CI workflow

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       name: Generate Docs
       ref: ${{ inputs.tag }}
-      run: ./go ${{ needs.parse.outputs.language }}:docs skip_update
+      run: ./go ${{ needs.parse.outputs.language }}:docs
       artifact-name: documentation
       artifact-path: docs/api/**/*
 

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -79,7 +79,7 @@ jobs:
       ref: ${{ inputs.tag }}
       run: ./go ${{ needs.parse.outputs.language }}:docs
       artifact-name: documentation
-      artifact-path: docs/api/**/*
+      artifact-path: build/docs/api/**/*
 
   commit-docs:
     name: Commit Documentation

--- a/Rakefile
+++ b/Rakefile
@@ -1426,12 +1426,13 @@ namespace :all do
   end
 
   desc 'Build all API Documentation'
-  task :docs do
-    Rake::Task['java:docs'].invoke
-    Rake::Task['py:docs'].invoke
-    Rake::Task['rb:docs'].invoke
-    Rake::Task['dotnet:docs'].invoke
-    Rake::Task['node:docs'].invoke
+  task :docs do |_task, arguments|
+    args = arguments.to_a.compact
+    Rake::Task['java:docs'].invoke(*args)
+    Rake::Task['py:docs'].invoke(*args)
+    Rake::Task['rb:docs'].invoke(*args)
+    Rake::Task['dotnet:docs'].invoke(*args)
+    Rake::Task['node:docs'].invoke(*args)
   end
 
   desc 'Build all artifacts for all language bindings'

--- a/Rakefile
+++ b/Rakefile
@@ -656,8 +656,6 @@ namespace :node do
     puts 'Generating Node documentation'
     FileUtils.rm_rf('build/docs/api/javascript/')
     Bazel.execute('run', [], '//javascript/selenium-webdriver:docs')
-
-    update_gh_pages unless arguments.to_a.include?('skip_update')
   end
 
   desc 'Update JavaScript changelog'
@@ -766,8 +764,6 @@ namespace :py do
 
     FileUtils.mkdir_p('build/docs/api')
     FileUtils.cp_r('bazel-bin/py/docs/_build/html/.', 'build/docs/api/py')
-
-    update_gh_pages unless arguments.to_a.include?('skip_update')
   end
 
   desc 'Install Python wheel locally'
@@ -938,8 +934,6 @@ namespace :rb do
     Bazel.execute('run', [], '//rb:docs')
     FileUtils.mkdir_p('build/docs/api')
     FileUtils.cp_r('bazel-bin/rb/docs.sh.runfiles/_main/docs/api/rb/.', 'build/docs/api/rb')
-
-    update_gh_pages unless arguments.to_a.include?('skip_update')
   end
 
   desc 'Update Ruby changelog'
@@ -1099,8 +1093,6 @@ namespace :dotnet do
     puts 'Generating .NET documentation'
     FileUtils.rm_rf('build/docs/api/dotnet/')
     Bazel.execute('run', [], '//dotnet:docs')
-
-    update_gh_pages unless arguments.to_a.include?('skip_update')
   end
 
   desc 'Update .NET changelog'
@@ -1289,8 +1281,6 @@ namespace :java do
 
     puts 'Generating Java documentation'
     Rake::Task['javadocs'].invoke
-
-    update_gh_pages unless arguments.to_a.include?('skip_update')
   end
 
   desc 'Update Maven dependencies'
@@ -1435,16 +1425,13 @@ namespace :all do
      'Rakefile'].each { |file| @git.add(file) }
   end
 
-  desc 'Update all API Documentation'
-  task :docs do |_task, arguments|
-    args = arguments.to_a
-    Rake::Task['java:docs'].invoke(*(args + ['skip_update']))
-    Rake::Task['py:docs'].invoke(*(args + ['skip_update']))
-    Rake::Task['rb:docs'].invoke(*(args + ['skip_update']))
-    Rake::Task['dotnet:docs'].invoke(*(args + ['skip_update']))
-    Rake::Task['node:docs'].invoke(*(args + ['skip_update']))
-
-    update_gh_pages
+  desc 'Build all API Documentation'
+  task :docs do
+    Rake::Task['java:docs'].invoke
+    Rake::Task['py:docs'].invoke
+    Rake::Task['rb:docs'].invoke
+    Rake::Task['dotnet:docs'].invoke
+    Rake::Task['node:docs'].invoke
   end
 
   desc 'Build all artifacts for all language bindings'
@@ -1588,36 +1575,6 @@ def updated_version(current, desired = nil, nightly = nil)
     # if current version is not nightly, need to bump the version and make nightly
     "#{current.split(/\.|-/).tap { |i| (i[1] = i[1].to_i + 1) && (i[2] = 0) }.join('.')}#{nightly}"
   end
-end
-
-def update_gh_pages(force: true)
-  puts 'Switching to gh-pages branch...'
-  @git.fetch('https://github.com/seleniumhq/selenium.git', {ref: 'gh-pages'})
-
-  unless force
-    puts 'Stash changes that are not docs...'
-    @git.lib.send(:command, 'stash', ['push', '-m', 'stash wip', '--', ':(exclude)build/docs/api/'])
-  end
-
-  @git.checkout('gh-pages', force: force)
-
-  updated = false
-
-  %w[java rb py dotnet javascript].each do |language|
-    source = "build/docs/api/#{language}"
-    destination = "docs/api/#{language}"
-
-    next unless Dir.exist?(source) && !Dir.empty?(source)
-
-    puts "Updating documentation for #{language}..."
-    FileUtils.rm_rf(destination)
-    FileUtils.mv(source, destination)
-
-    @git.add(destination)
-    updated = true
-  end
-
-  puts(updated ? 'Documentation staged. Ready for commit.' : 'No documentation changes found.')
 end
 
 def previous_tag(current_version, language = nil)


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?

Remove the `update_gh_pages` function and all `skip_update` references from Rakefile and CI workflows.

- Remove `update_gh_pages` function from Rakefile
- Remove `skip_update` argument handling from all `*:docs` tasks (java, py, rb, dotnet, node)
- Simplify `all:docs` task to no longer pass `skip_update` arguments
- Update `.github/workflows/update-documentation.yml` to remove `skip_update` from the run command

### 🔧 Implementation Notes

The documentation update workflow should be responsible for branch management and commits in the CI

### 💡 Additional Considerations

More rakefile updates incoming.

### 🔄 Types of changes

- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `update_gh_pages` function from Rakefile

- Remove `skip_update` argument handling from language-specific docs tasks

- Simplify `all:docs` task to invoke language tasks without skip_update

- Update CI workflow to remove skip_update from documentation generation command


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rakefile docs tasks"] -->|"remove skip_update args"| B["Simplified task invocation"]
  C["update_gh_pages function"] -->|"deleted"| D["CI workflow responsibility"]
  E["GitHub Actions workflow"] -->|"remove skip_update param"| F["Cleaner command execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-documentation.yml</strong><dd><code>Remove skip_update from workflow command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-documentation.yml

<ul><li>Remove <code>skip_update</code> argument from the documentation generation command<br> <li> Simplify the run command to only pass language and docs task</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16977/files#diff-762373f28dabfb9bf0baf6a4fb9d5ca47a3ff3a5c16c908e74b52d2eb81ddbc9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Remove update_gh_pages and skip_update handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Delete <code>update_gh_pages</code> function entirely (48 lines removed)<br> <li> Remove <code>skip_update</code> conditional logic from all language-specific docs <br>tasks (java, py, rb, dotnet, node)<br> <li> Simplify <code>all:docs</code> task to invoke language tasks without skip_update <br>arguments<br> <li> Update <code>all:docs</code> task description from "Update" to "Build"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16977/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+7/-50</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

