### PR TITLE
[build] retrigger CI after auto-format commits

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check last commit author
         id: check
         run: |

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Check last commit author
         id: check
         run: |
-          LAST_AUTHOR=$(git log -1 --format='%an')
-          if [ "$LAST_AUTHOR" = "Selenium CI Bot" ]; then
+          LAST_AUTHOR_EMAIL=$(git log -1 --format='%ae')
+          if [ "$LAST_AUTHOR_EMAIL" = "selenium-ci@users.noreply.github.com" ]; then
             echo "::notice::Last commit was from Selenium CI Bot - skipping commit-fixes"
             echo "should-commit=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -64,10 +64,33 @@ jobs:
           echo "::error::Code needs formatting. Run ./scripts/format.sh locally and push changes."
           exit 1
 
+  check-bot-commit:
+    name: Check bot commit
+    needs: format
+    if: always() && needs.format.result == 'failure' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    outputs:
+      should-commit: ${{ steps.check.outputs.should-commit }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Check last commit author
+        id: check
+        run: |
+          LAST_AUTHOR=$(git log -1 --format='%an')
+          if [ "$LAST_AUTHOR" = "Selenium CI Bot" ]; then
+            echo "::notice::Last commit was from Selenium CI Bot - skipping commit-fixes"
+            echo "should-commit=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-commit=true" >> "$GITHUB_OUTPUT"
+          fi
+
   commit-fixes:
     name: Commit fixes
-    needs: format
-    if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    needs: check-bot-commit
+    if: needs.check-bot-commit.outputs.should-commit == 'true'
     permissions:
       contents: write
       actions: read
@@ -76,3 +99,5 @@ jobs:
       artifact-name: format-changes
       commit-message: "Auto-format code"
       ref: ${{ github.event.pull_request.head.ref }}
+    secrets:
+      SELENIUM_CI_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}


### PR DESCRIPTION
### **User description**
A PR had a lint issue that the autofix job autofixed, except there was another failure, and the way GitHub
does commits from `GITHUB_TOKEN`, it does not send the commit added / PR updated event, so the jobs do not rerun,
so the failures were hidden, which is not what we want.

### 💥 What does this PR do?

1. Use `SELENIUM_CI_TOKEN` to commit the changes so auto-fix pushes trigger a full CI run
2. Adds loop prevention to skip auto-formatting if the last commit was already from "Selenium CI Bot"

### 🔧 Implementation Notes

Added a `check-bot-commit` job that:
- Runs after `format` fails (for PRs on non-forks)
- Checks if the last commit author is "Selenium CI Bot"
- Outputs `should-commit=true/false`

The `commit-fixes` job now only runs if `should-commit == 'true'`.

### 💡 Additional Considerations

Requires `SELENIUM_CI_TOKEN` secret to be configured with appropriate permissions. Falls back to current behavior if not available.

### 🔄 Types of changes

- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Adds loop prevention to skip auto-formatting if last commit from bot

- Uses SELENIUM_CI_TOKEN to trigger full CI run on auto-fix commits

- Implements check-bot-commit job to detect previous bot commits

- Prevents infinite commit loops in auto-format workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  format["format job fails"]
  check["check-bot-commit job"]
  commit["commit-fixes job"]
  format -- "always runs after failure" --> check
  check -- "checks last commit author" --> commit
  commit -- "only runs if should-commit=true" --> trigger["triggers full CI run"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-lint.yml</strong><dd><code>Add bot commit detection and token-based CI retrigger</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-lint.yml

<ul><li>Added new <code>check-bot-commit</code> job that detects if last commit was from <br>Selenium CI Bot<br> <li> Job outputs <code>should-commit</code> flag to prevent infinite commit loops<br> <li> Modified <code>commit-fixes</code> job to depend on <code>check-bot-commit</code> instead of <br><code>format</code><br> <li> Added <code>SELENIUM_CI_TOKEN</code> secret pass-through to <code>commit-changes</code> workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17000/files#diff-57157b14b324e35015a6c3e7dcacbca988efb53e3441e11e4ab4a07cbba16161">+27/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

