### PR TITLE
[grid] Dynamic Grid standalone support passing basic auth credential

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/docker/DockerSessionFactory.java
@@ -51,6 +51,7 @@ import org.openqa.selenium.PersistentCapabilities;
 import org.openqa.selenium.RetrySessionRequestException;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.UsernameAndPassword;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.docker.Container;
 import org.openqa.selenium.docker.ContainerConfig;
@@ -186,6 +187,7 @@ public class DockerSessionFactory implements SessionFactory {
       URL remoteAddress = getUrl(port, containerIp);
       ClientConfig clientConfig =
           ClientConfig.defaultConfig().baseUrl(remoteAddress).readTimeout(sessionTimeout);
+      clientConfig = applyBasicAuth(clientConfig);
       HttpClient client = clientFactory.createClient(clientConfig);
 
       attributeMap.put("docker.browser.image", browserImage.toString());
@@ -520,8 +522,26 @@ public class DockerSessionFactory implements SessionFactory {
         obj -> {
           HttpResponse response = client.execute(new HttpRequest(GET, "/status"));
           LOG.fine(string(response));
+          if (401 == response.getStatus()) {
+            LOG.warning(
+                "Server requires basic authentication. "
+                    + "Set SE_ROUTER_USERNAME and SE_ROUTER_PASSWORD environment variables "
+                    + "to provide credentials.");
+          }
           return 200 == response.getStatus();
         });
+  }
+
+  private ClientConfig applyBasicAuth(ClientConfig clientConfig) {
+    String routerUsername = System.getenv("SE_ROUTER_USERNAME");
+    String routerPassword = System.getenv("SE_ROUTER_PASSWORD");
+    if (routerUsername != null
+        && !routerUsername.isEmpty()
+        && routerPassword != null
+        && !routerPassword.isEmpty()) {
+      return clientConfig.authenticateAs(new UsernameAndPassword(routerUsername, routerPassword));
+    }
+    return clientConfig;
   }
 
   private URL getUrl(int port, String containerIp) {


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Dynamic Grid in Docker deploy passing all env variables `SE_*` to browser containers.
When deploying Dynamic Grid in Standalone Docker, `SE_ROUTER_USERNAME`, `SE_ROUTER_PASSWORD` to enable Grid basic authen, then it also passes to the browser container to start a session (using container standalone). There is a step to verify server to start

> 10:54:02.827 INFO [DockerSessionFactory.apply] - Waiting for server to start (job: selenium-session-chrome-1770720840810-90139f98, url: [http://10.1.2.193:4444/wd/hub)⁠](http://10.1.2.193:4444/wd/hub))

Without basic auth, this step will never pass event container is up fully.
So, Node Docker will get credential from env var to HttpClient config.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
