### PR TITLE
[py][java][js] SE_DEBUG warns only when overriding user settings

### DIFF
--- a/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -276,6 +276,15 @@ public class ChromeDriverService extends DriverService {
       }
       if (Debug.isDebugAll()
           || (verbose == null && Boolean.getBoolean(CHROME_DRIVER_VERBOSE_LOG_PROPERTY))) {
+        if (Debug.isDebugAll()
+            && (logLevel != null
+                || silent != null
+                || Boolean.getBoolean(CHROME_DRIVER_SILENT_OUTPUT_PROPERTY)
+                || System.getProperty(CHROME_DRIVER_LOG_LEVEL_PROPERTY) != null)) {
+          System.err.println(
+              "WARNING: Environment Variable `SE_DEBUG` is set; forcing ChromeDriver --verbose and"
+                  + " overriding --silent/--log-level settings.");
+        }
         withVerbose(true);
       }
       if (silent == null && Boolean.getBoolean(CHROME_DRIVER_SILENT_OUTPUT_PROPERTY)) {

--- a/java/src/org/openqa/selenium/edge/EdgeDriverService.java
+++ b/java/src/org/openqa/selenium/edge/EdgeDriverService.java
@@ -270,6 +270,15 @@ public class EdgeDriverService extends DriverService {
       }
       if (Debug.isDebugAll()
           || (verbose == null && Boolean.getBoolean(EDGE_DRIVER_VERBOSE_LOG_PROPERTY))) {
+        if (Debug.isDebugAll()
+            && (logLevel != null
+                || silent != null
+                || Boolean.getBoolean(EDGE_DRIVER_SILENT_OUTPUT_PROPERTY)
+                || System.getProperty(EDGE_DRIVER_LOG_LEVEL_PROPERTY) != null)) {
+          System.err.println(
+              "WARNING: Environment Variable `SE_DEBUG` is set; forcing EdgeDriver --verbose and"
+                  + " overriding --silent/--log-level settings.");
+        }
         withVerbose(true);
       }
       if (silent == null && Boolean.getBoolean(EDGE_DRIVER_SILENT_OUTPUT_PROPERTY)) {

--- a/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
+++ b/java/src/org/openqa/selenium/firefox/GeckoDriverService.java
@@ -235,6 +235,11 @@ public class GeckoDriverService extends FirefoxDriverService {
     protected void loadSystemProperties() {
       parseLogOutput(GECKO_DRIVER_LOG_PROPERTY);
       if (Debug.isDebugAll()) {
+        if (logLevel != null || System.getProperty(GECKO_DRIVER_LOG_LEVEL_PROPERTY) != null) {
+          System.err.println(
+              "WARNING: Environment Variable `SE_DEBUG` is set; forcing GeckoDriver log level to"
+                  + " DEBUG and overriding configured log level.");
+        }
         logLevel = FirefoxDriverLogLevel.DEBUG;
       } else if (logLevel == null) {
         logLevel =

--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -86,6 +86,9 @@ public class LoggingOptions {
   public void setLoggingLevel() {
     String configLevel = config.get(LOGGING_SECTION, "log-level").orElse(DEFAULT_LOG_LEVEL);
     if (Debug.isDebugAll()) {
+      System.err.println(
+          "WARNING: Environment Variable `SE_DEBUG` is set; forcing Grid log level to FINE and"
+              + " overriding configured log level.");
       configLevel = Level.FINE.getName();
     }
 
@@ -183,6 +186,11 @@ public class LoggingOptions {
   }
 
   private OutputStream getOutputStream() {
+    if (Debug.isDebugAll() && config.get(LOGGING_SECTION, "log-file").isEmpty()) {
+      System.err.println(
+          "WARNING: Environment Variable `SE_DEBUG` is set; defaulting Grid log output to stderr"
+              + " instead of stdout.");
+    }
     return config
         .get(LOGGING_SECTION, "log-file")
         .map(

--- a/java/src/org/openqa/selenium/internal/Debug.java
+++ b/java/src/org/openqa/selenium/internal/Debug.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.internal;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
@@ -26,6 +27,7 @@ import java.util.logging.StreamHandler;
 public class Debug {
 
   private static final boolean IS_DEBUG;
+  private static final AtomicBoolean DEBUG_WARNING_LOGGED = new AtomicBoolean(false);
   private static boolean loggerConfigured = false;
   private static Logger seleniumLogger;
 
@@ -47,7 +49,14 @@ public class Debug {
   }
 
   public static boolean isDebugAll() {
-    return Boolean.parseBoolean(System.getenv("SE_DEBUG"));
+    boolean everything = Boolean.parseBoolean(System.getenv("SE_DEBUG"));
+    if (everything && DEBUG_WARNING_LOGGED.compareAndSet(false, true)) {
+      String warn =
+          "WARNING: Environment Variable `SE_DEBUG` is set; Selenium is forcing verbose logging"
+              + " which may override user-specified settings.";
+      System.err.println(warn);
+    }
+    return everything;
   }
 
   public static void configureLogger() {

--- a/java/src/org/openqa/selenium/remote/service/DriverService.java
+++ b/java/src/org/openqa/selenium/remote/service/DriverService.java
@@ -485,6 +485,11 @@ public class DriverService implements Closeable {
 
       String defaultLocation = Debug.isDebugAll() ? LOG_STDERR : LOG_NULL;
       String logLocation = System.getProperty(logProperty, defaultLocation);
+      if (Debug.isDebugAll() && System.getProperty(logProperty) == null) {
+        System.err.println(
+            "WARNING: Environment Variable `SE_DEBUG` is set; defaulting driver log output to"
+                + " stderr.");
+      }
       switch (logLocation) {
         case LOG_STDOUT:
           withLogOutput(System.out);

--- a/javascript/selenium-webdriver/lib/logging.js
+++ b/javascript/selenium-webdriver/lib/logging.js
@@ -481,14 +481,12 @@ class LogManager {
 }
 
 const logManager = new LogManager()
-let seDebugWarningEmitted = false
 
 // Enable debug logging if SE_DEBUG or SELENIUM_VERBOSE environment variable is set
 if (typeof process !== 'undefined' && process.env && (process.env.SE_DEBUG || process.env.SELENIUM_VERBOSE)) {
   logManager.root_.setLevel(Level.ALL)
   logManager.root_.addHandler(consoleHandler)
-  if (process.env.SE_DEBUG && !seDebugWarningEmitted) {
-    seDebugWarningEmitted = true
+  if (process.env.SE_DEBUG) {
     logManager.root_.warning(
       'Environment Variable `SE_DEBUG` is set; Selenium is forcing verbose logging which may override user-specified settings.',
     )

--- a/javascript/selenium-webdriver/lib/logging.js
+++ b/javascript/selenium-webdriver/lib/logging.js
@@ -481,11 +481,18 @@ class LogManager {
 }
 
 const logManager = new LogManager()
+let seDebugWarningEmitted = false
 
 // Enable debug logging if SE_DEBUG or SELENIUM_VERBOSE environment variable is set
 if (typeof process !== 'undefined' && process.env && (process.env.SE_DEBUG || process.env.SELENIUM_VERBOSE)) {
   logManager.root_.setLevel(Level.ALL)
   logManager.root_.addHandler(consoleHandler)
+  if (process.env.SE_DEBUG && !seDebugWarningEmitted) {
+    seDebugWarningEmitted = true
+    logManager.root_.warning(
+      'Environment Variable `SE_DEBUG` is set; Selenium is forcing verbose logging which may override user-specified settings.',
+    )
+  }
 }
 
 /**

--- a/py/selenium/webdriver/__init__.py
+++ b/py/selenium/webdriver/__init__.py
@@ -24,6 +24,10 @@ if os.environ.get("SE_DEBUG"):
     logger.setLevel(logging.DEBUG)
     if not logger.handlers:
         logger.addHandler(logging.StreamHandler())
+    logger.warning(
+        "Environment Variable `SE_DEBUG` is set; "
+        "Selenium is forcing verbose logging which may override user-specified settings."
+    )
 
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeService

--- a/py/selenium/webdriver/chromium/service.py
+++ b/py/selenium/webdriver/chromium/service.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 import os
 import sys
 from collections.abc import Mapping, Sequence
@@ -55,9 +56,17 @@ class ChromiumService(service.Service):
             self.log_output = log_output
 
         if os.environ.get("SE_DEBUG"):
-            self._service_args = [
-                arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-path", "silent"))
-            ]
+            has_arg_conflicts = any(x in arg for arg in self._service_args for x in ("log-level", "log-path", "silent"))
+            has_output_conflict = self.log_output is not None
+            if has_arg_conflicts or has_output_conflict:
+                logging.getLogger(__name__).warning(
+                    "Environment Variable `SE_DEBUG` is set; "
+                    "forcing ChromiumDriver --verbose and overriding log-level/log-output/silent settings."
+                )
+            if has_arg_conflicts:
+                self._service_args = [
+                    arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-path", "silent"))
+                ]
             self._service_args.append("--verbose")
             self.log_output = sys.stderr
 

--- a/py/selenium/webdriver/firefox/service.py
+++ b/py/selenium/webdriver/firefox/service.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 import os
 import sys
 from collections.abc import Mapping, Sequence
@@ -49,11 +50,19 @@ class Service(service.Service):
         driver_path_env_key = driver_path_env_key or "SE_GECKODRIVER"
 
         if os.environ.get("SE_DEBUG"):
-            if "--log" in self._service_args:
-                idx = self._service_args.index("--log")
-                del self._service_args[idx : idx + 2]
-            else:
-                self._service_args = [arg for arg in self._service_args if not arg.startswith("--log=")]
+            has_log_arg = "--log" in self._service_args or any(arg.startswith("--log=") for arg in self._service_args)
+            has_output_conflict = log_output is not None
+            if has_log_arg or has_output_conflict:
+                logging.getLogger(__name__).warning(
+                    "Environment Variable `SE_DEBUG` is set; "
+                    "forcing GeckoDriver log level to DEBUG and overriding configured log level/output."
+                )
+            if has_log_arg:
+                if "--log" in self._service_args:
+                    idx = self._service_args.index("--log")
+                    del self._service_args[idx : idx + 2]
+                else:
+                    self._service_args = [arg for arg in self._service_args if not arg.startswith("--log=")]
             self._service_args.append("--log")
             self._service_args.append("debug")
             log_output = sys.stderr

--- a/py/selenium/webdriver/ie/service.py
+++ b/py/selenium/webdriver/ie/service.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 import os
 import sys
 from collections.abc import Sequence
@@ -58,9 +59,17 @@ class Service(service.Service):
             self._service_args.append(f"--log-level={log_level}")
 
         if os.environ.get("SE_DEBUG"):
-            self._service_args = [
-                arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-file"))
-            ]
+            has_arg_conflicts = any(x in arg for arg in self._service_args for x in ("log-level", "log-file"))
+            has_output_conflict = log_output is not None
+            if has_arg_conflicts or has_output_conflict:
+                logging.getLogger(__name__).warning(
+                    "Environment Variable `SE_DEBUG` is set; "
+                    "forcing IEDriver log level to DEBUG and overriding configured log level/output."
+                )
+            if has_arg_conflicts:
+                self._service_args = [
+                    arg for arg in self._service_args if not any(x in arg for x in ("log-level", "log-file"))
+                ]
             self._service_args.append("--log-level=DEBUG")
             log_output = sys.stderr
 


### PR DESCRIPTION
### 🔗 Related Issues
Related to #16901 and #16903 

### 💥 What does this PR do?
Updates SE_DEBUG warning messages across Python, Java, JavaScript when there are actual conflicts with user-specified settings.

### 🔧 Implementation Notes
**Java:**
- ChromeDriverService, EdgeDriverService: Check for logLevel, silent, or their system properties
- GeckoDriverService: Check for logLevel or its system property
- DriverService: Only warn when defaulting to stderr and no system property is configured
- LoggingOptions: Added warnings for Grid log level and output changes

**Python:**
- chromium/service.py, firefox/service.py, ie/service.py: Check for both service_args conflicts AND log_output being set before warning

**JavaScript:**
- logging.js: Warning already uses "may override" language which is appropriate for module-load-time behavior

### 🔄 Types of changes
- Bug fix (backwards compatible)
