### PR TITLE
[dotnet] [bidi] Adjusted name for Capabilities in new session result

### DIFF
--- a/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
@@ -26,9 +26,9 @@ internal sealed record NewParameters(CapabilitiesRequest Capabilities) : Paramet
 
 public sealed class NewOptions : CommandOptions;
 
-public sealed record NewResult(string SessionId, Capability Capabilities) : EmptyResult;
+public sealed record NewResult(string SessionId, Capabilities Capabilities) : EmptyResult;
 
-public sealed record Capability(bool AcceptInsecureCerts, string BrowserName, string BrowserVersion, string PlatformName, bool SetWindowRect, string UserAgent)
+public sealed record Capabilities(bool AcceptInsecureCerts, string BrowserName, string BrowserVersion, string PlatformName, bool SetWindowRect, string UserAgent)
 {
     public ProxyConfiguration? Proxy { get; set; }
 


### PR DESCRIPTION
https://w3c.github.io/webdriver-bidi/#command-session-new

### 💥 What does this PR do?
Type renaming for clarity:
* Renamed the `Capability` record to `Capabilities`.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)
