### PR TITLE
[dotnet] Warn if SM log level is unknown

### DIFF
--- a/dotnet/src/webdriver/Manager/SeleniumManager.cs
+++ b/dotnet/src/webdriver/Manager/SeleniumManager.cs
@@ -372,7 +372,13 @@ public static partial class SeleniumManager
                             _logger.LogMessage(dateTime, LogEventLevel.Debug, message);
                             break;
                         case "TRACE":
+                            _logger.LogMessage(dateTime, LogEventLevel.Trace, message);
+                            break;
                         default:
+                            if (_logger.IsEnabled(LogEventLevel.Warn))
+                            {
+                                _logger.Warn($"Unknown log level '{logLevel}' in Selenium Manager log message. Original message: {e.Data}");
+                            }
                             _logger.LogMessage(dateTime, LogEventLevel.Trace, message);
                             break;
                     }

--- a/dotnet/src/webdriver/Manager/SeleniumManager.cs
+++ b/dotnet/src/webdriver/Manager/SeleniumManager.cs
@@ -391,7 +391,8 @@ public static partial class SeleniumManager
         }
     }
 
-    const string LogMessageRegexPattern = @"^\[(.*) (INFO|WARN|ERROR|DEBUG|TRACE)\t?\] (.*)$";
+    // Example log message: [2026-02-10T19:33:13.886Z ERROR] You need to specify a browser or driver
+    const string LogMessageRegexPattern = @"^\[(.*) ([A-Z]+)\t?\] (.*)$";
 
 #if NET8_0_OR_GREATER
     [GeneratedRegex(LogMessageRegexPattern)]


### PR DESCRIPTION
* Added explicit handling for the "TRACE" log level, ensuring that trace messages are logged at the correct level.
* Added a warning log for unknown log levels and defaulted their messages to the trace log level, improving visibility into unexpected log entries.

### 💡 Additional Considerations
Hopefully we will see this WARN message and adjust parsing properly.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
