### PR TITLE
[dotnet] Mark network request id as non-nullable

### DIFF
--- a/dotnet/src/webdriver/HttpRequestData.cs
+++ b/dotnet/src/webdriver/HttpRequestData.cs
@@ -56,5 +56,5 @@ public class HttpRequestData
     /// <summary>
     /// Gets the ID of the HTTP request.
     /// </summary>
-    public string? RequestId { get; internal set; }
+    public string RequestId { get; internal set; } = null!;
 }

--- a/dotnet/src/webdriver/HttpResponseData.cs
+++ b/dotnet/src/webdriver/HttpResponseData.cs
@@ -37,7 +37,7 @@ public class HttpResponseData
     /// <summary>
     /// Gets or sets the ID of the request that generated this response.
     /// </summary>
-    public string? RequestId { get; set; }
+    public string RequestId { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the URL of the HTTP response.

--- a/dotnet/test/remote/RemoteSessionEventTests.cs
+++ b/dotnet/test/remote/RemoteSessionEventTests.cs
@@ -34,7 +34,7 @@ public class RemoteSessionEventTests : DriverTestFixture
         {
             remoteDriver.Url = simpleTestPage;
 
-            var payload = new Dictionary<string, object?>
+            var payload = new Dictionary<string, object>
             {
                 { "testName", "LoginTest" },
                 { "error", "Element not found" }


### PR DESCRIPTION
Fix some build warnings via marking RequestId as "required". Conceptually it is really required.

Ideally it should be in ctor, but it is as is. Fixing it properly is a breaking change.

### 💥 What does this PR do?
8 warnings left.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
