### PR TITLE
[build] add smart targeting and --lint flag to format.sh

### DIFF
--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -1,41 +1,142 @@
-# Code formatter.
+# Code formatter - runs targeted formatters based on what changed from trunk.
+# Usage: format.ps1 [-All] [-PreCommit] [-PrePush] [-Lint]
+#   (default)     Check all changes relative to trunk including uncommitted work
+#   -All          Format everything, skip change detection
+#   -PreCommit    Only check staged changes
+#   -PrePush      Only check committed changes relative to trunk
+#   -Lint         Also run linters before formatting
+
+param(
+    [switch]$All,
+    [switch]$PreCommit,
+    [switch]$PrePush,
+    [switch]$Lint
+)
 
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
+
+# Validate mutually exclusive flags
+if ($PreCommit -and $PrePush) {
+    Write-Error "Cannot use both -PreCommit and -PrePush"
+    exit 1
+}
 
 function section($message) {
     Write-Host "- $message" -ForegroundColor Green
 }
 
-$WORKSPACE_ROOT = (bazel info workspace)
-$GOOGLE_JAVA_FORMAT = (bazel run --run_under=echo //scripts:google-java-format)
+# Find what's changed compared to trunk (skip if -All)
+$formatAll = $All
+$trunkRef = git rev-parse --verify trunk 2>$null
 
-section "Buildifier"
-Write-Host "    buildifier" -ForegroundColor Green
-bazel run //:buildifier
-
-section "Java"
-Write-Host "    google-java-format" -ForegroundColor Green
-Get-ChildItem -Path "$PWD/java" -Include "*.java" -Recurse | ForEach-Object {
-    &"$GOOGLE_JAVA_FORMAT" --replace $_.FullName
+if (-not $formatAll -and $trunkRef) {
+    $base = git merge-base HEAD $trunkRef 2>$null
+    if ($base) {
+        if ($PreCommit) {
+            $changed = git diff --name-only --cached
+        } elseif ($PrePush) {
+            $changed = git diff --name-only $base HEAD
+        } else {
+            $committed = git diff --name-only $base HEAD
+            $staged = git diff --name-only --cached
+            $unstaged = git diff --name-only
+            $untracked = git ls-files --others --exclude-standard
+            $changed = ($committed + $staged + $unstaged + $untracked) | Sort-Object -Unique
+        }
+    } else {
+        $formatAll = $true
+    }
+} elseif (-not $formatAll) {
+    # No trunk ref found, format everything
+    $formatAll = $true
 }
 
-section "Javascript"
-Write-Host "    javascript/selenium-webdriver - prettier" -ForegroundColor Green
-$NODE_WEBDRIVER = "$WORKSPACE_ROOT/javascript/selenium-webdriver"
-bazel run //javascript:prettier -- "$NODE_WEBDRIVER" --write "$NODE_WEBDRIVER/.prettierrc" --log-level=warn
+# Helper to check if a pattern matches changed files
+function changedMatches($pattern) {
+    if ($formatAll) { return $true }
+    return ($changed | Where-Object { $_ -match $pattern }).Count -gt 0
+}
 
-section "Ruby"
-Write-Host "    rubocop" -ForegroundColor Green
-bazel run //rb:lint
+$WORKSPACE_ROOT = (bazel info workspace)
 
-section "Rust"
-Write-Host "    rustfmt" -ForegroundColor Green
-bazel run @rules_rust//:rustfmt
+# Capture baseline to detect formatter-introduced changes
+$baseline = git status --porcelain
 
-section "Python"
-Write-Host "    python - ruff" -ForegroundColor Green
-bazel run //py:ruff-format
+# Always run buildifier and copyright
+section "Buildifier"
+Write-Host "    buildifier"
+bazel run //:buildifier
 
 section "Copyright"
+Write-Host "    update_copyright"
 bazel run //scripts:update_copyright
+
+# Run language formatters only if those files changed
+if (changedMatches '^java/') {
+    section "Java"
+    Write-Host "    google-java-format"
+    $GOOGLE_JAVA_FORMAT = (bazel run --run_under=echo //scripts:google-java-format)
+    Get-ChildItem -Path "$WORKSPACE_ROOT/java" -Include "*.java" -Recurse | ForEach-Object {
+        & "$GOOGLE_JAVA_FORMAT" --replace $_.FullName
+    }
+}
+
+if (changedMatches '^javascript/selenium-webdriver/') {
+    section "JavaScript"
+    Write-Host "    prettier"
+    $NODE_WEBDRIVER = "$WORKSPACE_ROOT/javascript/selenium-webdriver"
+    bazel run //javascript:prettier -- "$NODE_WEBDRIVER" --write "$NODE_WEBDRIVER/.prettierrc" --log-level=warn
+}
+
+if (changedMatches '^rb/|^rake_tasks/|^Rakefile') {
+    section "Ruby"
+    Write-Host "    rubocop -a"
+    if ($Lint) {
+        bazel run //rb:rubocop -- -a
+    } else {
+        bazel run //rb:rubocop -- -a --fail-level F
+    }
+}
+
+if (changedMatches '^rust/') {
+    section "Rust"
+    Write-Host "    rustfmt"
+    bazel run @rules_rust//:rustfmt
+}
+
+if (changedMatches '^py/') {
+    section "Python"
+    if ($Lint) {
+        Write-Host "    ruff check"
+        bazel run //py:ruff-check
+    }
+    Write-Host "    ruff format"
+    bazel run //py:ruff-format
+}
+
+if (changedMatches '^dotnet/') {
+    section ".NET"
+    Write-Host "    dotnet format"
+    bazel run //dotnet:format -- style --severity warn
+    bazel run //dotnet:format -- whitespace
+}
+
+# Run shellcheck and actionlint when -Lint is passed
+if ($Lint) {
+    section "Shell/Actions"
+    Write-Host "    actionlint (with shellcheck)"
+    $SHELLCHECK = (bazel run --run_under=echo @multitool//tools/shellcheck)
+    bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
+}
+
+# Check if formatting introduced new changes (comparing to baseline)
+$after = git status --porcelain
+if ($after -ne $baseline) {
+    Write-Host ""
+    Write-Host "Formatters modified files:" -ForegroundColor Red
+    git diff --name-only
+    exit 1
+}
+
+Write-Host "Format check passed." -ForegroundColor Green

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 # Code formatter - runs targeted formatters based on what changed from trunk.
-# Can be run manually or as a pre-push/pre-commit hook.
-# Usage: format.sh [--lint]
+# Usage: format.sh [--pre-commit] [--pre-push] [--lint]
+#   --pre-commit  Only check staged changes (for pre-commit hooks)
+#   --pre-push    Only check committed changes (for pre-push hooks)
+#   --lint        Also run linters after formatting
+#   (default)     Check all changes: committed + staged + unstaged
 set -eufo pipefail
 
 echo "Note: for more flexibility, use './go format' or './go dotnet:format' or './go format -dotnet', etc" >&2
 echo "" >&2
 
 run_lint=false
+mode="default"
 for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
+        --pre-commit) mode="pre-commit" ;;
+        --pre-push) mode="pre-push" ;;
         *)
             echo "Unknown option: $arg" >&2
-            echo "Usage: $0 [--lint]" >&2
+            echo "Usage: $0 [--pre-commit] [--pre-push] [--lint]" >&2
             exit 1
             ;;
     esac
@@ -33,10 +39,20 @@ trunk_ref="$(git rev-parse --verify selenium/trunk 2>/dev/null \
 if [[ -n "$trunk_ref" ]]; then
     base="$(git merge-base HEAD "$trunk_ref" 2>/dev/null || echo "")"
     if [[ -n "$base" ]]; then
-        # Include both committed changes (for pre-push) and staged changes (for pre-commit)
-        committed="$(git diff --name-only "$base" HEAD)"
-        staged="$(git diff --name-only --cached)"
-        changed="$(printf '%s\n%s' "$committed" "$staged" | sort -u)"
+        case "$mode" in
+            pre-commit)
+                changed="$(git diff --name-only --cached)"
+                ;;
+            pre-push)
+                changed="$(git diff --name-only "$base" HEAD)"
+                ;;
+            default)
+                committed="$(git diff --name-only "$base" HEAD)"
+                staged="$(git diff --name-only --cached)"
+                unstaged="$(git diff --name-only)"
+                changed="$(printf '%s\n%s\n%s' "$committed" "$staged" "$unstaged" | sort -u)"
+                ;;
+        esac
     else
         format_all=true
         changed=""

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 # Code formatter - runs targeted formatters based on what changed from trunk.
-# Usage: format.sh [--pre-commit] [--pre-push] [--lint]
+# Usage: format.sh [--all] [--pre-commit] [--pre-push] [--lint]
 #   (default)     Check all changes relative to trunk including uncommitted work
