### PR TITLE
[build] Support per-language patch releases

### DIFF
--- a/.github/workflows/parse-release-tag.yml
+++ b/.github/workflows/parse-release-tag.yml
@@ -1,0 +1,77 @@
+name: Parse Release Tag
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., selenium-4.28.0 or selenium-4.28.1-ruby)'
+        required: true
+        type: string
+    outputs:
+      tag:
+        description: 'The validated tag'
+        value: ${{ jobs.parse.outputs.tag }}
+      version:
+        description: 'The version number (e.g., 4.28.0)'
+        value: ${{ jobs.parse.outputs.version }}
+      language:
+        description: 'The language (ruby, python, etc.) or "all" for full releases'
+        value: ${{ jobs.parse.outputs.language }}
+
+permissions: {}
+
+jobs:
+  parse:
+    name: Parse Tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.parse.outputs.tag }}
+      version: ${{ steps.parse.outputs.version }}
+      language: ${{ steps.parse.outputs.language }}
+    steps:
+      - name: Parse and validate tag
+        id: parse
+        shell: bash
+        run: |
+          TAG="${{ inputs.tag }}"
+          TAG="${TAG//[[:space:]]/}"
+
+          # Validate tag format: selenium-X.Y.Z or selenium-X.Y.Z-lang
+          if [[ ! "$TAG" =~ ^selenium-[0-9]+\.[0-9]+\.[0-9]+(-(ruby|python|javascript|java|dotnet))?$ ]]; then
+            echo "::error::Invalid tag format: '$TAG'. Expected selenium-X.Y.Z or selenium-X.Y.Z-lang (ruby, python, javascript, java, dotnet)"
+            exit 1
+          fi
+
+          # Extract version
+          VERSION=$(echo "$TAG" | sed -E 's/^selenium-([0-9]+\.[0-9]+\.[0-9]+)(-(ruby|python|javascript|java|dotnet))?$/\1/')
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # Extract language suffix
+          if [[ "$TAG" =~ -(ruby|python|javascript|java|dotnet)$ ]]; then
+            LANG_SUFFIX="${BASH_REMATCH[1]}"
+          else
+            LANG_SUFFIX=""
+          fi
+
+          # Patch releases must have a language suffix
+          if [[ "$PATCH" -gt 0 && -z "$LANG_SUFFIX" ]]; then
+            echo "::error::Patch releases must specify a language (e.g., selenium-${VERSION}-ruby)"
+            exit 1
+          fi
+
+          # Full releases must not have a language suffix
+          if [[ "$PATCH" -eq 0 && -n "$LANG_SUFFIX" ]]; then
+            echo "::error::Full releases (X.Y.0) cannot have a language suffix"
+            exit 1
+          fi
+
+          # Set language (already validated by regex above)
+          if [[ -n "$LANG_SUFFIX" ]]; then
+            LANGUAGE="$LANG_SUFFIX"
+          else
+            LANGUAGE="all"
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "language=$LANGUAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/parse-release-tag.yml
+++ b/.github/workflows/parse-release-tag.yml
@@ -72,6 +72,8 @@ jobs:
             LANGUAGE="all"
           fi
 
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "language=$LANGUAGE" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "language=$LANGUAGE"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,8 +3,8 @@ name: Release Preparation
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Selenium version to release'
+      tag:
+        description: 'Release tag (e.g., selenium-4.28.0 or selenium-4.28.1-ruby)'
         required: true
       chrome_channel:
         description: 'Chrome Channel for CDP'
@@ -25,24 +25,33 @@ jobs:
     with:
       title: Release approval needed
       message: |
-        Selenium ${{ github.event.inputs.version }} release preparation started.
+        Selenium ${{ github.event.inputs.tag }} release preparation started.
         Please approve to lock trunk when ready.
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  parse-tag:
+    name: Parse Tag
+    uses: ./.github/workflows/parse-release-tag.yml
+    with:
+      tag: ${{ inputs.tag }}
+
   # Run rust jobs in parallel with approval since work is not on trunk
+  # Skip for patch releases (language != 'all')
   generate-rust-version:
     name: Generate Rust Version
-    if: github.event.repository.fork == false
+    needs: parse-tag
+    if: github.event.repository.fork == false && needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update Rust Version
-      run: ./go rust:version ${{ inputs.version }}
+      run: ./go rust:version ${{ needs.parse-tag.outputs.version }}
       artifact-name: rust-version
 
   push-rust-version:
     name: Push Rust Version
-    needs: generate-rust-version
+    needs: [parse-tag, generate-rust-version]
+    if: needs.parse-tag.outputs.language == 'all'
     permissions:
       contents: write
       actions: read
@@ -50,23 +59,25 @@ jobs:
     with:
       artifact-name: rust-version
       commit-message: "update selenium manager version and rust changelog"
-      push-branch: rust-release-${{ inputs.version }}
+      push-branch: rust-release-${{ needs.parse-tag.outputs.version }}
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
   selenium-manager:
     name: Release Selenium Manager
-    needs: push-rust-version
+    needs: [parse-tag, push-rust-version]
+    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/ci-rust.yml
     with:
       release: true
