### PR TITLE
[dotnet] Add linting support with configurable dotnet format

### DIFF
--- a/dotnet/.editorconfig
+++ b/dotnet/.editorconfig
@@ -1,2 +1,2 @@
 [*.cs]
-csharp_style_namespace_declarations=file_scoped:error
+csharp_style_namespace_declarations=file_scoped:suggestion

--- a/dotnet/.editorconfig
+++ b/dotnet/.editorconfig
@@ -1,2 +1,2 @@
 [*.cs]
-csharp_style_namespace_declarations=file_scoped:suggestion
+csharp_style_namespace_declarations=file_scoped:error

--- a/dotnet/private/dotnet_format.bzl
+++ b/dotnet/private/dotnet_format.bzl
@@ -52,10 +52,10 @@ DOTNET_DIR="$WORKSPACE_ROOT/dotnet"
 
 cd "$DOTNET_DIR"
 
-echo "Running dotnet format on all projects..."
+echo "Running dotnet format $@ on all projects..."
 find "$DOTNET_DIR/src" "$DOTNET_DIR/test" -name "*.csproj" 2>/dev/null | while read -r proj; do
     echo "  Formatting $proj..."
-    "$DOTNET" format "$proj" || exit 1
+    "$DOTNET" format "$@" "$proj" || exit 1
 done || exit 1
 
 echo "Done."
@@ -90,14 +90,14 @@ set DOTNET_DIR=%WORKSPACE_ROOT%\\dotnet
 
 cd /d "%DOTNET_DIR%"
 
-echo Running dotnet format on all projects...
+echo Running dotnet format %* on all projects...
 for /r "%DOTNET_DIR%\\src" %%%%p in (*.csproj) do (
     echo   Formatting %%%%p...
-    "%DOTNET%" format "%%%%p" || exit /b 1
+    "%DOTNET%" format %* "%%%%p" || exit /b 1
 )
 for /r "%DOTNET_DIR%\\test" %%%%p in (*.csproj) do (
     echo   Formatting %%%%p...
-    "%DOTNET%" format "%%%%p" || exit /b 1
+    "%DOTNET%" format %* "%%%%p" || exit /b 1
 )
 
 echo Done.

--- a/dotnet/test/common/WebElementWrapper.cs
+++ b/dotnet/test/common/WebElementWrapper.cs
@@ -20,79 +20,78 @@
 using System.Collections.ObjectModel;
 using System.Drawing;
 
