### PR TITLE
[bazel] fix running google formatter with too many files

### DIFF
--- a/rake_tasks/java.rake
+++ b/rake_tasks/java.rake
@@ -396,8 +396,13 @@ task :format do
   java_files = Dir.glob(File.join(Dir.pwd, 'java', '**', '*.java'))
   return if java_files.empty?
 
-  args = ['--', '--replace'] + java_files
-  Bazel.execute('run', args, '//scripts:google-java-format')
+  Tempfile.create('google-java-format-files') do |f|
+    java_files.each { |file| f.puts(file) }
+    f.flush
+
+    args = ['--', '--replace', "@#{f.path}"]
+    Bazel.execute('run', args, '//scripts:google-java-format')
+  end
 end
 
 # ErrorProne runs at build time, SpotBugs runs as test targets in RBE


### PR DESCRIPTION
Current formatting script fails on GitHub Actions with "too many arguments" error:

```
INFO: Running command line: bazel-bin/scripts/google-java-format --replace /home/runner/work/selenium/selenium/java/src/dev/selenium/tools/javadoc/JavadocJarMaker.java /home/runner/work/selenium/selenium/java/src/dev/selenium/tools/modules/ModuleGenerator.java
...
...
/home/runner/work/selenium/selenium/java/test/org/openqa/selenium/testing/drivers/TestInternetExplorerSupplier.java /home/runner/work/selenium/selenium/java/test/org/openqa/selenium/testing/drivers/WebDriverBuilder.java /home/runner/work/selenium/selenium/java/test/org/openqa/selenium/virtualauthenticator/VirtualAuthenticatorTest.java
FATAL: execv of '/bin/bash' failed: (error: 7): Argument list too long
```

### 🔗 Related Issues

See for example
https://github.com/SeleniumHQ/selenium/actions/runs/21830997104/job/62992987104?pr=17064

### 💥 What does this PR do?
Passes files list via argfile, not as an array of arguments.

### 🔧 Implementation Notes

Before:
```bash
bazel run //scripts:google-java-format -- --replace JavadocJarMaker.java ModuleGenerator.java ... VirtualAuthenticatorTest.java
```

After:
```bash
bazel run //scripts:google-java-format -- --replace @/var/folders/z1/35579q8s5cvcnmb6cnp0xpjw0000gn/T/google-java-format-files20260209-81962-mdwsdj
```


### 🔄 Types of changes
- Bug fix (backwards compatible)
