### PR TITLE
[build] Remove git.add() calls from rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,22 +61,18 @@ task :update_browsers, [:channel] do |_task, arguments|
 
   puts 'pinning updated browsers and drivers'
   Bazel.execute('run', args, '//scripts:pinned_browsers')
-  SeleniumRake.git.add('common/repositories.bzl')
 end
 
 desc 'Update Selenium Manager to latest release'
 task :update_manager do |_task, _arguments|
   puts 'Updating Selenium Manager references'
   Bazel.execute('run', [], '//scripts:selenium_manager')
-
-  SeleniumRake.git.add('common/selenium_manager.bzl')
 end
 
 desc 'Update multitool binaries to latest releases'
 task :update_multitool do |_task, _arguments|
   puts 'Updating multitool binary versions'
   Bazel.execute('run', [], '//scripts:update_multitool_binaries')
-  SeleniumRake.git.add('multitool.lock.json')
 end
 
 desc 'Update dependencies for release'
@@ -92,19 +88,6 @@ task :update_cdp, [:channel] do |_task, arguments|
 
   puts "Updating Chrome DevTools references to include latest from #{chrome_channel} channel"
   Bazel.execute('run', args, '//scripts:update_cdp')
-
-  ['common/devtools/',
-   'dotnet/src/webdriver/DevTools/',
-   'dotnet/src/webdriver/Selenium.WebDriver.csproj',
-   'dotnet/test/common/DevTools/',
-   'dotnet/test/common/CustomDriverConfigs/',
-   'dotnet/selenium-dotnet-version.bzl',
-   'java/src/org/openqa/selenium/devtools/',
-   'javascript/selenium-webdriver/BUILD.bazel',
-   'py/BUILD.bazel',
-   'rb/lib/selenium/devtools/',
-   'rb/Gemfile.lock',
-   'rake_tasks/java.rake'].each { |file| SeleniumRake.git.add(file) }
 end
 
 task ios_driver: 'appium:build'
@@ -113,7 +96,6 @@ desc 'Update AUTHORS file'
 task :authors do
   puts 'Updating AUTHORS file'
   sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS) | sort -uf > AUTHORS"
-  SeleniumRake.git.add('AUTHORS')
 end
 
 # Example: `./go prep_release[4.31.0,early-stable]`
@@ -293,7 +275,6 @@ namespace :all do
 
       text = File.read(file).gsub(old_version_pattern, "The latest released version of Selenium is #{major_minor}")
       File.write(file, text)
-      SeleniumRake.git.add(file)
     end
   end
 

--- a/rake_tasks/common.rb
+++ b/rake_tasks/common.rb
@@ -70,7 +70,6 @@ module SeleniumRake
 
     content = File.read(changelog)
     File.write(changelog, "#{header}\n#{entries}\n\n#{content}")
-    git.add(changelog)
   end
 
   def self.verify_package_published(url)

--- a/rake_tasks/dotnet.rake
+++ b/rake_tasks/dotnet.rake
@@ -97,7 +97,6 @@ task :version, [:version] do |_task, arguments|
   file = 'dotnet/selenium-dotnet-version.bzl'
   text = File.read(file).gsub(old_version, new_version)
   File.open(file, 'w') { |f| f.puts text }
-  SeleniumRake.git.add(file)
 end
 
 desc 'Update .NET dependencies to latest versions'
@@ -112,5 +111,4 @@ task :pin do
   Bazel.execute('run', ['--', '--dependencies-file', "#{Dir.pwd}/dotnet/paket.dependencies",
                         '--output-folder', "#{Dir.pwd}/dotnet"],
                 '@rules_dotnet//tools/paket2bazel:paket2bazel')
-  %w[dotnet/paket.lock dotnet/paket.nuget.bzl].each { |f| SeleniumRake.git.add(f) }
 end

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -364,7 +364,6 @@ desc 'Pin Maven dependencies'
 task :pin do
   args = ['--action_env=RULES_JVM_EXTERNAL_REPIN=1']
   Bazel.execute('run', args, '@maven//:pin')
-  %w[MODULE.bazel java/maven_install.json].each { |file| SeleniumRake.git.add(file) }
 end
 
 desc 'Update Java changelog'
@@ -382,7 +381,6 @@ task :version, [:version] do |_task, arguments|
   file = 'java/version.bzl'
   text = File.read(file).gsub(old_version, new_version)
   File.open(file, 'w') { |f| f.puts text }
-  SeleniumRake.git.add(file)
 end
 
 desc 'Run Java formatter (google-java-format)'

