### PR TITLE
[dotnet] [bidi] Fix namespace for Permissions module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Permissions/PermissionsBiDiExtensions.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/PermissionsBiDiExtensions.cs
@@ -17,7 +17,6 @@
 // under the License.
 // </copyright>
 
-using OpenQA.Selenium.BiDi.Extensions.Permissions;
 using System;
 
 namespace OpenQA.Selenium.BiDi.Permissions;

--- a/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
@@ -28,9 +28,9 @@ public sealed class PermissionsModule : Module
 {
     private PermissionsJsonSerializerContext _jsonContext = null!;
 
-    public async Task<SetPermissionResult> SetPermissionAsync(PermissionDescriptor desriptor, PermissionState state, string origin, SetPermissionOptions? options = null)
+    public async Task<SetPermissionResult> SetPermissionAsync(PermissionDescriptor descriptor, PermissionState state, string origin, SetPermissionOptions? options = null)
     {
-        var @params = new SetPermissionCommandParameters(desriptor, state, origin, options?.EmbeddedOrigin, options?.UserContext);
+        var @params = new SetPermissionCommandParameters(descriptor, state, origin, options?.EmbeddedOrigin, options?.UserContext);
 
         return await Broker.ExecuteCommandAsync(new SetPermissionCommand(@params), options, _jsonContext.SetPermissionCommand, _jsonContext.SetPermissionResult).ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
@@ -18,14 +18,13 @@
 // </copyright>
 
 using OpenQA.Selenium.BiDi.Json.Converters;
-using OpenQA.Selenium.BiDi.Permissions;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
-namespace OpenQA.Selenium.BiDi.Extensions.Permissions;
+namespace OpenQA.Selenium.BiDi.Permissions;
 
-public class PermissionsModule : Module
+public sealed class PermissionsModule : Module
 {
     private PermissionsJsonSerializerContext _jsonContext = null!;
 


### PR DESCRIPTION
### **User description**
This pull request makes minor changes to the `Permissions` module in the .NET WebDriver BiDi implementation, primarily focusing on namespace corrections and class declaration improvements.

### 💥 What does this PR do?
- **Namespace corrections:**
  - Changed the namespace of `PermissionsModule` from `OpenQA.Selenium.BiDi.Extensions.Permissions` to `OpenQA.Selenium.BiDi.Permissions` for consistency.
  - Removed an unnecessary `using` directive for `OpenQA.Selenium.BiDi.Extensions.Permissions` in `PermissionsBiDiExtensions.cs`.

- **Class declaration improvement:**
  - Made the `PermissionsModule` class `sealed` to prevent inheritance, clarifying its intended usage.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix namespace for `PermissionsModule` from `Extensions.Permissions` to `Permissions`

- Remove unnecessary `using` directive for old namespace

- Make `PermissionsModule` class `sealed` to prevent inheritance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PermissionsModule<br/>Old namespace"] -- "namespace correction" --> B["PermissionsModule<br/>New namespace"]
  C["using directive<br/>Extensions.Permissions"] -- "removed" --> D["Clean imports"]
  E["public class<br/>PermissionsModule"] -- "sealed" --> F["sealed class<br/>PermissionsModule"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PermissionsBiDiExtensions.cs</strong><dd><code>Remove outdated namespace import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Permissions/PermissionsBiDiExtensions.cs

<ul><li>Removed unnecessary <code>using OpenQA.Selenium.BiDi.Extensions.Permissions</code> <br>directive<br> <li> Namespace declaration remains <code>OpenQA.Selenium.BiDi.Permissions</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16981/files#diff-2dee4d90d7550998e84f156be716862c3a8cb8bfc0db608250330858d3eb1480">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PermissionsModule.cs</strong><dd><code>Fix namespace and seal PermissionsModule class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs

<ul><li>Changed namespace from <code>OpenQA.Selenium.BiDi.Extensions.Permissions</code> to <br><code>OpenQA.Selenium.BiDi.Permissions</code><br> <li> Removed self-referential <code>using OpenQA.Selenium.BiDi.Permissions</code> <br>directive<br> <li> Made <code>PermissionsModule</code> class <code>sealed</code> to prevent inheritance</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16981/files#diff-43bc55f28e2b5839633f82c5443a3eb5650a6748059a91c624a6c4538570f508">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

