### PR TITLE
[javascript] Add headless flag to internal Chrome tests

### DIFF
--- a/javascript/selenium-webdriver/testing/index.js
+++ b/javascript/selenium-webdriver/testing/index.js
@@ -343,6 +343,16 @@ class Environment {
         builder.setCapability('moz:debuggerAddress', true)
       }
 
+      // Necessary to connect the driver to Chrome browser from within Bazel.
+      if (browser.name === Browser.CHROME && process.env.BAZEL_TEST) {
+        let options = builder.getChromeOptions()
+        if (!options) {
+          options = new chrome.Options()
+        }
+        options.addArguments('--headless=new')
+        builder.setChromeOptions(options)
+      }
+
       // Enable BiDi for supporting browsers.
       if (browser.name === Browser.FIREFOX || browser.name === Browser.CHROME || browser.name === Browser.EDGE) {
         builder.setCapability('webSocketUrl', true)


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Make internal javascript testing on Chrome headless because Chromedriver will otherwise not connect with Chrome.
This change was implimented in the internal testing `Environment` object.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
I used the Environment object in the "testing/index.js" file because it seemed to be solely used for internal testing (in Bazel), which is the only place this bug exists.

<!--- What alternatives to this approach did you consider? -->
I considered trying to add environment flags via Bazel commands.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
The tests don't all pass. Hopefully fixing them can be my focus in future PRs.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
