### PR TITLE
[dotnet] [bidi] Support UserContexts in AddPreloadScript command options

### DIFF
--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -25,13 +25,15 @@ namespace OpenQA.Selenium.BiDi.Script;
 internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params)
     : Command<AddPreloadScriptParameters, AddPreloadScriptResult>(@params, "script.addPreloadScript");
 
-internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, string? Sandbox) : Parameters;
+internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts, string? Sandbox) : Parameters;
 
 public sealed class AddPreloadScriptOptions : CommandOptions
 {
     public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
 
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+
+    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
 
     public string? Sandbox { get; set; }
 }

--- a/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
@@ -76,7 +76,7 @@ public sealed class ScriptModule : Module
 
     public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, AddPreloadScriptOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var @params = new AddPreloadScriptParameters(functionDeclaration, options?.Arguments, options?.Contexts, options?.Sandbox);
+        var @params = new AddPreloadScriptParameters(functionDeclaration, options?.Arguments, options?.Contexts, options?.UserContexts, options?.Sandbox);
 
         return await ExecuteCommandAsync(new AddPreloadScriptCommand(@params), options, _jsonContext.AddPreloadScriptCommand, _jsonContext.AddPreloadScriptResult, cancellationToken).ConfigureAwait(false);
     }
@@ -121,6 +121,7 @@ public sealed class ScriptModule : Module
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
         jsonSerializerOptions.Converters.Add(new PreloadScriptConverter(bidi));
         jsonSerializerOptions.Converters.Add(new RealmConverter(bidi));
         jsonSerializerOptions.Converters.Add(new InternalIdConverter(bidi));


### PR DESCRIPTION
https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript

### 💥 What does this PR do?
The changes primarily introduce a new `UserContexts` parameter to relevant data structures and ensure proper serialization. This allows preload scripts to be targeted to specific user contexts, improving flexibility and control.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
