### PR TITLE
[dotnet] [bidi] Change MovePointer X/Y types to double

### DIFF
--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -108,7 +108,7 @@ public sealed record DownPointer(int Button) : Pointer, IPointerCommonProperties
 
 public sealed record UpPointer(int Button) : Pointer;
 
-public sealed record MovePointer(int X, int Y) : Pointer, IPointerCommonProperties
+public sealed record MovePointer(double X, double Y) : Pointer, IPointerCommonProperties
 {
     public int? Duration { get; set; }
 


### PR DESCRIPTION
```
input.PointerMoveAction = {
  type: "pointerMove",
  x: float,
  y: float,
  // ...
}
```

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)
