### PR TITLE
[java] Remove unneeded protection from BiDi Connection constructor

### DIFF
--- a/java/src/org/openqa/selenium/bidi/Command.java
+++ b/java/src/org/openqa/selenium/bidi/Command.java
@@ -17,39 +17,44 @@
 
 package org.openqa.selenium.bidi;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.JsonInput;
 
 public class Command<X> {
 
   private final String method;
-  private final Map<String, Object> params;
+  private final Map<String, @Nullable Object> params;
   private final Function<JsonInput, X> mapper;
   private final boolean sendsResponse;
 
-  public Command(String method, Map<String, Object> params) {
+  public Command(String method, Map<String, @Nullable Object> params) {
     this(method, params, Object.class);
   }
 
-  public Command(String method, Map<String, Object> params, Type typeOfX) {
+  public Command(String method, Map<String, @Nullable Object> params, Type typeOfX) {
     this(
         method, params, input -> input.readNonNull(Require.nonNull("Type to convert to", typeOfX)));
   }
 
-  public Command(String method, Map<String, Object> params, Function<JsonInput, X> mapper) {
+  public Command(
+      String method, Map<String, @Nullable Object> params, Function<JsonInput, X> mapper) {
     this(method, params, mapper, true);
   }
 
   public Command(
       String method,
-      Map<String, Object> params,
+      Map<String, @Nullable Object> params,
       Function<JsonInput, X> mapper,
       boolean sendsResponse) {
     this.method = Require.nonNull("Method name", method);
-    this.params = Map.copyOf(Require.nonNull("Command parameters", params));
+    this.params = unmodifiableMap(new HashMap<>(Require.nonNull("Command parameters", params)));
     this.mapper = Require.nonNull("Mapper for result", mapper);
     this.sendsResponse = sendsResponse;
   }
@@ -58,7 +63,7 @@ public class Command<X> {
     return method;
   }
 
-  public Map<String, Object> getParams() {
+  public Map<String, @Nullable Object> getParams() {
     return params;
   }
 

--- a/java/src/org/openqa/selenium/bidi/Connection.java
+++ b/java/src/org/openqa/selenium/bidi/Connection.java
@@ -68,12 +68,12 @@ public class Connection implements Closeable {
           });
   private static final AtomicLong NEXT_ID = new AtomicLong(1L);
   private final AtomicLong EVENT_CALLBACK_ID = new AtomicLong(1);
-  private WebSocket socket;
   private final Map<Long, Consumer<Either<Throwable, JsonInput>>> methodCallbacks =
       new ConcurrentHashMap<>();
   private final ReadWriteLock callbacksLock = new ReentrantReadWriteLock(true);
   private final Map<Event<?>, Map<Long, Consumer<?>>> eventCallbacks = new HashMap<>();
   private final HttpClient client;
+  private final WebSocket socket;
   private final AtomicBoolean underlyingSocketClosed = new AtomicBoolean(false);
 
   public Connection(HttpClient client, String url) {
@@ -81,15 +81,7 @@ public class Connection implements Closeable {
     Require.nonNull("URL to connect to", url);
 
     this.client = client;
-    // If WebDriver close() is called, it closes the session if it is the last browsing context.
-    // It also closes the WebSocket from the remote end.
-    // If WebDriver quit() is called, it also tries to close an already closed websocket and that
-    // causes errors.
-    // Ideally, such errors should not prevent freeing up resources.
-    // This measure is needed until "session.end" from BiDi is implemented by the browsers.
-    if (!underlyingSocketClosed.get()) {
-      socket = this.client.openSocket(new HttpRequest(GET, url), new Listener());
-    }
+    this.socket = this.client.openSocket(new HttpRequest(GET, url), new Listener());
   }
 
   private static class NamedConsumer<X> implements Consumer<X> {


### PR DESCRIPTION
At this moment, `underlyingSocketClosed` is freshly created, and its value if always `false`.

This guard was rather needed in methods `close()` and `clearListeners()`.

### 🔗 Related Issues
See https://github.com/SeleniumHQ/selenium/issues/13316 and https://github.com/SeleniumHQ/selenium/pull/13333/changes

### 💥 What does this PR do?
Removed "if" from the place where it was always `true`.

Just a tiny code cleanup.
The benefit is that field `Connection.socket` is now final and non-nullable.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
