### PR TITLE
Report exactly which JSON value was incorrect

### DIFF
--- a/java/src/org/openqa/selenium/json/InstanceCoercer.java
+++ b/java/src/org/openqa/selenium/json/InstanceCoercer.java
@@ -118,7 +118,11 @@ class InstanceCoercer extends TypeCoercer<Object> {
                         try {
                           field.set(instance, value);
                         } catch (IllegalAccessException e) {
-                          throw new JsonException(e);
+                          throw new JsonException(
+                              String.format(
+                                  "Cannot set %s.%s = %s",
+                                  instance.getClass().getName(), field.getName(), value),
+                              e);
                         }
                       };
                   return new TypeAndWriter(type, writer);
@@ -141,7 +145,11 @@ class InstanceCoercer extends TypeCoercer<Object> {
                         try {
                           method.invoke(instance, value);
                         } catch (ReflectiveOperationException e) {
-                          throw new JsonException(e);
+                          throw new JsonException(
+                              String.format(
+                                  "Cannot call method %s.%s(%s)",
+                                  instance.getClass().getName(), method.getName(), value),
+                              e);
                         }
                       };
                   return new TypeAndWriter(type, writer);
@@ -156,26 +164,21 @@ class InstanceCoercer extends TypeCoercer<Object> {
       constructor.setAccessible(true);
       return constructor;
     } catch (ReflectiveOperationException e) {
-      throw new JsonException(e);
+      throw new JsonException("Cannot create instance of " + type, e);
     }
   }
 
   private static Class<?> getClss(Type type) {
-    Class<?> target = null;
-
     if (type instanceof Class) {
-      target = (Class<?>) type;
+      return (Class<?>) type;
     } else if (type instanceof ParameterizedType) {
       Type rawType = ((ParameterizedType) type).getRawType();
       if (rawType instanceof Class) {
-        target = (Class<?>) rawType;
+        return (Class<?>) rawType;
       }
     }
 
-    if (target == null) {
-      throw new JsonException("Cannot determine base class");
-    }
-    return target;
+    throw new JsonException("Cannot determine base class for " + type);
   }
 
   private static class TypeAndWriter {

--- a/java/src/org/openqa/selenium/json/InstantCoercer.java
+++ b/java/src/org/openqa/selenium/json/InstantCoercer.java
@@ -18,14 +18,17 @@
 package org.openqa.selenium.json;
 
 import java.lang.reflect.Type;
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 
 public class InstantCoercer extends TypeCoercer<Instant> {
+  private static final Pattern DIGITS_ONLY = Pattern.compile("\\d+");
+
   @Override
   public boolean test(Class<?> aClass) {
     return Instant.class.isAssignableFrom(aClass);
@@ -40,15 +43,20 @@ public class InstantCoercer extends TypeCoercer<Instant> {
         return Instant.ofEpochMilli(jsonInput.nextNumber().longValue());
       } else if (JsonType.STRING.equals(token)) {
         String raw = jsonInput.nextString();
+        if (DIGITS_ONLY.matcher(raw).matches()) {
+          try {
+            return Instant.ofEpochMilli(new BigInteger(raw).longValueExact());
+          } catch (NumberFormatException | ArithmeticException invalidLong) {
+            throw new JsonException(
+                String.format("\"%s\" is not a valid timestamp", raw), invalidLong);
+          }
+        }
         try {
           TemporalAccessor parsed = DateTimeFormatter.ISO_INSTANT.parse(raw);
           return Instant.from(parsed);
-        } catch (DateTimeParseException ignored) {
-          try {
-            return Instant.ofEpochMilli(new BigDecimal(raw).longValue());
-          } catch (NumberFormatException e) {
-            throw new JsonException(raw + " does not look like an Instant");
-          }
+        } catch (DateTimeParseException invalidDateTime) {
+          throw new JsonException(
+              String.format("\"%s\" does not look like an Instant", raw), invalidDateTime);
         }
       }
 

--- a/java/src/org/openqa/selenium/json/Json.java
+++ b/java/src/org/openqa/selenium/json/Json.java
@@ -133,7 +133,7 @@ public class Json {
       jsonOutput.write(toConvert, maxDepth);
       return writer.toString();
     } catch (IOException e) {
-      throw new JsonException(e);
+      throw new JsonException("Cannot convert " + toConvert + " to json", e);
     }
   }
 

--- a/java/src/org/openqa/selenium/json/JsonInput.java
+++ b/java/src/org/openqa/selenium/json/JsonInput.java
@@ -258,7 +258,7 @@ public class JsonInput implements Closeable {
 
       return new BigDecimal(builder.toString()).doubleValue();
     } catch (NumberFormatException e) {
-      throw new JsonException("Unable to parse to a number: " + builder + ". " + input);
+      throw new JsonException("Unable to parse to a number: " + builder + ". " + input, e);
     }
   }
 

--- a/java/src/org/openqa/selenium/json/NumberCoercer.java
+++ b/java/src/org/openqa/selenium/json/NumberCoercer.java
@@ -62,10 +62,12 @@ class NumberCoercer<T extends Number> extends TypeCoercer<T> {
           break;
 
         case STRING:
+          String numberAsString = jsonInput.nextString();
           try {
-            number = new BigDecimal(jsonInput.nextString());
+            number = new BigDecimal(numberAsString);
           } catch (NumberFormatException e) {
-            throw new JsonException(e);
+            throw new JsonException(
+                String.format("Not a numeric value: \"%s\"", numberAsString), e);
           }
           break;
 

--- a/java/src/org/openqa/selenium/json/ObjectCoercer.java
+++ b/java/src/org/openqa/selenium/json/ObjectCoercer.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import org.openqa.selenium.internal.Require;
 
-class ObjectCoercer extends TypeCoercer {
+class ObjectCoercer extends TypeCoercer<Object> {
 
   private final JsonTypeCoercer coercer;
 

--- a/java/test/org/openqa/selenium/interactions/CombinedInputActionsTest.java
+++ b/java/test/org/openqa/selenium/interactions/CombinedInputActionsTest.java
@@ -246,7 +246,7 @@ class CombinedInputActionsTest extends JupiterTestBase {
     wait.until(presenceOfElementLocated(By.id("ifr")));
     driver.switchTo().frame("ifr");
 
-    WebElement link = driver.findElement(By.id("link"));
+    WebElement link = wait.until(presenceOfElementLocated(By.id("link")));
 
     new Actions(driver).moveToElement(link).click().perform();
 
@@ -297,13 +297,6 @@ class CombinedInputActionsTest extends JupiterTestBase {
 
     assertThat(x).isCloseTo(location.getX() + 20, Offset.offset(5));
     assertThat(y).isCloseTo(location.getY() + 10, Offset.offset(5));
-  }
-
-  private boolean fuzzyPositionMatching(int expectedX, int expectedY, int actualX, int actualY) {
-    // Everything within 5 pixels range is OK
-    final int ALLOWED_DEVIATION = 5;
-    return Math.abs(expectedX - actualX) < ALLOWED_DEVIATION
-        && Math.abs(expectedY - actualY) < ALLOWED_DEVIATION;
   }
 
   /**
@@ -388,7 +381,7 @@ class CombinedInputActionsTest extends JupiterTestBase {
 
   @Test
   @NotYetImplemented(SAFARI)
-  public void canClickOnASuckerFishStyleMenu() throws InterruptedException {
+  public void canClickOnASuckerFishStyleMenu() {
     driver.get(pages.javascriptPage);
     unfocusMenu();
 

--- a/java/test/org/openqa/selenium/json/BUILD.bazel
+++ b/java/test/org/openqa/selenium/json/BUILD.bazel
@@ -13,5 +13,6 @@ java_test_suite(
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
         artifact("com.google.code.gson:gson"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )

--- a/java/test/org/openqa/selenium/json/JsonTest.java
+++ b/java/test/org/openqa/selenium/json/JsonTest.java
@@ -19,10 +19,12 @@ package org.openqa.selenium.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.openqa.selenium.Proxy.ProxyType.PAC;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
+import static org.openqa.selenium.json.PropertySetting.BY_FIELD;
 
 import com.google.common.reflect.TypeToken;
 import java.io.StringReader;
@@ -32,6 +34,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -124,7 +127,7 @@ class JsonTest {
 
     Json json = new Json();
     String raw = json.toJson(map);
-    BeanWithSetter seen = json.toType(raw, BeanWithSetter.class, PropertySetting.BY_FIELD);
+    BeanWithSetter seen = json.toType(raw, BeanWithSetter.class, BY_FIELD);
 
     assertThat(seen.theName).isEqualTo("fishy");
   }
@@ -135,7 +138,7 @@ class JsonTest {
 
     Json json = new Json();
     String raw = json.toJson(map);
-    BeanWithFinalField seen = json.toType(raw, BeanWithFinalField.class, PropertySetting.BY_FIELD);
+    BeanWithFinalField seen = json.toType(raw, BeanWithFinalField.class, BY_FIELD);
 
     assertThat(seen.theName).isEqualTo("fishy");
   }
@@ -203,14 +206,101 @@ class JsonTest {
   }
 
   @Test
-  void shouldBeAbleToReadAnInstant() {
-    // We will lose the nanoseconds
-    Instant now = Instant.ofEpochMilli(System.currentTimeMillis());
-    String raw = String.valueOf(now.toEpochMilli());
+  void canReadNumericValues() {
+    String raw =
+        "{\"id\": 1234567890123456789, \"age\": 1234567890, \"fee\": \"999.888\", \"amount\":"
+            + " \"999888.777666\"}";
 
-    Instant instant = new Json().toType(raw, Instant.class);
+    NumericValues bean = new Json().toType(raw, NumericValues.class, BY_FIELD);
 
-    assertThat(instant).isEqualTo(now);
+    assertThat(bean.id).isEqualTo(1234567890123456789L);
+    assertThat(bean.age).isEqualTo(1234567890);
+    assertThat(bean.fee).isEqualTo(999.888f);
+    assertThat(bean.amount).isEqualTo(999888.777666);
+    assertThat(bean.remainder).isNull();
+  }
+
+  @Test
+  void reportsWhichNumericValueWasInvalid() {
+    String raw = "{\"id\": 123, \"age\": \"df8e0744-b1db-49b2-96df-45bd0d70dcd3\"}";
+
+    assertThatThrownBy(() -> new Json().toType(raw, NumericValues.class, BY_FIELD))
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Unable to parse: " + raw)
+        .cause()
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Not a numeric value: \"df8e0744-b1db-49b2-96df-45bd0d70dcd3\"");
+  }
+
+  @Test
+  void reportsTooLargeNumericValue() {
+    String raw = "{\"id\": 123456789012345678901234567890}";
+
+    assertThatThrownBy(() -> new Json().toType(raw, NumericValues.class, BY_FIELD))
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Unable to parse: " + raw)
+        .cause()
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Unable to parse to a number: 123456789012345678901234567890")
+        .cause()
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessage("For input string: \"123456789012345678901234567890\"");
+  }
+
+  @Test
+  void canReadBooleanValues() {
+    String raw = "{\"hero\": true, \"gangster\": false}";
+
+    BooleanValues bean = new Json().toType(raw, BooleanValues.class, BY_FIELD);
+
+    assertThat(bean.hero).isEqualTo(true);
+    assertThat(bean.gangster).isEqualTo(false);
+  }
+
+  @Test
+  void reportsWhichBooleanValueWasInvalid() {
+    String raw = "{\"hero\": true, \"gangster\": \"not sure\"}";
+
+    assertThatThrownBy(() -> new Json().toType(raw, BooleanValues.class, BY_FIELD))
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Unable to parse: " + raw)
+        .cause()
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("Expected to read a BOOLEAN but instead have: STRING")
+        .hasMessageContaining("to read: \"not sure\"");
+  }
+
+  @Test
+  void shouldBeAbleToReadAnInstantFromTimestamp() {
+    long now = System.currentTimeMillis();
+
+    Dates instant = new Json().toType("{\"birth\": " + now + "}", Dates.class, BY_FIELD);
+
+    assertThat(instant.birth).isEqualTo(Instant.ofEpochMilli(now));
+  }
+
+  @Test
+  void shouldBeAbleToReadAnInstantFromTimestampAsString() {
+    long now = System.currentTimeMillis();
+
+    Dates instant = new Json().toType("{\"birth\": \"" + now + "\"}", Dates.class, BY_FIELD);
+
+    assertThat(instant.birth).isEqualTo(Instant.ofEpochMilli(now));
+  }
+
+  @Test
+  void reportsWhichInstantValueWasInvalid() {
+    String raw = "\"2025-13-32\"";
+
+    assertThatThrownBy(() -> new Json().toType(raw, Instant.class))
+        .isInstanceOf(JsonException.class)
+        .hasMessage("Unable to parse: \"2025-13-32\"")
+        .cause()
+        .isInstanceOf(JsonException.class)
+        .hasMessageStartingWith("\"2025-13-32\" does not look like an Instant")
+        .cause()
+        .isInstanceOf(java.time.format.DateTimeParseException.class)
+        .hasMessageContaining("Text '2025-13-32' could not be parsed");
   }
 
   @Test
@@ -255,18 +345,24 @@ class JsonTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void shouldBeAbleToCopeWithStringsThatLookLikeBooleans() {
     String json = "{\"value\":\"false\",\"context\":\"foo\",\"sessionId\":\"1210083863107\"}";
-    new Json().toType(json, Response.class);
+    Response parsed = new Json().toType(json, Response.class);
+    assertThat(parsed.getValue()).isEqualTo("false");
+    assertThat(parsed.getSessionId()).isEqualTo("1210083863107");
+    assertThat(parsed.getState()).isNull();
+    assertThat(parsed.getStatus()).isNull();
   }
 
   @Test
   void shouldBeAbleToSetAnObjectToABoolean() {
-    String json = "{\"value\":true,\"context\":\"foo\",\"sessionId\":\"1210084658750\"}";
+    String json = "{\"value\":true,\"context\":\"foo\",\"sessionId\":\"true\"}";
 
     Response response = new Json().toType(json, Response.class);
 
     assertThat(response.getValue()).isEqualTo(true);
+    assertThat(response.getSessionId()).isEqualTo("true");
   }
 
   @Test
@@ -589,5 +685,24 @@ class JsonTest {
       toReturn.cheese = String.valueOf(args.get("cheese"));
       return toReturn;
     }
+  }
+
+  static class NumericValues {
+    long id;
+    int age;
+    float fee;
+    double amount;
+    @Nullable Double remainder;
+  }
+
+  static class BooleanValues {
+    boolean hero;
+    Boolean gangster;
+  }
+
+  static class Dates {
+    Instant birth;
+    Date wedding;
+    Instant death;
   }
 }


### PR DESCRIPTION
### **User description**
### 💥 What does this PR do?
Adds valuable information to JSON parsing exception: which field was invalid.

### 🔧 Example
Example of JSON parsing exception that was not clean enough:

```
org.openqa.selenium.json.JsonException: java.lang.NumberFormatException: Character array is missing "e" notation exponential mark.
Build info: version: '4.40.0-SNAPSHOT', revision: '048a50178d*'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.2', java.version: '17.0.17'
Driver info: driver.version: unknown
	at org.openqa.selenium.json.NumberCoercer.lambda$apply$0(NumberCoercer.java:68)
	at org.openqa.selenium.json.JsonTypeCoercer.lambda$buildCoercer$6(JsonTypeCoercer.java:171)
	at org.openqa.selenium.json.JsonTypeCoercer.coerce(JsonTypeCoercer.java:146)
	at org.openqa.selenium.json.JsonInput.read(JsonInput.java:428)
	at org.openqa.selenium.bidi.script.RemoteValue.fromJson(RemoteValue.java:136)
	... 53 more
Caused by: java.lang.NumberFormatException: Character array is missing "e" notation exponential mark.
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:645)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:471)
	at java.base/java.math.BigDecimal.<init>(BigDecimal.java:900)
	at org.openqa.selenium.json.NumberCoercer.lambda$apply$0(NumberCoercer.java:66)
```

See https://github.com/SeleniumHQ/selenium/pull/16918


### 🔄 Types of changes
- Bug fix (backwards compatible)


___

### **PR Type**
Bug fix


___

### **Description**
- Enriches JSON parsing exceptions with specific field/value information

- Improves error messages in numeric, instant, and object coercion

- Adds detailed context about which values failed to parse

- Includes comprehensive test coverage for error scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON Parsing Errors"] -->|Add context| B["Field/Value Information"]
  B -->|NumberCoercer| C["Numeric Value Details"]
  B -->|InstantCoercer| D["Timestamp Format Details"]
  B -->|InstanceCoercer| E["Object Property Details"]
  C -->|Tests| F["Validation Coverage"]
  D -->|Tests| F
  E -->|Tests| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InstanceCoercer.java</strong><dd><code>Add context to field and method invocation errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/InstanceCoercer.java

<ul><li>Enhanced exception messages when setting fields with context about <br>class, field name, and value<br> <li> Improved exception messages when invoking setter methods with method <br>signature details<br> <li> Simplified <code>getClss()</code> method with early returns and added type <br>information to error message</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-08cecc5873f77483a2ec2c8e051c6ec37b26bd81bccc57a6bf13ca0d34469095">+14/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InstantCoercer.java</strong><dd><code>Improve instant parsing with better error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/InstantCoercer.java

<ul><li>Changed from <code>BigDecimal</code> to <code>BigInteger</code> for parsing digit-only strings <br>as timestamps<br> <li> Added pattern matching to detect numeric-only timestamp strings<br> <li> Enhanced error messages with formatted strings showing the invalid <br>timestamp value<br> <li> Improved exception chaining with original cause exceptions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-d0e5d2d6b05d6614348c2cd5a18d8e83776e4be8ff648a1a0c9fa47d4bdf178b">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Json.java</strong><dd><code>Add context to JSON conversion errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/Json.java

<ul><li>Added descriptive message to JSON conversion exception indicating what <br>value failed to convert</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-e3ef10c05b6ecf8d714eaa87edbded5f35cca66d46387d60844e3499e6ceb33c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonInput.java</strong><dd><code>Improve number parsing error chain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/JsonInput.java

<ul><li>Added original exception as cause to number parsing error for better <br>error chain context</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-162d1e84f8475ebea31dd037e38d700e07beacf189da303f454b1b62ad7b8483">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NumberCoercer.java</strong><dd><code>Add numeric value context to coercion errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/NumberCoercer.java

<ul><li>Extracted numeric string value to variable for better error reporting<br> <li> Enhanced exception message to show the actual invalid numeric string <br>value<br> <li> Improved exception chaining with original cause</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-a60e8b93d13f5cc9a7cd33deb847bc0a61d11b0a19ca9bae6472ddd9c0ef12c2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ObjectCoercer.java</strong><dd><code>Add generic type parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/src/org/openqa/selenium/json/ObjectCoercer.java

- Added generic type parameter to class declaration for type safety


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-807213b36ac3972433ce85c5872f545dc06bf37450f65de31803f3a3a1ff4805">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonTest.java</strong><dd><code>Add comprehensive JSON parsing error tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/json/JsonTest.java

<ul><li>Added new test classes <code>NumericValues</code>, <code>BooleanValues</code>, and <code>Dates</code> for <br>comprehensive testing<br> <li> Added tests for numeric value parsing with valid and invalid inputs<br> <li> Added tests for boolean value parsing with error scenarios<br> <li> Added tests for instant parsing from timestamps and ISO format with <br>detailed error validation<br> <li> Updated existing instant parsing test to use new test structure<br> <li> Enhanced existing boolean and string parsing tests with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-ca8b46815d2ed84d1c82776cf430ab11d8b9cdb91a4c904338c96dc482147623">+125/-10</a></td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add jspecify dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/json/BUILD.bazel

<ul><li>Added <code>org.jspecify:jspecify</code> dependency for nullable annotations <br>support</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/17003/files#diff-87e848c9bcdbbace6012379ef08bcba84e5cd2ad6dd7bfda525f0fa5453ff983">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

