### PR TITLE
[dotnet] Truncate internal log messages

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
@@ -85,6 +85,13 @@ public interface ILogContext : IDisposable
     ILogContext SetLevel(Type issuer, LogEventLevel level);
 
     /// <summary>
+    /// Sets the truncation length for log messages in the current context.
+    /// </summary>
+    /// <param name="length">The maximum length of log messages before truncation occurs.</param>
+    /// <returns>The current instance of <see cref="ILogContext"/> with the truncation length set.</returns>
+    ILogContext WithTruncation(int length);
+
+    /// <summary>
     /// Gets a list of log handlers.
     /// </summary>
     ILogHandlerList Handlers { get; }

--- a/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
@@ -87,9 +87,9 @@ public interface ILogContext : IDisposable
     /// <summary>
     /// Sets the truncation length for log messages in the current context.
     /// </summary>
-    /// <param name="length">The maximum length of log messages before truncation occurs.</param>
+    /// <param name="length">The maximum length of log messages before truncation occurs. Pass <see langword="null"/> to disable truncation.</param>
     /// <returns>The current instance of <see cref="ILogContext"/> with the truncation length set.</returns>
-    ILogContext WithTruncation(int length);
+    ILogContext WithTruncation(int? length);
 
     /// <summary>
     /// Gets a list of log handlers.

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -34,10 +34,10 @@ internal sealed class LogContext : ILogContext
     private LogEventLevel _level;
     private readonly ILogContext? _parentLogContext;
     private ConcurrentDictionary<Type, ILogger>? _loggers;
-    private int _truncationLength;
+    private int? _truncationLength;
     private readonly Lazy<LogHandlerList> _lazyLogHandlerList;
 
-    public LogContext(LogEventLevel level, ILogContext? parentLogContext, ConcurrentDictionary<Type, ILogger>? loggers, int truncationLength, IEnumerable<ILogHandler>? handlers)
+    public LogContext(LogEventLevel level, ILogContext? parentLogContext, ConcurrentDictionary<Type, ILogger>? loggers, int? truncationLength, IEnumerable<ILogHandler>? handlers)
     {
         _level = level;
         _parentLogContext = parentLogContext;
@@ -128,9 +128,9 @@ internal sealed class LogContext : ILogContext
         return this;
     }
 
-    public ILogContext WithTruncation(int length)
+    public ILogContext WithTruncation(int? length)
     {
-        if (length < 0)
+        if (length.HasValue && length.Value < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(length), "Truncation length must be non-negative.");
         }
@@ -177,26 +177,28 @@ internal sealed class LogContext : ILogContext
         return new ConcurrentDictionary<Type, ILogger>(cloned);
     }
 
-    private static string TruncateMessage(string message, int truncationLength)
+    private static string TruncateMessage(string message, int? truncationLength)
     {
-        if (message.Length <= truncationLength)
+        if (!truncationLength.HasValue || message.Length <= truncationLength.Value)
         {
             return message;
         }
 
+        int length = truncationLength.Value;
+
         // Calculate marker length: " ...truncated N... " (14 chars + digit count)
-        int removedCount = message.Length - truncationLength;
+        int removedCount = message.Length - length;
         int markerLength = 14 + removedCount.ToString().Length + 4; // " ...truncated " + digits + "... "
 
-        if (markerLength >= truncationLength)
+        if (markerLength >= length)
         {
             // Fallback to simple truncation if marker won't fit
-            return truncationLength >= 3
-                ? message.Substring(0, truncationLength - 3) + "..."
-                : message.Substring(0, truncationLength);
+            return length >= 3
+                ? message.Substring(0, length - 3) + "..."
+                : message.Substring(0, length);
         }
 
-        int contentLength = truncationLength - markerLength;
+        int contentLength = length - markerLength;
         int prefixLength = contentLength / 2;
         int suffixLength = contentLength - prefixLength;
 

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -130,6 +130,10 @@ internal sealed class LogContext : ILogContext
 
     public ILogContext WithTruncation(int length)
     {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Truncation length must be non-negative.");
+        }
         _truncationLength = length;
         return this;
     }

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -42,7 +42,7 @@ internal sealed class LogContext : ILogContext
     {
         if (truncationLength is not null && truncationLength.Value < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(truncationLength), "Truncation length cannot be negative.");
+            throw new ArgumentOutOfRangeException(nameof(truncationLength), "Truncation length must be non-negative.");
         }
         _level = level;
         _parentLogContext = parentLogContext;

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -40,6 +40,10 @@ internal sealed class LogContext : ILogContext
 
     public LogContext(LogEventLevel level, ILogContext? parentLogContext, ConcurrentDictionary<Type, ILogger>? loggers, int? truncationLength, IEnumerable<ILogHandler>? handlers)
     {
+        if (truncationLength is not null && truncationLength.Value < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(truncationLength), "Truncation length cannot be negative.");
+        }
         _level = level;
         _parentLogContext = parentLogContext;
         _loggers = CloneLoggers(loggers, level);

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -184,24 +184,29 @@ internal sealed class LogContext : ILogContext
             return message;
         }
 