+#   --all         Format everything, skip change detection (previous behavior)
 #   --pre-commit  Only check staged changes
 #   --pre-push    Only check committed changes relative to trunk
 #   --lint        Also run linters before formatting
 set -eufo pipefail
 
 run_lint=false
+format_all=false
 mode="default"
 for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
+        --all) format_all=true ;;
 
         --pre-commit|--pre-push)
             [[ "$mode" == "default" ]] || { echo "Cannot use both --pre-commit and --pre-push" >&2; exit 1; }
@@ -19,7 +22,7 @@ for arg in "$@"; do
             ;;
         *)
             echo "Unknown option: $arg" >&2
-            echo "Usage: $0 [--pre-commit] [--pre-push] [--lint]" >&2
+            echo "Usage: $0 [--all] [--pre-commit] [--pre-push] [--lint]" >&2
             exit 1
             ;;
     esac
@@ -29,11 +32,10 @@ section() {
     echo "- $*" >&2
 }
 
-# Find what's changed compared to trunk
-format_all=false
+# Find what's changed compared to trunk (skip if --all)
 trunk_ref="$(git rev-parse --verify trunk 2>/dev/null || echo "")"
 
-if [[ -n "$trunk_ref" ]]; then
+if [[ "$format_all" == "false" && -n "$trunk_ref" ]]; then
     base="$(git merge-base HEAD "$trunk_ref" 2>/dev/null || echo "")"
     if [[ -n "$base" ]]; then
         case "$mode" in
