### PR TITLE
[build] consolidate pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -126,17 +126,66 @@ jobs:
             run: ./go rust:version ${{ needs.normalize-version.outputs.version }} && ./go rust:update
           - name: authors
             run: ./go authors
-          - name: changelogs
-            run: ./go all:changelogs && ./go rust:changelogs
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update ${{ matrix.name }}
       run: ${{ matrix.run }}
       artifact-name: patch-${{ matrix.name }}
 
+  calculate-changelog-depth:
+    name: Calculate Changelog Depth
+    needs: normalize-version
+    runs-on: ubuntu-latest
+    outputs:
+      depth: ${{ steps.calc.outputs.depth }}
+    steps:
+      - name: Calculate fetch depth from tag
+        id: calc
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.normalize-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$VERSION" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            MAJOR=${BASH_REMATCH[1]}
+            MINOR=${BASH_REMATCH[2]}
+            PATCH=${BASH_REMATCH[3]}
+
+            if [ "$PATCH" -gt 1 ]; then
+              PREV="selenium-${MAJOR}.${MINOR}.$((PATCH-1))"
+            elif [ "$PATCH" -eq 1 ]; then
+              PREV="selenium-${MAJOR}.${MINOR}.0"
+            elif [ "$MINOR" -gt 0 ]; then
+              PREV="selenium-${MAJOR}.$((MINOR-1)).0"
+            else
+              # First release of major version (X.0.0), use full history
+              echo "depth=0" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            COUNT=$(gh api "repos/${{ github.repository }}/compare/${PREV}...${{ github.sha }}" --jq '.total_commits' 2>/dev/null) || {
+              echo "::warning::Failed to get commit count, using full history"
+              echo "depth=0" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+            echo "depth=$((COUNT + 1))" >> "$GITHUB_OUTPUT"
+          else
+            echo "depth=0" >> "$GITHUB_OUTPUT"
+          fi
+
+  generate-changelogs:
+    name: Generate Changelogs
+    needs: [restrict-trunk, normalize-version, calculate-changelog-depth]
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Update Changelogs
+      run: ./go all:changelogs && ./go rust:changelogs
+      artifact-name: patch-changelogs
+      fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
+
   create-pr:
     name: Create Pull Request
-    needs: [normalize-version, release-updates]
+    needs: [normalize-version, release-updates, generate-changelogs]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trunk

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -118,79 +118,23 @@ jobs:
             run: ./go update_cdp ${{ inputs.chrome_channel }}
           - name: manager
             run: ./go update_manager
-          - name: dependencies
-            run: ./go release_update
+          - name: versions
+            run: ./go all:version ${{ needs.normalize-version.outputs.version }} && ./go all:update
+          - name: rust
+            run: ./go rust:version ${{ needs.normalize-version.outputs.version }} && ./go rust:update
           - name: authors
             run: ./go authors
+          - name: changelogs
+            run: ./go all:changelogs && ./go rust:changelogs
     uses: ./.github/workflows/bazel.yml
     with:
       name: Update ${{ matrix.name }}
       run: ${{ matrix.run }}
       artifact-name: patch-${{ matrix.name }}
 
-  generate-versions:
-    name: Generate Versions
-    needs: [restrict-trunk, normalize-version]
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Bump Versions
-      run: ./go all:version ${{ needs.normalize-version.outputs.version }}
-      artifact-name: patch-versions
-
-  calculate-changelog-depth:
-    name: Calculate Changelog Depth
-    needs: normalize-version
-    runs-on: ubuntu-latest
-    outputs:
-      depth: ${{ steps.calc.outputs.depth }}
-    steps:
-      - name: Calculate fetch depth from tag
-        id: calc
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.normalize-version.outputs.version }}
-        run: |
-          set -euo pipefail
-          if [[ "$VERSION" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            MAJOR=${BASH_REMATCH[1]}
-            MINOR=${BASH_REMATCH[2]}
-            PATCH=${BASH_REMATCH[3]}
-
-            if [ "$PATCH" -gt 1 ]; then
-              PREV="selenium-${MAJOR}.${MINOR}.$((PATCH-1))"
-            elif [ "$PATCH" -eq 1 ]; then
-              PREV="selenium-${MAJOR}.${MINOR}.0"
-            elif [ "$MINOR" -gt 0 ]; then
-              PREV="selenium-${MAJOR}.$((MINOR-1)).0"
-            else
-              # First release of major version (X.0.0), use full history
-              echo "depth=0" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            COUNT=$(gh api "repos/${{ github.repository }}/compare/${PREV}...${{ github.sha }}" --jq '.total_commits' 2>/dev/null) || {
-              echo "::warning::Failed to get commit count, using full history"
-              echo "depth=0" >> "$GITHUB_OUTPUT"
-              exit 0
-            }
-            echo "depth=$((COUNT + 1))" >> "$GITHUB_OUTPUT"
-          else
-            echo "depth=0" >> "$GITHUB_OUTPUT"
-          fi
-
-  generate-changelogs:
-    name: Generate Changelogs
-    needs: [restrict-trunk, normalize-version, calculate-changelog-depth]
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Update Changelogs
-      run: ./go all:changelogs && ./go rust:changelogs
-      artifact-name: patch-changelogs
-      fetch-depth: ${{ needs.calculate-changelog-depth.outputs.depth }}
-
   create-pr:
     name: Create Pull Request
-    needs: [normalize-version, generate-updates, generate-versions, generate-changelogs]
+    needs: [normalize-version, generate-updates]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trunk
@@ -227,9 +171,9 @@ jobs:
           apply_patch browsers "update pinned browser versions"
           apply_patch devtools "update devtools versions"
           apply_patch manager "update selenium manager versions"
-          apply_patch dependencies "update dependency versions"
+          apply_patch versions "bump bindings version and dependencies"
+          apply_patch rust "bump rust version and dependencies"
           apply_patch authors "update authors file"
-          apply_patch versions "bump versions in preparation for release"
           apply_patch changelogs "changelogs updated"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -248,9 +192,9 @@ jobs:
             | Browser and driver versions | ${{ steps.apply.outputs.browsers == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | CDP version | ${{ steps.apply.outputs.devtools == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Selenium Manager version | ${{ steps.apply.outputs.manager == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Update dependencies | ${{ steps.apply.outputs.dependencies == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Bindings Version & Dependencies | ${{ steps.apply.outputs.versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Rust Version & Dependencies | ${{ steps.apply.outputs.rust == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Update Authors | ${{ steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Bump Versions | ${{ steps.apply.outputs.versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Draft Changelogs | ${{ steps.apply.outputs.changelogs == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
 
             ---

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -105,8 +105,8 @@ jobs:
           fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-  generate-updates:
-    name: Generate ${{ matrix.name }}
+  release-updates:
+    name: Generate ${{ matrix.name }} update
     needs: [restrict-trunk, normalize-version]
     strategy:
       fail-fast: false
@@ -118,9 +118,11 @@ jobs:
             run: ./go update_cdp ${{ inputs.chrome_channel }}
           - name: manager
             run: ./go update_manager
-          - name: versions
+          - name: multitool
+            run: ./go update_multitool
+          - name: binding-versions
             run: ./go all:version ${{ needs.normalize-version.outputs.version }} && ./go all:update
-          - name: rust
+          - name: rust-versions
             run: ./go rust:version ${{ needs.normalize-version.outputs.version }} && ./go rust:update
           - name: authors
             run: ./go authors
@@ -134,7 +136,7 @@ jobs:
 
   create-pr:
     name: Create Pull Request
-    needs: [normalize-version, generate-updates]
+    needs: [normalize-version, release-updates]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trunk
@@ -171,8 +173,9 @@ jobs:
           apply_patch browsers "update pinned browser versions"
           apply_patch devtools "update devtools versions"
           apply_patch manager "update selenium manager versions"
-          apply_patch versions "bump bindings version and dependencies"
-          apply_patch rust "bump rust version and dependencies"
+          apply_patch multitool "update multitool binaries"
+          apply_patch binding-versions "bump bindings version and dependencies"
+          apply_patch rust-versions "bump rust version and dependencies"
           apply_patch authors "update authors file"
           apply_patch changelogs "changelogs updated"
       - name: Create Pull Request
@@ -192,9 +195,10 @@ jobs:
             | Browser and driver versions | ${{ steps.apply.outputs.browsers == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | CDP version | ${{ steps.apply.outputs.devtools == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Selenium Manager version | ${{ steps.apply.outputs.manager == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Bindings Version & Dependencies | ${{ steps.apply.outputs.versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Rust Version & Dependencies | ${{ steps.apply.outputs.rust == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
-            | Update Authors | ${{ steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Multitool binaries | ${{ steps.apply.outputs.multitool == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Bindings Version & Dependencies | ${{ steps.apply.outputs.binding-versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Rust Version & Dependencies | ${{ steps.apply.outputs.rust-versions == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
+            | Authors | ${{ steps.apply.outputs.authors == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
             | Draft Changelogs | ${{ steps.apply.outputs.changelogs == 'true' && '✅ Updated' || '⏭️ Skipped (no changes)' }} |
 
             ---

--- a/Rakefile
+++ b/Rakefile
@@ -98,19 +98,21 @@ task :authors do
   sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS) | sort -uf > AUTHORS"
 end
 
-# Example: `./go prep_release[4.31.0,early-stable]`
-# Equivalent to .github/workflows/pre-release.yml in a single command
+# Example: `./go release_updates 4.31.0,early-stable`
+# Equivalent to `.github/workflows/pre-release.yml` in a single command
 desc 'Update everything in preparation for a release'
-task :prep_release, [:version, :channel] do |_task, arguments|
+task :release_updates, [:version, :channel] do |_task, arguments|
   version = arguments[:version]
-  raise 'Missing required version: ./go prep_release[4.31.0,early-stable]' if version.nil? || version.empty?
+  raise 'Missing required version: ./go release_updates 4.31.0,early-stable' if version.nil? || version.empty?
 
   Rake::Task['update_browsers'].invoke(arguments[:channel])
   Rake::Task['update_cdp'].invoke(arguments[:channel])
   Rake::Task['update_manager'].invoke
-  Rake::Task['java:update'].invoke
+  Rake::Task['update_multitool'].invoke
   Rake::Task['authors'].invoke
   Rake::Task['all:version'].invoke(version)
+  Rake::Task['all:update'].invoke
+  Rake::Task['rust:update'].invoke
   Rake::Task['all:changelogs'].invoke
   Rake::Task['rust:changelogs'].invoke
 end

--- a/Rakefile
+++ b/Rakefile
@@ -98,12 +98,12 @@ task :authors do
   sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS) | sort -uf > AUTHORS"
 end
 
-# Example: `./go release_updates 4.31.0,early-stable`
-# Equivalent to `generate-updates` job in `.github/workflows/pre-release.yml`
+# Example: `./go release_updates 4.31.0 early-stable`
+# Equivalent to `release-updates` job in `.github/workflows/pre-release.yml`
 desc 'Update everything in preparation for a release'
 task :release_updates, [:version, :channel] do |_task, arguments|
   version = arguments[:version]
-  raise 'Missing required version: ./go release_updates 4.31.0,early-stable' if version.nil? || version.empty?
+  raise 'Missing required version: ./go release_updates 4.31.0 early-stable' if version.nil? || version.empty?
 
   Rake::Task['update_browsers'].invoke(arguments[:channel])
   Rake::Task['update_cdp'].invoke(arguments[:channel])

--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,7 @@ task :authors do
 end
 
 # Example: `./go release_updates 4.31.0,early-stable`
-# Equivalent to `.github/workflows/pre-release.yml` in a single command
+# Equivalent to `generate-updates` job in `.github/workflows/pre-release.yml`
 desc 'Update everything in preparation for a release'
 task :release_updates, [:version, :channel] do |_task, arguments|
   version = arguments[:version]
@@ -112,6 +112,7 @@ task :release_updates, [:version, :channel] do |_task, arguments|
   Rake::Task['authors'].invoke
   Rake::Task['all:version'].invoke(version)
   Rake::Task['all:update'].invoke
+  Rake::Task['rust:version'].invoke(version)
   Rake::Task['rust:update'].invoke
   Rake::Task['all:changelogs'].invoke
   Rake::Task['rust:changelogs'].invoke

--- a/rake_tasks/ruby.rake
+++ b/rake_tasks/ruby.rake
@@ -126,8 +126,6 @@ task :version, [:version] do |_task, arguments|
   file = 'rb/lib/selenium/webdriver/version.rb'
   text = File.read(file).gsub(old_version, new_version)
   File.open(file, 'w') { |f| f.puts text }
-
-  Rake::Task['rb:update'].invoke
 end
 
 desc 'Run Ruby linting'

--- a/rake_tasks/rust.rake
+++ b/rake_tasks/rust.rake
@@ -54,6 +54,4 @@ task :version, [:version] do |_task, arguments|
     text = File.read(file).gsub(old_version, new_version)
     File.open(file, 'w') { |f| f.puts text }
   end
-
-  Rake::Task['rust:update'].invoke
 end


### PR DESCRIPTION
### **User description**
Ruby & Rust version bumps update their lockfiles requiring re-pinning, which makes things inconsistent, this is here to help

### What does this PR do?

- Ruby & Rust version tasks no longer include calling update task
- Neither versions ~nor changelogs~ need to be managed in separate jobs during pre-release
- *Edit*: turns out changelogs does need to be in a separate job so it can use calculate-depth job, it will still run in parallel just not in the matrix
- Explicitly calling version and update in same step for pre-release workflow
- Adding explicit Rust handling since Rust is no longer part of `all:` tasks

### Implementation Notes

Pre-release workflow runs the updates separately in parallel for visibility. The same functionality in one task:
`./go release_updates`

The pre-release workflow matrix for release-updates now includes:
- `bindings-versions`: `./go all:version && ./go all:update` (bindings)
- `rust-versions`: `./go rust:version && ./go rust:update` (Rust separately)
- `changelogs`: `./go all:changelogs && ./go rust:changelogs`

This ensures:
1. Ruby's lockfile coupling is handled (version runs before update in same job)
2. Rust is handled separately since it's excluded from `all:` tasks
3. Reduced workflow complexity without creating top-level jobs

- The separate Rust release flow (generate-rust-version -> push-rust-version -> selenium-manager) remains unchanged for Selenium Manager releases

### Additional Considerations

Plan to merge this before #16987

### Types of changes

- Cleanup (formatting, renaming)


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidate pre-release workflow by merging separate jobs into single matrix job

- Remove automatic update invocations from Ruby and Rust version bump tasks

- Add explicit Rust handling in release workflow since excluded from `all:` tasks

- Rename and restructure release preparation task for clarity and consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pre-release Workflow"] -->|"Consolidate"| B["Single release-updates Job"]
  B -->|"Matrix includes"| C["Browsers, DevTools, Manager"]
  B -->|"Matrix includes"| D["Multitool, Binding-versions, Rust-versions"]
  B -->|"Matrix includes"| E["Authors, Changelogs"]
  F["Ruby/Rust version tasks"] -->|"Remove auto-update"| G["Manual update invocation"]
  H["prep_release task"] -->|"Rename to"| I["release_updates task"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ruby.rake</strong><dd><code>Remove automatic update from Ruby version task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/ruby.rake

<ul><li>Remove automatic <code>rb:update</code> task invocation from <code>rb:version</code> task<br> <li> Version bump now only updates version file without triggering <br>dependency updates</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16997/files#diff-950c9e840ec1c9705250897fe8a7359b341ee4e0c1448a295e6801a1622e2ddf">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rust.rake</strong><dd><code>Remove automatic update from Rust version task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/rust.rake

<ul><li>Remove automatic <code>rust:update</code> task invocation from <code>rust:version</code> task<br> <li> Version bump now only updates Cargo.toml and BUILD.bazel without <br>triggering dependency updates</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16997/files#diff-89ea9f2317c28a0f780bf1045b5341f50ad76f73f2c5977b948db2a1c36c3751">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pre-release.yml</strong><dd><code>Consolidate workflow jobs into single matrix job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pre-release.yml

<ul><li>Rename <code>generate-updates</code> job to <code>release-updates</code> and consolidate <br>multiple separate jobs into single matrix job<br> <li> Add <code>binding-versions</code> and <code>rust-versions</code> matrix entries that explicitly <br>run version and update tasks in sequence<br> <li> Replace <code>release_update</code> with <code>update_multitool</code> and add explicit <br>changelog generation<br> <li> Remove separate <code>generate-versions</code> and <code>generate-changelogs</code> jobs<br> <li> Update <code>create-pr</code> job dependencies and patch application logic to <br>reflect consolidated workflow<br> <li> Update PR body table to show new component names and remove redundant <br>entries</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16997/files#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607">+18/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Rakefile</strong><dd><code>Rename and restructure release preparation task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Rakefile

<ul><li>Rename <code>prep_release</code> task to <code>release_updates</code> for consistency with <br>workflow naming<br> <li> Update task to invoke <code>update_multitool</code> instead of <code>java:update</code><br> <li> Add explicit invocations of <code>all:update</code> and <code>rust:update</code> tasks to handle <br>dependency updates separately<br> <li> Update documentation comments and error messages to reflect new task <br>name</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16997/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

