### PR TITLE
[dotnet] Fix generation of inline docs for devtools members

### DIFF
--- a/third_party/dotnet/devtools/src/generator/ProtocolDefinition/ProtocolDefinitionItem.cs
+++ b/third_party/dotnet/devtools/src/generator/ProtocolDefinition/ProtocolDefinitionItem.cs
@@ -5,10 +5,10 @@ namespace OpenQA.Selenium.DevToolsGenerator.ProtocolDefinition
 {
     public abstract class ProtocolDefinitionItem : IDefinition
     {
-
         [JsonPropertyName("deprecated")]
         public bool Deprecated { get; set; }
 
+        [JsonIgnore]
         public string? Description
         {
             get => InitialDescription?.Replace("<", "&lt;").Replace(">", "&gt;");
@@ -28,6 +28,7 @@ namespace OpenQA.Selenium.DevToolsGenerator.ProtocolDefinition
         }
 
         [JsonPropertyName("description")]
+        [JsonInclude]
         protected string? InitialDescription { get; set; }
     }
 }


### PR DESCRIPTION
This pull request makes a minor update to the `ProtocolDefinitionItem` class in the DevTools generator, primarily affecting JSON serialization behavior for the `description` property.

Serialization improvements:

* Marked the `Description` property with `[JsonIgnore]` to prevent it from being included in JSON serialization, ensuring only the internal `InitialDescription` is serialized.
* Added `[JsonInclude]` to the `InitialDescription` property to explicitly allow its serialization, supporting correct deserialization and serialization of the description field.

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/16715

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
