### PR TITLE
[build] Separate rust from all: namespace

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -140,7 +140,7 @@ jobs:
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update Changelogs
-      run: ./go all:changelogs
+      run: ./go all:changelogs && ./go rust:changelogs
       artifact-name: patch-changelogs
 
   create-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     uses: ./.github/workflows/bazel.yml
     with:
       name: Reset Versions
-      run: ./go all:version nightly
+      run: ./go all:version nightly && ./go rust:version nightly
       artifact-name: version-reset
 
   update-version:

--- a/Rakefile
+++ b/Rakefile
@@ -112,16 +112,27 @@ task :prep_release, [:version, :channel] do |_task, arguments|
   Rake::Task['authors'].invoke
   Rake::Task['all:version'].invoke(version)
   Rake::Task['all:changelogs'].invoke
+  Rake::Task['rust:changelogs'].invoke
 end
 
-desc 'Run linters for all languages (skip languages with: ./go lint -rb -rust)'
+desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'
 task :lint do |_task, arguments|
   failures = []
+  skip = arguments.to_a.select { |a| a.start_with?('-') }.map { |a| a.delete_prefix('-') }
 
   begin
     Rake::Task['all:lint'].invoke(*arguments.to_a)
   rescue StandardError => e
     failures << e.message
+  end
+
+  unless skip.include?('rust')
+    puts 'Linting rust...'
+    begin
+      Rake::Task['rust:lint'].invoke
+    rescue StandardError => e
+      failures << "rust: #{e.message}"
+    end
   end
 
   puts 'Linting Bazel files...'
@@ -162,20 +173,18 @@ end
 task 'release-java' => 'java:release'
 
 namespace :all do
-  desc 'Pin dependencies for all languages'
+  desc 'Pin dependencies for all language bindings'
   task :pin do
     Rake::Task['java:pin'].invoke
     Rake::Task['rb:pin'].invoke
-    Rake::Task['rust:pin'].invoke
     Rake::Task['node:pin'].invoke
     Rake::Task['dotnet:pin'].invoke
   end
 
-  desc 'Update dependencies for all languages'
+  desc 'Update dependencies for all language bindings'
   task :update do
     Rake::Task['java:update'].invoke
     Rake::Task['rb:update'].invoke
-    Rake::Task['rust:update'].invoke
     Rake::Task['node:update'].invoke
     Rake::Task['dotnet:update'].invoke
   end
@@ -238,9 +247,9 @@ namespace :all do
     Rake::Task['node:release'].invoke(*args)
   end
 
-  desc 'Run linters for all languages (skip with: ./go all:lint -rb -rust)'
+  desc 'Run linters for all language bindings (skip with: ./go all:lint -rb)'
   task :lint do |_task, arguments|
-    all_langs = %w[java py rb node rust]
+    all_langs = %w[java py rb node]
     skip = arguments.to_a.select { |a| a.start_with?('-') }.map { |a| a.delete_prefix('-') }
     invalid = skip - all_langs
     raise "Unknown languages: #{invalid.join(', ')}. Valid: #{all_langs.join(', ')}" if invalid.any?
@@ -256,7 +265,7 @@ namespace :all do
     raise "Lint failed:\n#{failures.join("\n")}" unless failures.empty?
   end
 
-  desc 'Update all versions'
+  desc 'Update versions for all language bindings'
   task :version, [:version] do |_task, arguments|
     version = arguments[:version] || 'nightly'
     puts "Updating all versions to #{version}"
@@ -266,7 +275,6 @@ namespace :all do
     Rake::Task['node:version'].invoke(version)
     Rake::Task['py:version'].invoke(version)
     Rake::Task['dotnet:version'].invoke(version)
-    Rake::Task['rust:version'].invoke(version)
 
     unless version == 'nightly'
       major_minor = arguments[:version][/^\d+\.\d+/]
@@ -278,7 +286,7 @@ namespace :all do
     end
   end
 
-  desc 'Update all changelogs'
+  desc 'Update changelogs for all language bindings'
   task :changelogs do |_task, _arguments|
     puts 'Updating all changelogs'
     Rake::Task['java:changelogs'].invoke
@@ -286,6 +294,5 @@ namespace :all do
     Rake::Task['node:changelogs'].invoke
     Rake::Task['py:changelogs'].invoke
     Rake::Task['dotnet:changelogs'].invoke
-    Rake::Task['rust:changelogs'].invoke
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -118,16 +118,15 @@ end
 desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'
 task :lint do |_task, arguments|
   failures = []