--- a/rake_tasks/node.rake
+++ b/rake_tasks/node.rake
@@ -31,7 +31,6 @@ end
 desc 'Pin JavaScript dependencies via pnpm lockfile'
 task :pin do
   Bazel.execute('run', ['--', 'install', '--dir', Dir.pwd, '--lockfile-only'], '@pnpm//:pnpm')
-  SeleniumRake.git.add('pnpm-lock.yaml')
 end
 
 desc 'Update JavaScript dependencies and refresh lockfile (use "latest" to bump ranges)'
@@ -119,7 +118,6 @@ task :version, [:version] do |_task, arguments|
   %w[javascript/selenium-webdriver/package.json javascript/selenium-webdriver/BUILD.bazel].each do |file|
     text = File.read(file).gsub(old_version, new_version)
     File.open(file, 'w') { |f| f.puts text }
-    SeleniumRake.git.add(file)
   end
 end
 

--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -141,7 +141,6 @@ task :version, [:version] do |_task, arguments|
    'py/docs/source/conf.py'].each do |file|
     text = File.read(file).gsub(old_version, new_version)
     File.open(file, 'w') { |f| f.puts text }
-    SeleniumRake.git.add(file)
   end
 
   old_short_version = old_version.split('.')[0..1].join('.')
@@ -150,7 +149,6 @@ task :version, [:version] do |_task, arguments|
   conf = 'py/docs/source/conf.py'
   text = File.read(conf).gsub(old_short_version, new_short_version)
   File.open(conf, 'w') { |f| f.puts text }
-  SeleniumRake.git.add(conf)
 end
 
 desc 'Run Python linter (ruff check + format)'

--- a/rake_tasks/ruby.rake
+++ b/rake_tasks/ruby.rake
@@ -126,7 +126,6 @@ task :version, [:version] do |_task, arguments|
   file = 'rb/lib/selenium/webdriver/version.rb'
   text = File.read(file).gsub(old_version, new_version)
   File.open(file, 'w') { |f| f.puts text }
-  SeleniumRake.git.add(file)
 
   Rake::Task['rb:update'].invoke
 end
@@ -194,16 +193,12 @@ task :pin, [:force] do |_task, arguments|
 
   new_content = module_content.sub(/    gem_checksums = \{[^}]+\},/m, formatted)
   File.write(module_bazel, new_content)
-
-  SeleniumRake.git.add(module_bazel)
 end
 
 desc 'Update Ruby dependencies and sync checksums to MODULE.bazel'
 task :update do
   puts 'updating and pinning gem versions'
   Bazel.execute('run', [], '//rb:bundle-update')
-  SeleniumRake.git.add('rb/Gemfile.lock')
   Bazel.execute('run', [], '//rb:rbs-update')
-  SeleniumRake.git.add('rb/rbs_collection.lock.yaml')
   Rake::Task['rb:pin'].invoke
 end

--- a/rake_tasks/rust.rake
+++ b/rake_tasks/rust.rake
@@ -53,10 +53,7 @@ task :version, [:version] do |_task, arguments|
   ['rust/Cargo.toml', 'rust/BUILD.bazel'].each do |file|
     text = File.read(file).gsub(old_version, new_version)
     File.open(file, 'w') { |f| f.puts text }
-    SeleniumRake.git.add(file)
   end
 
   Rake::Task['rust:update'].invoke
-  SeleniumRake.git.add('rust/Cargo.Bazel.lock')
-  SeleniumRake.git.add('rust/Cargo.lock')
 end


### PR DESCRIPTION
### **User description**
2 clever ideas conflicting.

I've been using explicit git add commands in Rakefiles to ensure only files we cared about were
committed. Then I moved the actual commit logic from rakefiles to CI (better separation of concerns)
Recently we switched to using git diff in our bazel workflow to store a patch that can be used by 
calling workflows. Except if you stage a file it's no longer in the diff. 

### 💥 What does this PR do?

Removes all `SeleniumRake.git.add()` calls from rake tasks.

Files modified by rake tasks are now left unstaged, letting users review and stage changes explicitly.

Removed 36 lines across 8 files:
- `Rakefile` - update_browsers, update_manager, update_multitool, update_cdp, authors, all:version
- `rake_tasks/java.rake` - pin, version
- `rake_tasks/python.rake` - version
- `rake_tasks/ruby.rake` - version, pin, update
- `rake_tasks/rust.rake` - version
- `rake_tasks/node.rake` - pin, version
- `rake_tasks/dotnet.rake` - version, pin
- `rake_tasks/common.rb` - update_changelog

