### PR TITLE
[rb] Add rubocop binary target for flexible linting

### DIFF
--- a/rb/BUILD.bazel
+++ b/rb/BUILD.bazel
@@ -211,6 +211,15 @@ _LINT_DEPS = [
     "@bundle",
 ]
 
+rb_binary(
+    name = "rubocop",
+    testonly = True,
+    args = _LINT_ARGS,
+    data = _LINT_DATA,
+    main = "@bundle//bin:rubocop",
+    deps = _LINT_DEPS,
+)
+
 rb_test(
     name = "lint",
     args = ["--autocorrect"] + _LINT_ARGS,
@@ -220,15 +229,6 @@ rb_test(
         "no-sandbox",
         "skip-rbe",
     ],
-    deps = _LINT_DEPS,
-)
-
-rb_binary(
-    name = "lint-unsafe",
-    testonly = True,
-    args = ["--autocorrect-all"] + _LINT_ARGS,
-    data = _LINT_DATA,
-    main = "@bundle//bin:rubocop",
     deps = _LINT_DEPS,
 )
 


### PR DESCRIPTION

### 💥 What does this PR do?

Adds a flexible `//rb:rubocop` binary target that accepts any rubocop flags, 
and removes the now-redundant `//rb:lint-unsafe` target.

### 🔧 Implementation Notes

- `//rb:rubocop` includes only the config and file paths, letting you pass any flags via `--`
- Examples:
  - `bazel run //rb:rubocop -- --autocorrect-all` (replaces `//rb:lint-unsafe`)
  - `bazel run //rb:rubocop -- --only Metrics/AbcSize`
  - `bazel run //rb:rubocop -- --auto-gen-config`
- `//rb:lint` unchanged - still runs as a test with `--autocorrect`

### 💡 Additional Considerations

This matches the pattern I've been using with ruff and format

### 🔄 Types of changes

- Cleanup (formatting, renaming)
