### PR TITLE
[dotnet] Temporary disable CS1591 warning for BiDi namespace

### DIFF
--- a/dotnet/src/webdriver/BiDi/.editorconfig
+++ b/dotnet/src/webdriver/BiDi/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+# Temporary disable CS1591: XML comment warnings
+# BiDi is under development; avoid noise from missing XML comments
+# Remove when stable: https://github.com/SeleniumHQ/selenium/issues/16095
+dotnet_diagnostic.CS1591.severity = none

--- a/dotnet/src/webdriver/BiDi/.editorconfig
+++ b/dotnet/src/webdriver/BiDi/.editorconfig
@@ -1,5 +1,5 @@
 [*.cs]
-# Temporary disable CS1591: XML comment warnings
+# Temporarily disable CS1591: XML comment warnings
 # BiDi is under development; avoid noise from missing XML comments
 # Remove when stable: https://github.com/SeleniumHQ/selenium/issues/16095
 dotnet_diagnostic.CS1591.severity = none


### PR DESCRIPTION
This pull request makes a small configuration change to the `.editorconfig` file for the BiDi project. The change temporarily disables compiler warnings about missing XML comments in C# files, reducing noise during development while the BiDi feature is still under active work. This should be removed when the code is stable.

It means we can focus on real warnings.

### 🔧 Implementation Notes
Suppressed via nested `.editorconfig`. We will delete this file when we are ready to create a public documentation.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
