### PR TITLE
[build] Skip macOS-only archive rules on unsupported platforms

### DIFF
--- a/common/private/dmg_archive.bzl
+++ b/common/private/dmg_archive.bzl
@@ -1,8 +1,8 @@
 def _dmg_archive_impl(repository_ctx):
-    hdiutil = repository_ctx.which("hdiutil")
-    if not hdiutil:
-        # Create BUILD with expected targets so queries succeed; builds will fail with missing files
-        repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+    repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+
+    if not repository_ctx.which("hdiutil"):
+        # hdiutil is macOS-only; skip download on other platforms
         return
 
     url = repository_ctx.attr.url
@@ -31,11 +31,6 @@ def _dmg_archive_impl(repository_ctx):
         archive = zip_name,
         stripPrefix = repository_ctx.attr.strip_prefix,
         output = repository_ctx.attr.output,
-    )
-
-    repository_ctx.file(
-        "BUILD.bazel",
-        repository_ctx.attr.build_file_content,
     )
 
 dmg_archive = repository_rule(

--- a/common/private/dmg_archive.bzl
+++ b/common/private/dmg_archive.bzl
@@ -1,4 +1,10 @@
 def _dmg_archive_impl(repository_ctx):
+    hdiutil = repository_ctx.which("hdiutil")
+    if not hdiutil:
+        # Create BUILD with expected targets so queries succeed; builds will fail with missing files
+        repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+        return
+
     url = repository_ctx.attr.url
     (ignored, ignored, dmg_name) = url.rpartition("/")
     dmg_name = dmg_name.replace("%20", "_")

--- a/common/private/pkg_archive.bzl
+++ b/common/private/pkg_archive.bzl
@@ -1,8 +1,8 @@
 def _pkg_archive_impl(repository_ctx):
-    pkgutil = repository_ctx.which("pkgutil")
-    if not pkgutil:
-        # Create BUILD with expected targets so queries succeed; builds will fail with missing files
-        repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+    repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+
+    if not repository_ctx.which("pkgutil"):
+        # pkgutil is macOS-only; skip download on other platforms
         return
 
     url = repository_ctx.attr.url
@@ -32,8 +32,6 @@ def _pkg_archive_impl(repository_ctx):
 
     for (key, value) in repository_ctx.attr.move.items():
         repository_ctx.execute(["mv", pkg_name + "/" + key, value])
-
-    repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
 
 pkg_archive = repository_rule(
     _pkg_archive_impl,

--- a/common/private/pkg_archive.bzl
+++ b/common/private/pkg_archive.bzl
@@ -1,4 +1,10 @@
 def _pkg_archive_impl(repository_ctx):
+    pkgutil = repository_ctx.which("pkgutil")
+    if not pkgutil:
+        # Create BUILD with expected targets so queries succeed; builds will fail with missing files
+        repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+        return
+
     url = repository_ctx.attr.url
     (ignored, ignored, pkg_name) = url.rpartition("/")
     idx = pkg_name.find("?")

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -50,8 +50,8 @@ js_library(
 
     http_archive(
         name = "linux_beta_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/148.0b5/linux-x86_64/en-US/firefox-148.0b5.tar.xz",
-        sha256 = "1fdfc9f8745312ff02cca569dee7950e26733613605ffc11b630585a7fd638cc",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/148.0b6/linux-x86_64/en-US/firefox-148.0b6.tar.xz",
+        sha256 = "f49b2bca17d36bd2fdd277d81a4b5f5e3cf4f034fb18622f658fb5090d4de62b",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -72,8 +72,8 @@ js_library(
 
     dmg_archive(
         name = "mac_beta_firefox",
-        url = "https://ftp.mozilla.org/pub/firefox/releases/148.0b5/mac/en-US/Firefox%20148.0b5.dmg",
-        sha256 = "d2527e345b78acba3ded68a09031f957e3ff1173a8c872a409074d1dc4e034e1",
+        url = "https://ftp.mozilla.org/pub/firefox/releases/148.0b6/mac/en-US/Firefox%20148.0b6.dmg",
+        sha256 = "7f79d044c1b0eb8894e28c0043d3152a102a6f1121a53ff8f5f80478ab6d94fe",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -123,10 +123,10 @@ js_library(
 
     pkg_archive(
         name = "mac_edge",
-        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/4f2967c0-d097-4ac0-92b7-15af707ac2ac/MicrosoftEdge-144.0.3719.82.pkg",
-        sha256 = "b09345f33d65c3b4a81ae3001fc3d9bc529b11b39c0e2e0f6571c086b28208c7",
+        url = "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/4decc3c7-748d-42a6-be1d-9f976831cf72/MicrosoftEdge-144.0.3719.92.pkg",
+        sha256 = "a28f7d0d27e163fdd23755dadb5870d6a1c87183f2185d25e618365afd1e3940",
         move = {
-            "MicrosoftEdge-144.0.3719.82.pkg/Payload/Microsoft Edge.app": "Edge.app",
+            "MicrosoftEdge-144.0.3719.92.pkg/Payload/Microsoft Edge.app": "Edge.app",
         },
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -143,8 +143,8 @@ js_library(
 
     deb_archive(
         name = "linux_edge",
-        url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_144.0.3719.82-1_amd64.deb",
-        sha256 = "5bbc13fb568d17b66e8583d0d9502f56027ee465aca291270ccf4585da710488",
+        url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_144.0.3719.92-1_amd64.deb",
+        sha256 = "7e2d6f408734ebd1d2eedfe917e6c2fd005bc996e942f820532b7da63299501a",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -165,8 +165,8 @@ js_library(
 
     http_archive(
         name = "linux_edgedriver",
-        url = "https://msedgedriver.microsoft.com/144.0.3719.82/edgedriver_linux64.zip",
-        sha256 = "2406cd14224e77e709ed4b704e4510980577e53a25956fec4a558cb8a4b43671",
+        url = "https://msedgedriver.microsoft.com/144.0.3719.92/edgedriver_linux64.zip",
+        sha256 = "4f1bcca134b2c246ec72250ff50257a8cdca1c575fbd64e595bcd1c558788728",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
@@ -182,8 +182,8 @@ js_library(
 
     http_archive(
         name = "mac_edgedriver",
-        url = "https://msedgedriver.microsoft.com/144.0.3719.82/edgedriver_mac64_m1.zip",
-        sha256 = "76ab16cdff3ceea7e30add9f183948cda068dfd3b05d3a6e26e667ffcef54c7b",
+        url = "https://msedgedriver.microsoft.com/144.0.3719.92/edgedriver_mac64_m1.zip",
+        sha256 = "ddc62f83e3462a5d69b627b686d6c03e77db8ad7e6cc5d3f8dfbc431a6438d65",
         build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])

--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -43,7 +43,7 @@ exports_files(["Firefox.app"])
 
 js_library(
     name = "firefox-js",
-    data = glob(["Firefox.app/**/*"]),
+    data = glob(["Firefox.app/**/*"], allow_empty = True),
 )
 """,
     )
@@ -82,7 +82,7 @@ exports_files(["Firefox.app"])
 
 js_library(
     name = "firefox-js",
-    data = glob(["Firefox.app/**/*"]),
+    data = glob(["Firefox.app/**/*"], allow_empty = True),
 )
 """,
     )
@@ -136,7 +136,7 @@ exports_files(["Edge.app"])
 
 js_library(
     name = "edge-js",
-    data = glob(["Edge.app/**/*"]),
+    data = glob(["Edge.app/**/*"], allow_empty = True),
 )
 """,
     )

--- a/scripts/pinned_browsers.py
+++ b/scripts/pinned_browsers.py
@@ -285,7 +285,7 @@ exports_files(["Edge.app"])
 
 js_library(
     name = "edge-js",
-    data = glob(["Edge.app/**/*"]),
+    data = glob(["Edge.app/**/*"], allow_empty = True),
 )
 \"\"\",
     )
@@ -509,7 +509,7 @@ exports_files(["Firefox.app"])
 
 js_library(
     name = "firefox-js",
-    data = glob(["Firefox.app/**/*"]),
+    data = glob(["Firefox.app/**/*"], allow_empty = True),
 )
 \"\"\",
     )


### PR DESCRIPTION
### **User description**
When running bazel query deps(//some:test) on Linux CI, the query tries to resolve all dependencies, including browsers for non-applicable OS.

This error:
```
Evaluation of query "deps(//dotnet/test/common:AlertsTest-edge)" failed: preloading transitive closure failed: no such target '@@+pin_browsers_extension+mac_edge//:Edge.app': target 'Edge.app' not declared in package '' defined by /home/runner/.bazel/external/+pin_browsers_extension+mac_edge/BUILD.bazel
```

This is coming from pkg_archive and dmg_archive rules which attempt to execute `pkgutil` and `hdiutil` respectively, neither of which are available on Linux.


### 💥 What does this PR do?
* Exits the pkg_archive and dmg_archive implementation before the unavailable command executes
* Set the file in that rule so it doesn't error
* Let js_library know that the data can be empty if it doesn't apply

### 🔧 Implementation Notes
Verified this fixes my issue: https://github.com/SeleniumHQ/selenium/actions/runs/21306668754/job/61335755897#step:19:30

### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Skip macOS-only archive rules when required tools unavailable

- Check for `hdiutil` and `pkgutil` before execution

- Create empty BUILD file and return early on unsupported platforms

- Prevents bazel query failures on Linux/Windows CI environments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repository Rule Execution"] --> B{"Tool Available?"}
  B -->|Yes| C["Download & Extract Archive"]
  B -->|No| D["Create Empty BUILD.bazel"]
  D --> E["Return Early"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dmg_archive.bzl</strong><dd><code>Add hdiutil availability check to dmg_archive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/private/dmg_archive.bzl

<ul><li>Added check for <code>hdiutil</code> availability using <code>repository_ctx.which()</code><br> <li> Creates empty BUILD.bazel file with skip comment if tool not found<br> <li> Returns early to prevent execution on unsupported platforms</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16985/files#diff-8f3c4ac9e72d574b928a56cce6bd058d37c9e4ba052e3e23a77ed67e748ee797">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg_archive.bzl</strong><dd><code>Add pkgutil availability check to pkg_archive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/private/pkg_archive.bzl

<ul><li>Added check for <code>pkgutil</code> availability using <code>repository_ctx.which()</code><br> <li> Creates empty BUILD.bazel file with skip comment if tool not found<br> <li> Returns early to prevent execution on unsupported platforms</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16985/files#diff-7795ce290614a59395636d453b76605e3f6a3d54cebe584c365b22becbfd746f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

