### PR TITLE
[java] parse all JSON numbers the same way

### DIFF
--- a/java/src/org/openqa/selenium/json/InstantCoercer.java
+++ b/java/src/org/openqa/selenium/json/InstantCoercer.java
@@ -17,17 +17,22 @@
 
 package org.openqa.selenium.json;
 
+import java.io.StringReader;
 import java.lang.reflect.Type;
-import java.math.BigInteger;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.BiFunction;
-import java.util.regex.Pattern;
+import org.openqa.selenium.internal.Require;
 
 public class InstantCoercer extends TypeCoercer<Instant> {
-  private static final Pattern DIGITS_ONLY = Pattern.compile("\\d+");
+
+  private final JsonTypeCoercer typeCoercer;
+
+  InstantCoercer(JsonTypeCoercer typeCoercer) {
+    this.typeCoercer = Require.nonNull("TypeCoercer", typeCoercer);
+  }
 
   @Override
   public boolean test(Class<?> aClass) {
@@ -39,28 +44,43 @@ public class InstantCoercer extends TypeCoercer<Instant> {
     return (jsonInput, setting) -> {
       JsonType token = jsonInput.peek();
 
-      if (JsonType.NUMBER.equals(token)) {
-        return Instant.ofEpochMilli(jsonInput.nextNumber().longValue());
-      } else if (JsonType.STRING.equals(token)) {
-        String raw = jsonInput.nextString();
-        if (DIGITS_ONLY.matcher(raw).matches()) {
+      switch (token) {
+        case NUMBER:
+          return Instant.ofEpochMilli(jsonInput.nextNumber().longValue());
+        case STRING:
+          String raw = jsonInput.nextString();
           try {
-            return Instant.ofEpochMilli(new BigInteger(raw).longValueExact());
-          } catch (NumberFormatException | ArithmeticException invalidLong) {
-            throw new JsonException(
-                String.format("\"%s\" is not a valid timestamp", raw), invalidLong);
-          }
-        }
-        try {
-          TemporalAccessor parsed = DateTimeFormatter.ISO_INSTANT.parse(raw);
-          return Instant.from(parsed);
-        } catch (DateTimeParseException invalidDateTime) {
-          throw new JsonException(
-              String.format("\"%s\" does not look like an Instant", raw), invalidDateTime);
-        }
-      }
+            TemporalAccessor parsed = DateTimeFormatter.ISO_INSTANT.parse(raw);
+            return Instant.from(parsed);
+          } catch (DateTimeParseException invalidDateTime) {
+            var failure =
+                new JsonException(
+                    String.format("\"%s\" does not look like an Instant", raw), invalidDateTime);
 
-      throw new JsonException("Unable to parse: " + jsonInput.read(Object.class));
+            // any PropertySetting is okay here, as we know it won't be used
+            try (JsonInput nestedInput =
+                new JsonInput(new StringReader(raw), typeCoercer, PropertySetting.BY_NAME)) {
+              Number number = nestedInput.nextNumber();
+              // ensure the 'raw' string has been read to the end
+              nestedInput.nextEnd();
+              double doubleValue = number.doubleValue();
+              if (doubleValue % 1 != 0) {
+                throw new JsonException("unexpected decimal value");
+              } else if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+                throw new JsonException("value out of range");
+              }
+              return Instant.ofEpochMilli(number.longValue());
+            } catch (JsonException invalidLong) {
+              failure.addSuppressed(
+                  new JsonException(
+                      String.format("\"%s\" is not a valid timestamp", raw), invalidLong));
+            }
+
+            throw failure;
+          }
+        default:
+          throw new JsonException("Unable to parse: " + token + " as Instant");
+      }
     };
   }
 }

