### PR TITLE
[py] Make extensions tests work when not running bazel

### DIFF
--- a/py/conftest.py
+++ b/py/conftest.py
@@ -180,6 +180,19 @@ def pytest_generate_tests(metafunc):
 selenium_driver = None
 
 
+def get_extensions_location():
+    """Locate the test extensions directory.
+
+    Use Runfiles to locate it if running with bazel, otherwise find it in the local source tree.
+    """
+    if Runfiles is not None:
+        r = Runfiles.Create()
+        extensions = r.Rlocation("selenium/py/test/extensions")
+    else:
+        extensions = str((Path(__file__).parent.parent / "common" / "extensions").resolve())
+    return extensions
+
+
 class ContainerProtocol:
     def __contains__(self, name):
         if name.lower() in self.__dict__:

--- a/py/private/ruff_check.py
+++ b/py/private/ruff_check.py
@@ -28,7 +28,7 @@ import sys
 from python.runfiles import Runfiles
 
 ALL_DIRS = ["py", "scripts", "common", "dotnet", "java", "javascript", "rb"]
-EXCLUDES = ["**/node_modules/**", "**/.bundle/**"]
+EXCLUDES = ["**/node_modules/**", "**/.bundle/**", "**/devtools/**"]
 
 
 def run_check(ruff, exclude_args, dirs, extra_args):

--- a/py/private/ruff_format.py
+++ b/py/private/ruff_format.py
@@ -28,7 +28,7 @@ import sys
 from python.runfiles import Runfiles
 
 ALL_DIRS = ["py", "scripts", "common", "dotnet", "java", "javascript", "rb"]
-EXCLUDES = ["**/node_modules/**", "**/.bundle/**"]
+EXCLUDES = ["**/node_modules/**", "**/.bundle/**", "**/devtools/**"]
 
 
 def run_format(ruff, exclude_args, dirs, extra_args):

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -169,6 +169,8 @@ docstring-code-line-length = 120
 
 [tool.ruff.lint.isort]
 known-first-party = ["selenium", "test"]
