### PR TITLE
restore BiDi constructor without timeout parameter

### DIFF
--- a/java/src/org/openqa/selenium/bidi/BiDi.java
+++ b/java/src/org/openqa/selenium/bidi/BiDi.java
@@ -30,6 +30,14 @@ public class BiDi implements Closeable {
   private final Duration timeout;
   private final Connection connection;
 
+  /**
+   * @deprecated Use constructor with timeout parameter: {@link #BiDi(Connection, Duration)}
+   */
+  @Deprecated(forRemoval = true)
+  public BiDi(Connection connection) {
+    this(connection, Duration.ofSeconds(30));
+  }
+
   public BiDi(Connection connection, Duration timeout) {
     this.connection = Require.nonNull("WebSocket connection", connection);
     this.timeout = Require.nonNull("WebSocket timeout", timeout);


### PR DESCRIPTION
This constructor has been used in Appium (not anymore), and probably some other projects. Let it stay deprecated until Selenium 5.0


### 🔗 Related Issues
https://github.com/appium/java-client/pull/2383

### 🔧 Implementation Notes
We will need to remove this constructor after few released. Maybe in Selenium 5.0

### 💡 Additional Considerations
In Appium, it's not needed anymore (after https://github.com/appium/java-client/pull/2383 has been merged).
But just in case, let's keep this constructor for a while - probably it makes somebody's life easier.

### 🔄 Types of changes
- Bug fix (backwards compatible)
