### PR TITLE
[py] Use lazy imports in webdriver __init__.py

### DIFF
--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -69,6 +69,21 @@ _LAZY_IMPORTS = {
     "Proxy": ("selenium.webdriver.common.proxy", "Proxy"),
 }
 
+# Submodules that can be lazily imported as modules
+_LAZY_SUBMODULES = {
+    "chrome": "selenium.webdriver.chrome",
+    "chromium": "selenium.webdriver.chromium",
+    "common": "selenium.webdriver.common",
+    "edge": "selenium.webdriver.edge",
+    "firefox": "selenium.webdriver.firefox",
+    "ie": "selenium.webdriver.ie",
+    "remote": "selenium.webdriver.remote",
+    "safari": "selenium.webdriver.safari",
+    "support": "selenium.webdriver.support",
+    "webkitgtk": "selenium.webdriver.webkitgtk",
+    "wpewebkit": "selenium.webdriver.wpewebkit",
+}
+
 
 def __getattr__(name):
     if name in _LAZY_IMPORTS:
@@ -77,6 +92,10 @@ def __getattr__(name):
         value = getattr(module, attr_name)
         globals()[name] = value
         return value
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(_LAZY_SUBMODULES[name])
+        globals()[name] = module
+        return module
     raise AttributeError(f"module 'selenium.webdriver' has no attribute {name!r}")
 
 

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import importlib
 import logging
 import os
 
@@ -25,38 +26,62 @@ if os.environ.get("SE_DEBUG"):
     if not logger.handlers:
         logger.addHandler(logging.StreamHandler())
 
-from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.chrome.service import Service as ChromeService
-from selenium.webdriver.chrome.webdriver import WebDriver as Chrome
-from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.proxy import Proxy
-from selenium.webdriver.edge.options import Options as EdgeOptions
-from selenium.webdriver.edge.service import Service as EdgeService
-from selenium.webdriver.edge.webdriver import WebDriver as ChromiumEdge
-from selenium.webdriver.edge.webdriver import WebDriver as Edge
-from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver.firefox.service import Service as FirefoxService
-from selenium.webdriver.firefox.webdriver import WebDriver as Firefox
-from selenium.webdriver.ie.options import Options as IeOptions
-from selenium.webdriver.ie.service import Service as IeService
-from selenium.webdriver.ie.webdriver import WebDriver as Ie
-from selenium.webdriver.remote.webdriver import WebDriver as Remote
-from selenium.webdriver.safari.options import Options as SafariOptions
-from selenium.webdriver.safari.service import Service as SafariService
-from selenium.webdriver.safari.webdriver import WebDriver as Safari
-from selenium.webdriver.webkitgtk.options import Options as WebKitGTKOptions
-from selenium.webdriver.webkitgtk.service import Service as WebKitGTKService
-from selenium.webdriver.webkitgtk.webdriver import WebDriver as WebKitGTK
-from selenium.webdriver.wpewebkit.options import Options as WPEWebKitOptions
-from selenium.webdriver.wpewebkit.service import Service as WPEWebKitService
-from selenium.webdriver.wpewebkit.webdriver import WebDriver as WPEWebKit
-
 __version__ = "4.41.0.202601181916"
 
