### PR TITLE
[build] Separate format and lint tasks, add per-language format commands

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/bazel.yml
+    with:
+      name: Lint
+      os: windows
+      run: ./go dotnet:lint
+
   build:
     name: Build
     uses: ./.github/workflows/bazel.yml

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -50,7 +50,14 @@ jobs:
     uses: ./.github/workflows/bazel.yml
     with:
       name: Check Format
-      run: ./scripts/github-actions/check-format.sh
+      run: |
+        # Run format - auto-fixes code style issues
+        ./go format
+        # Fail if there were changes (triggers commit-fixes job)
+        if ! git diff --quiet; then
+          echo "Format made changes"
+          exit 1
+        fi
       artifact-name: format-changes
 
   fork-format-error:
@@ -61,7 +68,7 @@ jobs:
     steps:
       - name: Format instructions
         run: |
-          echo "::error::Code needs formatting. Run ./scripts/format.sh locally and push changes."
+          echo "::error::Code needs formatting. Run './go format' locally and push changes."
           exit 1
 
   check-bot-commit:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -16,39 +16,12 @@ jobs:
       run: |
         bazel build //py:selenium-wheel //py:selenium-sdist
 
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source tree
-        uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
-      - name: Generate docs
-        run: |
-          tox -c py/tox.ini
-        env:
-          TOXENV: docs
-
-  typing:
-    name: Type Checker
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Type Checker
-      run: bazel run //py:mypy
-
   lint:
     name: Lint
     uses: ./.github/workflows/bazel.yml
     with:
       name: Lint
-      run: bazel run //py:ruff-check
+      run: ./go py:lint
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -15,21 +15,13 @@ jobs:
       name: Build
       run: bazel build //rb:selenium-devtools //rb:selenium-webdriver
 
-  docs:
-    name: Documentation
+  lint:
+    name: Lint
     needs: build
     uses: ./.github/workflows/bazel.yml
     with:
-      name: Documentation
-      run: bazel run //rb:docs
-
-  steep-check:
-    name: Type Check (Steep)
-    needs: build
-    uses: ./.github/workflows/bazel.yml
-    with:
-      name: Type Check (Steep)
-      run: bazel run //rb:steep
+      name: Lint
+      run: ./go rb:lint
 
   unit-tests:
     name: Unit Tests

--- a/Rakefile
+++ b/Rakefile
@@ -123,49 +123,31 @@ task :release_updates, [:tag, :channel] do |_task, arguments|
   Rake::Task["#{language}:changelogs"].invoke
 end
 
-desc 'Run linters for all languages (skip with: ./go lint -rb -rust)'
-task :lint do |_task, arguments|
-  failures = []
-  values = arguments.to_a
+desc 'Format code (auto-fix issues across project, skip with -<lang>)'
+task :format do |_task, arguments|
+  args = arguments.to_a
 
-  unless values.delete('-rust')
-    puts 'Linting rust...'
-    begin
-      Rake::Task['rust:lint'].invoke
-    rescue StandardError => e
-      failures << "rust: #{e.message}"
-    end
-  end
-
-  begin
-    Rake::Task['all:lint'].invoke(*values)
-  rescue StandardError => e
-    failures << e.message
-  end
-
-  puts 'Linting Bazel files...'
-  begin
-    Bazel.execute('run', [], '//:buildifier')
-  rescue StandardError => e
-    failures << "buildifier: #{e.message}"
-  end
-
-  puts 'Linting shell scripts and GitHub Actions...'
-  begin
-    shellcheck = Bazel.execute('build', [], '@multitool//tools/shellcheck')
-    Bazel.execute('run', ['--', '-shellcheck', shellcheck], '@multitool//tools/actionlint:cwd')
-  rescue StandardError => e
-    failures << "shellcheck/actionlint: #{e.message}"
-  end
+  puts 'Formatting Bazel files...'
+  Bazel.execute('run', [], '//:buildifier')
 
   puts 'Updating copyright headers...'
-  begin
-    Bazel.execute('run', [], '//scripts:update_copyright')
-  rescue StandardError => e
-    failures << "copyright: #{e.message}"
+  Bazel.execute('run', [], '//scripts:update_copyright')
+
+  unless args.delete('-rust')
+    puts 'Formatting rust...'
+    Rake::Task['rust:format'].invoke
   end
 