-namespace OpenQA.Selenium
+namespace OpenQA.Selenium;
+
+public class WebElementWrapper(IWebElement element) : IWebElement, IWrapsElement
 {
-    public class WebElementWrapper(IWebElement element) : IWebElement, IWrapsElement
+    public IWebElement WrappedElement { get; } = element;
+
+    public string TagName => WrappedElement.TagName;
+
+    public string Text => WrappedElement.Text;
+
+    public bool Enabled => WrappedElement.Enabled;
+
+    public bool Selected => WrappedElement.Selected;
+
+    public Point Location => WrappedElement.Location;
+
+    public Size Size => WrappedElement.Size;
+
+    public bool Displayed => WrappedElement.Displayed;
+
+    public void Clear()
     {
-        public IWebElement WrappedElement { get; } = element;
+        WrappedElement.Clear();
+    }
 
-        public string TagName => WrappedElement.TagName;
+    public void Click()
+    {
+        WrappedElement.Click();
+    }
 
-        public string Text => WrappedElement.Text;
+    public IWebElement FindElement(By by)
+    {
+        return WrappedElement.FindElement(by);
+    }
 
-        public bool Enabled => WrappedElement.Enabled;
+    public ReadOnlyCollection<IWebElement> FindElements(By by)
+    {
+        return WrappedElement.FindElements(by);
+    }
 
-        public bool Selected => WrappedElement.Selected;
+    public string GetAttribute(string attributeName)
+    {
+        return WrappedElement.GetAttribute(attributeName);
+    }
 
-        public Point Location => WrappedElement.Location;
+    public string GetCssValue(string propertyName)
+    {
+        return WrappedElement.GetCssValue(propertyName);
+    }
 
-        public Size Size => WrappedElement.Size;
+    public string GetDomAttribute(string attributeName)
+    {
+        return WrappedElement.GetDomAttribute(attributeName);
+    }
 
-        public bool Displayed => WrappedElement.Displayed;
+    public string GetDomProperty(string propertyName)
+    {
+        return WrappedElement.GetDomProperty(propertyName);
+    }
 
-        public void Clear()
-        {
-            WrappedElement.Clear();
-        }
+    public ISearchContext GetShadowRoot()
+    {
+        return WrappedElement.GetShadowRoot();
+    }
 
-        public void Click()
-        {
-            WrappedElement.Click();
-        }
+    public void SendKeys(string text)
+    {
+        WrappedElement.SendKeys(text);
+    }
 
-        public IWebElement FindElement(By by)
-        {
-            return WrappedElement.FindElement(by);
-        }
-
-        public ReadOnlyCollection<IWebElement> FindElements(By by)
-        {
-            return WrappedElement.FindElements(by);
-        }
-
-        public string GetAttribute(string attributeName)
-        {
-            return WrappedElement.GetAttribute(attributeName);
-        }
-
-        public string GetCssValue(string propertyName)
-        {
-            return WrappedElement.GetCssValue(propertyName);
-        }
-
-        public string GetDomAttribute(string attributeName)
-        {
-            return WrappedElement.GetDomAttribute(attributeName);
-        }
-
-        public string GetDomProperty(string propertyName)
-        {
-            return WrappedElement.GetDomProperty(propertyName);
-        }
-
-        public ISearchContext GetShadowRoot()
-        {
-            return WrappedElement.GetShadowRoot();
-        }
-
-        public void SendKeys(string text)
-        {
-            WrappedElement.SendKeys(text);
-        }
-
-        public void Submit()
-        {
-            WrappedElement.Submit();
-        }
+    public void Submit()
+    {
+        WrappedElement.Submit();
     }
 }

--- a/rake_tasks/dotnet.rake
+++ b/rake_tasks/dotnet.rake
@@ -120,3 +120,9 @@ task :format do |_task, arguments|
   puts '  Running dotnet format whitespace...'
   Bazel.execute('run', ['--', 'whitespace'], '//dotnet:format')
 end
+
+desc 'Run .NET linter (format + style + analyzers)'
+task :lint do |_task, arguments|
+  puts '  Running dotnet format...'
+  Bazel.execute('run', ['--'] + arguments.to_a, '//dotnet:format')
+end

--- a/rake_tasks/dotnet.rake
+++ b/rake_tasks/dotnet.rake
@@ -112,3 +112,11 @@ task :pin do
                         '--output-folder', "#{Dir.pwd}/dotnet"],
                 '@rules_dotnet//tools/paket2bazel:paket2bazel')
 end
+
+desc 'Run .NET formatter (whitespace only)'
+task :format do |_task, arguments|
+  raise ArgumentError, 'arguments not supported for this task' unless arguments.to_a.empty?
+
+  puts '  Running dotnet format whitespace...'
+  Bazel.execute('run', ['--', 'whitespace'], '//dotnet:format')
+end

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -15,8 +15,8 @@ echo "    buildifier" >&2
 bazel run //:buildifier
 
 section "Dotnet"
-echo "    dotnet format" >&2
-bazel run //dotnet:format
+echo "    dotnet format whitespace" >&2
+bazel run //dotnet:format -- whitespace
 
 section "Java"
 echo "    google-java-format" >&2


### PR DESCRIPTION
### **User description**
Figuring out how to get linting and formatting working across project

### 💥 What does this PR do?

In #16986 I added support for dotnet's format feature, but it hard coded one setting.

This PR allows the user to pass in parameters just like to native format:
```bash
bazel run //dotnet:format                  # everything (format + style + analyzers)
bazel run //dotnet:format -- whitespace    # whitespace only
bazel run //dotnet:format -- style         # style rules only
bazel run //dotnet:format -- analyzers     # analyzers only
```

