### PR TITLE
[rust] Fix suppport for webview2 (#15797)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1202,7 +1202,7 @@ pub trait SeleniumManager {
 
         let mut commands = Vec::new();
         if WINDOWS.is(self.get_os()) {
-            if !escaped_browser_path.is_empty() {
+            if !escaped_browser_path.is_empty() && !self.is_webview2() {
                 return Ok(get_win_file_version(&escaped_browser_path));
             }
             if !self.is_browser_version_unstable() {


### PR DESCRIPTION
### 🔗 Related Issues
Fixes #15797.

### 💥 What does this PR do?
The support of webview2 is broken since  4.33:

```
./selenium-manager --browser webview2 --debug
[2026-01-27T13:23:53.690Z DEBUG] msedgedriver not found in PATH
[2026-01-27T13:23:53.691Z DEBUG] webview2 detected at C:\Program Files (x86)\Microsoft\EdgeWebView\Application
[2026-01-27T13:23:53.692Z DEBUG] webview2 not found in the system
[2026-01-27T13:23:53.696Z DEBUG] Reading msedgedriver latest version from https://msedgedriver.microsoft.com/LATEST_STABLE
[2026-01-27T13:23:53.845Z DEBUG] Latest msedgedriver major version is 144
[2026-01-27T13:23:53.845Z DEBUG] Reading msedgedriver version from https://msedgedriver.microsoft.com/LATEST_RELEASE_144_WINDOWS
[2026-01-27T13:23:53.912Z DEBUG] Required driver: msedgedriver 144.0.3719.92
[2026-01-27T13:23:53.912Z DEBUG] msedgedriver 144.0.3719.92 already in the cache
[2026-01-27T13:23:53.913Z INFO ] Driver path: C:\Users\boni\.cache\selenium\msedgedriver\win64\144.0.3719.92\msedgedriver.exe
[2026-01-27T13:23:53.914Z INFO ] Browser path: C:\Program Files (x86)\Microsoft\EdgeWebView\Application
```

This PR fixes it:

```
./selenium-manager --browser webview2 --debug
[2026-01-27T13:24:32.978Z DEBUG] msedgedriver not found in PATH
[2026-01-27T13:24:32.980Z DEBUG] webview2 detected at C:\Program Files (x86)\Microsoft\EdgeWebView\Application
[2026-01-27T13:24:32.980Z DEBUG] Running command: REG QUERY HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5} /v pv
[2026-01-27T13:24:33.013Z DEBUG] Output: "\r\nHKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}\r\n    pv    REG_SZ    144.0.3719.93\r\n"
[2026-01-27T13:24:33.019Z DEBUG] Detected browser: webview2 144.0.3719.93
[2026-01-27T13:24:33.023Z DEBUG] Required driver: msedgedriver 144.0.3719.92
[2026-01-27T13:24:33.024Z DEBUG] msedgedriver 144.0.3719.92 already in the cache
[2026-01-27T13:24:33.024Z INFO ] Driver path: C:\Users\boni\.cache\selenium\msedgedriver\win64\144.0.3719.92\msedgedriver.exe
[2026-01-27T13:24:33.024Z INFO ] Browser path: C:\Program Files (x86)\Microsoft\EdgeWebView\Application\144.0.3719.93\msedge.exe
```

### 🔄 Types of changes
- Bug fix (backwards compatible)