-      branch: rust-release-${{ inputs.version }}
+      branch: rust-release-${{ needs.parse-tag.outputs.version }}
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
   cleanup-rust-branch:
     name: Cleanup Rust Branch
-    needs: selenium-manager
+    needs: [parse-tag, selenium-manager]
+    if: needs.parse-tag.outputs.language == 'all'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -75,39 +86,22 @@ jobs:
           token: ${{ secrets.SELENIUM_CI_TOKEN }}
       - name: Delete rust release branch
         run: |
-          git push origin --delete rust-release-${{ inputs.version }}
+          git push origin --delete rust-release-${{ needs.parse-tag.outputs.version }}
 
   restrict-trunk:
     name: Restrict Trunk Branch
-    needs: [get-approval, selenium-manager]
+    needs: [parse-tag, get-approval, selenium-manager]
+    if: always() && !cancelled() && needs.get-approval.result == 'success' && (needs.selenium-manager.result == 'success' || needs.selenium-manager.result == 'skipped')
     uses: ./.github/workflows/restrict-trunk.yml
     with:
       restrict: true
     secrets: inherit
 
-  normalize-version:
-    name: Normalize Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.value }}
-    steps:
-      - name: Normalize version
-        id: version
-        shell: bash
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          VERSION="${VERSION//[[:space:]]/}"
-          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            VERSION="${VERSION}.0"
-          elif [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: '$VERSION'. Expected major.minor or major.minor.patch"
-            exit 1
-          fi
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
-  release-updates:
+  # Full release updates - only for full releases (language == 'all')
+  full-release-updates:
     name: Generate ${{ matrix.name }} update
-    needs: [restrict-trunk, normalize-version]
+    needs: [parse-tag, restrict-trunk]
+    if: needs.parse-tag.outputs.language == 'all'
     strategy:
       fail-fast: false
       matrix:
@@ -121,9 +115,9 @@ jobs:
           - name: multitool
             run: ./go update_multitool
           - name: binding-versions
-            run: ./go all:version ${{ needs.normalize-version.outputs.version }} && ./go all:update
+            run: ./go all:version ${{ needs.parse-tag.outputs.version }} && ./go all:update
           - name: rust-versions
-            run: ./go rust:version ${{ needs.normalize-version.outputs.version }} && ./go rust:update
+            run: ./go rust:version ${{ needs.parse-tag.outputs.version }} && ./go rust:update
           - name: authors
             run: ./go authors
     uses: ./.github/workflows/bazel.yml
@@ -132,9 +126,20 @@ jobs:
       run: ${{ matrix.run }}
       artifact-name: patch-${{ matrix.name }}
 
+  # Patch release updates - only for patch releases (language != 'all')
+  patch-release-updates:
+    name: Generate ${{ needs.parse-tag.outputs.language }} version update
+    needs: [parse-tag, restrict-trunk]
+    if: needs.parse-tag.outputs.language != 'all'
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Update ${{ needs.parse-tag.outputs.language }} version
+      run: ./go ${{ needs.parse-tag.outputs.language }}:version ${{ needs.parse-tag.outputs.version }} && ./go ${{ needs.parse-tag.outputs.language }}:update
+      artifact-name: patch-binding-versions
+
   calculate-changelog-depth:
     name: Calculate Changelog Depth
-    needs: normalize-version
+    needs: parse-tag
     runs-on: ubuntu-latest
     outputs:
       depth: ${{ steps.calc.outputs.depth }}
@@ -143,7 +148,8 @@ jobs:
         id: calc
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.normalize-version.outputs.version }}
+          VERSION: ${{ needs.parse-tag.outputs.version }}
+        shell: bash
         run: |
           set -euo pipefail
           if [[ "$VERSION" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
@@ -173,9 +179,11 @@ jobs:
             echo "depth=0" >> "$GITHUB_OUTPUT"
           fi
 
-  generate-changelogs:
+  # Full release changelogs
+  full-release-changelogs:
     name: Generate Changelogs
-    needs: [restrict-trunk, normalize-version, calculate-changelog-depth]
+    needs: [parse-tag, restrict-trunk, calculate-changelog-depth]
+    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update Changelogs
@@ -183,9 +191,22 @@ jobs:
       artifact-name: patch-changelogs
       fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
 
+  # Patch release changelog - single language
+  patch-release-changelogs:
+    name: Generate ${{ needs.parse-tag.outputs.language }} Changelog
+    needs: [parse-tag, restrict-trunk, calculate-changelog-depth]
+    if: needs.parse-tag.outputs.language != 'all'
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Update ${{ needs.parse-tag.outputs.language }} Changelog
+      run: ./go ${{ needs.parse-tag.outputs.language }}:changelogs
+      artifact-name: patch-changelogs
+      fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
+
   create-pr:
     name: Create Pull Request
-    needs: [normalize-version, release-updates, generate-changelogs]
+    needs: [parse-tag, full-release-updates, patch-release-updates, full-release-changelogs, patch-release-changelogs]
+    if: always() && !cancelled() && (needs.full-release-updates.result == 'success' || needs.full-release-updates.result == 'skipped') && (needs.patch-release-updates.result == 'success' || needs.patch-release-updates.result == 'skipped') && (needs.full-release-changelogs.result == 'success' || needs.full-release-changelogs.result == 'skipped') && (needs.patch-release-changelogs.result == 'success' || needs.patch-release-changelogs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trunk
@@ -233,21 +254,28 @@ jobs:
           token: ${{ secrets.SELENIUM_CI_TOKEN }}
           author: Selenium CI Bot <selenium-ci@users.noreply.github.com>
           delete-branch: true
-          branch: release-preparation-${{ needs.normalize-version.outputs.version }}
+          branch: release-preparation-${{ needs.parse-tag.outputs.tag }}
           base: trunk
-          title: "[build] Prepare for release of Selenium ${{ needs.normalize-version.outputs.version }}"
+          title: "[build] Prepare for release of ${{ needs.parse-tag.outputs.tag }}"
           body: |
+
+            ### Release Info
+            | | |
+            |-----------|--------|
+            | **Tag** | ${{ needs.parse-tag.outputs.tag }} |
+            | **Version** | ${{ needs.parse-tag.outputs.version }} |
+            | **Language** | ${{ needs.parse-tag.outputs.language }} |
 
             ### Updates Applied
             | Component | Status |
             |-----------|--------|
-            | Browser and driver versions | ${{ steps.apply.outputs.browsers == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | CDP version | ${{ steps.apply.outputs.devtools == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Selenium Manager version | ${{ steps.apply.outputs.manager == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Multitool binaries | ${{ steps.apply.outputs.multitool == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Browser and driver versions | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.browsers == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
+            | CDP version | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.devtools == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
+            | Selenium Manager version | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.manager == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
+            | Multitool binaries | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.multitool == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
             | Bindings Version & Dependencies | ${{ steps.apply.outputs.binding-versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Rust Version & Dependencies | ${{ steps.apply.outputs.rust-versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Authors | ${{ steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Rust Version & Dependencies | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.rust-versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
+            | Authors | ${{ needs.parse-tag.outputs.language != 'all' && 'N/A' || (steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)') }} |
             | Draft Changelogs | ${{ steps.apply.outputs.changelogs == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
 
             ---

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,8 +36,7 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
 
-  # Run rust jobs in parallel with approval since work is not on trunk
-  # Skip for patch releases (language != 'all')
+  # Rust jobs can execute in parallel with approval job since work is in a separate branch
   generate-rust-version:
     name: Generate Rust Version
     needs: parse-tag
@@ -51,7 +50,6 @@ jobs:
   push-rust-version:
     name: Push Rust Version
     needs: [parse-tag, generate-rust-version]
-    if: needs.parse-tag.outputs.language == 'all'
     permissions:
       contents: write
       actions: read
@@ -66,7 +64,6 @@ jobs:
   selenium-manager:
     name: Release Selenium Manager
     needs: [parse-tag, push-rust-version]
-    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/ci-rust.yml
     with:
       release: true
@@ -77,7 +74,6 @@ jobs:
   cleanup-rust-branch:
     name: Cleanup Rust Branch
     needs: [parse-tag, selenium-manager]
-    if: needs.parse-tag.outputs.language == 'all'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -97,8 +93,7 @@ jobs:
       restrict: true
     secrets: inherit
 
-  # Full release updates - only for full releases (language == 'all')
-  full-release-updates:
+  release-updates:
     name: Generate ${{ matrix.name }} update
     needs: [parse-tag, restrict-trunk]
     if: needs.parse-tag.outputs.language == 'all'
@@ -126,7 +121,6 @@ jobs:
       run: ${{ matrix.run }}
       artifact-name: patch-${{ matrix.name }}
 
-  # Patch release updates - only for patch releases (language != 'all')
   patch-release-updates:
     name: Generate ${{ needs.parse-tag.outputs.language }} version update
     needs: [parse-tag, restrict-trunk]
@@ -179,34 +173,22 @@ jobs:
             echo "depth=0" >> "$GITHUB_OUTPUT"
           fi
 
-  # Full release changelogs
-  full-release-changelogs:
+  generate-changelogs:
     name: Generate Changelogs
     needs: [parse-tag, restrict-trunk, calculate-changelog-depth]
-    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update Changelogs
-      run: ./go all:changelogs && ./go rust:changelogs
-      artifact-name: patch-changelogs
-      fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
-
-  # Patch release changelog - single language
-  patch-release-changelogs:
-    name: Generate ${{ needs.parse-tag.outputs.language }} Changelog
-    needs: [parse-tag, restrict-trunk, calculate-changelog-depth]
-    if: needs.parse-tag.outputs.language != 'all'
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Update ${{ needs.parse-tag.outputs.language }} Changelog
-      run: ./go ${{ needs.parse-tag.outputs.language }}:changelogs
+      run: ./go ${{ needs.parse-tag.outputs.language }}:changelogs${{ needs.parse-tag.outputs.language == 'all' && ' && ./go rust:changelogs' || '' }}
       artifact-name: patch-changelogs
       fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
 
   create-pr:
     name: Create Pull Request
-    needs: [parse-tag, full-release-updates, patch-release-updates, full-release-changelogs, patch-release-changelogs]
-    if: always() && !cancelled() && (needs.full-release-updates.result == 'success' || needs.full-release-updates.result == 'skipped') && (needs.patch-release-updates.result == 'success' || needs.patch-release-updates.result == 'skipped') && (needs.full-release-changelogs.result == 'success' || needs.full-release-changelogs.result == 'skipped') && (needs.patch-release-changelogs.result == 'success' || needs.patch-release-changelogs.result == 'skipped')
+    needs: [parse-tag, release-updates, patch-release-updates, generate-changelogs]
+    if: >-
+      always() && !cancelled() && needs.release-updates.result != 'failure' && needs.patch-release-updates.result != 'failure' &&
+      needs.generate-changelogs.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trunk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-  prepare:
+  parse-tag:
     name: Parse Tag
     needs: extract-tag
     uses: ./.github/workflows/parse-release-tag.yml
@@ -51,18 +51,18 @@ jobs:
 
   get-approval:
     name: Get Approval
-    needs: prepare
+    needs: parse-tag
     uses: ./.github/workflows/get-approval.yml
     with:
       title: Release approval required
-      message: Approval is needed to publish ${{ needs.prepare.outputs.tag }}.
+      message: Approval is needed to publish ${{ needs.parse-tag.outputs.tag }}.
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   publish:
     name: Build and Publish ${{ matrix.language }}
-    needs: [prepare, get-approval]
-    if: needs.prepare.outputs.language == 'all' || needs.prepare.outputs.language == matrix.language
+    needs: [parse-tag, get-approval]
+    if: needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language
     strategy:
       fail-fast: false
       matrix:
@@ -78,8 +78,8 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: [prepare, publish]
-    if: needs.prepare.outputs.language == 'all'
+    needs: [parse-tag, publish]
+    if: needs.parse-tag.outputs.language == 'all'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -110,22 +110,18 @@ jobs:
           artifacts: "build/dist/*.*"
           bodyFile: "scripts/github-actions/release_header.md"
           generateReleaseNotes: true
-          name: "Selenium ${{ needs.prepare.outputs.version }}"
-          tag: "${{ needs.prepare.outputs.tag }}"
+          name: "Selenium ${{ needs.parse-tag.outputs.version }}"
+          tag: "${{ needs.parse-tag.outputs.tag }}"
           commit: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-
-  verify:
-    name: Verify Published Packages
-    needs: [prepare, docs]
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Verify packages
-      run: ./go ${{ needs.prepare.outputs.language }}:verify
 
   docs:
     name: Update ${{ matrix.language }} Documentation
-    needs: [prepare, publish, github-release]
-    if: always() && !cancelled() && needs.publish.result == 'success' && (needs.github-release.result == 'success' || needs.github-release.result == 'skipped') && (needs.prepare.outputs.language == 'all' || needs.prepare.outputs.language == matrix.language)
+    needs: [parse-tag, publish, github-release]
+    if: >-
+      always() && !cancelled() &&
+      needs.publish.result == 'success' &&
+      needs.github-release.result != 'failure' &&
+      (needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language)
     permissions:
       contents: write
     strategy:
@@ -134,10 +130,18 @@ jobs:
         language: [java, python, ruby, dotnet, javascript]
     uses: ./.github/workflows/update-documentation.yml
     with:
-      tag: ${{ needs.prepare.outputs.tag }}
+      tag: ${{ needs.parse-tag.outputs.tag }}
       language: ${{ matrix.language }}
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
+
+  verify:
+    name: Verify Published Packages
+    needs: [parse-tag, docs]
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Verify packages
+      run: ./go ${{ needs.parse-tag.outputs.language }}:verify
 
   unrestrict-trunk:
     name: Unrestrict Trunk Branch
@@ -149,39 +153,37 @@ jobs:
 
   reset-version:
     name: Generate Nightly Versions
-    needs: [prepare, docs]
-    if: needs.prepare.outputs.language == 'all'
+    needs: [parse-tag, docs]
     uses: ./.github/workflows/bazel.yml
     with:
       name: Reset Versions
-      run: ./go all:version nightly && ./go rust:version nightly
+      run: ./go ${{ needs.parse-tag.outputs.language }}:version nightly${{ needs.parse-tag.outputs.language == 'all' && ' && ./go rust:version nightly' || '' }}
       artifact-name: version-reset
 
   update-version:
     name: Push Nightly Versions
-    needs: [prepare, reset-version, unrestrict-trunk]
-    if: needs.prepare.outputs.language == 'all'
+    needs: [parse-tag, reset-version, unrestrict-trunk]
     permissions:
       contents: write
       actions: read
     uses: ./.github/workflows/commit-changes.yml
     with:
       artifact-name: version-reset
-      commit-message: "[build] Reset versions to nightly after ${{ needs.prepare.outputs.tag }} release"
+      commit-message: "[build] Reset versions to nightly after ${{ needs.parse-tag.outputs.tag }} release"
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 
   nightly:
     name: Publish Nightly Packages
-    needs: [prepare, update-version]
-    if: needs.prepare.outputs.language == 'all'
+    needs: [parse-tag, update-version]
+    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/nightly.yml
     secrets: inherit
 
   mirror:
     name: Update Release Mirror
-    needs: [prepare, nightly]
-    if: needs.prepare.outputs.language == 'all'
+    needs: [parse-tag, nightly]
+    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/mirror-selenium-releases.yml
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,21 +79,32 @@ jobs:
   github-release:
     name: GitHub Release
     needs: [parse-tag, publish]
-    if: needs.parse-tag.outputs.language == 'all'
+    if: >-
+      needs.parse-tag.outputs.language == 'all' ||
+      needs.parse-tag.outputs.language == 'java' ||
+      needs.parse-tag.outputs.language == 'dotnet'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout repo
+        if: needs.parse-tag.outputs.language == 'all'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Download release packages
+      - name: Download all release packages
+        if: needs.parse-tag.outputs.language == 'all'
         uses: actions/download-artifact@v4
         with:
           pattern: release-packages-*
           merge-multiple: true
+      - name: Download release packages
+        if: needs.parse-tag.outputs.language != 'all'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-packages-${{ needs.parse-tag.outputs.language }}
       - name: Delete nightly release and tag
+        if: needs.parse-tag.outputs.language == 'all'
         env:
           GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
         run: |
@@ -104,6 +115,7 @@ jobs:
             gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/nightly
           fi
       - name: Create GitHub release
+        if: needs.parse-tag.outputs.language == 'all'
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -113,6 +125,14 @@ jobs:
           name: "Selenium ${{ needs.parse-tag.outputs.version }}"
           tag: "${{ needs.parse-tag.outputs.tag }}"
           commit: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      - name: Update GitHub release
+        if: needs.parse-tag.outputs.language != 'all'
+        env:
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
+          VERSION: ${{ needs.parse-tag.outputs.version }}
+        run: |
+          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.[0-9]+$/.0/')
+          gh release upload "selenium-$BASE_VERSION" build/dist/*.* --clobber
 
   docs:
     name: Update ${{ matrix.language }} Documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,9 @@ jobs:
   nightly:
     name: Publish Nightly Packages
     needs: [parse-tag, update-version]
-    if: needs.parse-tag.outputs.language == 'all'
     uses: ./.github/workflows/nightly.yml
+    with:
+      language: ${{ needs.parse-tag.outputs.language }}
     secrets: inherit
 
   mirror:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
             TAG="$INPUT_TAG"
           else
             # Extract tag from branch name: release-preparation-selenium-4.28.1-ruby -> selenium-4.28.1-ruby
-            TAG=$(echo "$PR_HEAD_REF" | sed 's/^release-preparation-//')
+            TAG="${PR_HEAD_REF#release-preparation-}"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
@@ -62,7 +62,6 @@ jobs:
   publish:
     name: Build and Publish ${{ matrix.language }}
     needs: [parse-tag, get-approval]
-    if: needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +70,7 @@ jobs:
     with:
       name: Publish ${{ matrix.language }}
       gpg-sign: ${{ matrix.language == 'java' }}
-      run: ./go ${{ matrix.language }}:release
+      run: ${{ (needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language) && format('./go {0}:release', matrix.language) || 'echo skipping' }}
       artifact-name: release-packages-${{ matrix.language }}
       artifact-path: build/dist/*.*
     secrets: inherit
@@ -131,7 +130,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
           VERSION: ${{ needs.parse-tag.outputs.version }}
         run: |
-          BASE_VERSION=$(echo "$VERSION" | sed -E 's/\.[0-9]+$/.0/')
+          BASE_VERSION="${VERSION%.*}.0"
           gh release upload "selenium-$BASE_VERSION" build/dist/*.* --clobber
 
   docs:
@@ -140,8 +139,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       needs.publish.result == 'success' &&
-      needs.github-release.result != 'failure' &&
-      (needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language)
+      needs.github-release.result != 'failure'
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       name: Publish ${{ matrix.language }}
       gpg-sign: ${{ matrix.language == 'java' }}
       run: ${{ (needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language) && format('./go {0}:release', matrix.language) || 'echo skipping' }}
-      artifact-name: release-packages-${{ matrix.language }}
+      artifact-name: ${{ (needs.parse-tag.outputs.language == 'all' || needs.parse-tag.outputs.language == matrix.language) && format('release-packages-{0}', matrix.language) || '' }}
       artifact-path: build/dist/*.*
     secrets: inherit
 
@@ -150,6 +150,7 @@ jobs:
     with:
       tag: ${{ needs.parse-tag.outputs.tag }}
       language: ${{ matrix.language }}
+      skip: ${{ needs.parse-tag.outputs.language != 'all' && needs.parse-tag.outputs.language != matrix.language }}
     secrets:
       SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g., selenium-4.28.0)'
+        description: 'Release tag (e.g., selenium-4.28.0 or selenium-4.28.1-ruby)'
         required: true
 
 env:
@@ -16,8 +16,8 @@ permissions:
   contents: read
 
 jobs:
-  prepare:
-    name: Prepare Release
+  extract-tag:
+    name: Extract Tag
     runs-on: ubuntu-latest
     if: >
       github.event.repository.fork == false &&
@@ -25,11 +25,10 @@ jobs:
        github.event.pull_request.merged == true) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''))
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
+      tag: ${{ steps.extract.outputs.tag }}
     steps:
-      - name: Extract tag and version
-        id: tag
+      - name: Extract tag from input or PR branch
+        id: extract
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
@@ -38,11 +37,17 @@ jobs:
           if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             TAG="$INPUT_TAG"
           else
-            VERSION=$(echo "$PR_HEAD_REF" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-            TAG="selenium-${VERSION}"
+            # Extract tag from branch name: release-preparation-selenium-4.28.1-ruby -> selenium-4.28.1-ruby
+            TAG=$(echo "$PR_HEAD_REF" | sed 's/^release-preparation-//')
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$(echo "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+  prepare:
+    name: Parse Tag
+    needs: extract-tag
+    uses: ./.github/workflows/parse-release-tag.yml
+    with:
+      tag: ${{ needs.extract-tag.outputs.tag }}
 
   get-approval:
     name: Get Approval
@@ -56,11 +61,12 @@ jobs:
 
   publish:
     name: Build and Publish ${{ matrix.language }}
-    needs: get-approval
+    needs: [prepare, get-approval]
+    if: needs.prepare.outputs.language == 'all' || needs.prepare.outputs.language == matrix.language
     strategy:
       fail-fast: false
       matrix:
-        language: [java, py, rb, dotnet, node]
+        language: [java, python, ruby, dotnet, javascript]
     uses: ./.github/workflows/bazel.yml
     with:
       name: Publish ${{ matrix.language }}
@@ -73,6 +79,7 @@ jobs:
   github-release:
     name: GitHub Release
     needs: [prepare, publish]
+    if: needs.prepare.outputs.language == 'all'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -109,21 +116,22 @@ jobs:
 
   verify:
     name: Verify Published Packages
-    needs: docs
+    needs: [prepare, docs]
     uses: ./.github/workflows/bazel.yml
     with:
       name: Verify packages
-      run: ./go all:verify
+      run: ./go ${{ needs.prepare.outputs.language }}:verify
 
   docs:
     name: Update ${{ matrix.language }} Documentation
     needs: [prepare, publish, github-release]
+    if: always() && !cancelled() && needs.publish.result == 'success' && (needs.github-release.result == 'success' || needs.github-release.result == 'skipped') && (needs.prepare.outputs.language == 'all' || needs.prepare.outputs.language == matrix.language)
     permissions:
       contents: write
     strategy:
       fail-fast: false
       matrix:
-        language: [java, py, rb, dotnet, node]
+        language: [java, python, ruby, dotnet, javascript]
     uses: ./.github/workflows/update-documentation.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}
@@ -141,7 +149,8 @@ jobs:
 
   reset-version:
     name: Generate Nightly Versions
-    needs: docs
+    needs: [prepare, docs]
+    if: needs.prepare.outputs.language == 'all'
     uses: ./.github/workflows/bazel.yml
     with:
       name: Reset Versions
@@ -151,6 +160,7 @@ jobs:
   update-version:
     name: Push Nightly Versions
     needs: [prepare, reset-version, unrestrict-trunk]
+    if: needs.prepare.outputs.language == 'all'
     permissions:
       contents: write
       actions: read
@@ -163,13 +173,15 @@ jobs:
 
   nightly:
     name: Publish Nightly Packages
-    needs: [update-version]
+    needs: [prepare, update-version]
+    if: needs.prepare.outputs.language == 'all'
     uses: ./.github/workflows/nightly.yml
     secrets: inherit
 
   mirror:
     name: Update Release Mirror
-    needs: [nightly]
+    needs: [prepare, nightly]
+    if: needs.prepare.outputs.language == 'all'
     uses: ./.github/workflows/mirror-selenium-releases.yml
     secrets: inherit
 

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -15,10 +15,10 @@ on:
         options:
           - all
           - java
-          - rb
-          - py
+          - ruby
+          - python
           - dotnet
-          - node
+          - javascript
 
   workflow_call:
     inputs:
@@ -55,18 +55,13 @@ jobs:
         run: |
           echo "version=$(echo "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
-          # Check for language suffix and map to internal names
-          case "$TAG" in
-            *-javascript) LANG="node" ;;
-            *-python) LANG="py" ;;
-            *-ruby) LANG="rb" ;;
-            *-java) LANG="java" ;;
-            *-dotnet) LANG="dotnet" ;;
-            *) LANG="all" ;;
-          esac
-
+          # Extract language from tag suffix or use input
           if [ -n "$INPUT_LANG" ] && [ "$INPUT_LANG" != "all" ]; then
             LANG="$INPUT_LANG"
+          elif [[ "$TAG" =~ -(javascript|python|ruby|java|dotnet)$ ]]; then
+            LANG="${BASH_REMATCH[1]}"
+          else
+            LANG="all"
           fi
           echo "language=$LANG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -26,9 +26,12 @@ on:
         required: true
         type: string
       language:
-        required: false
         type: string
         default: ""
+      skip:
+        description: We're not releasing this one right now
+        type: boolean
+        default: false
     secrets:
       SELENIUM_CI_TOKEN:
         required: true
@@ -42,6 +45,7 @@ env:
 jobs:
   parse:
     name: Parse Tag
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.parse.outputs.version }}
@@ -68,6 +72,7 @@ jobs:
   generate-docs:
     name: Generate Documentation
     needs: parse
+    if: ${{ !inputs.skip }}
     uses: ./.github/workflows/bazel.yml
     with:
       name: Generate Docs
@@ -79,6 +84,7 @@ jobs:
   commit-docs:
     name: Commit Documentation
     needs: [parse, generate-docs]
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages

--- a/Rakefile
+++ b/Rakefile
@@ -100,24 +100,28 @@ task :authors do
   sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS) | sort -uf > AUTHORS"
 end
 
-# Example: `./go release_updates 4.31.0 early-stable`
-# Equivalent to `release-updates` job in `.github/workflows/pre-release.yml`
+# Example: `./go release_updates selenium-4.31.0 early-stable`
+# Example: `./go release_updates selenium-4.31.1-ruby`
 desc 'Update everything in preparation for a release'
-task :release_updates, [:version, :channel] do |_task, arguments|
-  version = arguments[:version]
-  raise 'Missing required version: ./go release_updates 4.31.0 early-stable' if version.nil? || version.empty?
+task :release_updates, [:tag, :channel] do |_task, arguments|
+  parsed = SeleniumRake.parse_tag(arguments[:tag])
+  version = parsed[:version]
+  language = parsed[:language]
 
-  Rake::Task['update_browsers'].invoke(arguments[:channel])
-  Rake::Task['update_cdp'].invoke(arguments[:channel])
-  Rake::Task['update_manager'].invoke
-  Rake::Task['update_multitool'].invoke
-  Rake::Task['authors'].invoke
-  Rake::Task['all:version'].invoke(version)
-  Rake::Task['all:update'].invoke
-  Rake::Task['rust:version'].invoke(version)
-  Rake::Task['rust:update'].invoke
-  Rake::Task['all:changelogs'].invoke
-  Rake::Task['rust:changelogs'].invoke
+  if parsed[:patch].zero?
+    Rake::Task['update_browsers'].invoke(arguments[:channel])
+    Rake::Task['update_cdp'].invoke(arguments[:channel])
+    Rake::Task['update_manager'].invoke
+    Rake::Task['update_multitool'].invoke
+    Rake::Task['authors'].invoke
+    Rake::Task['rust:version'].invoke(version)
+    Rake::Task['rust:update'].invoke
+    Rake::Task['rust:changelogs'].invoke
+  end
+
+  Rake::Task["#{language}:version"].invoke(version)
+  Rake::Task["#{language}:update"].invoke
+  Rake::Task["#{language}:changelogs"].invoke
 end
 
 desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'

--- a/rake_tasks/common.rb
+++ b/rake_tasks/common.rb
@@ -14,8 +14,27 @@ BINDING_TARGETS = {
 
 # Shared utilities used by language-specific rake tasks
 module SeleniumRake
+  BINDINGS = %w[ruby python javascript java dotnet].freeze
+
   class << self
     attr_accessor :git
+  end
+
+  # Parse a release tag like "selenium-4.28.0" or "selenium-4.28.1-ruby"
+  # Returns { version:, language:, patch: } where language defaults to 'all'
+  def self.parse_tag(tag)
+    pattern = /^selenium-(\d+\.\d+\.\d+)(?:-(#{BINDINGS.join('|')}))?$/
+    match = tag&.match(pattern)
+    raise "Invalid tag format: #{tag}" unless match
+
+    version = match[1]
+    language = match[2] || 'all'
+    patch = version.split('.')[2].to_i
+
+    raise "Patch releases must specify a language (e.g., selenium-#{version}-ruby)" if patch.positive? && language == 'all'
+    raise 'Full releases (X.Y.0) cannot have a language suffix' if patch.zero? && language != 'all'
+
+    {version: version, language: language, patch: patch}
   end
 
   def self.updated_version(current, desired = nil, nightly = nil)

--- a/rake_tasks/common.rb
+++ b/rake_tasks/common.rb
@@ -31,7 +31,9 @@ module SeleniumRake
     language = match[2] || 'all'
     patch = version.split('.')[2].to_i
 
-    raise "Patch releases must specify a language (e.g., selenium-#{version}-ruby)" if patch.positive? && language == 'all'
+    if patch.positive? && language == 'all'
+      raise "Patch releases must specify a language (e.g., selenium-#{version}-ruby)"
+    end
     raise 'Full releases (X.Y.0) cannot have a language suffix' if patch.zero? && language != 'all'
 
     {version: version, language: language, patch: patch}


### PR DESCRIPTION
### **User description**

Binding specific releases should work exactly the same as a full release now.
Whether Minor release or Patch release, kick off the pre-release workflow and specify the tagname
and the script should do the rest. Once the PR is up, merge it, release workflow will start,
and Bob should be your uncle.

### 🔗 Related Issues

Builds on #16997 (consolidated pre-release workflow)

Both minor releases and patch releases have the same CI procees:
* kick off the pre-release workflow
* give it permission to lock trunk during release
* merge it 
* give release workflow permission to publish

### 💥 What does this PR do?

Enable patch releases for individual language bindings
Instead of passing language and version, you pass the exact tagname you want (e.g., `selenium-4.28.1-ruby`).

**Tag format and validation:**
- Validates tags match `selenium-4.30.0`, `selenium-4.28.1-ruby`, `selenium-4.28.1-python`, etc.

**Pre-release workflow for patches:**
- Skip Selenium Manager release
- Skip browser pins, CDP, manager, and multitool updates
- Run only the relevant language's version/changelog tasks
- PR body table shows "N/A" for skipped components

**Release workflow changes:**
- Filter publish and docs matrix to selected language only
- ~Skip GitHub release creation for patch releases~
- Java/dotnet patch releases update existing GitHub release with new artifacts
- Reset version to nightly for the released language
- Skip ~nightly reset and~ mirror update for patch releases
- Publish nightly for the released language only

### 🔧 Implementation Notes

- Both pre-release and release workflows call the reusable workflow for consistent parsing of tag name
- Uses full language names in workflow matrix (`ruby`, `python`, `javascript`, `java`, `dotnet`)
- Release workflow extracts tag from PR branch name created by pre-relese workflow

- Updated `release_updates` Rake task accepts tag (e.g., `selenium-4.28.1-ruby`) and runs appropriate tasks

### 💡 Additional Considerations

Who wants to try it???

### 🔄 Types of changes

- New feature (non-breaking* change which adds functionality)

*hopefully


___

### **PR Type**
Enhancement


___

### **Description**
- Enable per-language patch releases (e.g., `selenium-4.28.1-ruby`) without full release

- Parse and validate release tags with language suffix support

- Skip Rust/SM, browser pins, CDP updates for patch releases

- Filter publish/docs matrix to selected language only

- Make version tasks invoke their own update tasks automatically


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Tag Input<br/>selenium-4.28.1-ruby"] --> B["Parse Tag Job"]
  B --> C{Language<br/>Suffix?}
  C -->|Patch Release| D["Extract Language<br/>ruby/python/java/etc"]
  C -->|Full Release| E["Language = all"]
  D --> F["Skip Rust/SM/Browser/CDP"]
  E --> G["Run All Updates"]
  F --> H["Per-Language Version<br/>& Changelog Tasks"]
  G --> I["All Component Updates"]
  H --> J["Filtered Publish Matrix"]
  I --> K["Full Publish Matrix"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>java.rake</strong><dd><code>Invoke update task after version bump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/java.rake

<ul><li>Added automatic invocation of <code>java:update</code> task after version bump<br> <li> Ensures dependencies are updated when version changes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-246090ca8a73cd7067bce748108c78b39b6efb08cb02f6bd3f870a322c40afc1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node.rake</strong><dd><code>Invoke update task after version bump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/node.rake

<ul><li>Added automatic invocation of <code>node:update</code> task after version bump<br> <li> Ensures dependencies are updated when version changes</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-cb32118d210d5f91423b64058db86f294fdc6bf58c18c00d4e68e4e189c693fd">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Add tag parsing and per-language release support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Replaced <code>version</code> input with <code>tag</code> input supporting language suffixes<br> <li> Added <code>parse-tag</code> job to extract version, language, and validate tag <br>format<br> <li> Validate patch releases (Z>0) must have language suffix, full releases <br>(Z=0) cannot<br> <li> Skip Rust/SM, browser, devtools, multitool, authors jobs for patch <br>releases<br> <li> Use per-language version/changelog tasks instead of <code>all:version</code> and <br><code>all:changelogs</code><br> <li> Updated PR body table to show "N/A" for skipped components in patch <br>releases<br> <li> Renamed "dependencies" to "multitool" for clarity<br> <li> Changed <code>release_update</code> to <code>update_multitool</code> direct call</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+118/-46</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Filter release jobs by language and skip for patch releases</code></dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Updated <code>prepare</code> job to parse tag and extract language suffix<br> <li> Added language validation and patch release requirements<br> <li> Filter <code>publish</code> matrix to run only for selected language<br> <li> Skip <code>github-release</code> job for patch releases (language != 'all')<br> <li> Skip <code>nightly</code> and <code>mirror</code> jobs for patch releases<br> <li> Use per-language <code>verify</code> task instead of <code>all:verify</code><br> <li> Use per-language <code>version nightly</code> task instead of <code>all:version nightly</code><br> <li> Changed language matrix values from abbreviations (py, rb, node) to <br>full names (python, ruby, javascript)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+56/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-documentation.yml</strong><dd><code>Use full language names in documentation workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-documentation.yml

<ul><li>Updated language options to use full names (ruby, python, javascript) <br>instead of abbreviations<br> <li> Updated tag parsing to map language suffixes to full names</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-762373f28dabfb9bf0baf6a4fb9d5ca47a3ff3a5c16c908e74b52d2eb81ddbc9">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Remove release_update wrapper task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Removed <code>release_update</code> wrapper task that only called <code>update_multitool</code><br> <li> Workflows now call <code>update_multitool</code> directly</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16987/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