+known-third-party = []
+known-local-folder = ["conftest"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/py/test/selenium/webdriver/common/bidi_webextension_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_webextension_tests.py
@@ -21,19 +21,16 @@ import shutil
 import tempfile
 
 import pytest
-from python.runfiles import Runfiles
 
+from conftest import get_extensions_location
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
+EXTENSIONS = get_extensions_location()
 EXTENSION_ID = "webextensions-selenium-example-v3@example.com"
 EXTENSION_PATH = "webextensions-selenium-example-signed"
 EXTENSION_ARCHIVE_PATH = "webextensions-selenium-example.xpi"
-
-# Use bazel Runfiles to locate the test extension directory
-r = Runfiles.Create()
-extensions = r.Rlocation("selenium/py/test/extensions")
 
 
 def install_extension(driver, **kwargs):
@@ -70,21 +67,21 @@ class TestFirefoxWebExtension:
 
     def test_install_extension_path(self, driver, pages):
         """Test installing an extension from a directory path."""
-        path = os.path.join(extensions, EXTENSION_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_PATH)
         ext_info = install_extension(driver, path=path)
         verify_extension_injection(driver, pages)
         uninstall_extension_and_verify_extension_uninstalled(driver, ext_info)
 
     def test_install_archive_extension_path(self, driver, pages):
         """Test installing an extension from an archive path."""
-        path = os.path.join(extensions, EXTENSION_ARCHIVE_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_ARCHIVE_PATH)
         ext_info = install_extension(driver, archive_path=path)
         verify_extension_injection(driver, pages)
         uninstall_extension_and_verify_extension_uninstalled(driver, ext_info)
 
     def test_install_base64_extension_path(self, driver, pages):
         """Test installing an extension from a base64 encoded string."""
-        path = os.path.join(extensions, EXTENSION_ARCHIVE_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_ARCHIVE_PATH)
         with open(path, "rb") as file:
             base64_encoded = base64.b64encode(file.read()).decode("utf-8")
         ext_info = install_extension(driver, base64_value=base64_encoded)
@@ -94,14 +91,14 @@ class TestFirefoxWebExtension:
 
     def test_install_unsigned_extension(self, driver, pages):
         """Test installing an unsigned extension."""
-        path = os.path.join(extensions, "webextensions-selenium-example")
+        path = os.path.join(EXTENSIONS, "webextensions-selenium-example")
         ext_info = install_extension(driver, path=path)
         verify_extension_injection(driver, pages)
         uninstall_extension_and_verify_extension_uninstalled(driver, ext_info)
 
     def test_install_with_extension_id_uninstall(self, driver, pages):
         """Test uninstalling an extension using just the extension ID."""
-        path = os.path.join(extensions, EXTENSION_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_PATH)
         ext_info = install_extension(driver, path=path)
         extension_id = ext_info.get("extension")
         # Uninstall using the extension ID
@@ -161,7 +158,7 @@ class TestChromiumWebExtension:
 
     def test_install_extension_path(self, chromium_driver, pages_chromium):
         """Test installing an extension from a directory path."""
-        path = os.path.join(extensions, EXTENSION_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_PATH)
         ext_info = chromium_driver.webextension.install(path=path)
 
         verify_extension_injection(chromium_driver, pages_chromium)
@@ -169,7 +166,7 @@ class TestChromiumWebExtension:
 
     def test_install_unsigned_extension(self, chromium_driver, pages_chromium):
         """Test installing an unsigned extension."""
-        path = os.path.join(extensions, "webextensions-selenium-example")
+        path = os.path.join(EXTENSIONS, "webextensions-selenium-example")
         ext_info = chromium_driver.webextension.install(path=path)
 
         verify_extension_injection(chromium_driver, pages_chromium)
@@ -177,7 +174,7 @@ class TestChromiumWebExtension:
 
     def test_install_with_extension_id_uninstall(self, chromium_driver):
         """Test uninstalling an extension using just the extension ID."""
-        path = os.path.join(extensions, EXTENSION_PATH)
+        path = os.path.join(EXTENSIONS, EXTENSION_PATH)
         ext_info = chromium_driver.webextension.install(path=path)
         extension_id = ext_info.get("extension")
         # Uninstall using the extension ID

--- a/py/test/selenium/webdriver/common/bidi_webextension_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_webextension_tests.py
@@ -22,10 +22,11 @@ import tempfile
 
 import pytest
 
-from conftest import get_extensions_location
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
+
+from conftest import get_extensions_location
 
 EXTENSIONS = get_extensions_location()
 EXTENSION_ID = "webextensions-selenium-example-v3@example.com"

--- a/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
+++ b/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
@@ -19,20 +19,20 @@ import os
 import zipfile
 
 import pytest
-from python.runfiles import Runfiles
 
+from conftest import get_extensions_location
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
-r = Runfiles.Create()
-extensions = r.Rlocation("selenium/py/test/extensions")
+EXTENSIONS = get_extensions_location()
+
 
 pytestmark = pytest.mark.xfail_remote(reason="Remote WebDriver does not expose Firefox-specific addon APIs")
 
 
 @pytest.mark.no_driver_after_test
 def test_install_uninstall_signed_addon_xpi(driver, pages):
-    extension = os.path.join(extensions, "webextensions-selenium-example.xpi")
+    extension = os.path.join(EXTENSIONS, "webextensions-selenium-example.xpi")
 
     id = driver.install_addon(extension)
     assert id == "webextensions-selenium-example-v3@example.com"
@@ -50,7 +50,7 @@ def test_install_uninstall_signed_addon_xpi(driver, pages):
 
 @pytest.mark.no_driver_after_test
 def test_install_uninstall_signed_addon_zip(driver, pages):
-    extension = os.path.join(extensions, "webextensions-selenium-example.zip")
+    extension = os.path.join(EXTENSIONS, "webextensions-selenium-example.zip")
 
     id = driver.install_addon(extension)
     assert id == "webextensions-selenium-example-v3@example.com"
@@ -68,7 +68,7 @@ def test_install_uninstall_signed_addon_zip(driver, pages):
 
 @pytest.mark.no_driver_after_test
 def test_install_uninstall_unsigned_addon_zip(driver, pages):
-    extension = os.path.join(extensions, "webextensions-selenium-example-unsigned.zip")
+    extension = os.path.join(EXTENSIONS, "webextensions-selenium-example-unsigned.zip")
 
     id = driver.install_addon(extension, temporary=True)
     assert id == "webextensions-selenium-example-v3@example.com"
@@ -86,9 +86,9 @@ def test_install_uninstall_unsigned_addon_zip(driver, pages):
 
 @pytest.mark.no_driver_after_test
 def test_install_uninstall_signed_addon_dir(driver, pages):
-    zip = os.path.join(extensions, "webextensions-selenium-example.zip")
+    zip = os.path.join(EXTENSIONS, "webextensions-selenium-example.zip")
 
-    target = os.path.join(extensions, "webextensions-selenium-example-unzip")
+    target = os.path.join(EXTENSIONS, "webextensions-selenium-example-unzip")
     with zipfile.ZipFile(zip, "r") as zip_ref:
         zip_ref.extractall(target)
 
@@ -108,8 +108,8 @@ def test_install_uninstall_signed_addon_dir(driver, pages):
 
 @pytest.mark.no_driver_after_test
 def test_install_uninstall_unsigned_addon_dir(driver, pages):
-    zip = os.path.join(extensions, "webextensions-selenium-example-unsigned.zip")
-    target = os.path.join(extensions, "webextensions-selenium-example-unsigned-unzip")
+    zip = os.path.join(EXTENSIONS, "webextensions-selenium-example-unsigned.zip")
+    target = os.path.join(EXTENSIONS, "webextensions-selenium-example-unsigned-unzip")
     with zipfile.ZipFile(zip, "r") as zip_ref:
         zip_ref.extractall(target)
 

--- a/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
+++ b/py/test/selenium/webdriver/firefox/ff_installs_addons_tests.py
@@ -20,9 +20,10 @@ import zipfile
 
 import pytest
 
-from conftest import get_extensions_location
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
+
+from conftest import get_extensions_location
 
 EXTENSIONS = get_extensions_location()
 

--- a/py/test/selenium/webdriver/firefox/firefox_profile_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_profile_tests.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from conftest import Driver
-
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 
 

--- a/py/test/selenium/webdriver/firefox/firefox_profile_tests.py
+++ b/py/test/selenium/webdriver/firefox/firefox_profile_tests.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from conftest import Driver
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
+
+from conftest import Driver
 
 
 def test_profile_is_used(request, server):


### PR DESCRIPTION
### 💥 What does this PR do?

This PR allows extensions tests to work when not running bazel.

Currently, there are 2 test files that use bazel Runfiles to locate web extensions when running tests. If you try to run these directly with pytest (without bazel), they will fail because Runfiles doesn't exist.

This PR adds a function to locate extensions in the local source tree when Runfiles isn't installed, and updates tests to use it for locating extensions.

This also fixes a subtle bug where the new `ruff-check.py` was giving incorrect results when finding import ordering issues.

It also skips `devtools` when running `ruff-check.py` and `ruff-format.py` from bazel.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Dev/Test
- Bug fix (backwards compatible)