### PR TITLE
[dotnet] [bidi] Expand SetViewport options with optional UserContexts

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContext.cs
@@ -106,9 +106,9 @@ public sealed record BrowsingContext
         return BiDi.BrowsingContext.TraverseHistoryAsync(this, delta, options, cancellationToken);
     }
 
-    public Task<SetViewportResult> SetViewportAsync(SetViewportOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<SetViewportResult> SetViewportAsync(ContextSetViewportOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return BiDi.BrowsingContext.SetViewportAsync(this, options, cancellationToken);
+        return BiDi.BrowsingContext.SetViewportAsync(ContextSetViewportOptions.WithContext(options, this), cancellationToken);
     }
 
     public Task<PrintResult> PrintAsync(PrintOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
@@ -86,9 +86,9 @@ public sealed class BrowsingContextModule : Module
         return await ExecuteCommandAsync(new ReloadCommand(@params), options, _jsonContext.ReloadCommand, _jsonContext.ReloadResult, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SetViewportResult> SetViewportAsync(BrowsingContext context, SetViewportOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<SetViewportResult> SetViewportAsync(SetViewportOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var @params = new SetViewportParameters(context, options?.Viewport, options?.DevicePixelRatio);
+        var @params = new SetViewportParameters(options?.Context, options?.Viewport, options?.DevicePixelRatio, options?.UserContexts);
 
         return await ExecuteCommandAsync(new SetViewportCommand(@params), options, _jsonContext.SetViewportCommand, _jsonContext.SetViewportResult, cancellationToken).ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
@@ -17,6 +17,7 @@
 // under the License.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
@@ -25,13 +26,37 @@ namespace OpenQA.Selenium.BiDi.BrowsingContext;
 internal sealed class SetViewportCommand(SetViewportParameters @params)
     : Command<SetViewportParameters, SetViewportResult>(@params, "browsingContext.setViewport");
 
-internal sealed record SetViewportParameters(BrowsingContext Context, [property: JsonConverter(typeof(OptionalConverter<Viewport?>))] Optional<Viewport?>? Viewport, [property: JsonConverter(typeof(OptionalConverter<double?>))] Optional<double?>? DevicePixelRatio) : Parameters;
+internal sealed record SetViewportParameters(
+    BrowsingContext? Context,
+    [property: JsonConverter(typeof(OptionalConverter<Viewport?>))] Optional<Viewport?>? Viewport,
+    [property: JsonConverter(typeof(OptionalConverter<double?>))] Optional<double?>? DevicePixelRatio,
+    IEnumerable<Browser.UserContext>? UserContexts)
+    : Parameters;
 
 public sealed class SetViewportOptions : CommandOptions
+{
+    public BrowsingContext? Context { get; set; }
+
+    public Optional<Viewport?>? Viewport { get; set; }
+
+    public Optional<double?>? DevicePixelRatio { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+}
+
+public sealed class ContextSetViewportOptions : CommandOptions
 {
     public Optional<Viewport?>? Viewport { get; set; }
 
     public Optional<double?>? DevicePixelRatio { get; set; }
+
+    internal static SetViewportOptions WithContext(ContextSetViewportOptions? options, BrowsingContext context) => new()
+    {
+        Context = context,
+        Viewport = options?.Viewport,
+        DevicePixelRatio = options?.DevicePixelRatio,
+        Timeout = options?.Timeout
+    };
 }
 
 public readonly record struct Viewport(long Width, long Height);


### PR DESCRIPTION
https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport

### 💥 What does this PR do?
`SetViewport` command flow to better support context-aware viewport settings and user contexts. The main changes involve refactoring the options and parameter classes, updating method signatures, and improving how context is passed through the API.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)
