### PR TITLE
[dotnet] Correlate low level http requests/responses and log failures

### DIFF
--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -435,10 +435,13 @@ public class HttpCommandExecutor : ICommandExecutor
         /// <returns>The http response message content.</returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            string requestId = request.GetHashCode().ToString("x8");
+
             if (_logger.IsEnabled(LogEventLevel.Trace))
             {
                 StringBuilder requestLogMessageBuilder = new();
-                requestLogMessageBuilder.AppendFormat(">> {0} {1}",
+                requestLogMessageBuilder.AppendFormat(">> [{0}] {1} {2}",
+                    requestId,
                     request.Method,
                     request.RequestUri?.ToString() ?? "null");
 
@@ -455,13 +458,29 @@ public class HttpCommandExecutor : ICommandExecutor
                 _logger.Trace(requestLogMessageBuilder.ToString());
             }
 
-            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage response;
+
+            try
+            {
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsEnabled(LogEventLevel.Trace))
+                {
+                    _logger.Trace($"<< [{requestId}] {ex}");
+                }
+
+                throw;
+            }
 
             if (_logger.IsEnabled(LogEventLevel.Trace))
             {
                 StringBuilder responseLogMessageBuilder = new();
-
-                responseLogMessageBuilder.AppendFormat("<< {0} {1}", (int)response.StatusCode, response.ReasonPhrase);
+                responseLogMessageBuilder.AppendFormat("<< [{0}] {1} {2}",
+                    requestId,
+                    (int)response.StatusCode,
+                    response.ReasonPhrase);
 
                 if (!response.IsSuccessStatusCode && response.Content != null)
                 {

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -469,7 +469,7 @@ public class HttpCommandExecutor : ICommandExecutor
             {
                 if (isTracingEnabled)
                 {
-                    _logger.Trace($"<< [{correlationId}] {ex}");
+                    _logger.Trace($"!! [{correlationId}] {ex}");
                 }
 
                 throw;

--- a/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/HttpCommandExecutor.cs
@@ -435,13 +435,14 @@ public class HttpCommandExecutor : ICommandExecutor
         /// <returns>The http response message content.</returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            string requestId = request.GetHashCode().ToString("x8");
+            bool isTracingEnabled = _logger.IsEnabled(LogEventLevel.Trace);
+            string? correlationId = isTracingEnabled ? request.GetHashCode().ToString("x8") : null;
 
-            if (_logger.IsEnabled(LogEventLevel.Trace))
+            if (isTracingEnabled)
             {
                 StringBuilder requestLogMessageBuilder = new();
                 requestLogMessageBuilder.AppendFormat(">> [{0}] {1} {2}",
-                    requestId,
+                    correlationId,
                     request.Method,
                     request.RequestUri?.ToString() ?? "null");
 
@@ -466,19 +467,19 @@ public class HttpCommandExecutor : ICommandExecutor
             }
             catch (Exception ex)
             {
-                if (_logger.IsEnabled(LogEventLevel.Trace))
+                if (isTracingEnabled)
                 {
-                    _logger.Trace($"<< [{requestId}] {ex}");
+                    _logger.Trace($"<< [{correlationId}] {ex}");
                 }
 
                 throw;
             }
 
-            if (_logger.IsEnabled(LogEventLevel.Trace))
+            if (isTracingEnabled)
             {
                 StringBuilder responseLogMessageBuilder = new();
                 responseLogMessageBuilder.AppendFormat("<< [{0}] {1} {2}",
-                    requestId,
+                    correlationId,
                     (int)response.StatusCode,
                     response.ReasonPhrase);
 


### PR DESCRIPTION
* Each HTTP request is now assigned a unique `requestId` (derived from the request's hash code), which is included in both request and response log messages for easier correlation.

**Error handling enhancements:**

* If an exception occurs during the HTTP request, a trace log including the `requestId` and exception details is recorded before rethrowing the exception.

### 🔗 Related Issues
Contribute to https://github.com/SeleniumHQ/selenium/issues/17053

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality *and tests!*)
