### PR TITLE
[build] auto merge browser version updates if they pass all checks

### DIFF
--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -43,10 +43,13 @@ jobs:
           existing=$(gh pr list --head pinned-browser-updates --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             echo "::notice::PR #$existing already exists"
+            pr="$existing"
           else
-            gh pr create \
+            pr=$(gh pr create \
               --head pinned-browser-updates \
               --base trunk \
               --title "[dotnet][rb][java][js][py] Automated Browser Version Update" \
-              --body $'This is an automated pull request to update pinned browsers and drivers\n\nMerge after verify the new browser versions properly passing the tests and no bugs need to be filed'
+              --body $'This is an automated pull request to update pinned browsers and drivers\n\nMerge after verify the new browser versions properly passing the tests and no bugs need to be filed' \
+              --json number --jq '.number')
           fi
+          gh pr merge "$pr" --auto --merge --delete-branch

--- a/.github/workflows/pin-browsers.yml
+++ b/.github/workflows/pin-browsers.yml
@@ -52,4 +52,4 @@ jobs:
               --body $'This is an automated pull request to update pinned browsers and drivers\n\nMerge after verify the new browser versions properly passing the tests and no bugs need to be filed' \
               --json number --jq '.number')
           fi
-          gh pr merge "$pr" --auto --merge --delete-branch
+          gh pr merge "$pr" --auto --squash --delete-branch


### PR DESCRIPTION
### **User description**
These end up sitting out there. Shouldn't be any reason not to merge them if everything is passing.

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
* Once tests pass, the PR will merge and delete branch

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Anything else we want to auto-commit? 😀 

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Auto-merge browser version update PRs after tests pass

- Capture PR number from creation for merge operation

- Delete branch automatically upon successful merge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check existing PR"] --> B{"PR exists?"}
  B -->|Yes| C["Use existing PR number"]
  B -->|No| D["Create new PR and capture number"]
  C --> E["Auto-merge PR with delete-branch"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pin-browsers.yml</strong><dd><code>Add auto-merge logic for browser update PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pin-browsers.yml

<ul><li>Modified PR creation to capture the PR number for subsequent merge <br>operation<br> <li> Added auto-merge step that merges the PR and deletes the branch after <br>tests pass<br> <li> Handles both existing and newly created PRs with unified merge logic</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16991/files#diff-4cdb71ed282d9e7b522ed730c4fe1cd13cc17dd5d0bf665f4416e9646215a2c5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

