### PR TITLE
[rb] Update lint configuration and fix rubocop offenses

### DIFF
--- a/rb/.rubocop.yml
+++ b/rb/.rubocop.yml
@@ -25,8 +25,6 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
     - 'lib/selenium/webdriver/common/driver_finder.rb'
-    - 'lib/selenium/webdriver/common/options.rb'
-    - 'lib/selenium/webdriver/remote/capabilities.rb'
     - 'lib/selenium/webdriver/remote/http/curb.rb'
     - 'lib/selenium/webdriver/support/color.rb'
     - '../rake_tasks/**/*'
@@ -36,6 +34,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'selenium-*.gemspec'
+    - 'Steepfile'
     - '../rake_tasks/**/*'
     - '../Rakefile'
 
@@ -43,28 +42,21 @@ Metrics/ClassLength:
   CountComments: false
   Max: 160
   Exclude:
-    - 'lib/selenium/webdriver/common/driver.rb'
     - 'lib/selenium/webdriver/remote/bridge.rb'
     - 'lib/selenium/webdriver/remote/capabilities.rb'
     - 'spec/integration/selenium/webdriver/spec_support/test_environment.rb'
-    - 'spec/**/*.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 9
   Exclude:
     - 'lib/selenium/webdriver/support/color.rb'
-    - 'lib/selenium/webdriver/common/logger.rb'
     - '../rake_tasks/**/*'
 
 Metrics/MethodLength:
   CountComments: false
   Max: 22
   Exclude:
-    - 'lib/selenium/server.rb'
-    - 'lib/selenium/webdriver/common/options.rb'
-    - 'lib/selenium/webdriver/common/driver.rb'
     - 'lib/selenium/webdriver/common/driver_finder.rb'
-    - 'lib/selenium/webdriver/remote/http/default.rb'
     - '../rake_tasks/**/*'
 
 Metrics/ModuleLength:
@@ -77,9 +69,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 9
   Exclude:
-    - 'lib/selenium/webdriver/common/options.rb'
-    - 'lib/selenium/webdriver/common/local_driver.rb'
-    - 'lib/selenium/webdriver/common/logger.rb'
     - '../rake_tasks/**/*'
 
 Naming/BlockForwarding:
@@ -146,6 +135,10 @@ Style/Dir:
 # Consider documenting all top-level classes and modules
 Style/Documentation:
   Enabled: false
+
+Style/MixinUsage:
+  Exclude:
+    - 'spec/integration/selenium/webdriver/spec_helper.rb'
 
 Style/HashEachMethods:
   Enabled: true

--- a/rb/Steepfile
+++ b/rb/Steepfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength -- Disable due to the steep configuration not matching rubocop expectations
 target :lib do
   signature 'sig', '.gem_rbs_collection/rubyzip' # Signature directory
   check 'lib' # Directory name
@@ -88,4 +87,3 @@ target :lib do
     'zlib'
   )
 end
-# rubocop:enable Metrics/BlockLength

--- a/rb/lib/selenium/webdriver/support/block_event_listener.rb
+++ b/rb/lib/selenium/webdriver/support/block_event_listener.rb
@@ -25,8 +25,12 @@ module Selenium
           @callback = callback
         end
 
-        def method_missing(meth, *) # rubocop:disable Style/MissingRespondToMissing
+        def method_missing(meth, *)
           @callback.call(meth, *)
+        end
+
+        def respond_to_missing?(_meth, _include_private = false)
+          true
         end
       end # BlockEventListener
     end # Support

--- a/rb/lib/selenium/webdriver/support/color.rb
+++ b/rb/lib/selenium/webdriver/support/color.rb
@@ -72,26 +72,26 @@ module Selenium
           end
         end
 
-        def self.from_hsl(h, s, l, a) # rubocop:disable Naming/MethodParameterName
-          h = Float(h) / 360
-          s = Float(s) / 100
-          l = Float(l) / 100
-          a = Float(a || 1)
+        def self.from_hsl(hue, sat, light, alpha)
+          hue = Float(hue) / 360
+          sat = Float(sat) / 100
+          light = Float(light) / 100
+          alpha = Float(alpha || 1)
 
-          if s.zero?
-            r = l
+          if sat.zero?
+            r = light
             g = r
             b = r
           else
