### PR TITLE
[dotnet] [bidi] SetTouchOverride command in Emulation module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -101,6 +101,13 @@ public sealed class EmulationModule : Module
         return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<SetTouchOverrideResult> SetTouchOverrideAsync(long? maxTouchPoints, SetTouchOverrideOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var @params = new SetTouchOverrideParameters(maxTouchPoints, options?.Contexts, options?.UserContexts);
+
+        return await ExecuteCommandAsync(new SetTouchOverrideCommand(@params), options, _jsonContext.SetTouchOverrideCommand, _jsonContext.SetTouchOverrideResult, cancellationToken).ConfigureAwait(false);
+    }
+
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
@@ -126,5 +133,7 @@ public sealed class EmulationModule : Module
 [JsonSerializable(typeof(SetScreenSettingsOverrideResult))]
 [JsonSerializable(typeof(SetGeolocationOverrideCommand))]
 [JsonSerializable(typeof(SetGeolocationOverrideResult))]
+[JsonSerializable(typeof(SetTouchOverrideCommand))]
+[JsonSerializable(typeof(SetTouchOverrideResult))]
 
 internal partial class EmulationJsonSerializerContext : JsonSerializerContext;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
@@ -1,0 +1,37 @@
+// <copyright file="SetTouchOverrideCommand.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.Emulation;
+
+internal sealed class SetTouchOverrideCommand(SetTouchOverrideParameters @params)
+    : Command<SetTouchOverrideParameters, SetTouchOverrideResult>(@params, "emulation.setTouchOverride");
+
+internal sealed record SetTouchOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] long? MaxTouchPoints, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
+
+public sealed class SetTouchOverrideOptions : CommandOptions
+{
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+}
+
+public sealed record SetTouchOverrideResult : EmptyResult;

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -197,4 +197,24 @@ internal class EmulationTest : BiDiTestFixture
         },
         Throws.Nothing);
     }
+
+    [Test]
+    public void CanSetTouchOverride()
+    {
+        Assert.That(async () =>
+        {
+            await bidi.Emulation.SetTouchOverrideAsync(5, new() { Contexts = [context] });
+        },
+        Throws.Nothing);
+    }
+
+    [Test]
+    public void CanSetTouchOverrideToDefault()
+    {
+        Assert.That(async () =>
+        {
+            await bidi.Emulation.SetTouchOverrideAsync(null, new() { Contexts = [context] });
+        },
+        Throws.Nothing);
+    }
 }

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -199,6 +199,9 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetTouchOverride()
     {
         Assert.That(async () =>
@@ -209,6 +212,9 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Chrome, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Edge, "Not supported yet?")]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetTouchOverrideToDefault()
     {
         Assert.That(async () =>


### PR DESCRIPTION
https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride

### 💥 What does this PR do?
Implements new command with couple of unit tests.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
