### PR TITLE
[build] Add permissions for nightly job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,9 @@ jobs:
   nightly:
     name: Publish Nightly Packages
     needs: [parse-tag, update-version]
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/nightly.yml
     with:
       language: ${{ needs.parse-tag.outputs.language }}


### PR DESCRIPTION


### 💥 What does this PR do?
Adds `contents: write` and `packages: write` permissions to the `nightly` job in the release workflow.

When the release workflow calls the reusable `nightly.yml` workflow, the called workflow's permissions are constrained by the caller's permissions. Without explicit permissions on the `nightly` job, it only inherits `contents: read` from the top-level workflow permissions, causing the nightly workflow to fail when:
- Creating GitHub releases (requires `contents: write`)
- Publishing to GitHub Packages (requires `packages: write`)

### 🔧 Implementation Notes
Added a job-level `permissions` block to the `nightly` job, following the same pattern used by other jobs in the workflow (`github-release`, `docs`, `update-version`).

### 💡 Additional Considerations
None - this is a straightforward permissions fix.

### 🔄 Types of changes
- Bug fix (backwards compatible)