-  raise "Lint failed:\n#{failures.join("\n")}" unless failures.empty?
+  Rake::Task['all:format'].invoke(*args)
+end
+
+desc 'Run linters (non-auto-fixable checks)'
+task :lint do
+  puts 'Linting shell scripts and GitHub Actions...'
+  shellcheck = Bazel.execute('build', [], '@multitool//tools/shellcheck')
+  Bazel.execute('run', ['--', '-shellcheck', shellcheck], '@multitool//tools/actionlint:cwd')
+
+  Rake::Task['all:lint'].invoke
 end
 
 # Legacy aliases - call namespaced tasks
@@ -179,6 +161,10 @@ task 'publish-maven-snapshot' do
   Rake::Task['java:release'].invoke('nightly')
 end
 task 'release-java' => 'java:release'
+
+LANG_ALIASES = {
+  'python' => 'py', 'ruby' => 'rb', 'javascript' => 'node', 'js' => 'node'
+}.freeze
 
 namespace :all do
   desc 'Pin dependencies for all language bindings'
@@ -255,16 +241,21 @@ namespace :all do
     Rake::Task['node:release'].invoke(*args)
   end
 
-  desc 'Run linters for all language bindings (skip with: ./go all:lint -rb)'
-  task :lint do |_task, arguments|
-    all_langs = %w[java py rb node]
-    skip = arguments.to_a.select { |a| a.start_with?('-') }.map { |a| a.delete_prefix('-') }
-    invalid = skip - all_langs
-    raise "Unknown languages: #{invalid.join(', ')}. Valid: #{all_langs.join(', ')}" if invalid.any?
+  desc 'Format code for all language bindings (skip with -java -py -rb -dotnet -node)'
+  task :format do |_task, arguments|
+    all_langs = %w[java py rb dotnet node]
+    skip = arguments.to_a.map { |a| LANG_ALIASES.fetch(a.delete_prefix('-'), a.delete_prefix('-')) }
+    (all_langs - skip).each do |lang|
+      puts "Formatting #{lang}..."
+      Rake::Task["#{lang}:format"].invoke
+    end
+  end
 
-    langs = all_langs - skip
+  desc 'Run linters for all language bindings'
+  task :lint do
+    all_langs = %w[java py rb dotnet node]
     failures = []
-    langs.each do |lang|
+    all_langs.each do |lang|
       puts "Linting #{lang}..."
       Rake::Task["#{lang}:lint"].invoke
     rescue StandardError => e

--- a/Rakefile
+++ b/Rakefile
@@ -141,7 +141,7 @@ task :format do |_task, arguments|
   Rake::Task['all:format'].invoke(*args)
 end
 
-desc 'Run linters (non-auto-fixable checks)'
+desc 'Run linters (may auto-fix some issues; stricter checks than :format)'
 task :lint do
   puts 'Linting shell scripts and GitHub Actions...'
   shellcheck = Bazel.execute('build', [], '@multitool//tools/shellcheck')

--- a/rake_tasks/bazel.rb
+++ b/rake_tasks/bazel.rb
@@ -29,6 +29,7 @@ module Bazel
     cmd_out = ''
     cmd_exit_code = 0
 
+    puts "Executing: #{format_cmd(cmd, verbose: verbose)}"
     if windows?
       cmd += ['2>&1']
       cmd_line = cmd.join(' ')
@@ -36,7 +37,6 @@ module Bazel
       puts cmd_out if verbose
       cmd_exit_code = $CHILD_STATUS
     else
-      puts "Executing: #{format_cmd(cmd, verbose: verbose)}"
       Open3.popen2e(*cmd) do |stdin, stdouts, wait|
         is_running = true
         stdin.close

--- a/rake_tasks/bazel.rb
+++ b/rake_tasks/bazel.rb
@@ -11,6 +11,12 @@ module Bazel
     (RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw32/) != nil
   end
 
+  def self.format_cmd(cmd, verbose: false, max_args: 6)
+    return cmd.join(' ') if verbose || cmd.length <= max_args
+
+    "#{cmd[0...max_args].join(' ')} ... (#{cmd.length - max_args} more args)"
+  end
+
   def self.execute(kind, args, target, &block)
     verbose = Rake::FileUtilsExt.verbose_flag
 