@@ -53,12 +55,10 @@ if [[ -n "$trunk_ref" ]]; then
         esac
     else
         format_all=true
-        changed=""
     fi
-else
+elif [[ "$format_all" == "false" ]]; then
     # No trunk ref found, format everything
     format_all=true
-    changed=""
 fi
 
 # Helper to check if a pattern matches changed files

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,39 +1,122 @@
 #!/usr/bin/env bash
-# Code formatter.
+# Code formatter - runs targeted formatters based on what changed from trunk.
+# Can be run manually or as a pre-push/pre-commit hook.
+# Usage: format.sh [--lint]
 set -eufo pipefail
 
 echo "Note: for more flexibility, use './go format' or './go dotnet:format' or './go format -dotnet', etc" >&2
 echo "" >&2
 
+run_lint=false
+for arg in "$@"; do
+    case "$arg" in
+        --lint) run_lint=true ;;
+    esac
+done
+
 section() {
     echo "- $*" >&2
 }
 
+# Find what's changed compared to trunk
+format_all=false
+trunk_ref="$(git rev-parse --verify selenium/trunk 2>/dev/null \
+          || git rev-parse --verify origin/trunk 2>/dev/null \
+          || git rev-parse --verify trunk 2>/dev/null \
+          || echo "")"
+
+if [[ -n "$trunk_ref" ]]; then
+    base="$(git merge-base HEAD "$trunk_ref" 2>/dev/null || echo "")"
+    if [[ -n "$base" ]]; then
+        changed="$(git diff --name-only "$base" HEAD)"
+    else
+        format_all=true
+        changed=""
+    fi
+else
+    # No trunk ref found, format everything
+    format_all=true
+    changed=""
+fi
+
+# Helper to check if a pattern matches changed files
+changed_matches() {
+    [[ "$format_all" == "true" ]] || echo "$changed" | grep -qE "$1"
+}
+
 WORKSPACE_ROOT="$(bazel info workspace)"
 
-GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
-
+# Always run buildifier and copyright
 section "Buildifier"
 echo "    buildifier" >&2
 bazel run //:buildifier
 
-section "Java"
-echo "    google-java-format" >&2
-find "$PWD/java" -type f -name '*.java' | xargs "$GOOGLE_JAVA_FORMAT" --replace
+section "Copyright"
+echo "    update_copyright" >&2
+bazel run //scripts:update_copyright
 
