### PR TITLE
[dotnet] [bidi] Fully immutable commands and events

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/CloseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/CloseCommand.cs
@@ -22,6 +22,6 @@ namespace OpenQA.Selenium.BiDi.Browser;
 internal sealed class CloseCommand()
     : Command<Parameters, CloseResult>(Parameters.Empty, "browser.close");
 
-public sealed class CloseOptions : CommandOptions;
+public sealed record CloseOptions : CommandOptions;
 
 public sealed record CloseResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
@@ -24,13 +24,13 @@ internal sealed class CreateUserContextCommand(CreateUserContextParameters @para
 
 internal sealed record CreateUserContextParameters(bool? AcceptInsecureCerts, Session.ProxyConfiguration? Proxy, Session.UserPromptHandler? UnhandledPromptBehavior) : Parameters;
 
-public sealed class CreateUserContextOptions : CommandOptions
+public sealed record CreateUserContextOptions : CommandOptions
 {
-    public bool? AcceptInsecureCerts { get; set; }
+    public bool? AcceptInsecureCerts { get; init; }
 
-    public Session.ProxyConfiguration? Proxy { get; set; }
+    public Session.ProxyConfiguration? Proxy { get; init; }
 
-    public Session.UserPromptHandler? UnhandledPromptBehavior { get; set; }
+    public Session.UserPromptHandler? UnhandledPromptBehavior { get; init; }
 }
 
 public sealed record CreateUserContextResult(UserContext UserContext) : UserContextInfo(UserContext);

--- a/dotnet/src/webdriver/BiDi/Browser/GetClientWindowsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/GetClientWindowsCommand.cs
@@ -24,6 +24,6 @@ namespace OpenQA.Selenium.BiDi.Browser;
 internal sealed class GetClientWindowsCommand()
     : Command<Parameters, GetClientWindowsResult>(Parameters.Empty, "browser.getClientWindows");
 
-public sealed class GetClientWindowsOptions : CommandOptions;
+public sealed record GetClientWindowsOptions : CommandOptions;
 
 public sealed record GetClientWindowsResult(IReadOnlyList<ClientWindowInfo> ClientWindows) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Browser/GetUserContextsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/GetUserContextsCommand.cs
@@ -24,6 +24,6 @@ namespace OpenQA.Selenium.BiDi.Browser;
 internal sealed class GetUserContextsCommand()
     : Command<Parameters, GetUserContextsResult>(Parameters.Empty, "browser.getUserContexts");
 
-public class GetUserContextsOptions : CommandOptions;
+public record GetUserContextsOptions : CommandOptions;
 
 public sealed record GetUserContextsResult(IReadOnlyList<UserContextInfo> UserContexts) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Browser/RemoveUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/RemoveUserContextCommand.cs
@@ -24,6 +24,6 @@ internal sealed class RemoveUserContextCommand(RemoveUserContextParameters @para
 
 internal sealed record RemoveUserContextParameters(UserContext UserContext) : Parameters;
 
-public sealed class RemoveUserContextOptions : CommandOptions;
+public sealed record RemoveUserContextOptions : CommandOptions;
 
 public sealed record RemoveUserContextResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
@@ -36,9 +36,9 @@ internal sealed record DownloadBehaviorAllowed(string DestinationFolder) : Downl
 
 internal sealed record DownloadBehaviorDenied : DownloadBehavior;
 
-public sealed class SetDownloadBehaviorOptions : CommandOptions
+public sealed record SetDownloadBehaviorOptions : CommandOptions
 {
-    public IEnumerable<UserContext>? UserContexts { get; set; }
+    public IEnumerable<UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetDownloadBehaviorResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/ActivateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/ActivateCommand.cs
@@ -24,6 +24,6 @@ internal sealed class ActivateCommand(ActivateParameters @params)
 
 internal sealed record ActivateParameters(BrowsingContext Context) : Parameters;
 
-public sealed class ActivateOptions : CommandOptions;
+public sealed record ActivateOptions : CommandOptions;
 
 public sealed record ActivateResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextNetworkModule.cs
@@ -272,8 +272,8 @@ public sealed class BrowsingContextNetworkModule(BrowsingContext context, Networ
     }
 }
 
-public sealed class InterceptRequestOptions : ContextAddInterceptOptions;
+public sealed record InterceptRequestOptions : ContextAddInterceptOptions;
 
-public sealed class InterceptResponseOptions : ContextAddInterceptOptions;
+public sealed record InterceptResponseOptions : ContextAddInterceptOptions;
 
-public sealed class InterceptAuthOptions : ContextAddInterceptOptions;
+public sealed record InterceptAuthOptions : ContextAddInterceptOptions;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextScriptModule.cs
@@ -38,12 +38,10 @@ public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptM
 
     public Task<EvaluateResult> EvaluateAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, EvaluateOptions? options = null, ContextTargetOptions? targetOptions = null, CancellationToken cancellationToken = default)
     {
-        var contextTarget = new ContextTarget(context);
-
-        if (targetOptions is not null)
+        var contextTarget = new ContextTarget(context)
         {
-            contextTarget.Sandbox = targetOptions.Sandbox;
-        }
+            Sandbox = targetOptions?.Sandbox
+        };
 
         return scriptModule.EvaluateAsync(expression, awaitPromise, contextTarget, options, cancellationToken);
     }
@@ -57,12 +55,10 @@ public sealed class BrowsingContextScriptModule(BrowsingContext context, ScriptM
 
     public Task<EvaluateResult> CallFunctionAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, CallFunctionOptions? options = null, ContextTargetOptions? targetOptions = null, CancellationToken cancellationToken = default)
     {
-        var contextTarget = new ContextTarget(context);
-
-        if (targetOptions is not null)
+        var contextTarget = new ContextTarget(context)
         {
-            contextTarget.Sandbox = targetOptions.Sandbox;
-        }
+            Sandbox = targetOptions?.Sandbox
+        };
 
         return scriptModule.CallFunctionAsync(functionDeclaration, awaitPromise, contextTarget, options, cancellationToken);
     }

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
@@ -28,13 +28,13 @@ internal sealed class CaptureScreenshotCommand(CaptureScreenshotParameters @para
 
 internal sealed record CaptureScreenshotParameters(BrowsingContext Context, ScreenshotOrigin? Origin, ImageFormat? Format, ClipRectangle? Clip) : Parameters;
 
-public sealed class CaptureScreenshotOptions : CommandOptions
+public sealed record CaptureScreenshotOptions : CommandOptions
 {
-    public ScreenshotOrigin? Origin { get; set; }
+    public ScreenshotOrigin? Origin { get; init; }
 
-    public ImageFormat? Format { get; set; }
+    public ImageFormat? Format { get; init; }
 
-    public ClipRectangle? Clip { get; set; }
+    public ClipRectangle? Clip { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ScreenshotOrigin>))]

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
@@ -46,7 +46,7 @@ public enum ScreenshotOrigin
 
 public record struct ImageFormat(string Type)
 {
-    public double? Quality { get; set; }
+    public double? Quality { get; init; }
 }
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CloseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CloseCommand.cs
@@ -24,9 +24,9 @@ internal sealed class CloseCommand(CloseParameters @params)
 
 internal sealed record CloseParameters(BrowsingContext Context, bool? PromptUnload) : Parameters;
 
-public sealed class CloseOptions : CommandOptions
+public sealed record CloseOptions : CommandOptions
 {
-    public bool? PromptUnload { get; set; }
+    public bool? PromptUnload { get; init; }
 }
 
 public sealed record CloseResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
@@ -27,13 +27,13 @@ internal sealed class CreateCommand(CreateParameters @params)
 
 internal sealed record CreateParameters(ContextType Type, BrowsingContext? ReferenceContext, bool? Background, Browser.UserContext? UserContext) : Parameters;
 
-public sealed class CreateOptions : CommandOptions
+public sealed record CreateOptions : CommandOptions
 {
-    public BrowsingContext? ReferenceContext { get; set; }
+    public BrowsingContext? ReferenceContext { get; init; }
 
-    public bool? Background { get; set; }
+    public bool? Background { get; init; }
 
-    public Browser.UserContext? UserContext { get; set; }
+    public Browser.UserContext? UserContext { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ContextType>))]

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
@@ -26,16 +26,16 @@ internal sealed class GetTreeCommand(GetTreeParameters @params)
 
 internal sealed record GetTreeParameters(long? MaxDepth, BrowsingContext? Root) : Parameters;
 