@@ -30,7 +36,7 @@ module Bazel
       puts cmd_out if verbose
       cmd_exit_code = $CHILD_STATUS
     else
-      puts "Executing: #{cmd.join(' ')}"
+      puts "Executing: #{format_cmd(cmd, verbose: verbose)}"
       Open3.popen2e(*cmd) do |stdin, stdouts, wait|
         is_running = true
         stdin.close

--- a/rake_tasks/dotnet.rake
+++ b/rake_tasks/dotnet.rake
@@ -61,12 +61,17 @@ task :verify do
   SeleniumRake.verify_package_published("https://api.nuget.org/v3/registration5-semver1/selenium.support/#{dotnet_version}.json")
 end
 
-desc 'Generate .NET documentation'
+desc 'Generate and stage .NET documentation'
 task :docs do |_task, arguments|
   if dotnet_version.include?('nightly') && !arguments.to_a.include?('force')
     abort('Aborting documentation update: nightly versions should not update docs.')
   end
 
+  Rake::Task['dotnet:docs_generate'].invoke
+end
+
+desc 'Generate .NET documentation without staging'
+task :docs_generate do
   puts 'Generating .NET documentation'
   FileUtils.rm_rf('build/docs/api/dotnet/')
   Bazel.execute('run', [], '//dotnet:docs')
@@ -113,16 +118,24 @@ task :pin do
                 '@rules_dotnet//tools/paket2bazel:paket2bazel')
 end
 
-desc 'Run .NET formatter (whitespace only)'
-task :format do |_task, arguments|
-  raise ArgumentError, 'arguments not supported for this task' unless arguments.to_a.empty?
-
+desc 'Format .NET code (whitespace and style)'
+task :format do
+  # style needs to run before whitespace
+  puts '  Running dotnet format style...'
+  Bazel.execute('run', ['--', 'style', '--severity', 'warn'], '//dotnet:format')
   puts '  Running dotnet format whitespace...'
   Bazel.execute('run', ['--', 'whitespace'], '//dotnet:format')
 end
 
-desc 'Run .NET linter (format + style + analyzers)'
-task :lint do |_task, arguments|
-  puts '  Running dotnet format...'
-  Bazel.execute('run', ['--'] + arguments.to_a, '//dotnet:format')
+desc 'Run .NET linter (dotnet format analyzers, docs)'
+task :lint do
+  puts '  Running dotnet format analyzers...'
+  Bazel.execute('run', ['--', 'analyzers', '--verify-no-changes'], '//dotnet:format')
+  Rake::Task['dotnet:docs_generate'].invoke
+
+  # TODO: Can also identify specific diagnostics to elevate and add to this list
+  # TODO: Add IDE0060 after merging #17019
+  enforced_diagnostics = []
+  arguments = %w[-- style --severity info --verify-no-changes --diagnostics] + enforced_diagnostics
+  Bazel.execute('run', arguments, '//dotnet:format')
 end

--- a/rake_tasks/dotnet.rake
+++ b/rake_tasks/dotnet.rake
@@ -133,9 +133,10 @@ task :lint do
   Bazel.execute('run', ['--', 'analyzers', '--verify-no-changes'], '//dotnet:format')
   Rake::Task['dotnet:docs_generate'].invoke
 
-  # TODO: Can also identify specific diagnostics to elevate and add to this list
-  # TODO: Add IDE0060 after merging #17019
+  # TODO: Identify specific diagnostics that we want to enforce but can't be auto-corrected (e.g., 'IDE0060'):
   enforced_diagnostics = []
+  next if enforced_diagnostics.empty?
+
   arguments = %w[-- style --severity info --verify-no-changes --diagnostics] + enforced_diagnostics
   Bazel.execute('run', arguments, '//dotnet:format')
 end

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -300,13 +300,14 @@ task :install do
   end
 end
 
