### PR TITLE
[build] use matrix for nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,21 +63,25 @@ jobs:
           echo "release-in-progress=$([[ "$ENFORCEMENT" == "active" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
 
   nightly-release:
-    name: Nightly ${{ needs.prepare.outputs.language }}
+    name: Nightly ${{ matrix.language }}
     needs: prepare
     if: needs.prepare.outputs.release-in-progress != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java, python, ruby, dotnet, javascript]
     uses: ./.github/workflows/bazel.yml
     with:
-      name: Nightly ${{ needs.prepare.outputs.language }} Release
-      run: ./go ${{ needs.prepare.outputs.language }}:release nightly
-      artifact-name: ${{ needs.prepare.outputs.artifact-name }}
-      artifact-path: ${{ needs.prepare.outputs.artifact-path }}
+      name: Nightly ${{ matrix.language }} Release
+      run: ${{ (needs.prepare.outputs.language == 'all' || needs.prepare.outputs.language == matrix.language) && format('./go {0}:release nightly', matrix.language) || 'echo skipping' }}
+      artifact-name: ${{ matrix.language == 'java' && needs.prepare.outputs.artifact-name || '' }}
+      artifact-path: ${{ matrix.language == 'java' && needs.prepare.outputs.artifact-path || '' }}
     secrets: inherit
 
   release-grid:
     name: Release Grid
     needs: [prepare, nightly-release]
-    if: needs.prepare.outputs.artifact-name
+    if: always() && needs.prepare.outputs.artifact-name
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Ideally this is all one run, but for visibility and redundancy putting it in a matrix makes more sense.
Nightly job failed last night for a credential thing in Ruby, so not everything was properly published. This would fix that.
Easier to fix and rerun for one thing than multiple.

### 💥 What does this PR do?

* Use matrix strategy for nightly releases in parallel.
* Grid always runs if there are java assets to load

### 🔧 Implementation Notes

Follows same pattern as `release.yml` publish job.


### 🔄 Types of changes
- Bug fix (backwards compatible)