-public sealed class GetTreeOptions : CommandOptions
+public sealed record GetTreeOptions : CommandOptions
 {
-    public long? MaxDepth { get; set; }
+    public long? MaxDepth { get; init; }
 
-    public BrowsingContext? Root { get; set; }
+    public BrowsingContext? Root { get; init; }
 }
 
-public sealed class ContextGetTreeOptions : CommandOptions
+public sealed record ContextGetTreeOptions : CommandOptions
 {
-    public long? MaxDepth { get; set; }
+    public long? MaxDepth { get; init; }
 
     internal static GetTreeOptions WithContext(ContextGetTreeOptions? options, BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/HandleUserPromptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/HandleUserPromptCommand.cs
@@ -24,11 +24,11 @@ internal sealed class HandleUserPromptCommand(HandleUserPromptParameters @params
 
 internal sealed record HandleUserPromptParameters(BrowsingContext Context, bool? Accept, string? UserText) : Parameters;
 
-public sealed class HandleUserPromptOptions : CommandOptions
+public sealed record HandleUserPromptOptions : CommandOptions
 {
-    public bool? Accept { get; set; }
+    public bool? Accept { get; init; }
 
-    public string? UserText { get; set; }
+    public string? UserText { get; init; }
 }
 
 public sealed record HandleUserPromptResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/LocateNodesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/LocateNodesCommand.cs
@@ -26,13 +26,13 @@ internal sealed class LocateNodesCommand(LocateNodesParameters @params)
 
 internal sealed record LocateNodesParameters(BrowsingContext Context, Locator Locator, long? MaxNodeCount, Script.SerializationOptions? SerializationOptions, IEnumerable<Script.ISharedReference>? StartNodes) : Parameters;
 
-public sealed class LocateNodesOptions : CommandOptions
+public sealed record LocateNodesOptions : CommandOptions
 {
-    public long? MaxNodeCount { get; set; }
+    public long? MaxNodeCount { get; init; }
 
-    public Script.SerializationOptions? SerializationOptions { get; set; }
+    public Script.SerializationOptions? SerializationOptions { get; init; }
 
-    public IEnumerable<Script.ISharedReference>? StartNodes { get; set; }
+    public IEnumerable<Script.ISharedReference>? StartNodes { get; init; }
 }
 
 public sealed record LocateNodesResult(IReadOnlyList<Script.NodeRemoteValue> Nodes) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/Locator.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/Locator.cs
@@ -38,19 +38,19 @@ public sealed record ContextLocator(ContextValue Value) : Locator;
 
 public sealed record InnerTextLocator(string Value) : Locator
 {
-    public bool? IgnoreCase { get; set; }
+    public bool? IgnoreCase { get; init; }
 
-    public MatchType? MatchType { get; set; }
+    public MatchType? MatchType { get; init; }
 
-    public long? MaxDepth { get; set; }
+    public long? MaxDepth { get; init; }
 }
 
 public sealed record XPathLocator(string Value) : Locator;
 
 public sealed record AccessibilityValue
 {
-    public string? Name { get; set; }
-    public string? Role { get; set; }
+    public string? Name { get; init; }
+    public string? Role { get; init; }
 }
 
 public sealed record ContextValue(BrowsingContext Context);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/NavigateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/NavigateCommand.cs
@@ -27,9 +27,9 @@ internal sealed class NavigateCommand(NavigateParameters @params)
 
 internal sealed record NavigateParameters(BrowsingContext Context, string Url, ReadinessState? Wait) : Parameters;
 
-public sealed class NavigateOptions : CommandOptions
+public sealed record NavigateOptions : CommandOptions
 {
-    public ReadinessState? Wait { get; set; }
+    public ReadinessState? Wait { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ReadinessState>))]

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
@@ -29,21 +29,21 @@ internal sealed class PrintCommand(PrintParameters @params)
 
 internal sealed record PrintParameters(BrowsingContext Context, bool? Background, PrintMargin? Margin, PrintOrientation? Orientation, PrintPage? Page, IEnumerable<PrintPageRange>? PageRanges, double? Scale, bool? ShrinkToFit) : Parameters;
 
-public sealed class PrintOptions : CommandOptions
+public sealed record PrintOptions : CommandOptions
 {
-    public bool? Background { get; set; }
+    public bool? Background { get; init; }
 
-    public PrintMargin? Margin { get; set; }
+    public PrintMargin? Margin { get; init; }
 
-    public PrintOrientation? Orientation { get; set; }
+    public PrintOrientation? Orientation { get; init; }
 
-    public PrintPage? Page { get; set; }
+    public PrintPage? Page { get; init; }
 
-    public IEnumerable<PrintPageRange>? PageRanges { get; set; }
+    public IEnumerable<PrintPageRange>? PageRanges { get; init; }
 
-    public double? Scale { get; set; }
+    public double? Scale { get; init; }
 
-    public bool? ShrinkToFit { get; set; }
+    public bool? ShrinkToFit { get; init; }
 }
 
 public struct PrintMargin

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
@@ -48,13 +48,13 @@ public sealed class PrintOptions : CommandOptions
 
 public struct PrintMargin
 {
-    public double? Bottom { get; set; }
+    public double? Bottom { get; init; }
 
-    public double? Left { get; set; }
+    public double? Left { get; init; }
 
-    public double? Right { get; set; }
+    public double? Right { get; init; }
 
-    public double? Top { get; set; }
+    public double? Top { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<PrintOrientation>))]
@@ -66,9 +66,9 @@ public enum PrintOrientation
 
 public struct PrintPage
 {
-    public double? Height { get; set; }
+    public double? Height { get; init; }
 
-    public double? Width { get; set; }
+    public double? Width { get; init; }
 }
 
 [JsonConverter(typeof(PrintPageRangeConverter))]

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/ReloadCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/ReloadCommand.cs
@@ -24,11 +24,11 @@ internal sealed class ReloadCommand(ReloadParameters @params)
 
 internal sealed record ReloadParameters(BrowsingContext Context, bool? IgnoreCache, ReadinessState? Wait) : Parameters;
 
-public sealed class ReloadOptions : CommandOptions
+public sealed record ReloadOptions : CommandOptions
 {
-    public bool? IgnoreCache { get; set; }
+    public bool? IgnoreCache { get; init; }
 
-    public ReadinessState? Wait { get; set; }
+    public ReadinessState? Wait { get; init; }
 }
 
 public sealed record ReloadResult(Navigation? Navigation, string Url) : NavigateResult(Navigation, Url);

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
@@ -33,7 +33,7 @@ internal sealed record SetViewportParameters(
     IEnumerable<Browser.UserContext>? UserContexts)
     : Parameters;
 
-public sealed class SetViewportOptions : CommandOptions
+public sealed record SetViewportOptions : CommandOptions
 {
     public BrowsingContext? Context { get; init; }
 
@@ -44,7 +44,7 @@ public sealed class SetViewportOptions : CommandOptions
     public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
-public sealed class ContextSetViewportOptions : CommandOptions
+public sealed record ContextSetViewportOptions : CommandOptions
 {
     public Optional<Viewport?>? Viewport { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
@@ -35,20 +35,20 @@ internal sealed record SetViewportParameters(
 
 public sealed class SetViewportOptions : CommandOptions
 {
-    public BrowsingContext? Context { get; set; }
+    public BrowsingContext? Context { get; init; }
 
-    public Optional<Viewport?>? Viewport { get; set; }
+    public Optional<Viewport?>? Viewport { get; init; }
 
-    public Optional<double?>? DevicePixelRatio { get; set; }
+    public Optional<double?>? DevicePixelRatio { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed class ContextSetViewportOptions : CommandOptions
 {
-    public Optional<Viewport?>? Viewport { get; set; }
+    public Optional<Viewport?>? Viewport { get; init; }
 
-    public Optional<double?>? DevicePixelRatio { get; set; }
+    public Optional<double?>? DevicePixelRatio { get; init; }
 
     internal static SetViewportOptions WithContext(ContextSetViewportOptions? options, BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/TraverseHistoryCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/TraverseHistoryCommand.cs
@@ -24,6 +24,6 @@ internal sealed class TraverseHistoryCommand(TraverseHistoryParameters @params)
 
 internal sealed record TraverseHistoryParameters(BrowsingContext Context, long Delta) : Parameters;
 
-public sealed class TraverseHistoryOptions : CommandOptions;
+public sealed record TraverseHistoryOptions : CommandOptions;
 
 public sealed record TraverseHistoryResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/CommandOptions.cs
+++ b/dotnet/src/webdriver/BiDi/CommandOptions.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace OpenQA.Selenium.BiDi;
 
-public abstract class CommandOptions
+public abstract record CommandOptions
 {
-    public TimeSpan? Timeout { get; set; }
+    public TimeSpan? Timeout { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Emulation/SetForcedColorsModeThemeOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetForcedColorsModeThemeOverrideCommand.cs
@@ -28,11 +28,11 @@ internal sealed class SetForcedColorsModeThemeOverrideCommand(SetForcedColorsMod
 
 internal sealed record SetForcedColorsModeThemeOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ForcedColorsModeTheme? Theme, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetForcedColorsModeThemeOverrideOptions : CommandOptions
+public sealed record SetForcedColorsModeThemeOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ForcedColorsModeTheme>))]

--- a/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverrideCommand.cs
@@ -41,22 +41,22 @@ internal sealed record GeolocationPositionError
     internal string Type { get; } = "positionUnavailable";
 }
 
-public class SetGeolocationOverrideOptions : CommandOptions
+public record SetGeolocationOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
-public sealed class SetGeolocationCoordinatesOverrideOptions : SetGeolocationOverrideOptions
+public sealed record SetGeolocationCoordinatesOverrideOptions : SetGeolocationOverrideOptions
 {
-    public double? Accuracy { get; set; }
-    public double? Altitude { get; set; }
-    public double? AltitudeAccuracy { get; set; }
-    public double? Heading { get; set; }
-    public double? Speed { get; set; }
+    public double? Accuracy { get; init; }
+    public double? Altitude { get; init; }
+    public double? AltitudeAccuracy { get; init; }
+    public double? Heading { get; init; }
+    public double? Speed { get; init; }
 }
 
-public sealed class SetGeolocationPositionErrorOverrideOptions : SetGeolocationOverrideOptions;
+public sealed record SetGeolocationPositionErrorOverrideOptions : SetGeolocationOverrideOptions;
 
 public sealed record SetGeolocationOverrideResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetLocaleOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetLocaleOverrideCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetLocaleOverrideCommand(SetLocaleOverrideParameters @para
 
 internal sealed record SetLocaleOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? Locale, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetLocaleOverrideOptions : CommandOptions
+public sealed record SetLocaleOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetLocaleOverrideResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
@@ -33,11 +33,11 @@ public abstract record NetworkConditions;
 
 public sealed record NetworkConditionsOffline : NetworkConditions;
 
-public sealed class SetNetworkConditionsOptions : CommandOptions
+public sealed record SetNetworkConditionsOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetNetworkConditionsResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScreenOrientationOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScreenOrientationOverrideCommand.cs
@@ -28,11 +28,11 @@ internal sealed class SetScreenOrientationOverrideCommand(SetScreenOrientationOv
 
 internal sealed record SetScreenOrientationOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScreenOrientation? ScreenOrientation, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetScreenOrientationOverrideOptions : CommandOptions
+public sealed record SetScreenOrientationOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ScreenOrientationNatural>))]

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetScreenSettingsOverrideCommand(SetScreenSettingsOverride
 
 internal sealed record SetScreenSettingsOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScreenArea? ScreenArea, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetScreenSettingsOverrideOptions : CommandOptions
+public sealed record SetScreenSettingsOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record ScreenArea(long Width, long Height);

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScriptingEnabledCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScriptingEnabledCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetScriptingEnabledCommand(SetScriptingEnabledParameters @
 
 internal sealed record SetScriptingEnabledParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] bool? Enabled, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetScriptingEnabledOptions : CommandOptions
+public sealed record SetScriptingEnabledOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetScriptingEnabledResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetTimezoneOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetTimezoneOverrideCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetTimezoneOverrideCommand(SetTimezoneOverrideParameters @
 
 internal sealed record SetTimezoneOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? Timezone, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetTimezoneOverrideOptions : CommandOptions
+public sealed record SetTimezoneOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetTimezoneOverrideResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetTouchOverrideCommand(SetTouchOverrideParameters @params
 
 internal sealed record SetTouchOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] long? MaxTouchPoints, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetTouchOverrideOptions : CommandOptions
+public sealed record SetTouchOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetTouchOverrideResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Emulation/SetUserAgentOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetUserAgentOverrideCommand.cs
@@ -27,11 +27,11 @@ internal sealed class SetUserAgentOverrideCommand(SetUserAgentOverrideParameters
 
 internal sealed record SetUserAgentOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? UserAgent, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetUserAgentOverrideOptions : CommandOptions
+public sealed record SetUserAgentOverrideOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetUserAgentOverrideResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Input/PerformActionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/PerformActionsCommand.cs
@@ -26,6 +26,6 @@ internal sealed class PerformActionsCommand(PerformActionsParameters @params)
 
 internal sealed record PerformActionsParameters(BrowsingContext.BrowsingContext Context, IEnumerable<SourceActions> Actions) : Parameters;
 
-public sealed class PerformActionsOptions : CommandOptions;
+public sealed record PerformActionsOptions : CommandOptions;
 
 public sealed record PerformActionsResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Input/ReleaseActionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/ReleaseActionsCommand.cs
@@ -24,6 +24,6 @@ internal sealed class ReleaseActionsCommand(ReleaseActionsParameters @params)
 
 internal sealed record ReleaseActionsParameters(BrowsingContext.BrowsingContext Context) : Parameters;
 
-public sealed class ReleaseActionsOptions : CommandOptions;
+public sealed record ReleaseActionsOptions : CommandOptions;
 
 public sealed record ReleaseActionsResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Input/SetFilesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SetFilesCommand.cs
@@ -26,6 +26,6 @@ internal sealed class SetFilesCommand(SetFilesParameters @params)
 
 internal sealed record SetFilesParameters(BrowsingContext.BrowsingContext Context, Script.ISharedReference Element, IEnumerable<string> Files) : Parameters;
 
-public sealed class SetFilesOptions : CommandOptions;
+public sealed record SetFilesOptions : CommandOptions;
 
 public sealed record SetFilesResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -96,51 +96,51 @@ public abstract record PointerSourceAction : IPointerSourceAction;
 
 public sealed record PointerDownAction(int Button) : PointerSourceAction, IPointerCommonProperties
 {
-    public int? Width { get; set; }
-    public int? Height { get; set; }
-    public double? Pressure { get; set; }
-    public double? TangentialPressure { get; set; }
-    public int? Twist { get; set; }
-    public double? AltitudeAngle { get; set; }
-    public double? AzimuthAngle { get; set; }
+    public int? Width { get; init; }
+    public int? Height { get; init; }
+    public double? Pressure { get; init; }
+    public double? TangentialPressure { get; init; }
+    public int? Twist { get; init; }
+    public double? AltitudeAngle { get; init; }
+    public double? AzimuthAngle { get; init; }
 }
 
 public sealed record PointerUpAction(int Button) : PointerSourceAction;
 
 public sealed record PointerMoveAction(double X, double Y) : PointerSourceAction, IPointerCommonProperties
 {
-    public int? Duration { get; set; }
+    public int? Duration { get; init; }
 
-    public Origin? Origin { get; set; }
+    public Origin? Origin { get; init; }
 
-    public int? Width { get; set; }
-    public int? Height { get; set; }
-    public double? Pressure { get; set; }
-    public double? TangentialPressure { get; set; }
-    public int? Twist { get; set; }
-    public double? AltitudeAngle { get; set; }
-    public double? AzimuthAngle { get; set; }
+    public int? Width { get; init; }
+    public int? Height { get; init; }
+    public double? Pressure { get; init; }
+    public double? TangentialPressure { get; init; }
+    public int? Twist { get; init; }
+    public double? AltitudeAngle { get; init; }
+    public double? AzimuthAngle { get; init; }
 }
 
 public abstract record WheelSourceAction : IWheelSourceAction;
 
 public sealed record WheelScrollAction(int X, int Y, int DeltaX, int DeltaY) : WheelSourceAction
 {
-    public int? Duration { get; set; }
+    public int? Duration { get; init; }
 
-    public Origin? Origin { get; set; }
+    public Origin? Origin { get; init; }
 }
 
 public abstract record NoneSourceAction : INoneSourceAction;
 
 public sealed record PauseAction : ISourceAction, IKeySourceAction, IPointerSourceAction, IWheelSourceAction, INoneSourceAction
 {
-    public long? Duration { get; set; }
+    public long? Duration { get; init; }
 }
 
 public sealed record PointerParameters
 {
-    public PointerType? PointerType { get; set; }
+    public PointerType? PointerType { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<PointerType>))]
@@ -153,17 +153,17 @@ public enum PointerType
 
 public interface IPointerCommonProperties
 {
-    public int? Width { get; set; }
+    public int? Width { get; init; }
 
-    public int? Height { get; set; }
+    public int? Height { get; init; }
 
-    public double? Pressure { get; set; }
+    public double? Pressure { get; init; }
 
-    public double? TangentialPressure { get; set; }
+    public double? TangentialPressure { get; init; }
 
-    public int? Twist { get; set; }
+    public int? Twist { get; init; }
 
-    public double? AltitudeAngle { get; set; }
+    public double? AltitudeAngle { get; init; }
 
-    public double? AzimuthAngle { get; set; }
+    public double? AzimuthAngle { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SourceActions.cs
@@ -32,7 +32,7 @@ public interface ISourceAction;
 
 public abstract record SourceActions<T>(string Id) : SourceActions(Id), IEnumerable<ISourceAction> where T : ISourceAction
 {
-    public IList<ISourceAction> Actions { get; set; } = [];
+    public IList<ISourceAction> Actions { get; init; } = [];
 
     public IEnumerator<ISourceAction> GetEnumerator() => Actions.GetEnumerator();
 
@@ -70,7 +70,7 @@ public interface IPointerSourceAction : ISourceAction;
 
 public sealed record PointerActions(string Id) : SourceActions<IPointerSourceAction>(Id)
 {
-    public PointerParameters? Options { get; set; }
+    public PointerParameters? Options { get; init; }
 }
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]

--- a/dotnet/src/webdriver/BiDi/Log/LogEntry.cs
+++ b/dotnet/src/webdriver/BiDi/Log/LogEntry.cs
@@ -34,7 +34,7 @@ namespace OpenQA.Selenium.BiDi.Log;
 public abstract record LogEntry(Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)
     : EventArgs
 {
-    public Script.StackTrace? StackTrace { get; set; }
+    public Script.StackTrace? StackTrace { get; init; }
 }
 
 public sealed record GenericLogEntry(string Type, Level Level, Script.Source Source, string? Text, DateTimeOffset Timestamp)

--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -28,7 +28,7 @@ internal sealed class AddDataCollectorCommand(AddDataCollectorParameters @params
 
 internal sealed record AddDataCollectorParameters(IEnumerable<DataType> DataTypes, int MaxEncodedDataSize, CollectorType? CollectorType, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class AddDataCollectorOptions : CommandOptions
+public sealed record AddDataCollectorOptions : CommandOptions
 {
     public CollectorType? CollectorType { get; init; }
 
@@ -37,7 +37,7 @@ public sealed class AddDataCollectorOptions : CommandOptions
     public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
-public sealed class ContextAddDataCollectorOptions : CommandOptions
+public sealed record ContextAddDataCollectorOptions : CommandOptions
 {
     public CollectorType? CollectorType { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -30,18 +30,18 @@ internal sealed record AddDataCollectorParameters(IEnumerable<DataType> DataType
 
 public sealed class AddDataCollectorOptions : CommandOptions
 {
-    public CollectorType? CollectorType { get; set; }
+    public CollectorType? CollectorType { get; init; }
 
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed class ContextAddDataCollectorOptions : CommandOptions
 {
-    public CollectorType? CollectorType { get; set; }
+    public CollectorType? CollectorType { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 
     internal static AddDataCollectorOptions WithContext(ContextAddDataCollectorOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
@@ -28,7 +28,7 @@ internal sealed class AddInterceptCommand(AddInterceptParameters @params)
 
 internal sealed record AddInterceptParameters(IEnumerable<InterceptPhase> Phases, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<UrlPattern>? UrlPatterns) : Parameters;
 
-public class AddInterceptOptions() : CommandOptions
+public record AddInterceptOptions() : CommandOptions
 {
     internal AddInterceptOptions(ContextAddInterceptOptions? options) : this()
     {
@@ -41,7 +41,7 @@ public class AddInterceptOptions() : CommandOptions
     public IEnumerable<UrlPattern>? UrlPatterns { get; init; }
 }
 
-public class ContextAddInterceptOptions : CommandOptions
+public record ContextAddInterceptOptions : CommandOptions
 {
     public IEnumerable<UrlPattern>? UrlPatterns { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
@@ -36,14 +36,14 @@ public class AddInterceptOptions() : CommandOptions
         Timeout = options?.Timeout;
     }
 
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<UrlPattern>? UrlPatterns { get; set; }
+    public IEnumerable<UrlPattern>? UrlPatterns { get; init; }
 }
 
 public class ContextAddInterceptOptions : CommandOptions
 {
-    public IEnumerable<UrlPattern>? UrlPatterns { get; set; }
+    public IEnumerable<UrlPattern>? UrlPatterns { get; init; }
 }
 
 public sealed record AddInterceptResult(Intercept Intercept) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
@@ -26,7 +26,7 @@ internal sealed class ContinueRequestCommand(ContinueRequestParameters @params)
 
 internal sealed record ContinueRequestParameters(Request Request, BytesValue? Body, IEnumerable<CookieHeader>? Cookies, IEnumerable<Header>? Headers, string? Method, string? Url) : Parameters;
 
-public sealed class ContinueRequestOptions : CommandOptions
+public sealed record ContinueRequestOptions : CommandOptions
 {
     public BytesValue? Body { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
@@ -28,15 +28,15 @@ internal sealed record ContinueRequestParameters(Request Request, BytesValue? Bo
 
 public sealed class ContinueRequestOptions : CommandOptions
 {
-    public BytesValue? Body { get; set; }
+    public BytesValue? Body { get; init; }
 
-    public IEnumerable<CookieHeader>? Cookies { get; set; }
+    public IEnumerable<CookieHeader>? Cookies { get; init; }
 
-    public IEnumerable<Header>? Headers { get; set; }
+    public IEnumerable<Header>? Headers { get; init; }
 
-    public string? Method { get; set; }
+    public string? Method { get; init; }
 
-    public string? Url { get; set; }
+    public string? Url { get; init; }
 }
 
 public sealed record ContinueRequestResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
@@ -26,7 +26,7 @@ internal sealed class ContinueResponseCommand(ContinueResponseParameters @params
 
 internal sealed record ContinueResponseParameters(Request Request, IEnumerable<SetCookieHeader>? Cookies, IEnumerable<AuthCredentials>? Credentials, IEnumerable<Header>? Headers, string? ReasonPhrase, long? StatusCode) : Parameters;
 
-public sealed class ContinueResponseOptions : CommandOptions
+public sealed record ContinueResponseOptions : CommandOptions
 {
     public IEnumerable<SetCookieHeader>? Cookies { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
@@ -28,15 +28,15 @@ internal sealed record ContinueResponseParameters(Request Request, IEnumerable<S
 
 public sealed class ContinueResponseOptions : CommandOptions
 {
-    public IEnumerable<SetCookieHeader>? Cookies { get; set; }
+    public IEnumerable<SetCookieHeader>? Cookies { get; init; }
 
-    public IEnumerable<AuthCredentials>? Credentials { get; set; }
+    public IEnumerable<AuthCredentials>? Credentials { get; init; }
 
-    public IEnumerable<Header>? Headers { get; set; }
+    public IEnumerable<Header>? Headers { get; init; }
 
-    public string? ReasonPhrase { get; set; }
+    public string? ReasonPhrase { get; init; }
 
-    public long? StatusCode { get; set; }
+    public long? StatusCode { get; init; }
 }
 
 public sealed record ContinueResponseResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/ContinueWithAuthCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueWithAuthCommand.cs
@@ -38,14 +38,14 @@ internal sealed record ContinueWithAuthDefaultCredentials(Request Request) : Con
 
 internal sealed record ContinueWithAuthCancelCredentials(Request Request) : ContinueWithAuthNoCredentials(Request);
 
-public abstract class ContinueWithAuthOptions : CommandOptions;
+public abstract record ContinueWithAuthOptions : CommandOptions;
 
-public sealed class ContinueWithAuthCredentialsOptions : ContinueWithAuthOptions;
+public sealed record ContinueWithAuthCredentialsOptions : ContinueWithAuthOptions;
 
-public abstract class ContinueWithAuthNoCredentialsOptions : ContinueWithAuthOptions;
+public abstract record ContinueWithAuthNoCredentialsOptions : ContinueWithAuthOptions;
 
-public sealed class ContinueWithAuthDefaultCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
+public sealed record ContinueWithAuthDefaultCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
 
-public sealed class ContinueWithAuthCancelCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
+public sealed record ContinueWithAuthCancelCredentialsOptions : ContinueWithAuthNoCredentialsOptions;
 
 public sealed record ContinueWithAuthResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/FailRequestCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/FailRequestCommand.cs
@@ -24,6 +24,6 @@ internal sealed class FailRequestCommand(FailRequestParameters @params)
 
 internal sealed record FailRequestParameters(Request Request) : Parameters;
 
-public sealed class FailRequestOptions : CommandOptions;
+public sealed record FailRequestOptions : CommandOptions;
 
 public sealed record FailRequestResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
@@ -26,9 +26,9 @@ internal sealed record GetDataParameters(DataType DataType, Request Request, Col
 
 public sealed class GetDataOptions : CommandOptions
 {
-    public Collector? Collector { get; set; }
+    public Collector? Collector { get; init; }
 
-    public bool? Disown { get; set; }
+    public bool? Disown { get; init; }
 }
 
 public sealed record GetDataResult(BytesValue Bytes) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
@@ -24,7 +24,7 @@ internal sealed class GetDataCommand(GetDataParameters @params)
 
 internal sealed record GetDataParameters(DataType DataType, Request Request, Collector? Collector, bool? Disown) : Parameters;
 
-public sealed class GetDataOptions : CommandOptions
+public sealed record GetDataOptions : CommandOptions
 {
     public Collector? Collector { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/Initiator.cs
+++ b/dotnet/src/webdriver/BiDi/Network/Initiator.cs
@@ -24,13 +24,13 @@ namespace OpenQA.Selenium.BiDi.Network;
 
 public sealed record Initiator(InitiatorType Type)
 {
-    public long? ColumnNumber { get; set; }
+    public long? ColumnNumber { get; init; }
 
-    public long? LineNumber { get; set; }
+    public long? LineNumber { get; init; }
 
-    public Script.StackTrace? StackTrace { get; set; }
+    public Script.StackTrace? StackTrace { get; init; }
 
-    public Request? Request { get; set; }
+    public Request? Request { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<InitiatorType>))]

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.HighLevel.cs
@@ -61,11 +61,11 @@ public partial class NetworkModule
     }
 }
 
-public sealed class InterceptRequestOptions : AddInterceptOptions;
+public sealed record InterceptRequestOptions : AddInterceptOptions;
 
-public sealed class InterceptResponseOptions : AddInterceptOptions;
+public sealed record InterceptResponseOptions : AddInterceptOptions;
 
-public sealed class InterceptAuthOptions : AddInterceptOptions;
+public sealed record InterceptAuthOptions : AddInterceptOptions;
 
 public sealed record InterceptedRequest : BeforeRequestSentEventArgs
 {

--- a/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
@@ -26,7 +26,7 @@ internal sealed class ProvideResponseCommand(ProvideResponseParameters @params)
 
 internal sealed record ProvideResponseParameters(Request Request, BytesValue? Body, IEnumerable<SetCookieHeader>? Cookies, IEnumerable<Header>? Headers, string? ReasonPhrase, long? StatusCode) : Parameters;
 
-public sealed class ProvideResponseOptions : CommandOptions
+public sealed record ProvideResponseOptions : CommandOptions
 {
     public BytesValue? Body { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
@@ -28,15 +28,15 @@ internal sealed record ProvideResponseParameters(Request Request, BytesValue? Bo
 
 public sealed class ProvideResponseOptions : CommandOptions
 {
-    public BytesValue? Body { get; set; }
+    public BytesValue? Body { get; init; }
 
-    public IEnumerable<SetCookieHeader>? Cookies { get; set; }
+    public IEnumerable<SetCookieHeader>? Cookies { get; init; }
 
-    public IEnumerable<Header>? Headers { get; set; }
+    public IEnumerable<Header>? Headers { get; init; }
 
-    public string? ReasonPhrase { get; set; }
+    public string? ReasonPhrase { get; init; }
 
-    public long? StatusCode { get; set; }
+    public long? StatusCode { get; init; }
 }
 
 public sealed record ProvideResponseResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/RemoveDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/RemoveDataCollectorCommand.cs
@@ -24,6 +24,6 @@ internal sealed class RemoveDataCollectorCommand(RemoveDataCollectorParameters @
 
 internal sealed record RemoveDataCollectorParameters(Collector Collector) : Parameters;
 
-public class RemoveDataCollectorOptions : CommandOptions;
+public record RemoveDataCollectorOptions : CommandOptions;
 
 public sealed record RemoveDataCollectorResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/RemoveInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/RemoveInterceptCommand.cs
@@ -24,6 +24,6 @@ internal sealed class RemoveInterceptCommand(RemoveInterceptParameters @params)
 
 internal sealed record RemoveInterceptParameters(Intercept Intercept) : Parameters;
 
-public class RemoveInterceptOptions : CommandOptions;
+public record RemoveInterceptOptions : CommandOptions;
 
 public sealed record RemoveInterceptResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
@@ -28,12 +28,12 @@ internal sealed class SetCacheBehaviorCommand(SetCacheBehaviorParameters @params
 
 internal sealed record SetCacheBehaviorParameters(CacheBehavior CacheBehavior, IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 
-public sealed class SetCacheBehaviorOptions : CommandOptions
+public sealed record SetCacheBehaviorOptions : CommandOptions
 {
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 }
 
-public sealed class ContextSetCacheBehaviorOptions : CommandOptions
+public sealed record ContextSetCacheBehaviorOptions : CommandOptions
 {
     internal static SetCacheBehaviorOptions WithContext(ContextSetCacheBehaviorOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
@@ -30,7 +30,7 @@ internal sealed record SetCacheBehaviorParameters(CacheBehavior CacheBehavior, I
 
 public sealed class SetCacheBehaviorOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 }
 
 public sealed class ContextSetCacheBehaviorOptions : CommandOptions

--- a/dotnet/src/webdriver/BiDi/Network/SetCookieHeader.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCookieHeader.cs
@@ -21,17 +21,17 @@ namespace OpenQA.Selenium.BiDi.Network;
 
 public sealed record SetCookieHeader(string Name, BytesValue Value)
 {
-    public string? Domain { get; set; }
+    public string? Domain { get; init; }
 
-    public bool? HttpOnly { get; set; }
+    public bool? HttpOnly { get; init; }
 
-    public string? Expiry { get; set; }
+    public string? Expiry { get; init; }
 
-    public long? MaxAge { get; set; }
+    public long? MaxAge { get; init; }
 
-    public string? Path { get; set; }
+    public string? Path { get; init; }
 
-    public SameSite? SameSite { get; set; }
+    public SameSite? SameSite { get; init; }
 
-    public bool? Secure { get; set; }
+    public bool? Secure { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
@@ -28,9 +28,9 @@ internal sealed record SetExtraHeadersParameters(IEnumerable<Header> Headers, IE
 
 public sealed class SetExtraHeadersOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 public sealed record SetExtraHeadersResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
@@ -26,7 +26,7 @@ internal sealed class SetExtraHeadersCommand(SetExtraHeadersParameters @params)
 
 internal sealed record SetExtraHeadersParameters(IEnumerable<Header> Headers, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 
-public sealed class SetExtraHeadersOptions : CommandOptions
+public sealed record SetExtraHeadersOptions : CommandOptions
 {
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 

--- a/dotnet/src/webdriver/BiDi/Network/UrlPattern.cs
+++ b/dotnet/src/webdriver/BiDi/Network/UrlPattern.cs
@@ -31,15 +31,15 @@ public abstract record UrlPattern
 
 public sealed record PatternUrlPattern : UrlPattern
 {
-    public string? Protocol { get; set; }
+    public string? Protocol { get; init; }
 
-    public string? Hostname { get; set; }
+    public string? Hostname { get; init; }
 
-    public string? Port { get; set; }
+    public string? Port { get; init; }
 
-    public string? Pathname { get; set; }
+    public string? Pathname { get; init; }
 
-    public string? Search { get; set; }
+    public string? Search { get; init; }
 }
 
 public sealed record StringUrlPattern(string Pattern) : UrlPattern;

--- a/dotnet/src/webdriver/BiDi/Permissions/SetPermissionCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/SetPermissionCommand.cs
@@ -26,11 +26,11 @@ internal class SetPermissionCommand(SetPermissionCommandParameters @params)
 
 internal record SetPermissionCommandParameters(PermissionDescriptor Descriptor, PermissionState State, string Origin, string? EmbeddedOrigin, UserContext? UserContext) : Parameters;
 
-public class SetPermissionOptions : CommandOptions
+public record SetPermissionOptions : CommandOptions
 {
-    public string? EmbeddedOrigin { get; set; }
+    public string? EmbeddedOrigin { get; init; }
 
-    public UserContext? UserContext { get; set; }
+    public UserContext? UserContext { get; init; }
 }
 
 public sealed record SetPermissionResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -27,22 +27,22 @@ internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params
 
 internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts, string? Sandbox) : Parameters;
 
-public sealed class AddPreloadScriptOptions : CommandOptions
+public sealed record AddPreloadScriptOptions : CommandOptions
 {
-    public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
+    public IEnumerable<ChannelLocalValue>? Arguments { get; init; }
 
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 
-    public string? Sandbox { get; set; }
+    public string? Sandbox { get; init; }
 }
 
-public sealed class ContextAddPreloadScriptOptions : CommandOptions
+public sealed record ContextAddPreloadScriptOptions : CommandOptions
 {
-    public IEnumerable<ChannelLocalValue>? Arguments { get; set; }
+    public IEnumerable<ChannelLocalValue>? Arguments { get; init; }
 
-    public string? Sandbox { get; set; }
+    public string? Sandbox { get; init; }
 
     internal static AddPreloadScriptOptions WithContext(ContextAddPreloadScriptOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
@@ -28,15 +28,15 @@ internal sealed class CallFunctionCommand(CallFunctionParameters @params)
 
 internal sealed record CallFunctionParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, bool AwaitPromise, Target Target, IEnumerable<LocalValue>? Arguments, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, LocalValue? This, bool? UserActivation) : Parameters;
 
-public sealed class CallFunctionOptions : CommandOptions
+public sealed record CallFunctionOptions : CommandOptions
 {
-    public IEnumerable<LocalValue>? Arguments { get; set; }
+    public IEnumerable<LocalValue>? Arguments { get; init; }
 
-    public ResultOwnership? ResultOwnership { get; set; }
+    public ResultOwnership? ResultOwnership { get; init; }
 
-    public SerializationOptions? SerializationOptions { get; set; }
+    public SerializationOptions? SerializationOptions { get; init; }
 
-    public LocalValue? This { get; set; }
+    public LocalValue? This { get; init; }
 
-    public bool? UserActivation { get; set; }
+    public bool? UserActivation { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Script/ChannelProperties.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ChannelProperties.cs
@@ -21,7 +21,7 @@ namespace OpenQA.Selenium.BiDi.Script;
 
 public sealed record ChannelProperties(Channel Channel)
 {
-    public SerializationOptions? SerializationOptions { get; set; }
+    public SerializationOptions? SerializationOptions { get; init; }
 
-    public ResultOwnership? Ownership { get; set; }
+    public ResultOwnership? Ownership { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Script/DisownCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/DisownCommand.cs
@@ -26,6 +26,6 @@ internal sealed class DisownCommand(DisownParameters @params)
 
 internal sealed record DisownParameters(IEnumerable<Handle> Handles, Target Target) : Parameters;
 
-public sealed class DisownOptions : CommandOptions;
+public sealed record DisownOptions : CommandOptions;
 
 public sealed record DisownResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
@@ -30,13 +30,13 @@ internal sealed class EvaluateCommand(EvaluateParameters @params)
 
 internal sealed record EvaluateParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string Expression, Target Target, bool AwaitPromise, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, bool? UserActivation) : Parameters;
 
-public sealed class EvaluateOptions : CommandOptions
+public sealed record EvaluateOptions : CommandOptions
 {
-    public ResultOwnership? ResultOwnership { get; set; }
+    public ResultOwnership? ResultOwnership { get; init; }
 
-    public SerializationOptions? SerializationOptions { get; set; }
+    public SerializationOptions? SerializationOptions { get; init; }
 
-    public bool? UserActivation { get; set; }
+    public bool? UserActivation { get; init; }
 }
 
 // https://github.com/dotnet/runtime/issues/72604

--- a/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
@@ -26,16 +26,16 @@ internal sealed class GetRealmsCommand(GetRealmsParameters @params)
 
 internal sealed record GetRealmsParameters(BrowsingContext.BrowsingContext? Context, RealmType? Type) : Parameters;
 
-public sealed class GetRealmsOptions : CommandOptions
+public sealed record GetRealmsOptions : CommandOptions
 {
-    public BrowsingContext.BrowsingContext? Context { get; set; }
+    public BrowsingContext.BrowsingContext? Context { get; init; }
 
-    public RealmType? Type { get; set; }
+    public RealmType? Type { get; init; }
 }
 
-public sealed class ContextGetRealmsOptions : CommandOptions
+public sealed record ContextGetRealmsOptions : CommandOptions
 {
-    public RealmType? Type { get; set; }
+    public RealmType? Type { get; init; }
 
     internal static GetRealmsOptions WithContext(ContextGetRealmsOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Script/IRemoteReference.cs
+++ b/dotnet/src/webdriver/BiDi/Script/IRemoteReference.cs
@@ -25,17 +25,17 @@ public interface ISharedReference : IRemoteReference
 {
     public string SharedId { get; }
 
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 }
 
 public sealed record SharedReference(string SharedId) : ISharedReference
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 }
 
 public interface IRemoteObjectReference : IRemoteReference
 {
     public Handle Handle { get; }
 
-    public string? SharedId { get; set; }
+    public string? SharedId { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Script/LocalValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/LocalValue.cs
@@ -290,14 +290,14 @@ public abstract record RemoteReferenceLocalValue : LocalValue, IRemoteReference;
 
 public sealed record SharedReferenceLocalValue(string SharedId) : RemoteReferenceLocalValue, ISharedReference
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
     internal override string Type { get; } = null!;
 }
 
 public sealed record RemoteObjectReferenceLocalValue(Handle Handle) : RemoteReferenceLocalValue, IRemoteObjectReference
 {
-    public string? SharedId { get; set; }
+    public string? SharedId { get; init; }
 
     internal override string Type { get; } = null!;
 }

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
@@ -38,7 +38,7 @@ public abstract record RealmInfo(Realm Realm, string Origin) : EventArgs;
 
 public sealed record WindowRealmInfo(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(Realm, Origin)
 {
-    public string? Sandbox { get; set; }
+    public string? Sandbox { get; init; }
 }
 
 public sealed record DedicatedWorkerRealmInfo(Realm Realm, string Origin, IReadOnlyList<Realm> Owners) : RealmInfo(Realm, Origin);

--- a/dotnet/src/webdriver/BiDi/Script/RegExpValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RegExpValue.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.BiDi.Script;
 
 public sealed record RegExpValue(string Pattern)
 {
-    public string? Flags { get; set; }
+    public string? Flags { get; init; }
 
     internal static string? GetRegExpFlags(RegexOptions options)
     {

--- a/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
@@ -118,154 +118,154 @@ public sealed record UndefinedRemoteValue : PrimitiveProtocolRemoteValue;
 
 public sealed record SymbolRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record ArrayRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<RemoteValue>? Value { get; set; }
+    public IReadOnlyList<RemoteValue>? Value { get; init; }
 }
 
 public sealed record ObjectRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<IReadOnlyList<RemoteValue>>? Value { get; set; }
+    public IReadOnlyList<IReadOnlyList<RemoteValue>>? Value { get; init; }
 }
 
 public sealed record FunctionRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record RegExpRemoteValue(RegExpValue Value) : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record DateRemoteValue(string Value) : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record MapRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<IReadOnlyList<RemoteValue>>? Value { get; set; }
+    public IReadOnlyList<IReadOnlyList<RemoteValue>>? Value { get; init; }
 }
 
 public sealed record SetRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<RemoteValue>? Value { get; set; }
+    public IReadOnlyList<RemoteValue>? Value { get; init; }
 }
 
 public sealed record WeakMapRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record WeakSetRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record GeneratorRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record ErrorRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record ProxyRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record PromiseRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record TypedArrayRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record ArrayBufferRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record NodeListRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<RemoteValue>? Value { get; set; }
+    public IReadOnlyList<RemoteValue>? Value { get; init; }
 }
 
 public sealed record HtmlCollectionRemoteValue : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 
-    public IReadOnlyList<RemoteValue>? Value { get; set; }
+    public IReadOnlyList<RemoteValue>? Value { get; init; }
 }
 
 public sealed record NodeRemoteValue(string SharedId, NodeProperties? Value) : RemoteValue, ISharedReference
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 public sealed record WindowProxyRemoteValue(WindowProxyProperties Value) : RemoteValue
 {
-    public Handle? Handle { get; set; }
+    public Handle? Handle { get; init; }
 
-    public InternalId? InternalId { get; set; }
+    public InternalId? InternalId { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<Mode>))]

--- a/dotnet/src/webdriver/BiDi/Script/RemovePreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemovePreloadScriptCommand.cs
@@ -24,6 +24,6 @@ internal sealed class RemovePreloadScriptCommand(RemovePreloadScriptParameters @
 
 internal sealed record RemovePreloadScriptParameters(PreloadScript Script) : Parameters;
 
-public sealed class RemovePreloadScriptOptions : CommandOptions;
+public sealed record RemovePreloadScriptOptions : CommandOptions;
 
 public sealed record RemovePreloadScriptResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Script/SerializationOptions.cs
+++ b/dotnet/src/webdriver/BiDi/Script/SerializationOptions.cs
@@ -22,13 +22,13 @@ using OpenQA.Selenium.BiDi.Json.Converters;
 
 namespace OpenQA.Selenium.BiDi.Script;
 
-public sealed class SerializationOptions
+public sealed record SerializationOptions
 {
-    public long? MaxDomDepth { get; set; }
+    public long? MaxDomDepth { get; init; }
 
-    public long? MaxObjectDepth { get; set; }
+    public long? MaxObjectDepth { get; init; }
 
-    public ShadowTree? IncludeShadowTree { get; set; }
+    public ShadowTree? IncludeShadowTree { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<ShadowTree>))]

--- a/dotnet/src/webdriver/BiDi/Script/Source.cs
+++ b/dotnet/src/webdriver/BiDi/Script/Source.cs
@@ -21,5 +21,5 @@ namespace OpenQA.Selenium.BiDi.Script;
 
 public sealed record Source(Realm Realm)
 {
-    public BrowsingContext.BrowsingContext? Context { get; set; }
+    public BrowsingContext.BrowsingContext? Context { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Script/Target.cs
+++ b/dotnet/src/webdriver/BiDi/Script/Target.cs
@@ -29,7 +29,7 @@ public sealed record RealmTarget(Realm Realm) : Target;
 
 public sealed record ContextTarget(BrowsingContext.BrowsingContext Context) : Target
 {
-    public string? Sandbox { get; set; }
+    public string? Sandbox { get; init; }
 }
 
 public sealed class ContextTargetOptions

--- a/dotnet/src/webdriver/BiDi/Session/CapabilitiesRequest.cs
+++ b/dotnet/src/webdriver/BiDi/Session/CapabilitiesRequest.cs
@@ -23,7 +23,7 @@ namespace OpenQA.Selenium.BiDi.Session;
 
 public sealed record CapabilitiesRequest
 {
-    public CapabilityRequest? AlwaysMatch { get; set; }
+    public CapabilityRequest? AlwaysMatch { get; init; }
 
-    public IEnumerable<CapabilityRequest>? FirstMatch { get; set; }
+    public IEnumerable<CapabilityRequest>? FirstMatch { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Session/CapabilityRequest.cs
+++ b/dotnet/src/webdriver/BiDi/Session/CapabilityRequest.cs
@@ -21,15 +21,15 @@ namespace OpenQA.Selenium.BiDi.Session;
 
 public sealed record CapabilityRequest
 {
-    public bool? AcceptInsecureCerts { get; set; }
+    public bool? AcceptInsecureCerts { get; init; }
 
-    public string? BrowserName { get; set; }
+    public string? BrowserName { get; init; }
 
-    public string? BrowserVersion { get; set; }
+    public string? BrowserVersion { get; init; }
 
-    public string? PlatformName { get; set; }
+    public string? PlatformName { get; init; }
 
-    public ProxyConfiguration? ProxyConfiguration { get; set; }
+    public ProxyConfiguration? ProxyConfiguration { get; init; }
 
-    public UserPromptHandler? UnhandledPromptBehavior { get; set; }
+    public UserPromptHandler? UnhandledPromptBehavior { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Session/EndCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/EndCommand.cs
@@ -22,6 +22,6 @@ namespace OpenQA.Selenium.BiDi.Session;
 internal sealed class EndCommand()
     : Command<Parameters, EndResult>(Parameters.Empty, "session.end");
 
-public sealed class EndOptions : CommandOptions;
+public sealed record EndOptions : CommandOptions;
 
 public sealed record EndResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
@@ -30,9 +30,9 @@ public sealed record NewResult(string SessionId, Capabilities Capabilities) : Em
 
 public sealed record Capabilities(bool AcceptInsecureCerts, string BrowserName, string BrowserVersion, string PlatformName, bool SetWindowRect, string UserAgent)
 {
-    public ProxyConfiguration? Proxy { get; set; }
+    public ProxyConfiguration? Proxy { get; init; }
 
-    public UserPromptHandler? UnhandledPromptBehavior { get; set; }
+    public UserPromptHandler? UnhandledPromptBehavior { get; init; }
 
-    public string? WebSocketUrl { get; set; }
+    public string? WebSocketUrl { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
@@ -24,7 +24,7 @@ internal sealed class NewCommand(NewParameters @params)
 
 internal sealed record NewParameters(CapabilitiesRequest Capabilities) : Parameters;
 
-public sealed class NewOptions : CommandOptions;
+public sealed record NewOptions : CommandOptions;
 
 public sealed record NewResult(string SessionId, Capabilities Capabilities) : EmptyResult;
 

--- a/dotnet/src/webdriver/BiDi/Session/ProxyConfiguration.cs
+++ b/dotnet/src/webdriver/BiDi/Session/ProxyConfiguration.cs
@@ -36,15 +36,15 @@ public sealed record DirectProxyConfiguration : ProxyConfiguration;
 
 public sealed record ManualProxyConfiguration : ProxyConfiguration, ISocksProxyConfiguration
 {
-    public string? HttpProxy { get; set; }
+    public string? HttpProxy { get; init; }
 
-    public string? SslProxy { get; set; }
+    public string? SslProxy { get; init; }
 
-    public string? SocksProxy { get; set; }
+    public string? SocksProxy { get; init; }
 
-    public int? SocksVersion { get; set; }
+    public int? SocksVersion { get; init; }
 
-    public IEnumerable<string>? NoProxy { get; set; }
+    public IEnumerable<string>? NoProxy { get; init; }
 }
 
 public sealed record PacProxyConfiguration(string ProxyAutoConfigUrl) : ProxyConfiguration;
@@ -53,7 +53,7 @@ public sealed record SystemProxyConfiguration : ProxyConfiguration;
 
 public interface ISocksProxyConfiguration
 {
-    public string? SocksProxy { get; set; }
+    public string? SocksProxy { get; init; }
 
-    public int? SocksVersion { get; set; } // 0..255
+    public int? SocksVersion { get; init; } // 0..255
 }

--- a/dotnet/src/webdriver/BiDi/Session/StatusCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/StatusCommand.cs
@@ -24,4 +24,4 @@ internal sealed class StatusCommand()
 
 public sealed record StatusResult(bool Ready, string Message) : EmptyResult;
 
-public sealed class StatusOptions : CommandOptions;
+public sealed record StatusOptions : CommandOptions;

--- a/dotnet/src/webdriver/BiDi/Session/SubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SubscribeCommand.cs
@@ -26,11 +26,11 @@ internal sealed class SubscribeCommand(SubscribeParameters @params)
 
 internal sealed record SubscribeParameters(IEnumerable<string> Events, IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 
-public sealed class SubscribeOptions : CommandOptions
+public sealed record SubscribeOptions : CommandOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
 
 internal sealed record SubscribeResult(Subscription Subscription) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
@@ -26,6 +26,6 @@ internal sealed class UnsubscribeByIdCommand(UnsubscribeByIdParameters @params)
 
 internal sealed record UnsubscribeByIdParameters(IEnumerable<Subscription> Subscriptions) : Parameters;
 
-public sealed class UnsubscribeByIdOptions : CommandOptions;
+public sealed record UnsubscribeByIdOptions : CommandOptions;
 
 public sealed record UnsubscribeResult : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/Session/UserPromptHandler.cs
+++ b/dotnet/src/webdriver/BiDi/Session/UserPromptHandler.cs
@@ -24,17 +24,17 @@ namespace OpenQA.Selenium.BiDi.Session;
 
 public sealed record UserPromptHandler
 {
-    public UserPromptHandlerType? Alert { get; set; }
+    public UserPromptHandlerType? Alert { get; init; }
 
-    public UserPromptHandlerType? BeforeUnload { get; set; }
+    public UserPromptHandlerType? BeforeUnload { get; init; }
 
-    public UserPromptHandlerType? Confirm { get; set; }
+    public UserPromptHandlerType? Confirm { get; init; }
 
-    public UserPromptHandlerType? Default { get; set; }
+    public UserPromptHandlerType? Default { get; init; }
 
-    public UserPromptHandlerType? File { get; set; }
+    public UserPromptHandlerType? File { get; init; }
 
-    public UserPromptHandlerType? Prompt { get; set; }
+    public UserPromptHandlerType? Prompt { get; init; }
 }
 
 [JsonConverter(typeof(CamelCaseEnumConverter<UserPromptHandlerType>))]

--- a/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
@@ -24,16 +24,16 @@ internal sealed class DeleteCookiesCommand(DeleteCookiesParameters @params)
 
 internal sealed record DeleteCookiesParameters(CookieFilter? Filter, PartitionDescriptor? Partition) : Parameters;
 
-public sealed class DeleteCookiesOptions : CommandOptions
+public sealed record DeleteCookiesOptions : CommandOptions
 {
-    public CookieFilter? Filter { get; set; }
+    public CookieFilter? Filter { get; init; }
 
-    public PartitionDescriptor? Partition { get; set; }
+    public PartitionDescriptor? Partition { get; init; }
 }
 
-public sealed class ContextDeleteCookiesOptions : CommandOptions
+public sealed record ContextDeleteCookiesOptions : CommandOptions
 {
-    public CookieFilter? Filter { get; set; }
+    public CookieFilter? Filter { get; init; }
 
     internal static DeleteCookiesOptions WithContext(ContextDeleteCookiesOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
@@ -28,16 +28,16 @@ internal sealed class GetCookiesCommand(GetCookiesParameters @params)
 
 internal sealed record GetCookiesParameters(CookieFilter? Filter, PartitionDescriptor? Partition) : Parameters;
 
-public sealed class GetCookiesOptions : CommandOptions
+public sealed record GetCookiesOptions : CommandOptions
 {
-    public CookieFilter? Filter { get; set; }
+    public CookieFilter? Filter { get; init; }
 
-    public PartitionDescriptor? Partition { get; set; }
+    public PartitionDescriptor? Partition { get; init; }
 }
 
-public sealed class ContextGetCookiesOptions : CommandOptions
+public sealed record ContextGetCookiesOptions : CommandOptions
 {
-    public CookieFilter? Filter { get; set; }
+    public CookieFilter? Filter { get; init; }
 
     internal static GetCookiesOptions WithContext(ContextGetCookiesOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
@@ -51,23 +51,23 @@ public sealed record GetCookiesResult(IReadOnlyList<Network.Cookie> Cookies, Par
 
 public sealed record CookieFilter
 {
-    public string? Name { get; set; }
+    public string? Name { get; init; }
 
-    public Network.BytesValue? Value { get; set; }
+    public Network.BytesValue? Value { get; init; }
 
-    public string? Domain { get; set; }
+    public string? Domain { get; init; }
 
-    public string? Path { get; set; }
+    public string? Path { get; init; }
 
-    public long? Size { get; set; }
+    public long? Size { get; init; }
 
-    public bool? HttpOnly { get; set; }
+    public bool? HttpOnly { get; init; }
 
-    public bool? Secure { get; set; }
+    public bool? Secure { get; init; }
 
-    public Network.SameSite? SameSite { get; set; }
+    public Network.SameSite? SameSite { get; init; }
 
-    public DateTimeOffset? Expiry { get; set; }
+    public DateTimeOffset? Expiry { get; init; }
 }
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
@@ -79,7 +79,7 @@ public sealed record ContextPartitionDescriptor(BrowsingContext.BrowsingContext 
 
 public sealed record StorageKeyPartitionDescriptor : PartitionDescriptor
 {
-    public string? UserContext { get; set; }
+    public string? UserContext { get; init; }
 
-    public string? SourceOrigin { get; set; }
+    public string? SourceOrigin { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Storage/PartitionKey.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/PartitionKey.cs
@@ -21,7 +21,7 @@ namespace OpenQA.Selenium.BiDi.Storage;
 
 public sealed record PartitionKey
 {
-    public Browser.UserContext? UserContext { get; set; }
+    public Browser.UserContext? UserContext { get; init; }
 
-    public string? SourceOrigin { get; set; }
+    public string? SourceOrigin { get; init; }
 }

--- a/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
@@ -30,16 +30,16 @@ internal sealed record SetCookieParameters(PartialCookie Cookie, PartitionDescri
 
 public sealed record PartialCookie(string Name, Network.BytesValue Value, string Domain)
 {
-    public string? Path { get; set; }
+    public string? Path { get; init; }
 
-    public bool? HttpOnly { get; set; }
+    public bool? HttpOnly { get; init; }
 
-    public bool? Secure { get; set; }
+    public bool? Secure { get; init; }
 
-    public Network.SameSite? SameSite { get; set; }
+    public Network.SameSite? SameSite { get; init; }
 
     [JsonConverter(typeof(DateTimeOffsetSecondsConverter))]
-    public DateTimeOffset? Expiry { get; set; }
+    public DateTimeOffset? Expiry { get; init; }
 }
 
 public sealed class SetCookieOptions : CommandOptions

--- a/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
@@ -42,12 +42,12 @@ public sealed record PartialCookie(string Name, Network.BytesValue Value, string
     public DateTimeOffset? Expiry { get; init; }
 }
 
-public sealed class SetCookieOptions : CommandOptions
+public sealed record SetCookieOptions : CommandOptions
 {
-    public PartitionDescriptor? Partition { get; set; }
+    public PartitionDescriptor? Partition { get; init; }
 }
 
-public sealed class ContextSetCookieOptions : CommandOptions
+public sealed record ContextSetCookieOptions : CommandOptions
 {
     internal static SetCookieOptions WithContext(ContextSetCookieOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/Subscription.cs
+++ b/dotnet/src/webdriver/BiDi/Subscription.cs
@@ -50,18 +50,18 @@ public class Subscription : IAsyncDisposable
     }
 }
 
-public class SubscriptionOptions
+public sealed record SubscriptionOptions
 {
-    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; set; }
+    public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
-    public IEnumerable<Browser.UserContext>? UserContexts { get; set; }
+    public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 
-    public TimeSpan? Timeout { get; set; }
+    public TimeSpan? Timeout { get; init; }
 }
 
-public class ContextSubscriptionOptions
+public sealed record ContextSubscriptionOptions
 {
-    public TimeSpan? Timeout { get; set; }
+    public TimeSpan? Timeout { get; init; }
 
     internal static SubscriptionOptions WithContext(ContextSubscriptionOptions? options, BrowsingContext.BrowsingContext context) => new()
     {

--- a/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
@@ -39,6 +39,6 @@ public sealed record ExtensionBase64Encoded(ReadOnlyMemory<byte> Value) : Extens
 
 public sealed record ExtensionPath(string Path) : ExtensionData;
 
-public sealed class InstallOptions : CommandOptions;
+public sealed record InstallOptions : CommandOptions;
 
 public sealed record InstallResult(Extension Extension) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/WebExtension/UninstallCommand.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/UninstallCommand.cs
@@ -24,6 +24,6 @@ internal sealed class UninstallCommand(UninstallParameters @params)
 
 internal sealed record UninstallParameters(Extension Extension) : Parameters;
 
-public sealed class UninstallOptions : CommandOptions;
+public sealed record UninstallOptions : CommandOptions;
 
 public sealed record UninstallResult : EmptyResult;


### PR DESCRIPTION
Now we are forcing user to construct command options object and never change it. So everything in Bidi world now is immutable!

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/16095

### 💥 What does this PR do?
This pull request makes broad improvements to the BiDi WebDriver codebase by refactoring option types from classes to records and switching property setters to initializers. These changes enhance immutability, simplify object construction, and align with modern C# practices. The refactor affects command option types across browser and browsing context modules, as well as related value types and utility structs.

These changes collectively modernize the codebase, making it safer and easier to work with, especially when constructing and passing command options.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