-section "Javascript"
-echo "    javascript/selenium-webdriver - prettier" >&2
-NODE_WEBDRIVER="${WORKSPACE_ROOT}/javascript/selenium-webdriver"
-bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
+# Run language formatters only if those files changed
+if changed_matches '^java/'; then
+    section "Java"
+    echo "    google-java-format" >&2
+    GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
+    find "${WORKSPACE_ROOT}/java" -type f -name '*.java' | xargs "$GOOGLE_JAVA_FORMAT" --replace
+fi
 
-section "Ruby"
-echo "    rubocop" >&2
-bazel run //rb:rubocop -- -a --fail-level F
+if changed_matches '^javascript/selenium-webdriver/'; then
+    section "Javascript"
+    echo "    prettier" >&2
+    NODE_WEBDRIVER="${WORKSPACE_ROOT}/javascript/selenium-webdriver"
+    bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
+fi
 
-section "Rust"
-echo "   rustfmt" >&2
-bazel run @rules_rust//:rustfmt
+if changed_matches '^rb/|^rake_tasks/|^Rakefile'; then
+    section "Ruby"
+    echo "    rubocop -a" >&2
+    bazel run //rb:rubocop -- -a --fail-level F
+    if [[ "$run_lint" == "true" ]]; then
+        echo "    rubocop" >&2
+        bazel run //rb:rubocop
+    fi
+fi
 