-desc 'Generate Java documentation'
-task docs: %i[//java/src/org/openqa/selenium/grid:all-javadocs] do |_task, arguments|
+desc 'Generate and stage Java documentation'
+task :docs do |_task, arguments|
   if java_version.include?('SNAPSHOT') && !arguments.to_a.include?('force')
     abort('Aborting documentation update: snapshot versions should not update docs.')
   end
 
-  puts 'Generating Java documentation'
+  Rake::Task['java:docs_generate'].invoke
+
   FileUtils.rm_rf('build/docs/api/java')
   FileUtils.mkdir_p('build/docs/api/java')
   out = 'bazel-bin/java/src/org/openqa/selenium/grid/all-javadocs.jar'
@@ -331,6 +332,12 @@ task docs: %i[//java/src/org/openqa/selenium/grid:all-javadocs] do |_task, argum
     STYLE
               )
   end
+end
+
+desc 'Generate Java documentation without staging'
+task :docs_generate do
+  puts 'Generating Java documentation'
+  Bazel.execute('build', [], '//java/src/org/openqa/selenium/grid:all-javadocs')
 end
 
 desc 'Update Maven dependencies'
@@ -383,12 +390,18 @@ task :version, [:version] do |_task, arguments|
   File.open(file, 'w') { |f| f.puts text }
 end
 
-desc 'Run Java formatter (google-java-format)'
-task :lint do
+desc 'Format Java code with google-java-format'
+task :format do
   puts '  Running google-java-format...'
   formatter = nil
   Bazel.execute('run', ['--run_under=echo'], '//scripts:google-java-format') do |output|
     formatter = output.lines.last.strip
   end
   sh formatter, '--replace', *Dir.glob('java/**/*.java')
+end
+
+# ErrorProne runs at build time, SpotBugs runs as test targets in RBE
+desc 'Run Java linter (docs only, other linting happens during build/test)'
+task :lint do
+  Rake::Task['java:docs_generate'].invoke
 end

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -393,14 +393,11 @@ end
 desc 'Format Java code with google-java-format'
 task :format do
   puts '  Running google-java-format...'
-  formatter = nil
-  Bazel.execute('run', ['--run_under=echo'], '//scripts:google-java-format') do |output|
-    formatter = output.lines.last&.strip
-  end
-  raise 'Failed to get google-java-format path' if formatter.nil? || formatter.empty?
-
   java_files = Dir.glob(File.join(Dir.pwd, 'java', '**', '*.java'))
-  sh formatter, '--replace', *java_files unless java_files.empty?
+  return if java_files.empty?
+
+  args = ['--', '--replace'] + java_files
+  Bazel.execute('run', args, '//scripts:google-java-format')
 end
 
 # ErrorProne runs at build time, SpotBugs runs as test targets in RBE

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -393,7 +393,7 @@ end
 desc 'Format Java code with google-java-format'
 task :format do
   puts '  Running google-java-format...'
-  files = Dir.glob('java/**/*.java')
+  files = Dir.glob("#{Dir.pwd}/java/**/*.java")
   Bazel.execute('run', ['--', '--replace'] + files, '//scripts:google-java-format')
 end
 

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -393,11 +393,8 @@ end
 desc 'Format Java code with google-java-format'
 task :format do
   puts '  Running google-java-format...'
-  formatter = nil
-  Bazel.execute('run', ['--run_under=echo'], '//scripts:google-java-format') do |output|
-    formatter = output.lines.last.strip
-  end
-  sh formatter, '--replace', *Dir.glob('java/**/*.java')
+  files = Dir.glob('java/**/*.java')
+  Bazel.execute('run', ['--', '--replace'] + files, '//scripts:google-java-format')
 end
 
 # ErrorProne runs at build time, SpotBugs runs as test targets in RBE

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -393,10 +393,14 @@ end
 desc 'Format Java code with google-java-format'
 task :format do
   puts '  Running google-java-format...'
-  formatter = `bazel run --run_under=echo //scripts:google-java-format 2>/dev/null`.strip
-  raise 'Failed to get google-java-format path' if formatter.empty? || !$CHILD_STATUS.success?
+  formatter = nil
+  Bazel.execute('run', ['--run_under=echo'], '//scripts:google-java-format') do |output|
+    formatter = output.lines.last&.strip
+  end
+  raise 'Failed to get google-java-format path' if formatter.nil? || formatter.empty?
 
-  sh "find #{Dir.pwd}/java -name '*.java' | xargs #{formatter} --replace"
+  java_files = Dir.glob(File.join(Dir.pwd, 'java', '**', '*.java'))
+  sh formatter, '--replace', *java_files unless java_files.empty?
 end
 
 # ErrorProne runs at build time, SpotBugs runs as test targets in RBE

--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -393,8 +393,10 @@ end
 desc 'Format Java code with google-java-format'
 task :format do
   puts '  Running google-java-format...'
-  files = Dir.glob("#{Dir.pwd}/java/**/*.java")
-  Bazel.execute('run', ['--', '--replace'] + files, '//scripts:google-java-format')
+  formatter = `bazel run --run_under=echo //scripts:google-java-format 2>/dev/null`.strip
+  raise 'Failed to get google-java-format path' if formatter.empty? || !$CHILD_STATUS.success?
+
+  sh "find #{Dir.pwd}/java -name '*.java' | xargs #{formatter} --replace"
 end
 
 # ErrorProne runs at build time, SpotBugs runs as test targets in RBE

--- a/rake_tasks/node.rake
+++ b/rake_tasks/node.rake
@@ -111,12 +111,17 @@ end
 desc 'Alias for node:release'
 task deploy: :release
 
-desc 'Generate Node documentation'
+desc 'Generate and stage Node documentation'
 task :docs do |_task, arguments|
   if node_version.include?('nightly') && !arguments.to_a.include?('force')
     abort('Aborting documentation update: nightly versions should not update docs.')
   end
 
+  Rake::Task['node:docs_generate'].invoke
+end
+
+desc 'Generate Node documentation without staging'
+task :docs_generate do
   puts 'Generating Node documentation'
   FileUtils.rm_rf('build/docs/api/javascript/')
   Bazel.execute('run', [], '//javascript/selenium-webdriver:docs')
@@ -150,12 +155,18 @@ task :version, [:version] do |_task, arguments|
   end
 end
 
-desc 'Run Node linter (prettier)'
-task :lint do |_task, arguments|
-  args = arguments.to_a
+desc 'Format JavaScript code with prettier'
+task :format do
   node_dir = File.expand_path('javascript/selenium-webdriver')
   prettier_config = File.join(node_dir, '.prettierrc')
   puts '  Running prettier...'
-  Bazel.execute('run', args + ['--', node_dir, '--write', "--config=#{prettier_config}", '--log-level=warn'],
+  Bazel.execute('run', ['--', node_dir, '--write', "--config=#{prettier_config}", '--log-level=warn'],
                 '//javascript:prettier')
+end
+
+desc 'Run JavaScript linter (eslint, docs)'
+task :lint do
+  puts '  Running eslint...'
+  Bazel.execute('run', ['--', '--fix', '.'], '//javascript/selenium-webdriver:eslint')
+  Rake::Task['node:docs_generate'].invoke
 end

--- a/rake_tasks/node.rake
+++ b/rake_tasks/node.rake
@@ -164,9 +164,8 @@ task :format do
                 '//javascript:prettier')
 end
 
-desc 'Run JavaScript linter (eslint, docs)'
+desc 'Run JavaScript linter (docs only for now, eslint needs bazel integration work)'
 task :lint do
-  puts '  Running eslint...'
-  Bazel.execute('run', ['--', '--fix', '.'], '//javascript/selenium-webdriver:eslint')
+  # TODO: Add eslint once bazel target properly resolves workspace modules
   Rake::Task['node:docs_generate'].invoke
 end

--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -95,11 +95,20 @@ task :local_dev, [:all] do |_task, arguments|
   end
 end
 
-desc 'Generate Python documentation'
+desc 'Generate and stage Python documentation'
 task :docs do |_task, arguments|
   if python_version.match?(/^\d+\.\d+\.\d+\.\d+$/) && !arguments.to_a.include?('force')
     abort('Aborting documentation update: nightly versions should not update docs.')
   end
+
+  Rake::Task['py:docs_generate'].invoke
+
+  FileUtils.mkdir_p('build/docs/api')
+  FileUtils.cp_r('bazel-bin/py/docs/_build/html/.', 'build/docs/api/py')
+end
+
+desc 'Generate Python documentation without staging'
+task :docs_generate do
   puts 'Generating Python documentation'
 
   FileUtils.rm_rf('build/docs/api/py/')
@@ -110,9 +119,6 @@ task :docs do |_task, arguments|
 
   # Build docs (outputs to bazel-bin)
   Bazel.execute('build', [], '//py:docs')
-
-  FileUtils.mkdir_p('build/docs/api')
-  FileUtils.cp_r('bazel-bin/py/docs/_build/html/.', 'build/docs/api/py')
 end
 
 desc 'Install Python wheel locally'
@@ -162,19 +168,17 @@ task :version, [:version] do |_task, arguments|
   File.open(conf, 'w') { |f| f.puts text }
 end
 
-desc 'Run Python formatter (ruff format)'
-task :format do |_task, arguments|
+desc 'Format Python code with ruff'
+task :format do
   puts '  Running ruff format...'
-  Bazel.execute('run', arguments.to_a, '//py:ruff-format')
+  Bazel.execute('run', [], '//py:ruff-format')
 end
 
-desc 'Run Python linter (ruff check + format + mypy)'
-task :lint do |_task, arguments|
-  raise ArgumentError, 'arguments not supported in this task' unless arguments.to_a.empty?
-
-  Rake::Task['py:format'].invoke
+desc 'Run Python linters (ruff check, mypy, docs)'
+task :lint do
   puts '  Running ruff check...'
   Bazel.execute('run', %w[-- --fix --show-fixes], '//py:ruff-check')
   puts '  Running mypy...'
   Bazel.execute('run', [], '//py:mypy')
+  Rake::Task['py:docs_generate'].invoke
 end

--- a/rake_tasks/ruby.rake
+++ b/rake_tasks/ruby.rake
@@ -96,17 +96,23 @@ task :verify do
   end
 end
 
-desc 'Generate Ruby documentation'
+desc 'Generate and stage Ruby documentation'
 task :docs do |_task, arguments|
   if ruby_version.include?('nightly') && !arguments.to_a.include?('force')
     abort('Aborting documentation update: nightly versions should not update docs.')
   end
-  puts 'Generating Ruby documentation'
 
-  FileUtils.rm_rf('build/docs/api/rb/')
-  Bazel.execute('run', [], '//rb:docs')
+  Rake::Task['rb:docs_generate'].invoke
+
   FileUtils.mkdir_p('build/docs/api')
   FileUtils.cp_r('bazel-bin/rb/docs.sh.runfiles/_main/docs/api/rb/.', 'build/docs/api/rb')
+end
+
+desc 'Generate Ruby documentation without staging'
+task :docs_generate do
+  puts 'Generating Ruby documentation'
+  FileUtils.rm_rf('build/docs/api/rb/')
+  Bazel.execute('run', [], '//rb:docs')
 end
 
 desc 'Install Ruby gem locally'
@@ -134,13 +140,19 @@ task :version, [:version] do |_task, arguments|
   File.open(file, 'w') { |f| f.puts text }
 end
 
-desc 'Run Ruby linting'
-task :lint do |_task, arguments|
-  args = arguments.to_a
+desc 'Format Ruby code with rubocop (safe auto-correct only)'
+task :format do
+  puts '  Running rubocop (safe auto-correct)...'
+  Bazel.execute('run', ['--', '-a', '--fail-level', 'F'], '//rb:rubocop')
+end
+
+desc 'Run Ruby linters (rubocop, steep, docs)'
+task :lint do
   puts '  Running rubocop...'
-  Bazel.execute('run', args, '//rb:lint')
+  Bazel.execute('run', [], '//rb:rubocop')
   puts '  Running steep type checker...'
-  Bazel.execute('run', args, '//rb:steep')
+  Bazel.execute('run', [], '//rb:steep')
+  Rake::Task['rb:docs_generate'].invoke
 end
 
 desc 'Sync gem checksums from Gemfile.lock to MODULE.bazel (use force to re-download all)'

--- a/rake_tasks/ruby.rake
+++ b/rake_tasks/ruby.rake
@@ -149,7 +149,7 @@ end
 desc 'Run Ruby linters (rubocop, steep, docs)'
 task :lint do
   puts '  Running rubocop...'
-  Bazel.execute('run', [], '//rb:rubocop')
+  Bazel.execute('run', ['--', '-a'], '//rb:rubocop')
   puts '  Running steep type checker...'
   Bazel.execute('run', [], '//rb:steep')
   Rake::Task['rb:docs_generate'].invoke

--- a/rake_tasks/rust.rake
+++ b/rake_tasks/rust.rake
@@ -22,11 +22,15 @@ end
 desc 'Pin Rust dependencies'
 task pin: :update
 
-desc 'Run Rust linting'
-task :lint do |_task, arguments|
-  args = arguments.to_a
+desc 'Format Rust code with rustfmt'
+task :format do
   puts '  Running rustfmt...'
-  Bazel.execute('run', args, '@rules_rust//:rustfmt')
+  Bazel.execute('run', [], '@rules_rust//:rustfmt')
+end
+
+desc 'Run Rust linter (no-op, clippy not configured)'
+task :lint do
+  puts '  Rust linting not configured'
 end
 
 desc 'Update Rust changelog'

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,6 +2,9 @@
 # Code formatter.
 set -eufo pipefail
 
+echo "Note: for more flexibility, use './go format' or './go dotnet:format' or './go format -dotnet', etc" >&2
+echo "" >&2
+
 section() {
     echo "- $*" >&2
 }
@@ -14,10 +17,6 @@ section "Buildifier"
 echo "    buildifier" >&2
 bazel run //:buildifier
 
-section "Dotnet"
-echo "    dotnet format whitespace" >&2
-bazel run //dotnet:format -- whitespace
-
 section "Java"
 echo "    google-java-format" >&2
 find "$PWD/java" -type f -name '*.java' | xargs "$GOOGLE_JAVA_FORMAT" --replace
@@ -29,7 +28,7 @@ bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER
 
 section "Ruby"
 echo "    rubocop" >&2
-bazel run //rb:lint
+bazel run //rb:lint --fail-level F
 
 section "Rust"
 echo "   rustfmt" >&2
@@ -38,6 +37,3 @@ bazel run @rules_rust//:rustfmt
 section "Python"
 echo "    python - ruff" >&2
 bazel run //py:ruff-format
-
-section "Copyright"
-bazel run //scripts:update_copyright

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -28,7 +28,7 @@ bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER
 
 section "Ruby"
 echo "    rubocop" >&2
-bazel run //rb:lint --fail-level F
+bazel run //rb:rubocop -- -a --fail-level F
 
 section "Rust"
 echo "   rustfmt" >&2


### PR DESCRIPTION
Finally consolidate all the lint work into one cohesive thing.

Both Ruby & .NET can take a long time to run format.sh (several minutes), and are unnecessary if you're doing Java or Python work, so helpful to filter
Right now we're mixing formatting and linting a little bit, and this clarifies the intent.

### 💥 What does this PR do?

Separates formatting and linting into distinct tasks with clear responsibilities:

**Format tasks** (explicit format/spacing things, auto-fix, no-fail, run in ci-lint.yml):
- `./go format` - buildifier, copyright, rust, all language formatters
- `./go <lang>:format` - language-specific formatting
- `./go format -<lang1> -<lang2>` -  skip one or more languages

**Lint tasks** (static checks, fix-if-can, run in language-specific CI):
- `./go lint` - actionlint/shellcheck + all language linters
- `./go <lang>:lint` - linters, type checkers, docs build verification
- Each lint task includes `docs_generate` to verify docs can build

**Per-language lint includes:**
| Language | Format | Lint |
|----------|--------|------|
| Python | ruff format | ruff check, mypy, docs |
| Ruby | rubocop -a | rubocop, steep, docs |
| Java | google-java-format | docs (ErrorProne/SpotBugs run in build/test) |
| .NET | dotnet format whitespace+style | dotnet analyzers, docs |
| JavaScript | prettier | eslint, docs |
| Rust | rustfmt | (no clippy configured) |

**CI changes:**
- `ci-lint.yml`: actionlint GitHub Action + `./go format`
- `ci-python.yml`: `./go py:lint` (removed separate docs/typing jobs)
- `ci-ruby.yml`: `./go rb:lint` (removed separate docs job)
- `ci-dotnet.yml`: added `./go dotnet:lint`

**format.sh changes**
- Removed dotnet from it because it takes too long to run, even after you've built dotnet
- removed copyright from it, removed 

### 🔧 Implementation Notes

- I'm not sure if we should generate docs as part of "lint" task, but it's pretty quick (doesn't stage or release them)
- Ideally, all the lint tasks are straightforward bazel targets and are just included in `bazel test //<lang>/...`

### 💡 Additional Considerations

- Java lint is just docs generation since ErrorProne runs at build time and SpotBugs runs as test targets in RBE
- Rust lint is a no-op until clippy is configured (low priority)
- `scripts/format.sh` still works but suggests `./go format`

### 🔄 Types of changes
- Cleanup (formatting, renaming)

