### PR TITLE
[dotnet] [bidi] SetNetworkConditions command in Emulation module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -108,6 +108,13 @@ public sealed class EmulationModule : Module
         return await ExecuteCommandAsync(new SetTouchOverrideCommand(@params), options, _jsonContext.SetTouchOverrideCommand, _jsonContext.SetTouchOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<SetNetworkConditionsResult> SetNetworkConditionsAsync(NetworkConditions? networkConditions, SetNetworkConditionsOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var @params = new SetNetworkConditionsParameters(networkConditions, options?.Contexts, options?.UserContexts);
+
+        return await ExecuteCommandAsync(new SetNetworkConditionsCommand(@params), options, _jsonContext.SetNetworkConditionsCommand, _jsonContext.SetNetworkConditionsResult, cancellationToken).ConfigureAwait(false);
+    }
+
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
@@ -135,5 +142,7 @@ public sealed class EmulationModule : Module
 [JsonSerializable(typeof(SetGeolocationOverrideResult))]
 [JsonSerializable(typeof(SetTouchOverrideCommand))]
 [JsonSerializable(typeof(SetTouchOverrideResult))]
+[JsonSerializable(typeof(SetNetworkConditionsCommand))]
+[JsonSerializable(typeof(SetNetworkConditionsResult))]
 
 internal partial class EmulationJsonSerializerContext : JsonSerializerContext;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
@@ -1,0 +1,43 @@
+// <copyright file="SetNetworkConditionsCommand.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace OpenQA.Selenium.BiDi.Emulation;
+
+internal sealed class SetNetworkConditionsCommand(SetNetworkConditionsParameters @params)
+    : Command<SetNetworkConditionsParameters, SetNetworkConditionsResult>(@params, "emulation.setNetworkConditions");
+
+internal sealed record SetNetworkConditionsParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] NetworkConditions? NetworkConditions, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(NetworkConditionsOffline), "offline")]
+public abstract record NetworkConditions;
+
+public sealed record NetworkConditionsOffline : NetworkConditions;
+
+public sealed class SetNetworkConditionsOptions : CommandOptions
+{
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+}
+
+public sealed record SetNetworkConditionsResult : EmptyResult;

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -223,4 +223,24 @@ internal class EmulationTest : BiDiTestFixture
         },
         Throws.Nothing);
     }
+
+    [Test]
+    public void CanSetNetworkConditionsOffline()
+    {
+        Assert.That(async () =>
+        {
+            await bidi.Emulation.SetNetworkConditionsAsync(new NetworkConditionsOffline(), new() { Contexts = [context] });
+        },
+        Throws.Nothing);
+    }
+
+    [Test]
+    public void CanSetNetworkConditionsToDefault()
+    {
+        Assert.That(async () =>
+        {
+            await bidi.Emulation.SetNetworkConditionsAsync(null, new() { Contexts = [context] });
+        },
+        Throws.Nothing);
+    }
 }

--- a/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
+++ b/dotnet/test/common/BiDi/Emulation/EmulationTest.cs
@@ -225,6 +225,7 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetNetworkConditionsOffline()
     {
         Assert.That(async () =>
@@ -235,6 +236,7 @@ internal class EmulationTest : BiDiTestFixture
     }
 
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public void CanSetNetworkConditionsToDefault()
     {
         Assert.That(async () =>


### PR DESCRIPTION
https://w3c.github.io/webdriver-bidi/#command-emulation-setNetworkConditions

### 💥 What does this PR do?
Support new bidi command.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