-            luminocity2 = l < 0.5 ? l * (s + 1) : l + s - (l * s)
-            luminocity1 = (l * 2) - luminocity2
+            luminocity2 = light < 0.5 ? light * (sat + 1) : light + sat - (light * sat)
+            luminocity1 = (light * 2) - luminocity2
 
-            r = hue_to_rgb(luminocity1, luminocity2, h + (1.0 / 3.0))
-            g = hue_to_rgb(luminocity1, luminocity2, h)
-            b = hue_to_rgb(luminocity1, luminocity2, h - (1.0 / 3.0))
+            r = hue_to_rgb(luminocity1, luminocity2, hue + (1.0 / 3.0))
+            g = hue_to_rgb(luminocity1, luminocity2, hue)
+            b = hue_to_rgb(luminocity1, luminocity2, hue - (1.0 / 3.0))
           end
 
-          new (r * 255).round, (g * 255).round, (b * 255).round, a
+          new (r * 255).round, (g * 255).round, (b * 255).round, alpha
         end
 
         def self.hue_to_rgb(lum1, lum2, hue)

--- a/rb/lib/selenium/webdriver/support/event_firing_bridge.rb
+++ b/rb/lib/selenium/webdriver/support/event_firing_bridge.rb
@@ -120,8 +120,12 @@ module Selenium
           returned
         end
 
-        def method_missing(meth, ...) # rubocop:disable Style/MissingRespondToMissing
+        def method_missing(meth, ...)
           @delegate.__send__(meth, ...)
+        end
+
+        def respond_to_missing?(meth, include_private = false)
+          @delegate.respond_to?(meth, include_private) || super
         end
       end # EventFiringBridge
     end # Support

--- a/rb/sig/lib/selenium/webdriver/support/color.rbs
+++ b/rb/sig/lib/selenium/webdriver/support/color.rbs
@@ -36,7 +36,7 @@ module Selenium
 
         def self.from_string: (String str) -> untyped
 
-        def self.from_hsl: (untyped h, untyped s, untyped l, untyped a) -> untyped
+        def self.from_hsl: (untyped hue, untyped sat, untyped light, untyped alpha) -> untyped
 
         def self.hue_to_rgb: (untyped lum1, untyped lum2, untyped hue) -> untyped
 

--- a/rb/spec/integration/selenium/webdriver/driver_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/driver_spec.rb
@@ -82,13 +82,7 @@ module Selenium
           expect(driver.find_element(name: 'x').attribute('value')).to eq('name')
         end
 
-        it 'finds by class name' do # rubocop:disable RSpec/RepeatedExample
-          driver.navigate.to url_for('xhtmlTest.html')
-          expect(driver.find_element(class: 'header').text).to eq('XHTML Might Be The Future')
-        end
-
-        # TODO: Rewrite this test so it's not a duplicate of above or remove
-        it 'finds elements with a hash selector' do # rubocop:disable RSpec/RepeatedExample
+        it 'finds by class name' do
           driver.navigate.to url_for('xhtmlTest.html')
           expect(driver.find_element(class: 'header').text).to eq('XHTML Might Be The Future')
         end

--- a/rb/spec/integration/selenium/webdriver/spec_helper.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_helper.rb
@@ -25,7 +25,7 @@ require 'selenium-webdriver'
 require_relative 'spec_support'
 require_relative '../../../rspec_matchers'
 
-include Selenium # rubocop:disable Style/MixinUsage
+include Selenium
 
 GlobalTestEnv = WebDriver::SpecSupport::TestEnvironment.new
 


### PR DESCRIPTION
### 💥 What does this PR do?
Updates Ruby lint configuration and fixes rubocop offenses to reduce inline disable comments:

- Remove unnecessary exclusions from `.rubocop.yml` for files that now pass lint checks
- Add `Steepfile` to `BlockLength` exclusion instead of inline disable comment
- Add proper `respond_to_missing?` methods where `method_missing` is used (best practice in Ruby)
- Rename single-letter parameters to descriptive names in `Color.from_hsl`
- Remove duplicate test in `driver_spec.rb`
- Move `Style/MixinUsage` exclusion to `.rubocop.yml`

### 🔧 Implementation Notes
The goal is to reduce the number of inline rubocop disable comments by either:
1. Fixing the underlying code to comply with the rule
2. Moving necessary exclusions to `.rubocop.yml` where they're more visible

### 💡 Additional Considerations
None - all changes verified by pre-push hook running rubocop and steep.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