-        int length = truncationLength.Value;
+        int maxLength = truncationLength.Value;
+        int removedCharsLength = message.Length - maxLength;
 
-        // Calculate marker length: " ...truncated N... " (14 chars + digit count)
-        int removedCount = message.Length - length;
-        int markerLength = 14 + removedCount.ToString().Length + 4; // " ...truncated " + digits + "... "
+        // Build truncation marker
+        const string markerPrefix = " ...truncated ";
+        const string markerSuffix = "... ";
 
-        if (markerLength >= length)
+        string marker = $"{markerPrefix}{removedCharsLength}{markerSuffix}";
+
+        // If marker won't fit, don't truncate
+        if (marker.Length >= maxLength)
         {
-            // Fallback to simple truncation if marker won't fit
-            return length >= 3
-                ? message.Substring(0, length - 3) + "..."
-                : message.Substring(0, length);
+            return message;
         }
 
-        int contentLength = length - markerLength;
-        int prefixLength = contentLength / 2;
-        int suffixLength = contentLength - prefixLength;
+        // Split content evenly around marker
+        int availableContentLength = maxLength - marker.Length;
+        int prefixLength = availableContentLength / 2;
+        int suffixLength = availableContentLength - prefixLength;
 
-        return message.Substring(0, prefixLength) + " ...truncated " + removedCount + "... " + message.Substring(message.Length - suffixLength);
+        string prefix = message.Substring(0, prefixLength);
+        string suffix = message.Substring(message.Length - suffixLength);
+
+        return prefix + marker + suffix;
     }
 }

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -31,21 +31,18 @@ namespace OpenQA.Selenium.Internal.Logging;
 /// <inheritdoc cref="ILogContext"/>
 internal sealed class LogContext : ILogContext
 {
-    private ConcurrentDictionary<Type, ILogger>? _loggers;
-
     private LogEventLevel _level;
-
     private readonly ILogContext? _parentLogContext;
-
+    private ConcurrentDictionary<Type, ILogger>? _loggers;
+    private int _truncationLength;
     private readonly Lazy<LogHandlerList> _lazyLogHandlerList;
 
-    public LogContext(LogEventLevel level, ILogContext? parentLogContext, ConcurrentDictionary<Type, ILogger>? loggers, IEnumerable<ILogHandler>? handlers)
+    public LogContext(LogEventLevel level, ILogContext? parentLogContext, ConcurrentDictionary<Type, ILogger>? loggers, int truncationLength, IEnumerable<ILogHandler>? handlers)
     {
         _level = level;
-
         _parentLogContext = parentLogContext;
-
         _loggers = CloneLoggers(loggers, level);
+        _truncationLength = truncationLength;
 
         if (handlers is not null)
         {
@@ -66,7 +63,7 @@ internal sealed class LogContext : ILogContext
     {
         ConcurrentDictionary<Type, ILogger>? loggers = CloneLoggers(_loggers, minimumLevel);
 
-        var context = new LogContext(minimumLevel, this, loggers, Handlers);
+        var context = new LogContext(minimumLevel, this, loggers, _truncationLength, Handlers);
 
         Log.CurrentContext = context;
 
@@ -99,6 +96,8 @@ internal sealed class LogContext : ILogContext
     {
         if (IsEnabled(logger, level))
         {
+            message = TruncateMessage(message, _truncationLength);
+
             var logEvent = new LogEvent(logger.Issuer, DateTimeOffset.Now, level, message);
 
             foreach (var handler in Handlers)
@@ -126,7 +125,12 @@ internal sealed class LogContext : ILogContext
     public ILogContext SetLevel(Type issuer, LogEventLevel level)
     {
         GetLogger(issuer).Level = level;
+        return this;
+    }
 
+    public ILogContext WithTruncation(int length)
+    {
+        _truncationLength = length;
         return this;
     }
 
@@ -167,5 +171,31 @@ internal sealed class LogContext : ILogContext
         }
 
         return new ConcurrentDictionary<Type, ILogger>(cloned);
+    }
+
+    private static string TruncateMessage(string message, int truncationLength)
+    {
+        if (message.Length <= truncationLength)
+        {
+            return message;
+        }
+
+        // Calculate marker length: " ...truncated N... " (14 chars + digit count)
+        int removedCount = message.Length - truncationLength;
+        int markerLength = 14 + removedCount.ToString().Length + 4; // " ...truncated " + digits + "... "
+
+        if (markerLength >= truncationLength)
+        {
+            // Fallback to simple truncation if marker won't fit
+            return truncationLength >= 3
+                ? message.Substring(0, truncationLength - 3) + "..."
+                : message.Substring(0, truncationLength);
+        }
+
+        int contentLength = truncationLength - markerLength;
+        int prefixLength = contentLength / 2;
+        int suffixLength = contentLength - prefixLength;
+
+        return message.Substring(0, prefixLength) + " ...truncated " + removedCount + "... " + message.Substring(message.Length - suffixLength);
     }
 }

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -186,12 +186,12 @@ internal sealed class LogContext : ILogContext
         }
 
         int maxLength = truncationLength.Value;
-        int removedCharsLength = message.Length - maxLength;
+        string removedChars = (message.Length - maxLength).ToString();
 
         const string markerPrefix = "...[truncated ";
         const string markerSuffix = " chars]...";
 
-        int markerLength = markerPrefix.Length + removedCharsLength.ToString().Length + markerSuffix.Length;
+        int markerLength = markerPrefix.Length + removedChars.Length + markerSuffix.Length;
 
         // If marker won't fit, don't truncate
         if (markerLength >= maxLength)
@@ -208,7 +208,7 @@ internal sealed class LogContext : ILogContext
         var sb = new StringBuilder(maxLength);
         sb.Append(message, 0, prefixLength);
         sb.Append(markerPrefix);
-        sb.Append(removedCharsLength);
+        sb.Append(removedChars);
         sb.Append(markerSuffix);
         sb.Append(message, message.Length - suffixLength, suffixLength);
 

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -22,6 +22,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 
 namespace OpenQA.Selenium.Internal.Logging;
 
@@ -187,26 +188,30 @@ internal sealed class LogContext : ILogContext
         int maxLength = truncationLength.Value;
         int removedCharsLength = message.Length - maxLength;
 
-        // Build truncation marker
         const string markerPrefix = " ...truncated ";
         const string markerSuffix = "... ";
 
-        string marker = $"{markerPrefix}{removedCharsLength}{markerSuffix}";
+        int markerLength = markerPrefix.Length + removedCharsLength.ToString().Length + markerSuffix.Length;
 
         // If marker won't fit, don't truncate
-        if (marker.Length >= maxLength)
+        if (markerLength >= maxLength)
         {
             return message;
         }
 
         // Split content evenly around marker
-        int availableContentLength = maxLength - marker.Length;
+        int availableContentLength = maxLength - markerLength;
         int prefixLength = availableContentLength / 2;
         int suffixLength = availableContentLength - prefixLength;
 
-        string prefix = message.Substring(0, prefixLength);
-        string suffix = message.Substring(message.Length - suffixLength);
+        // Use StringBuilder for efficient string building
+        var sb = new StringBuilder(maxLength);
+        sb.Append(message, 0, prefixLength);
+        sb.Append(markerPrefix);
+        sb.Append(removedCharsLength);
+        sb.Append(markerSuffix);
+        sb.Append(message, message.Length - suffixLength, suffixLength);
 
-        return prefix + marker + suffix;
+        return sb.ToString();
     }
 }

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -188,8 +188,8 @@ internal sealed class LogContext : ILogContext
         int maxLength = truncationLength.Value;
         int removedCharsLength = message.Length - maxLength;
 
