### PR TITLE
[dotnet] [bidi] Refactor BiDi module initialization to pass BiDi explicitly

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
@@ -79,9 +79,9 @@ public sealed class BrowserModule : Module
         return await Broker.ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new BrowserJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
@@ -253,12 +253,12 @@ public sealed class BrowsingContextModule : Module
         return await Broker.SubscribeAsync("browsingContext.userPromptClosed", handler, options, _jsonContext.UserPromptClosedEventArgs).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new InternalIdConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new HandleConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new InternalIdConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new BrowsingContextJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -35,7 +35,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
 
         var interceptResult = await networkModule.AddInterceptAsync([InterceptPhase.BeforeRequestSent], addInterceptOptions).ConfigureAwait(false);
 
-        Interception interception = new(context.BiDi, interceptResult.Intercept);
+        Interception interception = new(networkModule, interceptResult.Intercept);
 
         await interception.OnBeforeRequestSentAsync(
             async req => await handler(new(req.BiDi, req.Context, req.IsBlocked, req.Navigation, req.RedirectCount, req.Request, req.Timestamp, req.Initiator, req.Intercepts)),
@@ -53,7 +53,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
 
         var interceptResult = await networkModule.AddInterceptAsync([InterceptPhase.ResponseStarted], addInterceptOptions).ConfigureAwait(false);
 
-        Interception interception = new(context.BiDi, interceptResult.Intercept);
+        Interception interception = new(networkModule, interceptResult.Intercept);
 
         await interception.OnResponseStartedAsync(
             async res => await handler(new(res.BiDi, res.Context, res.IsBlocked, res.Navigation, res.RedirectCount, res.Request, res.Timestamp, res.Response, res.Intercepts)),
@@ -71,7 +71,7 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
 
         var interceptResult = await networkModule.AddInterceptAsync([InterceptPhase.AuthRequired], addInterceptOptions).ConfigureAwait(false);
 
-        Interception interception = new(context.BiDi, interceptResult.Intercept);
+        Interception interception = new(networkModule, interceptResult.Intercept);
 
         await interception.OnAuthRequiredAsync(
             async auth => await handler(new(auth.BiDi, auth.Context, auth.IsBlocked, auth.Navigation, auth.RedirectCount, auth.Request, auth.Timestamp, auth.Response, auth.Intercepts)),

--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -100,10 +100,10 @@ public sealed class EmulationModule : Module
         return await Broker.ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new EmulationJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Input/InputModule.cs
+++ b/dotnet/src/webdriver/BiDi/Input/InputModule.cs
@@ -61,10 +61,10 @@ public sealed class InputModule : Module
         return await Broker.SubscribeAsync("input.fileDialogOpened", handler, options, _jsonContext.FileDialogInfo).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new HandleConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));
 
         _jsonContext = new InputJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Log/LogModule.cs
+++ b/dotnet/src/webdriver/BiDi/Log/LogModule.cs
@@ -39,12 +39,12 @@ public sealed class LogModule : Module
         return await Broker.SubscribeAsync("log.entryAdded", handler, options, _jsonContext.LogEntry).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new RealmConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new InternalIdConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new HandleConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new RealmConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new InternalIdConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));
 
         _jsonContext = new LogJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Module.cs
