### PR TITLE
[java] Fix "secure vs non-secure" error in tests

### DIFF
--- a/common/src/web/form_handling_js_submit.html
+++ b/common/src/web/form_handling_js_submit.html
@@ -21,7 +21,7 @@
     <title>Form with JS action</title>
 </head>
 <body>
-  <form id="theForm" method="get" action="javascript:alert('Tasty cheese');">
+  <form id="theForm" method="get" action="click_tests/submitted_page.html" onsubmit="return alert('Tasty cheese')">
       <input name="unused" type="submit">
   </form>
 

--- a/java/test/org/openqa/selenium/AlertsTest.java
+++ b/java/test/org/openqa/selenium/AlertsTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.openqa.selenium.WaitingConditions.newWindowIsOpened;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
@@ -467,7 +468,9 @@ class AlertsTest extends JupiterTestBase {
             new Page()
                 .withTitle("Testing Alerts")
                 .withBody(
-                    "<form id='theForm' action='javascript:alert(\"Tasty cheese\");'>",
+                    "<form id='theForm'"
+                        + "    action='/click_tests/submitted_page.html' "
+                        + "    onsubmit='return alert(\"Tasty cheese\");'>",
                     "<input id='unused' type='submit' value='Submit'>",
                     "</form>")));
 
@@ -477,6 +480,8 @@ class AlertsTest extends JupiterTestBase {
     alert.accept();
 
     assertThat(value).isEqualTo("Tasty cheese");
-    assertThat(driver.getTitle()).isEqualTo("Testing Alerts");
+
+    wait.until(titleIs("Submitted Successfully!"));
+    assertThat(driver.getCurrentUrl()).contains("submitted_page.html");
   }
 }

--- a/java/test/org/openqa/selenium/FormHandlingTest.java
+++ b/java/test/org/openqa/selenium/FormHandlingTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
 import static org.openqa.selenium.support.ui.ExpectedConditions.titleIs;
+import static org.openqa.selenium.support.ui.ExpectedConditions.urlContains;
 import static org.openqa.selenium.testing.drivers.Browser.FIREFOX;
 import static org.openqa.selenium.testing.drivers.Browser.IE;
 import static org.openqa.selenium.testing.drivers.Browser.SAFARI;