The previous also added dotnet to format.sh which adds about 100 seconds to execution.

This PR only runs: `bazel run //dotnet:format -- whitespace` which is about 30 seconds.

This PR then wraps the typical features with:
- `./go dotnet:format` - runs whitespace-only formatting
- `./go dotnet:lint` - runs full format + style + analyzers

Finally, @nvborisenko created `dotnet/.editorconfig` last year, I set it to error so it would fail the lint job.  

### 🔧 Implementation Notes

Whitespace-only mode is ~3x faster than full linting, making it suitable for the general `format.sh` script while full linting can be run separately.

### 💡 Additional Considerations

This is a precursor to a final lint PR that makes sure everything is handled consistently across bindings and properly run by CI.

More things can be enforced by `.editorconfig` now if you want (@RenderMichael / @nvborisenko)

### 🔄 Types of changes

- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add configurable dotnet format with argument support

- Implement separate format (whitespace) and lint (full) tasks

- Apply linting results to codebase with namespace declarations

- Enforce file-scoped namespace style via .editorconfig


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dotnet_format.bzl"] -- "accept arguments" --> B["format target"]
  B -- "whitespace mode" --> C["format.sh"]
  B -- "full mode" --> D["dotnet.rake"]
  D -- "format task" --> E["whitespace only"]
  D -- "lint task" --> F["format + style + analyzers"]
  G[".editorconfig"] -- "enforce error level" --> F
  H["WebElementWrapper.cs"] -- "apply linting" --> I["file-scoped namespace"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dotnet_format.bzl</strong><dd><code>Add argument passing to format target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/private/dotnet_format.bzl

<ul><li>Modified bash and batch scripts to accept and pass arguments to dotnet <br>format<br> <li> Updated echo messages to display passed arguments<br> <li> Changed format command invocation to include <code>$@</code> (bash) and <code>%*</code> (batch) <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16999/files#diff-13f22b78aef6bca0b121e119b6087893a0299d20c2ee3cc559933805f6886cfc">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dotnet.rake</strong><dd><code>Implement format and lint rake tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rake_tasks/dotnet.rake

<ul><li>Added <code>format</code> task that runs whitespace-only formatting via bazel<br> <li> Added <code>lint</code> task that runs full format with style and analyzers<br> <li> Both tasks use the dotnet:format bazel target with appropriate <br>arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16999/files#diff-b6869ab5dc82f781e692100b14c4800032621d0c2494593ae261855214140a54">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format.sh</strong><dd><code>Limit format.sh to whitespace mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/format.sh

<ul><li>Updated dotnet format invocation to use whitespace-only mode<br> <li> Changed command from <code>bazel run //dotnet:format</code> to <code>bazel run </code><br><code>//dotnet:format -- whitespace</code><br> <li> Updated echo message to reflect whitespace-only formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16999/files#diff-3a9054a1963ff6cd07b6054d4feecbb4a17b3e4fe87ac71aeb2db3f2524552fb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.editorconfig</strong><dd><code>Enforce file-scoped namespace as error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/.editorconfig

<ul><li>Changed <code>csharp_style_namespace_declarations</code> severity from suggestion <br>to error<br> <li> Enforces file-scoped namespace declarations as a linting requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16999/files#diff-cfb867d5de3aaa02df169c9665b9d05d4f96b045d92063289b1e1e9b2d88b2cf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebElementWrapper.cs</strong><dd><code>Apply file-scoped namespace formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dotnet/test/common/WebElementWrapper.cs

<ul><li>Converted namespace declaration from block-scoped to file-scoped <br>syntax<br> <li> Adjusted indentation of class and all members to align with <br>file-scoped namespace<br> <li> No functional changes, purely formatting and style compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/16999/files#diff-937930b02ee65f0ff9fa8ca5f3e03a0da087f04f96c7dc87e0f1f96f420dcce7">+54/-55</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