+++ b/dotnet/src/webdriver/BiDi/Module.cs
@@ -23,22 +23,19 @@ namespace OpenQA.Selenium.BiDi;
 
 public abstract class Module
 {
-    protected BiDi BiDi { get; private set; } = null!;
-
     protected Broker Broker { get; private set; } = null!;
 
-    protected abstract void Initialize(JsonSerializerOptions jsonSerializerOptions);
+    protected abstract void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions);
 
     internal static TModule Create<TModule>(BiDi bidi, Broker broker, JsonSerializerOptions jsonSerializerOptions)
         where TModule : Module, new()
     {
         TModule module = new()
         {
-            BiDi = bidi,
             Broker = broker
         };
 
-        module.Initialize(jsonSerializerOptions);
+        module.Initialize(bidi, jsonSerializerOptions);
 
         return module;
     }

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
@@ -30,7 +30,7 @@ public partial class NetworkModule
     {
         var interceptResult = await AddInterceptAsync([InterceptPhase.BeforeRequestSent], options).ConfigureAwait(false);
 
-        Interception interception = new(BiDi, interceptResult.Intercept);
+        Interception interception = new(this, interceptResult.Intercept);
 
         await interception.OnBeforeRequestSentAsync(async req => await handler(new(req.BiDi, req.Context, req.IsBlocked, req.Navigation, req.RedirectCount, req.Request, req.Timestamp, req.Initiator, req.Intercepts))).ConfigureAwait(false);
 
@@ -41,7 +41,7 @@ public partial class NetworkModule
     {
         var interceptResult = await AddInterceptAsync([InterceptPhase.ResponseStarted], options).ConfigureAwait(false);
 
-        Interception interception = new(BiDi, interceptResult.Intercept);
+        Interception interception = new(this, interceptResult.Intercept);
 
         await interception.OnResponseStartedAsync(async res => await handler(new(res.BiDi, res.Context, res.IsBlocked, res.Navigation, res.RedirectCount, res.Request, res.Timestamp, res.Response, res.Intercepts))).ConfigureAwait(false);
 
@@ -52,7 +52,7 @@ public partial class NetworkModule
     {
         var interceptResult = await AddInterceptAsync([InterceptPhase.AuthRequired], options).ConfigureAwait(false);
 
-        Interception interception = new(BiDi, interceptResult.Intercept);
+        Interception interception = new(this, interceptResult.Intercept);
 
         await interception.OnAuthRequiredAsync(async auth => await handler(new(auth.BiDi, auth.Context, auth.IsBlocked, auth.Navigation, auth.RedirectCount, auth.Request, auth.Timestamp, auth.Response, auth.Intercepts))).ConfigureAwait(false);
 
@@ -128,7 +128,7 @@ public sealed record InterceptedAuth : AuthRequiredEventArgs
     }
 }
 
-public sealed record Interception(BiDi BiDi, Intercept Intercept) : IAsyncDisposable
+public sealed record Interception(NetworkModule Network, Intercept Intercept) : IAsyncDisposable
 {
     IList<Subscription> OnBeforeRequestSentSubscriptions { get; } = [];
     IList<Subscription> OnResponseStartedSubscriptions { get; } = [];
@@ -136,7 +136,7 @@ public sealed record Interception(BiDi BiDi, Intercept Intercept) : IAsyncDispos
 
     public async Task RemoveAsync()
     {
-        await BiDi.Network.RemoveInterceptAsync(Intercept).ConfigureAwait(false);
+        await Network.RemoveInterceptAsync(Intercept).ConfigureAwait(false);
 
         foreach (var subscription in OnBeforeRequestSentSubscriptions)
         {
@@ -156,21 +156,21 @@ public sealed record Interception(BiDi BiDi, Intercept Intercept) : IAsyncDispos
 
     public async Task OnBeforeRequestSentAsync(Func<BeforeRequestSentEventArgs, Task> handler, SubscriptionOptions? options = null)
     {
-        var subscription = await BiDi.Network.OnBeforeRequestSentAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
+        var subscription = await Network.OnBeforeRequestSentAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
 
         OnBeforeRequestSentSubscriptions.Add(subscription);
     }
 
     public async Task OnResponseStartedAsync(Func<ResponseStartedEventArgs, Task> handler, SubscriptionOptions? options = null)
     {
-        var subscription = await BiDi.Network.OnResponseStartedAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
+        var subscription = await Network.OnResponseStartedAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
 
         OnResponseStartedSubscriptions.Add(subscription);
     }
 
     public async Task OnAuthRequiredAsync(Func<AuthRequiredEventArgs, Task> handler, SubscriptionOptions? options = null)
     {
-        var subscription = await BiDi.Network.OnAuthRequiredAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
+        var subscription = await Network.OnAuthRequiredAsync(async args => await Filter(args, handler), options).ConfigureAwait(false);
 
         OnAuthRequiredSubscriptions.Add(subscription);
     }

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
@@ -174,12 +174,12 @@ public sealed partial class NetworkModule : Module
         return await Broker.SubscribeAsync("network.authRequired", handler, options, _jsonContext.AuthRequiredEventArgs).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new CollectorConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new InterceptConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new CollectorConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new InterceptConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new NetworkJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
@@ -36,9 +36,9 @@ public class PermissionsModule : Module
         return await Broker.ExecuteCommandAsync(new SetPermissionCommand(@params), options, _jsonContext.SetPermissionCommand, _jsonContext.SetPermissionResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new PermissionsJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
@@ -117,13 +117,13 @@ public sealed class ScriptModule : Module
         return await Broker.SubscribeAsync("script.realmDestroyed", handler, options, _jsonContext.RealmDestroyedEventArgs).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new PreloadScriptConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new RealmConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new InternalIdConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new HandleConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new PreloadScriptConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new RealmConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new InternalIdConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));
 
         _jsonContext = new ScriptJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
@@ -60,10 +60,10 @@ internal sealed class SessionModule : Module
         return await Broker.ExecuteCommandAsync(new EndCommand(), options, _jsonContext.EndCommand, _jsonContext.EndResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new SessionJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/Storage/StorageModule.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/StorageModule.cs
@@ -49,10 +49,10 @@ public sealed class StorageModule : Module
         return await Broker.ExecuteCommandAsync(new SetCookieCommand(@params), options, _jsonContext.SetCookieCommand, _jsonContext.SetCookieResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(BiDi));
-        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
 
         _jsonContext = new StorageJsonSerializerContext(jsonSerializerOptions);
     }

--- a/dotnet/src/webdriver/BiDi/WebExtension/WebExtensionModule.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/WebExtensionModule.cs
@@ -42,9 +42,9 @@ public sealed class WebExtensionModule : Module
         return await Broker.ExecuteCommandAsync(new UninstallCommand(@params), options, _jsonContext.UninstallCommand, _jsonContext.UninstallResult).ConfigureAwait(false);
     }
 
-    protected override void Initialize(JsonSerializerOptions jsonSerializerOptions)
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
-        jsonSerializerOptions.Converters.Add(new WebExtensionConverter(BiDi));
+        jsonSerializerOptions.Converters.Add(new WebExtensionConverter(bidi));
 
         _jsonContext = new WebExtensionJsonSerializerContext(jsonSerializerOptions);
     }


### PR DESCRIPTION
The primary focus is to consistently pass the required dependencies explicitly. It allows keeping a reference to BiDi object only when required.

### 💥 What does this PR do?
Now modules should implement `Initialize(BiDi, JsonSerializerOptions)`.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)