-  skip = arguments.to_a.select { |a| a.start_with?('-') }.map { |a| a.delete_prefix('-') }
-  binding_args = arguments.to_a.reject { |a| a == '-rust' }
+  skip_rust = arguments.to_a.include?('-rust')
 
   begin
-    Rake::Task['all:lint'].invoke(*binding_args)
+    Rake::Task['all:lint'].invoke(*arguments.to_a.reject { |a| a == '-rust' })
   rescue StandardError => e
     failures << e.message
   end
 
-  unless skip.include?('rust')
+  unless skip_rust
     puts 'Linting rust...'
     begin
       Rake::Task['rust:lint'].invoke

--- a/Rakefile
+++ b/Rakefile
@@ -119,9 +119,10 @@ desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'
 task :lint do |_task, arguments|
   failures = []
   skip = arguments.to_a.select { |a| a.start_with?('-') }.map { |a| a.delete_prefix('-') }
+  binding_args = arguments.to_a.reject { |a| a == '-rust' }
 
   begin
-    Rake::Task['all:lint'].invoke(*arguments.to_a)
+    Rake::Task['all:lint'].invoke(*binding_args)
   rescue StandardError => e
     failures << e.message
   end

--- a/Rakefile
+++ b/Rakefile
@@ -118,21 +118,21 @@ end
 desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'
 task :lint do |_task, arguments|
   failures = []
-  skip_rust = arguments.to_a.include?('-rust')
+  values = arguments.to_a
 
-  begin
-    Rake::Task['all:lint'].invoke(*arguments.to_a.reject { |a| a == '-rust' })
-  rescue StandardError => e
-    failures << e.message
-  end
-
-  unless skip_rust
+  unless values.delete('-rust')
     puts 'Linting rust...'
     begin
       Rake::Task['rust:lint'].invoke
     rescue StandardError => e
       failures << "rust: #{e.message}"
     end
+  end
+
+  begin
+    Rake::Task['all:lint'].invoke(*values)
+  rescue StandardError => e
+    failures << e.message
   end
 
   puts 'Linting Bazel files...'


### PR DESCRIPTION
### **User description**
Rust stuff is sometimes in all namespace and sometimes not, this just clarifies it

### 💥 What does this PR do?

Separates rust (Selenium Manager) from the `all:` namespace since it has a different release cycle.

- Removes rust from `all:pin`, `all:update`, `all:lint`, `all:version`, `all:changelogs`
- Updates descriptions to say "language bindings" instead of "languages"
- Adds `rust:lint` explicitly to top-level `lint` task with `-rust` skip flag support
- Updates workflows to explicitly call rust tasks where needed

### 🔧 Implementation Notes

The `all:` namespace now means "language bindings" while `rust:` is for Selenium Manager. 
This matches how releases already work - rust releases separately via its own branch (`rust-release-$version`).

Workflow changes:
- `pre-release.yml`: Added explicit `rust:changelogs` call
- `release.yml`: Added explicit `rust:version nightly` call

### 💡 Additional Considerations

If we need one command to include rust we can do what we're doing with lint and putting it in main namespace
 

### 🔄 Types of changes

- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Separates Rust/Selenium Manager from `all:` namespace tasks

- Removes Rust from `all:pin`, `all:update`, `all:version`, `all:changelogs`

- Adds explicit `rust:lint` to top-level `lint` task with skip support

- Updates task descriptions to clarify "language bindings" vs Rust separation

- Updates CI workflows to explicitly call Rust tasks where needed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["all: namespace<br/>Language bindings only"] -->|removed| B["rust:pin<br/>rust:update<br/>rust:version<br/>rust:changelogs"]
  C["Top-level lint task"] -->|added| D["rust:lint<br/>with -rust skip flag"]
  E["CI Workflows"] -->|explicit calls| F["rust:changelogs<br/>rust:version nightly"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Separate Rust from all: namespace tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Removed Rust from <code>all:pin</code>, <code>all:update</code>, <code>all:version</code>, <code>all:changelogs</code> <br>tasks<br> <li> Added explicit <code>rust:lint</code> invocation to top-level <code>lint</code> task with <code>-rust</code> <br>skip flag support<br> <li> Updated task descriptions to say "language bindings" instead of <br>"languages"<br> <li> Updated <code>all:lint</code> to only include language bindings (removed rust from <br>list)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16995/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+18/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Add explicit Rust changelogs generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Added explicit <code>./go rust:changelogs</code> call after <code>all:changelogs</code> in <br>generate-changelogs job</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16995/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Add explicit Rust version reset for nightly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added explicit <code>./go rust:version nightly</code> call after <code>all:version </code><br><code>nightly</code> in reset-version job</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16995/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