### 🔧 Implementation Notes

The only things that I know that can sully the working directory are the version changes we make to python/ruby/node,
but those should be limited to just unit tests so won't matter for these operations.

There are a bunch of ways this could have gone, but I think trying to control which exact files is... excessive at this point.

### 💡 Additional Considerations

The git gem is still used for read-only operations (listing tags for changelog generation).


### 🔄 Types of changes

- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Remove all `SeleniumRake.git.add()` calls from rake tasks

- Allow users to explicitly stage modified files

- Enable git diff workflow for patch generation

- Improve separation of concerns between build and CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rake Tasks"] -->|"Previously auto-staged files"| B["Git Index"]
  A -->|"Now leaves files unstaged"| C["Working Directory"]
  C -->|"User explicitly stages"| B
  B -->|"Enables git diff workflow"| D["Patch Generation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.rb</strong><dd><code>Remove git.add() from changelog update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/common.rb

<ul><li>Removed <code>git.add(changelog)</code> call from <code>update_changelog</code> method<br> <li> Changelog file now left unstaged after updates</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-80cbde0e362ecd0b536b49c068c12a381d32d2cb8fc8329974f7f3a5b2b94437">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dotnet.rake</strong><dd><code>Remove git.add() from .NET tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/dotnet.rake

<ul><li>Removed <code>SeleniumRake.git.add(file)</code> from version task<br> <li> Removed <code>git.add()</code> calls for paket.lock and paket.nuget.bzl in pin task<br> <li> .NET version and dependency files now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-b6869ab5dc82f781e692100b14c4800032621d0c2494593ae261855214140a54">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>java.rake</strong><dd><code>Remove git.add() from Java tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/java.rake

<ul><li>Removed <code>git.add()</code> calls for MODULE.bazel and maven_install.json in pin <br>task<br> <li> Removed <code>git.add(file)</code> from version task<br> <li> Java version and Maven dependency files now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-246090ca8a73cd7067bce748108c78b39b6efb08cb02f6bd3f870a322c40afc1">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node.rake</strong><dd><code>Remove git.add() from Node tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/node.rake

<ul><li>Removed <code>SeleniumRake.git.add('pnpm-lock.yaml')</code> from pin task<br> <li> Removed <code>git.add()</code> calls from version task for package.json and <br>BUILD.bazel<br> <li> Node package and lockfile changes now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-cb32118d210d5f91423b64058db86f294fdc6bf58c18c00d4e68e4e189c693fd">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>python.rake</strong><dd><code>Remove git.add() from Python tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/python.rake

<ul><li>Removed <code>git.add(file)</code> calls from version task for multiple Python <br>files<br> <li> Removed <code>git.add(conf)</code> from version task for conf.py<br> <li> Python version files now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-dd9a04a51dc64de9b7d3a17dc401da7c0b7419bdb0f8148041e773d42daba3c4">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ruby.rake</strong><dd><code>Remove git.add() from Ruby tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/ruby.rake

<ul><li>Removed <code>git.add(file)</code> from version task<br> <li> Removed <code>git.add()</code> calls from pin task for MODULE.bazel<br> <li> Removed <code>git.add()</code> calls from update task for Gemfile.lock and <br>rbs_collection.lock.yaml<br> <li> Ruby version and dependency files now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-950c9e840ec1c9705250897fe8a7359b341ee4e0c1448a295e6801a1622e2ddf">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rust.rake</strong><dd><code>Remove git.add() from Rust tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/rust.rake

<ul><li>Removed <code>git.add(file)</code> calls from version task for Cargo.toml and <br>BUILD.bazel<br> <li> Removed <code>git.add()</code> calls for Cargo.Bazel.lock and Cargo.lock<br> <li> Rust version and lock files now left unstaged</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-89ea9f2317c28a0f780bf1045b5341f50ad76f73f2c5977b948db2a1c36c3751">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Remove git.add() from main Rakefile tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Removed <code>git.add('common/repositories.bzl')</code> from update_browsers task<br> <li> Removed <code>git.add('common/selenium_manager.bzl')</code> from update_manager <br>task<br> <li> Removed <code>git.add('multitool.lock.json')</code> from update_multitool task<br> <li> Removed large block of <code>git.add()</code> calls from update_cdp task (14 files)<br> <li> Removed <code>git.add('AUTHORS')</code> from authors task<br> <li> Removed <code>git.add(file)</code> from all:version task<br> <li> All modified files now left unstaged for explicit user staging</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16994/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+0/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