-section "Python"
-echo "    python - ruff" >&2
-bazel run //py:ruff-format
+if changed_matches '^rust/'; then
+    section "Rust"
+    echo "    rustfmt" >&2
+    bazel run @rules_rust//:rustfmt
+fi
+
+if changed_matches '^py/'; then
+    section "Python"
+    echo "    ruff format" >&2
+    bazel run //py:ruff-format
+    if [[ "$run_lint" == "true" ]]; then
+        echo "    ruff check" >&2
+        bazel run //py:ruff
+    fi
+fi
+
+if changed_matches '^dotnet/'; then
+    section ".NET"
+    echo "    dotnet format" >&2
+    bazel run //dotnet:format -- style --severity warn
+    bazel run //dotnet:format -- whitespace
+fi
+
+# Run shellcheck and actionlint when --lint is passed
+if [[ "$run_lint" == "true" ]]; then
+    section "Shell/Actions"
+    echo "    shellcheck + actionlint" >&2
+    SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"
+    bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
+fi
+
+# Check if formatting made changes
+if ! git diff --quiet; then
+    echo "" >&2
+    echo "Formatters modified files:" >&2
+    git diff --name-only >&2
+    exit 1
+fi
+
+echo "Format check passed." >&2

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -35,10 +35,7 @@ section() {
 
 # Find what's changed compared to trunk
 format_all=false
-trunk_ref="$(git rev-parse --verify selenium/trunk 2>/dev/null \
-          || git rev-parse --verify origin/trunk 2>/dev/null \
-          || git rev-parse --verify trunk 2>/dev/null \
-          || echo "")"
+trunk_ref="$(git rev-parse --verify trunk 2>/dev/null || echo "")"
 
 if [[ -n "$trunk_ref" ]]; then
     base="$(git merge-base HEAD "$trunk_ref" 2>/dev/null || echo "")"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -4,11 +4,8 @@
 #   (default)     Check all changes relative to trunk including uncommitted work
 #   --pre-commit  Only check staged changes
 #   --pre-push    Only check committed changes relative to trunk
-#   --lint        Also run linters after formatting
-set -ufo pipefail
-
-failed=0
-run() { "$@" || failed=1; }
+#   --lint        Also run linters before formatting
+set -eufo pipefail
 
 run_lint=false
 mode="default"
@@ -77,72 +74,66 @@ baseline="$(git status --porcelain)"
 # Always run buildifier and copyright
 section "Buildifier"
 echo "    buildifier" >&2
-run bazel run //:buildifier
+bazel run //:buildifier
 
 section "Copyright"
 echo "    update_copyright" >&2
-run bazel run //scripts:update_copyright
+bazel run //scripts:update_copyright
 
 # Run language formatters only if those files changed
 if changed_matches '^java/'; then
     section "Java"
     echo "    google-java-format" >&2
-    if GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"; then
-        run find "${WORKSPACE_ROOT}/java" -type f -name '*.java' -exec "$GOOGLE_JAVA_FORMAT" --replace {} +
-    else
-        failed=1
-    fi
+    GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
+    find "${WORKSPACE_ROOT}/java" -type f -name '*.java' -exec "$GOOGLE_JAVA_FORMAT" --replace {} +
 fi
 
 if changed_matches '^javascript/selenium-webdriver/'; then
     section "JavaScript"
     echo "    prettier" >&2
     NODE_WEBDRIVER="${WORKSPACE_ROOT}/javascript/selenium-webdriver"
-    run bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
+    bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
 fi
 
 if changed_matches '^rb/|^rake_tasks/|^Rakefile'; then
     section "Ruby"
     echo "    rubocop -a" >&2
-    run bazel run //rb:rubocop -- -a --fail-level F
     if [[ "$run_lint" == "true" ]]; then
-        echo "    rubocop" >&2
-        run bazel run //rb:rubocop
+        bazel run //rb:rubocop -- -a
+    else
+        bazel run //rb:rubocop -- -a --fail-level F
     fi
 fi
 
 if changed_matches '^rust/'; then
     section "Rust"
     echo "    rustfmt" >&2
-    run bazel run @rules_rust//:rustfmt
+    bazel run @rules_rust//:rustfmt
 fi
 
 if changed_matches '^py/'; then
     section "Python"
-    echo "    ruff format" >&2
-    run bazel run //py:ruff-format
     if [[ "$run_lint" == "true" ]]; then
         echo "    ruff check" >&2
-        run bazel run //py:ruff
+        bazel run //py:ruff-check
     fi
+    echo "    ruff format" >&2
+    bazel run //py:ruff-format
 fi
 
 if changed_matches '^dotnet/'; then
     section ".NET"
     echo "    dotnet format" >&2
-    run bazel run //dotnet:format -- style --severity warn
-    run bazel run //dotnet:format -- whitespace
+    bazel run //dotnet:format -- style --severity warn
+    bazel run //dotnet:format -- whitespace
 fi
 
 # Run shellcheck and actionlint when --lint is passed
 if [[ "$run_lint" == "true" ]]; then
     section "Shell/Actions"
     echo "    actionlint (with shellcheck)" >&2
-    if SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"; then
-        run bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
-    else
-        failed=1
-    fi
+    SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"
+    bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
 fi
 
 # Check if formatting introduced new changes (comparing to baseline)
@@ -150,10 +141,6 @@ if [[ "$(git status --porcelain)" != "$baseline" ]]; then
     echo "" >&2
     echo "Formatters modified files:" >&2
     git diff --name-only >&2
-    failed=1
-fi
-
-if [[ "$failed" -eq 1 ]]; then
     exit 1
 fi
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -13,8 +13,14 @@ for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
 
-        --pre-commit) mode="pre-commit" ;;
-        --pre-push) mode="pre-push" ;;
+        --pre-commit)
+            [[ "$mode" == "default" ]] || { echo "Cannot use both --pre-commit and --pre-push" >&2; exit 1; }
+            mode="pre-commit"
+            ;;
+        --pre-push)
+            [[ "$mode" == "default" ]] || { echo "Cannot use both --pre-commit and --pre-push" >&2; exit 1; }
+            mode="pre-push"
+            ;;
         *)
             echo "Unknown option: $arg" >&2
             echo "Usage: $0 [--pre-commit] [--pre-push] [--lint]" >&2
@@ -83,11 +89,11 @@ if changed_matches '^java/'; then
     section "Java"
     echo "    google-java-format" >&2
     GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
-    find "${WORKSPACE_ROOT}/java" -type f -name '*.java' | xargs "$GOOGLE_JAVA_FORMAT" --replace
+    find "${WORKSPACE_ROOT}/java" -type f -name '*.java' -exec "$GOOGLE_JAVA_FORMAT" --replace {} +
 fi
 
 if changed_matches '^javascript/selenium-webdriver/'; then
-    section "Javascript"
+    section "JavaScript"
     echo "    prettier" >&2
     NODE_WEBDRIVER="${WORKSPACE_ROOT}/javascript/selenium-webdriver"
     bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,14 +7,12 @@
 #   (default)     Check all changes: committed + staged + unstaged
 set -eufo pipefail
 
-echo "Note: for more flexibility, use './go format' or './go dotnet:format' or './go format -dotnet', etc" >&2
-echo "" >&2
-
 run_lint=false
 mode="default"
 for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