-        const string markerPrefix = " ...truncated ";
-        const string markerSuffix = "... ";
+        const string markerPrefix = "...[truncated ";
+        const string markerSuffix = " chars]...";
 
         int markerLength = markerPrefix.Length + removedCharsLength.ToString().Length + markerSuffix.Length;
 

--- a/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContextManager.cs
@@ -25,6 +25,7 @@ namespace OpenQA.Selenium.Internal.Logging;
 
 internal class LogContextManager
 {
+    internal const int DefaultTruncationLength = 1000;
     private static bool _seDebugWarned;
     private readonly AsyncLocal<ILogContext?> _currentAmbientLogContext = new();
 
@@ -42,7 +43,7 @@ internal class LogContextManager
             ? LogEventLevel.Debug
             : LogEventLevel.Warn;
 
-        GlobalContext = new LogContext(level, null, null, [defaultLogHandler]);
+        GlobalContext = new LogContext(level, null, null, DefaultTruncationLength, [defaultLogHandler]);
     }
 
     public ILogContext GlobalContext { get; }

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -248,6 +248,14 @@ public class LogTest
     }
 
     [Test]
+    public void ShouldThrowIfTruncationLengthIsNegative()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Log.CreateContext().WithTruncation(-1)
+        );
+    }
+
+    [Test]
     public void ShouldTruncateLongMessage()
     {
         var longMessage = new string('a', 150);

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -269,6 +269,20 @@ public class LogTest
         Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
         Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(expectedMessage));
     }