-# We need an explicit __all__ because the above won't otherwise be exported.
+# Lazy import mapping: name -> (module_path, attribute_name)
+_LAZY_IMPORTS = {
+    # Chrome
+    "Chrome": ("selenium.webdriver.chrome.webdriver", "WebDriver"),
+    "ChromeOptions": ("selenium.webdriver.chrome.options", "Options"),
+    "ChromeService": ("selenium.webdriver.chrome.service", "Service"),
+    # Edge
+    "Edge": ("selenium.webdriver.edge.webdriver", "WebDriver"),
+    "ChromiumEdge": ("selenium.webdriver.edge.webdriver", "WebDriver"),
+    "EdgeOptions": ("selenium.webdriver.edge.options", "Options"),
+    "EdgeService": ("selenium.webdriver.edge.service", "Service"),
+    # Firefox
+    "Firefox": ("selenium.webdriver.firefox.webdriver", "WebDriver"),
+    "FirefoxOptions": ("selenium.webdriver.firefox.options", "Options"),
+    "FirefoxProfile": ("selenium.webdriver.firefox.firefox_profile", "FirefoxProfile"),
+    "FirefoxService": ("selenium.webdriver.firefox.service", "Service"),
+    # IE
+    "Ie": ("selenium.webdriver.ie.webdriver", "WebDriver"),
+    "IeOptions": ("selenium.webdriver.ie.options", "Options"),
+    "IeService": ("selenium.webdriver.ie.service", "Service"),
+    # Safari
+    "Safari": ("selenium.webdriver.safari.webdriver", "WebDriver"),
+    "SafariOptions": ("selenium.webdriver.safari.options", "Options"),
+    "SafariService": ("selenium.webdriver.safari.service", "Service"),
+    # Remote
+    "Remote": ("selenium.webdriver.remote.webdriver", "WebDriver"),
+    # WebKitGTK
+    "WebKitGTK": ("selenium.webdriver.webkitgtk.webdriver", "WebDriver"),
+    "WebKitGTKOptions": ("selenium.webdriver.webkitgtk.options", "Options"),
+    "WebKitGTKService": ("selenium.webdriver.webkitgtk.service", "Service"),
+    # WPEWebKit
+    "WPEWebKit": ("selenium.webdriver.wpewebkit.webdriver", "WebDriver"),
+    "WPEWebKitOptions": ("selenium.webdriver.wpewebkit.options", "Options"),
+    "WPEWebKitService": ("selenium.webdriver.wpewebkit.service", "Service"),
+    # Common utilities
+    "ActionChains": ("selenium.webdriver.common.action_chains", "ActionChains"),
+    "DesiredCapabilities": ("selenium.webdriver.common.desired_capabilities", "DesiredCapabilities"),
+    "Keys": ("selenium.webdriver.common.keys", "Keys"),
+    "Proxy": ("selenium.webdriver.common.proxy", "Proxy"),
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module 'selenium.webdriver' has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__) + list(globals().keys())
+
+
 __all__ = [
     "ActionChains",
     "Chrome",

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -103,33 +103,4 @@ def __dir__():
     return sorted(set(__all__) | set(_LAZY_SUBMODULES.keys()))
 
 
-__all__ = [
-    "ActionChains",
-    "Chrome",
-    "ChromeOptions",
-    "ChromeService",
-    "ChromiumEdge",
-    "DesiredCapabilities",
-    "Edge",
-    "EdgeOptions",
-    "EdgeService",
-    "Firefox",
-    "FirefoxOptions",
-    "FirefoxProfile",
-    "FirefoxService",
-    "Ie",
-    "IeOptions",
-    "IeService",
-    "Keys",
-    "Proxy",
-    "Remote",
-    "Safari",
-    "SafariOptions",
-    "SafariService",
-    "WPEWebKit",
-    "WPEWebKitOptions",
-    "WPEWebKitService",
-    "WebKitGTK",
-    "WebKitGTKOptions",
-    "WebKitGTKService",
-]
+__all__ = sorted(_LAZY_IMPORTS.keys())

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -74,7 +74,9 @@ def __getattr__(name):
     if name in _LAZY_IMPORTS:
         module_path, attr_name = _LAZY_IMPORTS[name]
         module = importlib.import_module(module_path)
-        return getattr(module, attr_name)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module 'selenium.webdriver' has no attribute {name!r}")
 
 

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -100,7 +100,7 @@ def __getattr__(name):
 
 
 def __dir__():
-    return list(__all__) + list(globals().keys())
+    return sorted(set(__all__) | set(_LAZY_SUBMODULES.keys()))
 
 
 __all__ = [

--- a/py/selenium/webdriver/chrome/__init__.py
+++ b/py/selenium/webdriver/chrome/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/chrome/__init__.py
+++ b/py/selenium/webdriver/chrome/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "remote_connection", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/chrome/__init__.py
+++ b/py/selenium/webdriver/chrome/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/edge/__init__.py
+++ b/py/selenium/webdriver/edge/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/edge/__init__.py
+++ b/py/selenium/webdriver/edge/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "remote_connection", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/edge/__init__.py
+++ b/py/selenium/webdriver/edge/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/firefox/__init__.py
+++ b/py/selenium/webdriver/firefox/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/firefox/__init__.py
+++ b/py/selenium/webdriver/firefox/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["firefox_profile", "options", "remote_connection", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/firefox/__init__.py
+++ b/py/selenium/webdriver/firefox/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/ie/__init__.py
+++ b/py/selenium/webdriver/ie/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/ie/__init__.py
+++ b/py/selenium/webdriver/ie/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/ie/__init__.py
+++ b/py/selenium/webdriver/ie/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/safari/__init__.py
+++ b/py/selenium/webdriver/safari/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/safari/__init__.py
+++ b/py/selenium/webdriver/safari/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/safari/__init__.py
+++ b/py/selenium/webdriver/safari/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "permissions", "remote_connection", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/webkitgtk/__init__.py
+++ b/py/selenium/webdriver/webkitgtk/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/webkitgtk/__init__.py
+++ b/py/selenium/webdriver/webkitgtk/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/webkitgtk/__init__.py
+++ b/py/selenium/webdriver/webkitgtk/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))

--- a/py/selenium/webdriver/wpewebkit/__init__.py
+++ b/py/selenium/webdriver/wpewebkit/__init__.py
@@ -29,4 +29,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(_LAZY_SUBMODULES))
+    return sorted(_LAZY_SUBMODULES)