@@ -254,6 +255,8 @@ class FormHandlingTest extends JupiterTestBase {
     alert.accept();
 
     assertThat(text).isEqualTo("Tasty cheese");
+    wait.until(titleIs("Submitted Successfully!"));
+    wait.until(urlContains("submitted_page.html"));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/environment/GlobalTestEnvironment.java
+++ b/java/test/org/openqa/selenium/environment/GlobalTestEnvironment.java
@@ -17,10 +17,12 @@
 
 package org.openqa.selenium.environment;
 
-import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Used to hold a TestEnvironment in a static class-level field. */
 public class GlobalTestEnvironment {
+  private static final Logger LOG = Logger.getLogger(GlobalTestEnvironment.class.getName());
 
   private static TestEnvironment environment;
 
@@ -32,10 +34,14 @@ public class GlobalTestEnvironment {
     return environment;
   }
 
-  public static synchronized TestEnvironment getOrCreate(
-      Supplier<TestEnvironment> startThisIfNothingIsAlreadyRunning) {
+  public static synchronized TestEnvironment getOrCreate(boolean needsSecureServer) {
+    if (needsSecureServer && environment != null && !environment.isSecure()) {
+      LOG.log(Level.WARNING, "Restarting appServer with secureServer=true");
+      environment.stop();
+      environment = null;
+    }
     if (environment == null) {
-      environment = startThisIfNothingIsAlreadyRunning.get();
+      environment = new InProcessTestEnvironment(needsSecureServer);
       environment.assertIsValid();
     }
     return environment;

--- a/java/test/org/openqa/selenium/environment/TestEnvironment.java
+++ b/java/test/org/openqa/selenium/environment/TestEnvironment.java
@@ -33,4 +33,8 @@ public interface TestEnvironment {
 
     assertThat(hostName).isNotEqualTo(alternateHostName);
   }
+
+  default boolean isSecure() {
+    return getAppServer().isSecure();
+  }
 }

--- a/java/test/org/openqa/selenium/environment/webserver/AppServer.java
+++ b/java/test/org/openqa/selenium/environment/webserver/AppServer.java
@@ -34,6 +34,8 @@ public interface AppServer {
 
   String whereIsWithCredentials(String relativeUrl, String user, String password);
 
+  boolean isSecure();
+
   String create(Page page);
 
   void start();

--- a/java/test/org/openqa/selenium/environment/webserver/NettyAppServer.java
+++ b/java/test/org/openqa/selenium/environment/webserver/NettyAppServer.java
@@ -189,6 +189,10 @@ public class NettyAppServer implements AppServer {
     return createUrl(secure, "https", getHostName(), relativeUrl);
   }
 
+  public boolean isSecure() {
+    return secure != null;
+  }
+
   @Override
   public String whereIsWithCredentials(String relativeUrl, String user, String password) {
     return String.format(

--- a/java/test/org/openqa/selenium/javascript/JavaScriptTestSuite.java
+++ b/java/test/org/openqa/selenium/javascript/JavaScriptTestSuite.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.TestFactory;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.build.InProject;
 import org.openqa.selenium.environment.GlobalTestEnvironment;
-import org.openqa.selenium.environment.InProcessTestEnvironment;
 import org.openqa.selenium.environment.TestEnvironment;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.testing.drivers.WebDriverBuilder;
@@ -61,8 +60,8 @@ class JavaScriptTestSuite {
 
   @BeforeEach
   public void setup() {
-    // this field is actually in use, javascript test do access it
-    testEnvironment = GlobalTestEnvironment.getOrCreate(() -> new InProcessTestEnvironment(true));
+    // this field is actually in use, JavaScript test do access it
+    testEnvironment = GlobalTestEnvironment.getOrCreate(true);
   }
 
   @AfterEach

--- a/java/test/org/openqa/selenium/testing/JupiterTestBase.java
+++ b/java/test/org/openqa/selenium/testing/JupiterTestBase.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.environment.GlobalTestEnvironment;
 import org.openqa.selenium.environment.TestEnvironment;
@@ -49,17 +50,18 @@ public abstract class JupiterTestBase {
   protected AppServer appServer;
   protected Pages pages;
   protected WebDriver driver;
+  private String initialWindowHandle;
   protected Wait<WebDriver> wait;
   protected Wait<WebDriver> shortWait;
   protected WebDriver localDriver;
 
   @BeforeAll
-  public static void shouldTestBeRunAtAll() {
+  static void shouldTestBeRunAtAll() {
     assumeThat(Boolean.getBoolean("selenium.skiptest")).isFalse();
   }
 
   @BeforeEach
-  public void prepareEnvironment() {
+  final void prepareEnvironment() {
     boolean needsSecureServer =
         Optional.ofNullable(this.getClass().getAnnotation(NeedsSecureServer.class))
             .map(NeedsSecureServer::value)
@@ -75,6 +77,7 @@ public abstract class JupiterTestBase {
     shortWait = seleniumExtension::shortWaitUntil;
 
     if (driver != null) {
+      initialWindowHandle = driver.getWindowHandle();
       driver.get("about:blank");
       driver.get(pages.blankPage + "?test=" + seleniumExtension.currentTest());
       driver.manage().deleteAllCookies();
@@ -82,7 +85,7 @@ public abstract class JupiterTestBase {
   }
 
   @AfterEach
-  public void quitLocalDriver() {
+  final void quitLocalDriver() {
     if (localDriver != null) {
       try {
         localDriver.quit();
@@ -91,6 +94,25 @@ public abstract class JupiterTestBase {
       } catch (RuntimeException e) {
         LOG.log(Level.SEVERE, "Failed to quit browser: ", e);
         // fall through
+      }
+    }
+  }
+
+  @AfterEach
+  final void switchToInitialWindow() {
+    if (driver == null) {
+      return;
+    }
+
+    if (initialWindowHandle != null) {
+      try {
+        driver.switchTo().window(initialWindowHandle);
+      } catch (NoSuchWindowException | NoSuchSessionException ok) {
+        LOG.log(
+            Level.FINE,
+            String.format(
+                "The initial window has been closed in test %s: %s",
+                seleniumExtension.currentTest(), ok));
       }
     }
   }

--- a/java/test/org/openqa/selenium/testing/JupiterTestBase.java
+++ b/java/test/org/openqa/selenium/testing/JupiterTestBase.java
@@ -33,7 +33,6 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.environment.GlobalTestEnvironment;
-import org.openqa.selenium.environment.InProcessTestEnvironment;
 import org.openqa.selenium.environment.TestEnvironment;
 import org.openqa.selenium.environment.webserver.AppServer;
 import org.openqa.selenium.support.ui.Wait;
@@ -66,22 +65,8 @@ public abstract class JupiterTestBase {
             .map(NeedsSecureServer::value)
             .orElse(false);
 
-    environment =
-        GlobalTestEnvironment.getOrCreate(() -> new InProcessTestEnvironment(needsSecureServer));
+    environment = GlobalTestEnvironment.getOrCreate(needsSecureServer);
     appServer = environment.getAppServer();
-
-    if (needsSecureServer) {
-      try {
-        appServer.whereIsSecure("/");
-      } catch (IllegalStateException ex) {
-        // this should not happen with bazel, a new JVM is used for each class
-        // the annotation is on class level, so we should never see this
-        LOG.log(Level.WARNING, "appServer is restarted with secureServer=true", ex);
-        environment.stop();
-        environment = new InProcessTestEnvironment(true);
-        appServer = environment.getAppServer();
-      }
-    }
 
     pages = new Pages(appServer);
 


### PR DESCRIPTION
After switching "non-secure" test environment to "secure", the global `GlobalTestEnvironment` still continued holding the previous "non-secure" instance. And the following tests failed because this instance had been stopped already.



### 💥 What does this PR do?
Fixes tests which are broken when I run them locally in my IDE.

### 🔧 Implementation Notes
See commit messages.


### 🔄 Types of changes
- Bug fix (backwards compatible)
