### PR TITLE
[dotnet] [bidi] Add Speculation module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Speculation/PrefetchStatusUpdatedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/PrefetchStatusUpdatedEventArgs.cs
@@ -19,5 +19,5 @@
 
 namespace OpenQA.Selenium.BiDi.Speculation;
 
-public sealed record PrefetchStatusUpdatedEventArgs(string Context, string Url, PreloadingStatus Status)
+public sealed record PrefetchStatusUpdatedEventArgs(BrowsingContext.BrowsingContext Context, string Url, PreloadingStatus Status)
     : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Speculation/PrefetchStatusUpdatedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/PrefetchStatusUpdatedEventArgs.cs
@@ -1,0 +1,23 @@
+// <copyright file="PrefetchStatusUpdatedEventArgs.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+namespace OpenQA.Selenium.BiDi.Speculation;
+
+public sealed record PrefetchStatusUpdatedEventArgs(string Context, string Url, PreloadingStatus Status)
+    : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Speculation/PreloadingStatus.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/PreloadingStatus.cs
@@ -1,0 +1,32 @@
+// <copyright file="PreloadingStatus.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Text.Json.Serialization;
+using OpenQA.Selenium.BiDi.Json.Converters;
+
+namespace OpenQA.Selenium.BiDi.Speculation;
+
+[JsonConverter(typeof(CamelCaseEnumConverter<PreloadingStatus>))]
+public enum PreloadingStatus
+{
+    Pending,
+    Ready,
+    Success,
+    Failure
+}

--- a/dotnet/src/webdriver/BiDi/Speculation/SpeculationBiDiExtensions.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/SpeculationBiDiExtensions.cs
@@ -1,0 +1,35 @@
+// <copyright file="SpeculationBiDiExtensions.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+
+namespace OpenQA.Selenium.BiDi.Speculation;
+
+public static class SpeculationBiDiExtensions
+{
+    public static SpeculationModule AsSpeculation(this BiDi bidi)
+    {
+        if (bidi is null)
+        {
+            throw new ArgumentNullException(nameof(bidi));
+        }
+
+        return bidi.AsModule<SpeculationModule>();
+    }
+}

--- a/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
@@ -22,6 +22,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenQA.Selenium.BiDi.Json.Converters;
 
 namespace OpenQA.Selenium.BiDi.Speculation;
 
@@ -41,6 +42,8 @@ public sealed class SpeculationModule : Module
 
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
+        jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        
         _jsonContext = new SpeculationJsonSerializerContext(jsonSerializerOptions);
     }
 }

--- a/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
@@ -1,0 +1,49 @@
+// <copyright file="SpeculationModule.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenQA.Selenium.BiDi.Speculation;
+
+public sealed class SpeculationModule : Module
+{
+    private SpeculationJsonSerializerContext _jsonContext = null!;
+
+    public async Task<Subscription> OnPrefetchStatusUpdatedAsync(Func<PrefetchStatusUpdatedEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return await SubscribeAsync("speculation.prefetchStatusUpdated", handler, options, _jsonContext.PrefetchStatusUpdatedEventArgs, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<Subscription> OnPrefetchStatusUpdatedAsync(Action<PrefetchStatusUpdatedEventArgs> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return await SubscribeAsync("speculation.prefetchStatusUpdated", handler, options, _jsonContext.PrefetchStatusUpdatedEventArgs, cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
+    {
+        _jsonContext = new SpeculationJsonSerializerContext(jsonSerializerOptions);
+    }
+}
+
+[JsonSerializable(typeof(PrefetchStatusUpdatedEventArgs))]
+internal partial class SpeculationJsonSerializerContext : JsonSerializerContext;

--- a/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Speculation/SpeculationModule.cs
@@ -43,7 +43,7 @@ public sealed class SpeculationModule : Module
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
-        
+
         _jsonContext = new SpeculationJsonSerializerContext(jsonSerializerOptions);
     }
 }

--- a/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
+++ b/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
@@ -69,6 +69,6 @@ internal class SpeculationTests : BiDiTestFixture
         Assert.That(args, Is.Not.Null);
         Assert.That(args.Status, Is.EqualTo(PreloadingStatus.Pending));
         Assert.That(args.Url, Does.Contain("formPage.html"));
-        Assert.That(args.Context, Is.EqualTo(context.Id));
+        Assert.That(args.Context, Is.EqualTo(context));
     }
 }

--- a/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
+++ b/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
@@ -1,0 +1,74 @@
+// <copyright file="SpeculationTests.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenQA.Selenium.BiDi.BrowsingContext;
+using OpenQA.Selenium.Environment;
+
+namespace OpenQA.Selenium.BiDi.Speculation;
+
+internal class SpeculationTests : BiDiTestFixture
+{
+    [Test]
+    public async Task CanListenToPrefetchStatusUpdatedEvent()
+    {
+        var tcs = new TaskCompletionSource<PrefetchStatusUpdatedEventArgs>();
+
+        var speculation = bidi.AsSpeculation();
+
+        await using var subscription = await speculation.OnPrefetchStatusUpdatedAsync(args =>
+        {
+            tcs.TrySetResult(args);
+        });
+
+        // Navigate to a blank page first
+        await context.NavigateAsync(UrlBuilder.WhereIs("simpleTest.html"), new() { Wait = ReadinessState.Complete });
+
+        var targetUrl = UrlBuilder.WhereIs("formPage.html");
+
+        // Add speculation rules with "immediate" eagerness AND a clickable link
+        // The link is necessary for the where clause to match
+        await context.Script.EvaluateAsync($$"""
+            const link = document.createElement('a');
+            link.href = '{{targetUrl}}';
+            link.id = 'prefetch-link';
+            link.textContent = 'Prefetch Target';
+            document.body.appendChild(link);
+            
+            const script = document.createElement('script');
+            script.type = 'speculationrules';
+            script.textContent = JSON.stringify({
+              "prefetch": [{
+                "where": { "href_matches": "{{targetUrl}}" },
+                "eagerness": "immediate"
+              }]
+            });
+            document.head.appendChild(script);
+            """, false);
+
+        var args = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(args, Is.Not.Null);
+        Assert.That(args.Status, Is.EqualTo(PreloadingStatus.Pending));
+        Assert.That(args.Url, Does.Contain("formPage.html"));
+        Assert.That(args.Context, Is.EqualTo(context.Id));
+    }
+}

--- a/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
+++ b/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
@@ -28,6 +28,7 @@ namespace OpenQA.Selenium.BiDi.Speculation;
 internal class SpeculationTests : BiDiTestFixture
 {
     [Test]
+    [IgnoreBrowser(Selenium.Browser.Firefox, "Not supported yet?")]
     public async Task CanListenToPrefetchStatusUpdatedEvent()
     {
         var tcs = new TaskCompletionSource<PrefetchStatusUpdatedEventArgs>();

--- a/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
+++ b/dotnet/test/common/BiDi/Speculation/SpeculationTests.cs
@@ -52,7 +52,7 @@ internal class SpeculationTests : BiDiTestFixture
             link.id = 'prefetch-link';
             link.textContent = 'Prefetch Target';
             document.body.appendChild(link);
-            
+
             const script = document.createElement('script');
             script.type = 'speculationrules';
             script.textContent = JSON.stringify({


### PR DESCRIPTION
https://wicg.github.io/nav-speculation/prefetch.html#automated-testing

### 💥 What does this PR do?
This pull request introduces a new BiDi Speculation module for Selenium's .NET bindings, enabling support for handling speculation rules and prefetch status events. The changes include new module classes, event argument types, status enums, extension methods, and a test to validate event handling.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
