### PR TITLE
mark `wait.until` as non-nullable

### DIFF
--- a/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxDriver.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
@@ -183,6 +184,7 @@ public class FirefoxDriver extends RemoteWebDriver
     return caps;
   }
 
+  @NonNull
   @Override
   public Capabilities getCapabilities() {
     return capabilities;

--- a/java/src/org/openqa/selenium/remote/Augmenter.java
+++ b/java/src/org/openqa/selenium/remote/Augmenter.java
@@ -21,6 +21,7 @@ import static java.util.Collections.unmodifiableSet;
 import static net.bytebuddy.matcher.ElementMatchers.anyOf;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -212,7 +213,9 @@ public class Augmenter {
             .asSubclass(driver.getClass());
 
     try {
-      WebDriver toReturn = definition.getDeclaredConstructor().newInstance();
+      Constructor<? extends WebDriver> constructor = definition.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      WebDriver toReturn = constructor.newInstance();
 
       copyFields(driver.getClass(), driver, toReturn);
 
@@ -285,7 +288,7 @@ public class Augmenter {
   }
 
   private void copyField(Object source, Object target, Field field) {
-    if (Modifier.isFinal(field.getModifiers())) {
+    if (Modifier.isStatic(field.getModifiers())) {
       return;
     }
 

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -46,6 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.openqa.selenium.AcceptedW3CCapabilityKeys;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.Beta;
@@ -357,6 +358,7 @@ public class RemoteWebDriver
     this.executor = executor;
   }
 
+  @NonNull
   @Override
   public Capabilities getCapabilities() {
     if (capabilities == null) {

--- a/java/src/org/openqa/selenium/support/ui/ExpectedCondition.java
+++ b/java/src/org/openqa/selenium/support/ui/ExpectedCondition.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.support.ui;
 
 import com.google.common.base.Function;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebDriver;
 
@@ -29,13 +28,12 @@ import org.openqa.selenium.WebDriver;
  *
  * <p>Note that it is expected that ExpectedConditions are idempotent. They will be called in a loop
  * by the {@link WebDriverWait} and any modification of the state of the application under test may
- * have unexpected side-effects.
+ * have unexpected side effects.
  *
  * @param <T> The return type
  */
 // NB: this originally extended Guava's Function interface since Java didn't have one. To avoid code
 // such as "com.google.common.base.Function condition = ExpectedConditions.elementFound(By);"
 // breaking at compile time, we continue to extend Guava's Function interface.
-@NullMarked
 public interface ExpectedCondition<T extends @Nullable Object>
     extends Function<WebDriver, T>, java.util.function.Function<WebDriver, T> {}

--- a/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
@@ -42,7 +41,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 /** Canned {@link ExpectedCondition}s which are generally useful within webdriver tests. */
-@NullMarked
 @SuppressWarnings("MismatchedJavadocCode")
 public class ExpectedConditions {
   private static final Logger LOG = Logger.getLogger(ExpectedConditions.class.getName());

--- a/java/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.internal.Require;
@@ -76,7 +77,7 @@ public class FluentWait<T> implements Wait<T> {
 
   protected Duration timeout = DEFAULT_WAIT_DURATION;
   protected Duration interval = DEFAULT_WAIT_DURATION;
-  protected Supplier<String> messageSupplier = () -> null;
+  protected Supplier<@Nullable String> messageSupplier = () -> null;
 
   protected final List<Class<? extends Throwable>> ignoredExceptions = new ArrayList<>();
 
@@ -117,6 +118,7 @@ public class FluentWait<T> implements Wait<T> {
    * @return A self reference.
    */
   public FluentWait<T> withMessage(final String message) {
+    Require.nonNull("Message", message);
     this.messageSupplier = () -> message;
     return this;
   }
@@ -128,7 +130,7 @@ public class FluentWait<T> implements Wait<T> {
    * @return A self reference.
    */
   public FluentWait<T> withMessage(Supplier<String> messageSupplier) {
-    this.messageSupplier = messageSupplier;
+    this.messageSupplier = Require.nonNull("Message supplier", messageSupplier);
     return this;
   }
 
@@ -165,7 +167,7 @@ public class FluentWait<T> implements Wait<T> {
    * @see #ignoreAll(Collection)
    */
   public FluentWait<T> ignoring(Class<? extends Throwable> exceptionType) {
-    return this.ignoreAll(List.<Class<? extends Throwable>>of(exceptionType));
+    return this.ignoreAll(List.of(exceptionType));
   }
 
   /**
@@ -198,7 +200,7 @@ public class FluentWait<T> implements Wait<T> {
    * @throws TimeoutException If the timeout expires.
    */
   @Override
-  public <V> V until(Function<? super T, V> isTrue) {
+  public <V> V until(Function<? super T, @Nullable V> isTrue) {
     Instant end = clock.instant().plus(timeout);
 
     Throwable lastException;
@@ -220,7 +222,7 @@ public class FluentWait<T> implements Wait<T> {
       // Check the timeout after evaluating the function to ensure conditions
       // with a zero timeout can succeed.
       if (end.isBefore(clock.instant())) {
-        String message = messageSupplier != null ? messageSupplier.get() : null;
+        String message = messageSupplier.get();
 
         String timeoutMessage =
             String.format(
@@ -272,7 +274,7 @@ public class FluentWait<T> implements Wait<T> {
    *     on a function.
    * @return Nothing will ever be returned; this return type is only specified as a convenience.
    */
-  protected RuntimeException timeoutException(String message, Throwable lastException) {
+  protected RuntimeException timeoutException(String message, @Nullable Throwable lastException) {
     throw new TimeoutException(message, lastException);
   }
 }

--- a/java/src/org/openqa/selenium/support/ui/WebDriverWait.java
+++ b/java/src/org/openqa/selenium/support/ui/WebDriverWait.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.support.ui;
 
 import java.time.Clock;
 import java.time.Duration;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
@@ -79,7 +80,7 @@ public class WebDriverWait extends FluentWait<WebDriver> {
   }
 
   @Override
-  protected RuntimeException timeoutException(String message, Throwable lastException) {
+  protected RuntimeException timeoutException(String message, @Nullable Throwable lastException) {
     WebDriver exceptionDriver = driver;
     TimeoutException ex = new TimeoutException(message, lastException);
     ex.addInfo(WebDriverException.DRIVER_INFO, exceptionDriver.getClass().getName());

--- a/java/src/org/openqa/selenium/support/ui/package-info.java
+++ b/java/src/org/openqa/selenium/support/ui/package-info.java
@@ -15,24 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.openqa.selenium;
+@NullMarked
+package org.openqa.selenium.support.ui;
 
-import org.jspecify.annotations.Nullable;
-
-/** Thrown when a command does not complete in enough time. */
-public class TimeoutException extends WebDriverException {
-
-  public TimeoutException() {}
-
-  public TimeoutException(String message) {
-    super(message);
-  }
-
-  public TimeoutException(Throwable cause) {
-    super(cause);
-  }
-
-  public TimeoutException(String message, @Nullable Throwable cause) {
-    super(message, cause);
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/test/org/openqa/selenium/remote/AugmenterTest.java
+++ b/java/test/org/openqa/selenium/remote/AugmenterTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -114,8 +115,7 @@ class AugmenterTest {
     // This will force the class to be enhanced
     final Capabilities caps = new ImmutableCapabilities("magic.numbers", true);
 
-    DetonatingDriver driver = new DetonatingDriver();
-    driver.setCapabilities(caps);
+    DetonatingDriver driver = new DetonatingDriver(caps);
 
     WebDriver returned =
         getAugmenter()
@@ -337,12 +337,17 @@ class AugmenterTest {
 
   public static class DetonatingDriver extends RemoteWebDriver {
 
-    private Capabilities caps;
+    private final Capabilities caps;
 
-    public void setCapabilities(Capabilities caps) {
+    protected DetonatingDriver() {
+      this(null);
+    }
+
+    public DetonatingDriver(Capabilities caps) {
       this.caps = caps;
     }
 
+    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return caps;
@@ -366,6 +371,7 @@ class AugmenterTest {
 
   public static class ChildRemoteDriver extends RemoteWebDriver implements HasMagicNumbers {
 
+    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return new FirefoxOptions();
@@ -379,6 +385,7 @@ class AugmenterTest {
 
   public static class WithFinals extends RemoteWebDriver {
 
+    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return new ImmutableCapabilities();

--- a/java/test/org/openqa/selenium/remote/BUILD.bazel
+++ b/java/test/org/openqa/selenium/remote/BUILD.bazel
@@ -36,6 +36,7 @@ java_test_suite(
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.junit.jupiter:junit-jupiter-params"),
         artifact("org.mockito:mockito-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )
 
@@ -53,5 +54,6 @@ java_selenium_test_suite(
         "//java/test/org/openqa/selenium/testing/drivers",
         artifact("org.assertj:assertj-core"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )

--- a/java/test/org/openqa/selenium/support/ui/BUILD.bazel
+++ b/java/test/org/openqa/selenium/support/ui/BUILD.bazel
@@ -31,6 +31,7 @@ java_test_suite(
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
         artifact("org.mockito:mockito-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )
 
@@ -47,5 +48,6 @@ java_selenium_test_suite(
         "//java/test/org/openqa/selenium/testing/drivers",
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )

--- a/java/test/org/openqa/selenium/support/ui/FluentWaitTest.java
+++ b/java/test/org/openqa/selenium/support/ui/FluentWaitTest.java
@@ -28,6 +28,7 @@ import static org.openqa.selenium.support.ui.FluentWait.formatTimeout;
 
 import java.time.Duration;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
@@ -251,7 +252,8 @@ class FluentWaitTest {
     FluentWait<WebDriver> wait =
         new FluentWait<>(mockDriver, mockClock, mockSleeper) {
           @Override
-          protected RuntimeException timeoutException(String message, Throwable lastException) {
+          protected RuntimeException timeoutException(
+              String message, @Nullable Throwable lastException) {
             throw sentinelException;
           }
         };

--- a/java/test/org/openqa/selenium/support/ui/QuotesTest.java
+++ b/java/test/org/openqa/selenium/support/ui/QuotesTest.java
@@ -46,8 +46,8 @@ class QuotesTest {
   }
 
   /**
-   * Tests that Quotes.escape returns concatenated strings when the given string contains a tick and
-   * and ends with a quote.
+   * Tests that {@link Quotes#escape(String)} returns concatenated strings when the given string
+   * contains a tick and ends with a quote.
    */
   @Test
   void shouldProvideConcatenatedStringsWhenStringEndsWithQuote() {

--- a/java/test/org/openqa/selenium/support/ui/package-info.java
+++ b/java/test/org/openqa/selenium/support/ui/package-info.java
@@ -15,24 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.openqa.selenium;
+@NullMarked
+package org.openqa.selenium.support.ui;
 
-import org.jspecify.annotations.Nullable;
-
-/** Thrown when a command does not complete in enough time. */
-public class TimeoutException extends WebDriverException {
-
-  public TimeoutException() {}
-
-  public TimeoutException(String message) {
-    super(message);
-  }
-
-  public TimeoutException(Throwable cause) {
-    super(cause);
-  }
-
-  public TimeoutException(String message, @Nullable Throwable cause) {
-    super(message, cause);
-  }
-}
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
They always return true/false, WebDriver or WebElement. They never return null.

### 🔗 Related Issues
Fixes #16970

Adds `@NullMarked` annotation to `Wait`, `FluentWait` etc.
@TWiStErRob

### 🔄 Types of changes
- Bug fix (backwards compatible)