--- a/py/selenium/webdriver/wpewebkit/__init__.py
+++ b/py/selenium/webdriver/wpewebkit/__init__.py
@@ -14,3 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import importlib
+
+_LAZY_SUBMODULES = ["options", "service", "webdriver"]
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/py/selenium/webdriver/wpewebkit/__init__.py
+++ b/py/selenium/webdriver/wpewebkit/__init__.py
@@ -26,3 +26,7 @@ def __getattr__(name):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(_LAZY_SUBMODULES))


### PR DESCRIPTION
### **User description**
Step 1 in getting Bazel Python to work for us instead of against us

### 💥 What does this PR do?
Replace eager imports of all browser modules in `py/selenium/webdriver/__init__.py` with lazy loading via `__getattr__`. This:
- Enables future modularization of the Bazel build
- Improves import performance for users who only use a subset of browsers

The public API is fully backwards compatible - all existing import patterns continue to work identically.

### 🔧 Implementation Notes
Uses Python's `__getattr__` module-level function (PEP 562) to defer imports until attributes are actually accessed. This is the standard Python approach for lazy module loading.

### 💡 Additional Considerations
None - this is a drop-in replacement with no behavioral changes to the public API.

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace eager imports with lazy loading via `__getattr__`

- Improves import performance for subset browser usage

- Enables future Bazel build modularization

- Maintains full backwards compatibility with public API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Eager Imports<br/>All modules loaded<br/>at startup"] -->|"Replace with"| B["Lazy Import Mapping<br/>_LAZY_IMPORTS dict"]
  B -->|"__getattr__ function"| C["On-demand Loading<br/>Import when accessed"]
  C -->|"Result"| D["Faster startup<br/>Backwards compatible"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Convert eager imports to lazy loading mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

py/selenium/webdriver/__init__.py

<ul><li>Removed 24 eager import statements for browser modules and utilities<br> <li> Added <code>importlib</code> import for dynamic module loading<br> <li> Introduced <code>_LAZY_IMPORTS</code> dictionary mapping public names to module <br>paths and attributes<br> <li> Implemented <code>__getattr__</code> function to handle lazy loading on attribute <br>access<br> <li> Added <code>__dir__</code> function to support introspection of available <br>attributes<br> <li> Preserved <code>__all__</code> list for explicit public API exports</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16993/files#diff-732bc7e9407665904a87e936982e0941f13539f354f03b205efcd65ed803d28d">+55/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

