### PR TITLE
[docs] Add AI-assisted contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,11 +12,13 @@
 <!--- Why did you implement it this way? -->
 <!--- What alternatives to this approach did you consider? -->
 
-### 🤖 AI assistance (if used)
-<!-- Only required if substantial parts were AI-generated. See CONTRIBUTING.md for details. -->
-- Tool(s):
-- What was generated (code/tests/docs):
-- [ ] I reviewed all AI-assisted output and can explain the change
+### 🤖 AI assistance
+<!-- Check one. See CONTRIBUTING.md for policy details. -->
+- [ ] No substantial AI assistance used
+- [ ] AI assisted (complete below)
+  - Tool(s):
+  - What was generated:
+  - [ ] I reviewed all AI output and can explain the change
 
 ### 💡 Additional Considerations
 <!--- Are there any decisions that need to be made before accepting this PR? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,9 +16,9 @@
 <!-- Check one. See CONTRIBUTING.md for policy details. -->
 - [ ] No substantial AI assistance used
 - [ ] AI assisted (complete below)
-  - Tool(s):
-  - What was generated:
-  - [ ] I reviewed all AI output and can explain the change
+    - Tool(s):
+    - What was generated:
+    - [ ] I reviewed all AI output and can explain the change
 
 ### 💡 Additional Considerations
 <!--- Are there any decisions that need to be made before accepting this PR? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,12 @@
 <!--- Why did you implement it this way? -->
 <!--- What alternatives to this approach did you consider? -->
 
+### 🤖 AI assistance (if used)
+<!-- Only required if substantial parts were AI-generated. See CONTRIBUTING.md for details. -->
+- Tool(s):
+- What was generated (code/tests/docs):
+- [ ] I reviewed all AI-assisted output and can explain the change
+
 ### 💡 Additional Considerations
 <!--- Are there any decisions that need to be made before accepting this PR? -->
 <!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,34 @@ on Github.
 
 This document will guide you through the contribution process.
 
+### AI-assisted contributions (Copilot, LLMs, code generators)
+
+We allow contributors to use AI tools to help write code, tests, and documentation. However:
+
+**Human-in-the-loop is required:**
+- You are the author. You must read, review, and understand all AI-assisted output before requesting review.
+- You must be able to explain the change and rationale without referring back to the tool.
+
+**Disclosure:**
+- If substantial parts of the PR are AI-assisted, disclose it in the PR description 
+(tool name + what was generated). This is for reviewer context, not for judgment.
+
+**No autonomous agents:**
+- Do not use agents/bots to open PRs, push commits, or post review comments without
+direct human approval and ownership of the result.
+- Do not add `Co-Authored-By` tags for AI tools in commits. 
+AI tools are not authors; disclosure belongs in the PR description, not commit metadata.
+
+**Quality bar / reviewer time:**
+- Using AI assistance should not lower the bar. Bug fixes and features must include tests where possible
+- Maintainers may ask you to reduce scope, add tests, or justify value if a PR appears to be low-effort generated content.
+
+**Copyright and licensing:**
+- You are responsible for ensuring you have the rights to contribute your work under the project license. 
+Using AI tools does not remove third-party copyrights; content found to violate this will be removed.
+
+(Policy inspired by the [LLVM Project AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html))
+
 ### Step 1: Fork & Clone
 
 Fork the project [on Github](https://github.com/seleniumhq/selenium)


### PR DESCRIPTION
We need an explicit AI contribution policy so we're all on the same page

I don't think we're actually seeing a lot of AI slop right now, but that can change.

### 💥 What does this PR do?

Adds an AI-assisted contribution policy to CONTRIBUTING.md and updates the PR template to include AI disclosure fields.

**Policy covers:**
- Human-in-the-loop accountability
- Disclosure when substantial AI assistance used
- No autonomous agents opening PRs/pushing commits
- No Co-Authored-By tags for AI tools
- Quality bar unchanged
- Copyright responsibility unchanged

**PR template adds:**
- AI assistance section with required checkbox choice

### 🔧 Implementation Notes

Policy is inspired by the [LLVM Project AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)

Kept the policy short and enforceable rather than comprehensive.

### 🤖 AI assistance

- [ ] No substantial AI assistance used
- [x] AI assisted (complete below)
  - Tool(s): Claude Code
  - What was generated: Initial draft of policy text and PR template sections
  - [x] I reviewed all AI output and can explain the change

### 💡 Additional Considerations

- Copilot coding agent is disabled at the org level
- Enforcement is primarily social (maintainers can close non-compliant PRs)
- Maintainers need to remove co-author references during squash merge

### 🔄 Types of changes

- Cleanup (formatting, renaming)
