### PR TITLE
[java] fix parsing numeric values with exponents in JSON

### DIFF
--- a/java/src/org/openqa/selenium/json/JsonInput.java
+++ b/java/src/org/openqa/selenium/json/JsonInput.java
@@ -244,7 +244,7 @@ public class JsonInput implements Closeable {
       if (fractionalPart || number.stripTrailingZeros().scale() > 0) {
         return number.doubleValue();
       } else {
-        return number.longValue();
+        return number.longValueExact();
       }
     } catch (NumberFormatException e) {
       throw new JsonException("Unable to parse to a number: " + builder + ". " + input);

--- a/java/src/org/openqa/selenium/json/JsonInput.java
+++ b/java/src/org/openqa/selenium/json/JsonInput.java
@@ -240,11 +240,12 @@ public class JsonInput implements Closeable {
     } while (true);
 
     try {
-      Number number = new BigDecimal(builder.toString());
-      if (fractionalPart) {
+      BigDecimal number = new BigDecimal(builder.toString());
+      if (fractionalPart || number.stripTrailingZeros().scale() > 0) {
         return number.doubleValue();
+      } else {
+        return number.longValue();
       }
-      return number.longValue();
     } catch (NumberFormatException e) {
       throw new JsonException("Unable to parse to a number: " + builder + ". " + input);
     }

--- a/java/test/org/openqa/selenium/json/JsonInputTest.java
+++ b/java/test/org/openqa/selenium/json/JsonInputTest.java
@@ -72,10 +72,27 @@ class JsonInputTest {
   }
 
   @Test
+  void shouldParseNonDecimalNumbersWithExponentAsLongs() {
+    try (JsonInput input = newInput("42e+1")) {
+      assertThat(input.peek()).isEqualTo(NUMBER);
+      assertThat(input.nextNumber()).isEqualTo(420L);
+    }
+  }
+
+  @Test
   void shouldParseDecimalNumbersAsDoubles() {
     try (JsonInput input = newInput("42.0")) {
       assertThat(input.peek()).isEqualTo(NUMBER);
       assertThat((Double) input.nextNumber()).isEqualTo(42.0d);
+    }
+  }
+
+  @Test
+  void shouldParseDecimalNumbersWithExponentAsDoubles() {
+    try (JsonInput input = newInput("42e-1")) {
+      assertThat(input.peek()).isEqualTo(NUMBER);
+      Number x = input.nextNumber();
+      assertThat((Double) x).isEqualTo(4.2d);
     }
   }
 

--- a/java/test/org/openqa/selenium/json/JsonTest.java
+++ b/java/test/org/openqa/selenium/json/JsonTest.java
@@ -63,6 +63,17 @@ class JsonTest {
     assertThat((Number) new Json().toType("42", Number.class)).isEqualTo(42L);
     assertThat((Integer) new Json().toType("42", Integer.class)).isEqualTo(42);
     assertThat((Double) new Json().toType("42", Double.class)).isEqualTo(42.0);
+
+    assertThat((Double) new Json().toType("4.2e+1", Double.class)).isEqualTo(42.0);
+    assertThat((Integer) new Json().toType("4.2e+1", Integer.class)).isEqualTo(42);
+    assertThat((Long) new Json().toType("4.2e+1", Long.class)).isEqualTo(42L);
+
+    assertThat((Double) new Json().toType("42e+1", Double.class)).isEqualTo(420.0);
+    assertThat((Integer) new Json().toType("42e+1", Integer.class)).isEqualTo(420);
+    assertThat((Long) new Json().toType("42e+1", Long.class)).isEqualTo(420L);
+
+    assertThat((Double) new Json().toType("42e-1", Double.class)).isEqualTo(4.2);
+    assertThat((Double) new Json().toType("4.2e-1", Double.class)).isEqualTo(0.42);
   }
 
   @Test


### PR DESCRIPTION
### **User description**
1. `newInput("42e-1").nextNumber()` returned 4 (expected: 4.2);
2. `new Json().toType("42e-1", Double.class)` returned 4.0 (expected: 4.2)

### 🔗 Related Issues
This is an alternative implementation for problem https://github.com/SeleniumHQ/selenium/pull/16961

### 💥 What does this PR do?

Fixes parsing numeric values with exponents in JSON.

1. `newInput("42e-1").nextNumber()`
    * was: 4
    * now: 4.2
3. `new Json().toType("42e-1", Double.class)`
    * was: 5.0
    * now: 4.2


### 🔄 Types of changes
- Bug fix (backwards compatible)

@joerg1985 What do you think?


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes JSON number parsing with scientific notation (exponents)

- Detects fractional results from exponent calculations

- Returns appropriate type (long vs double) based on result

- Adds comprehensive test coverage for exponent scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON Number Input<br/>e.g. 42e-1"] --> B["Parse to BigDecimal"]
  B --> C["Check for Fractional Part<br/>or Exponent Result"]
  C --> D1["Has Fraction:<br/>Return Double"]
  C --> D2["No Fraction:<br/>Return Long"]
  D1 --> E["Correct Values<br/>42e-1 = 4.2"]
  D2 --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonInput.java</strong><dd><code>Add exponent result detection to number parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/JsonInput.java

<ul><li>Modified <code>nextNumber()</code> to detect fractional results from exponent <br>calculations<br> <li> Added check: <code>number.stripTrailingZeros().scale() > 0</code> to identify <br>decimals<br> <li> Returns <code>doubleValue()</code> for fractional results, <code>longValue()</code> for integers<br> <li> Fixes incorrect parsing of numbers like "42e-1" (was 4, now 4.2)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16988/files#diff-162d1e84f8475ebea31dd037e38d700e07beacf189da303f454b1b62ad7b8483">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonInputTest.java</strong><dd><code>Add exponent parsing tests to JsonInputTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/json/JsonInputTest.java

<ul><li>Added test for non-decimal numbers with positive exponent (42e+1 = <br>420L)<br> <li> Added test for decimal numbers with negative exponent (42e-1 = 4.2)<br> <li> Verifies correct type conversion (long vs double) based on result</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16988/files#diff-1cda9e5762ce05ff769e9273ce5c53ea8d016ba643ba86fee4166bc7d7acfa9e">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonTest.java</strong><dd><code>Add exponent conversion tests to JsonTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/json/JsonTest.java

<ul><li>Added tests for <code>Json.toType()</code> with various exponent formats<br> <li> Tests positive exponents: 4.2e+1 and 42e+1 with multiple target types<br> <li> Tests negative exponent: 42e-1 and 4.2e-1 returning correct double <br>values<br> <li> Validates type conversion (Double, Integer, Long) for exponent results</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16988/files#diff-ca8b46815d2ed84d1c82776cf430ab11d8b9cdb91a4c904338c96dc482147623">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