+
         --pre-commit) mode="pre-commit" ;;
         --pre-push) mode="pre-push" ;;
         *)

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Code formatter - runs targeted formatters based on what changed from trunk.
 # Usage: format.sh [--pre-commit] [--pre-push] [--lint]
-#   --pre-commit  Only check staged changes (for pre-commit hooks)
-#   --pre-push    Only check committed changes (for pre-push hooks)
+#   (default)     Check all changes relative to trunk including uncommitted work
+#   --pre-commit  Only check staged changes
+#   --pre-push    Only check committed changes relative to trunk
 #   --lint        Also run linters after formatting
-#   (default)     Check all changes: committed + staged + unstaged
-set -eufo pipefail
+set -ufo pipefail
+
+failed=0
+run() { "$@" || failed=1; }
 
 run_lint=false
 mode="default"
@@ -13,13 +16,9 @@ for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
 
-        --pre-commit)
+        --pre-commit|--pre-push)
             [[ "$mode" == "default" ]] || { echo "Cannot use both --pre-commit and --pre-push" >&2; exit 1; }
-            mode="pre-commit"
-            ;;
-        --pre-push)
-            [[ "$mode" == "default" ]] || { echo "Cannot use both --pre-commit and --pre-push" >&2; exit 1; }
-            mode="pre-push"
+            mode="${arg#--}"
             ;;
         *)
             echo "Unknown option: $arg" >&2
@@ -78,66 +77,72 @@ baseline="$(git status --porcelain)"
 # Always run buildifier and copyright
 section "Buildifier"
 echo "    buildifier" >&2
-bazel run //:buildifier
+run bazel run //:buildifier
 
 section "Copyright"
 echo "    update_copyright" >&2
-bazel run //scripts:update_copyright
+run bazel run //scripts:update_copyright
 
 # Run language formatters only if those files changed
 if changed_matches '^java/'; then
     section "Java"
     echo "    google-java-format" >&2
-    GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"
-    find "${WORKSPACE_ROOT}/java" -type f -name '*.java' -exec "$GOOGLE_JAVA_FORMAT" --replace {} +
+    if GOOGLE_JAVA_FORMAT="$(bazel run --run_under=echo //scripts:google-java-format)"; then
+        run find "${WORKSPACE_ROOT}/java" -type f -name '*.java' -exec "$GOOGLE_JAVA_FORMAT" --replace {} +
+    else
+        failed=1
+    fi
 fi
 
 if changed_matches '^javascript/selenium-webdriver/'; then
     section "JavaScript"
     echo "    prettier" >&2
     NODE_WEBDRIVER="${WORKSPACE_ROOT}/javascript/selenium-webdriver"
-    bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
+    run bazel run //javascript:prettier -- "${NODE_WEBDRIVER}" --write "${NODE_WEBDRIVER}/.prettierrc" --log-level=warn
 fi
 
 if changed_matches '^rb/|^rake_tasks/|^Rakefile'; then
     section "Ruby"
     echo "    rubocop -a" >&2
-    bazel run //rb:rubocop -- -a --fail-level F
+    run bazel run //rb:rubocop -- -a --fail-level F
     if [[ "$run_lint" == "true" ]]; then
         echo "    rubocop" >&2
-        bazel run //rb:rubocop
+        run bazel run //rb:rubocop
     fi
 fi
 
 if changed_matches '^rust/'; then
     section "Rust"
     echo "    rustfmt" >&2
-    bazel run @rules_rust//:rustfmt
+    run bazel run @rules_rust//:rustfmt
 fi
 
 if changed_matches '^py/'; then
     section "Python"
     echo "    ruff format" >&2
-    bazel run //py:ruff-format
+    run bazel run //py:ruff-format
     if [[ "$run_lint" == "true" ]]; then
         echo "    ruff check" >&2
-        bazel run //py:ruff
+        run bazel run //py:ruff
     fi
 fi
 
 if changed_matches '^dotnet/'; then
     section ".NET"
     echo "    dotnet format" >&2
-    bazel run //dotnet:format -- style --severity warn
-    bazel run //dotnet:format -- whitespace
+    run bazel run //dotnet:format -- style --severity warn
+    run bazel run //dotnet:format -- whitespace
 fi
 
 # Run shellcheck and actionlint when --lint is passed
 if [[ "$run_lint" == "true" ]]; then
     section "Shell/Actions"
     echo "    actionlint (with shellcheck)" >&2