+
+    [Test]
+    public void ShouldNotTruncateWhenNullIsPassed()
+    {
+        var longMessage = new string('a', 5000);
+
+        using var context = Log.CreateContext()
+            .WithTruncation(length: null).Handlers.Add(testLogHandler);
+
+        logger.Info(longMessage);
+
+        Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
+        Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(longMessage));
+    }
 }
 
 internal class TestLogHandler : ILogHandler

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -260,7 +260,7 @@ public class LogTest
     public void ShouldTruncateLongMessage()
     {
         var longMessage = new string('a', 150);
-        var expectedMessage = new string('a', 40) + " ...truncated 50... " + new string('a', 40);
+        var expectedMessage = new string('a', 37) + "...[truncated 50 chars]..." + new string('a', 37);
 
         using var context = Log.CreateContext().WithTruncation(100).Handlers.Add(testLogHandler);
 

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -155,7 +155,7 @@ public class LogTest
     [Test]
     public void ShouldCreateContextWithNullLogHandlers()
     {
-        var context = new LogContext(LogEventLevel.Info, null, null, handlers: null);
+        var context = new LogContext(LogEventLevel.Info, null, null, 50, handlers: null);
 
         Assert.That(context.Handlers, Is.Empty);
     }
@@ -245,6 +245,20 @@ public class LogTest
         }
 
         Assert.That(Log.CurrentContext, Is.SameAs(globalContext));
+    }
+
+    [Test]
+    public void ShouldTruncateLongMessage()
+    {
+        var longMessage = new string('a', 150);
+        var expectedMessage = new string('a', 40) + " ...truncated 50... " + new string('a', 40);
+
+        using var context = Log.CreateContext().WithTruncation(100).Handlers.Add(testLogHandler);
+
+        logger.Info(longMessage);
+
+        Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
+        Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(expectedMessage));
     }
 }
 

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -271,7 +271,33 @@ public class LogTest
     }
 
     [Test]
-    public void ShouldNotTruncateWhenNullIsPassed()
+    public void ShouldNotTruncateShortMessage()
+    {
+        var shortMessage = new string('a', 50);
+
+        using var context = Log.CreateContext().WithTruncation(100).Handlers.Add(testLogHandler);
+
+        logger.Info(shortMessage);
+
+        Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
+        Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(shortMessage));
+    }
+
+    [Test]
+    public void ShouldNotTruncateShortMessageIfMarkerIsLongerThanMaxLength()
+    {
+        var shortMessage = new string('a', 10);
+
+        using var context = Log.CreateContext().WithTruncation(5).Handlers.Add(testLogHandler);
+
+        logger.Info(shortMessage);
+
+        Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
+        Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(shortMessage));
+    }
+
+    [Test]
+    public void ShouldNotTruncateWhenDisabled()
     {
         var longMessage = new string('a', 5000);
 

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -155,7 +155,8 @@ public class LogTest
     [Test]
     public void ShouldCreateContextWithNullLogHandlers()
     {
-        var context = new LogContext(LogEventLevel.Info, null, null, 50, handlers: null);
+        const int truncationLength = 50;
+        var context = new LogContext(LogEventLevel.Info, null, null, truncationLength, handlers: null);
 
         Assert.That(context.Handlers, Is.Empty);
     }

--- a/dotnet/test/common/Internal/Logging/LogTest.cs
+++ b/dotnet/test/common/Internal/Logging/LogTest.cs
@@ -155,8 +155,7 @@ public class LogTest
     [Test]
     public void ShouldCreateContextWithNullLogHandlers()
     {
-        const int truncationLength = 50;
-        var context = new LogContext(LogEventLevel.Info, null, null, truncationLength, handlers: null);
+        var context = new LogContext(LogEventLevel.Info, null, null, null, handlers: null);
 
         Assert.That(context.Handlers, Is.Empty);
     }


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Implements https://github.com/SeleniumHQ/selenium/issues/16127

### 💡 Additional Considerations
Maximum log message length is 1000 characters by default, let's see whether it is comfortable to read logs.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