--- a/java/src/org/openqa/selenium/json/JsonInput.java
+++ b/java/src/org/openqa/selenium/json/JsonInput.java
@@ -220,7 +220,7 @@ public class JsonInput implements Closeable {
    */
   public Number nextNumber() {
     expect(JsonType.NUMBER);
-    boolean decimal = false;
+    boolean mightBeDecimal = false;
     StringBuilder builder = new StringBuilder();
     // We know it's safe to use a do/while loop since the first character was a number
     boolean read = true;
@@ -243,7 +243,7 @@ public class JsonInput implements Closeable {
         case '.':
         case 'e':
         case 'E':
-          decimal = true;
+          mightBeDecimal = true;
           builder.append(input.read());
           break;
         default:
@@ -252,7 +252,11 @@ public class JsonInput implements Closeable {
     } while (read);
 
     try {
-      if (!decimal) {
+      // The JSON Schema does state the decimal point should not be used distinguish between
+      // integers and floating point values.
+      // Therefore, using a Long is only a fast path here, but we should not rely on the `double`
+      // value below is a real floating point.
+      if (!mightBeDecimal) {
         return Long.valueOf(builder.toString());
       }
 
@@ -277,13 +281,24 @@ public class JsonInput implements Closeable {
   /**
    * Read the next element of the JSON input stream as an instant.
    *
+   * @deprecated Instant is not a basic JSON type, use the {@link InstantCoercer} instead.
    * @return {@link Instant} object
    * @throws JsonException if the next element isn't a {@code Long}
    * @throws UncheckedIOException if an I/O exception is encountered
    */
+  @Deprecated(forRemoval = true)
   public @Nullable Instant nextInstant() {
     Long time = read(Long.class);
     return (null != time) ? Instant.ofEpochSecond(time) : null;
+  }
+
+  /**
+   * Read the next element of the JSON input stream and expect the end of the input.
+   *
+   * @throws JsonException if the next element isn't the end of the input
+   */
+  public void nextEnd() {
+    expect(JsonType.END);
   }
 
   /**

--- a/java/src/org/openqa/selenium/json/JsonTypeCoercer.java
+++ b/java/src/org/openqa/selenium/json/JsonTypeCoercer.java
@@ -71,28 +71,35 @@ class JsonTypeCoercer {
     // From java
     builder.add(new BooleanCoercer());
 
-    builder.add(new NumberCoercer<>(Byte.class, Number::byteValue));
-    builder.add(new NumberCoercer<>(Double.class, Number::doubleValue));
-    builder.add(new NumberCoercer<>(Float.class, Number::floatValue));
-    builder.add(new NumberCoercer<>(Integer.class, Number::intValue));
-    builder.add(new NumberCoercer<>(Long.class, Number::longValue));
+    builder.add(new NumberCoercer<>(this, Byte.class, Number::byteValue));
+    builder.add(new NumberCoercer<>(this, Double.class, Number::doubleValue));
+    builder.add(new NumberCoercer<>(this, Float.class, Number::floatValue));
+    builder.add(new NumberCoercer<>(this, Integer.class, Number::intValue));
+    builder.add(new NumberCoercer<>(this, Long.class, Number::longValue));
     builder.add(
         new NumberCoercer<>(
+            this,
             Number.class,
             num -> {
+              if (num instanceof Long) {
+                return num;
+              }
+
               double doubleValue = num.doubleValue();
-              if (doubleValue % 1 != 0 || doubleValue > Long.MAX_VALUE) {
+              if (doubleValue % 1 != 0
+                  || doubleValue < Long.MIN_VALUE
+                  || doubleValue > Long.MAX_VALUE) {
                 return doubleValue;
               }
               return num.longValue();
             }));
-    builder.add(new NumberCoercer<>(Short.class, Number::shortValue));
+    builder.add(new NumberCoercer<>(this, Short.class, Number::shortValue));
     builder.add(new StringCoercer());
     builder.add(new EnumCoercer<>());
     builder.add(new UriCoercer());
     builder.add(new UrlCoercer());
     builder.add(new UuidCoercer());
-    builder.add(new InstantCoercer());
+    builder.add(new InstantCoercer(this));
 
     // From Selenium
     builder.add(

--- a/java/src/org/openqa/selenium/json/MapCoercer.java
+++ b/java/src/org/openqa/selenium/json/MapCoercer.java
@@ -53,9 +53,9 @@ class MapCoercer<T, I extends T> extends TypeCoercer<T> {
     Type valueType;
 
     if (type instanceof ParameterizedType) {
-      ParameterizedType pt = (ParameterizedType) type;
-      keyType = pt.getActualTypeArguments()[0];
-      valueType = pt.getActualTypeArguments()[1];
+      Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
+      keyType = typeArguments[0];
+      valueType = typeArguments[1];
     } else if (type instanceof Class) {
       keyType = Object.class;
       valueType = Object.class;

--- a/java/src/org/openqa/selenium/json/NumberCoercer.java
+++ b/java/src/org/openqa/selenium/json/NumberCoercer.java
@@ -17,8 +17,8 @@
 
 package org.openqa.selenium.json;
 
+import java.io.StringReader;
 import java.lang.reflect.Type;
-import java.math.BigDecimal;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -39,10 +39,12 @@ class NumberCoercer<T extends Number> extends TypeCoercer<T> {
             Map.entry(short.class, Short.class));
   }
 
+  private final JsonTypeCoercer typeCoercer;
   private final Class<T> stereotype;
   private final Function<Number, T> mapper;
 
-  NumberCoercer(Class<T> stereotype, Function<Number, T> mapper) {
+  NumberCoercer(JsonTypeCoercer typeCoercer, Class<T> stereotype, Function<Number, T> mapper) {
+    this.typeCoercer = Require.nonNull("TypeCoercer", typeCoercer);
     this.stereotype = Require.nonNull("Stereotype", stereotype);
     this.mapper = Require.nonNull("Mapper", mapper);
   }
@@ -63,9 +65,13 @@ class NumberCoercer<T extends Number> extends TypeCoercer<T> {
 
         case STRING:
           String numberAsString = jsonInput.nextString();
-          try {
-            number = new BigDecimal(numberAsString);
-          } catch (NumberFormatException e) {
+          // any PropertySetting is okay here, as we know it won't be used
+          try (JsonInput nestedInput =
+              new JsonInput(new StringReader(numberAsString), typeCoercer, setting)) {
+            number = nestedInput.nextNumber();
+            // ensure the 'numberAsString' string has been read to the end
+            nestedInput.nextEnd();
+          } catch (JsonException e) {
             throw new JsonException(
                 String.format("Not a numeric value: \"%s\"", numberAsString), e);
           }

--- a/java/src/org/openqa/selenium/json/ObjectCoercer.java
+++ b/java/src/org/openqa/selenium/json/ObjectCoercer.java
@@ -19,7 +19,6 @@ package org.openqa.selenium.json;
 
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiFunction;
 import org.openqa.selenium.internal.Require;
 
@@ -60,7 +59,7 @@ class ObjectCoercer extends TypeCoercer<Object> {
           break;
 
         case START_MAP:
-          target = Map.class;
+          target = Json.MAP_TYPE;
           break;
 
         default:

--- a/java/test/org/openqa/selenium/json/JsonTest.java
+++ b/java/test/org/openqa/selenium/json/JsonTest.java
@@ -271,6 +271,15 @@ class JsonTest {
   }
 
   @Test
+  void shouldBeAbleToReadAnInstant() {
+    Instant now = Instant.now();
+
+    Dates instant = new Json().toType("{\"birth\": \"" + now + "\"}", Dates.class, BY_FIELD);
+
+    assertThat(instant.birth).isEqualTo(now);
+  }
+
+  @Test
   void shouldBeAbleToReadAnInstantFromTimestamp() {
     long now = System.currentTimeMillis();
 


### PR DESCRIPTION
### 🔗 Related Issues
Selenium had three different ways of parsing numbers, now only one is left. 

### 💥 What does this PR do?
This will ensure we do not treat them differently in terms of exponential numbers or none latin characters.

### 🔧 Implementation Notes
This PR will also fix some minor issues:
 - the `JsonInput.nextEnd` has been adden to ensure the end of the given json has been reached (@asolntsev  thanks for the hint) 
 - the `InstantCoercer` does now first try to parse a `String` as `ISO_INSTANT`, rather than a timestamp nested in side a `String`. This is more a fallback and should not happen with most timestamps, as they are `Numbers`.
 - the `JsonInput.nextInstant` has been deprecated, as it is not used, there are no unit tests and does work different as all other `JsonInput.next` methods. e.g. it is `@Nullable` and all others are not nullable.
 - the `ObjectCoercer` does now better predict how to read a nested object

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