-    SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"
-    bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
+    if SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"; then
+        run bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
+    else
+        failed=1
+    fi
 fi
 
 # Check if formatting introduced new changes (comparing to baseline)
@@ -145,6 +150,10 @@ if [[ "$(git status --porcelain)" != "$baseline" ]]; then
     echo "" >&2
     echo "Formatters modified files:" >&2
     git diff --name-only >&2
+    failed=1
+fi
+
+if [[ "$failed" -eq 1 ]]; then
     exit 1
 fi
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -11,6 +11,11 @@ run_lint=false
 for arg in "$@"; do
     case "$arg" in
         --lint) run_lint=true ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            echo "Usage: $0 [--lint]" >&2
+            exit 1
+            ;;
     esac
 done
 
@@ -28,7 +33,10 @@ trunk_ref="$(git rev-parse --verify selenium/trunk 2>/dev/null \
 if [[ -n "$trunk_ref" ]]; then
     base="$(git merge-base HEAD "$trunk_ref" 2>/dev/null || echo "")"
     if [[ -n "$base" ]]; then
-        changed="$(git diff --name-only "$base" HEAD)"
+        # Include both committed changes (for pre-push) and staged changes (for pre-commit)
+        committed="$(git diff --name-only "$base" HEAD)"
+        staged="$(git diff --name-only --cached)"
+        changed="$(printf '%s\n%s' "$committed" "$staged" | sort -u)"
     else
         format_all=true
         changed=""

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -48,7 +48,8 @@ if [[ -n "$trunk_ref" ]]; then
                 committed="$(git diff --name-only "$base" HEAD)"
                 staged="$(git diff --name-only --cached)"
                 unstaged="$(git diff --name-only)"
-                changed="$(printf '%s\n%s\n%s' "$committed" "$staged" "$unstaged" | sort -u)"
+                untracked="$(git ls-files --others --exclude-standard)"
+                changed="$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untracked" | sort -u)"
                 ;;
         esac
     else
@@ -128,7 +129,7 @@ fi
 # Run shellcheck and actionlint when --lint is passed
 if [[ "$run_lint" == "true" ]]; then
     section "Shell/Actions"
-    echo "    shellcheck + actionlint" >&2
+    echo "    actionlint (with shellcheck)" >&2
     SHELLCHECK="$(bazel run --run_under=echo @multitool//tools/shellcheck)"
     bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
 fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -75,6 +75,9 @@ changed_matches() {
 
 WORKSPACE_ROOT="$(bazel info workspace)"
 
+# Capture baseline to detect formatter-introduced changes (allows pre-existing uncommitted work)
+baseline="$(git status --porcelain)"
+
 # Always run buildifier and copyright
 section "Buildifier"
 echo "    buildifier" >&2
@@ -140,8 +143,8 @@ if [[ "$run_lint" == "true" ]]; then
     bazel run @multitool//tools/actionlint:cwd -- -shellcheck "$SHELLCHECK"
 fi
 
-# Check if formatting made changes
-if ! git diff --quiet; then
+# Check if formatting introduced new changes (comparing to baseline)
+if [[ "$(git status --porcelain)" != "$baseline" ]]; then
     echo "" >&2
     echo "Formatters modified files:" >&2
     git diff --name-only >&2


### PR DESCRIPTION
Improve speed of format.sh so it can be used in pre-commit and pre-push hooks

### 🔗 Related Issues
independent of, but same implementation from Rake tasks in #17020 in format.sh

### 💥 What does this PR do?
Enhances `scripts/format.sh` with smart targeting and an optional `--lint` flag:

- **Smart targeting**: Compares HEAD to trunk's merge-base and only runs formatters for languages with changed files
- **Fall back**:  Format everything if trunk ref not found
- **--lint flag**: Optionally runs linters (ruff check, rubocop, shellcheck + actionlint) after formatting
- **Always runs**: buildifier and copyright (fast, affect everything)
- **Exit check**: Fails with exit 1 if formatters modified files (useful for CI/hooks)

### 🔧 Implementation Notes
- Could have called the Rake tasks from the shell script, but I'd rather some duplication here than have shell
files call Rake tasks. Rake tasks should always be entry point and wrap other things to keep flow consistent.

### 💡 Additional Considerations
- Future: Could add more linters as they become available (eslint, .NET analyzers)

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality)
