### PR TITLE
[grid] Restore stereotype capabilities merging in RelaySessionFactory

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
+++ b/java/src/org/openqa/selenium/grid/node/relay/RelaySessionFactory.java
@@ -164,6 +164,8 @@ public class RelaySessionFactory implements SessionFactory {
               "New session request capabilities do not " + "match the stereotype."));
     }
 
+    capabilities = capabilities.merge(filterRelayCapabilities(stereotype));
+
     LOG.info("Starting session for " + capabilities);
 
     try (Span span = tracer.getCurrentContext().createSpan("relay_session_factory.apply")) {

--- a/java/test/org/openqa/selenium/grid/node/relay/BUILD.bazel
+++ b/java/test/org/openqa/selenium/grid/node/relay/BUILD.bazel
@@ -7,6 +7,7 @@ java_test_suite(
     srcs = glob(["*Test.java"]),
     deps = [
         "//java/src/org/openqa/selenium/grid/config",
+        "//java/src/org/openqa/selenium/grid/data",
         "//java/src/org/openqa/selenium/grid/node",
         "//java/src/org/openqa/selenium/grid/node/relay",
         "//java/src/org/openqa/selenium/grid/server",

--- a/java/test/org/openqa/selenium/grid/node/relay/RelaySessionFactoryTest.java
+++ b/java/test/org/openqa/selenium/grid/node/relay/RelaySessionFactoryTest.java
@@ -160,7 +160,7 @@ public class RelaySessionFactoryTest {
   }
 
   @Test
-  void stereotypeSePrefixedCapsAreNotOverriddenByRemoteResponse() {
+  void remoteResponseOverridesStereotypeSePrefixedCaps() {
     String fakeSessionId = UUID.randomUUID().toString();
 
     // Remote returns its own se:downloadsEnabled value

--- a/java/test/org/openqa/selenium/grid/node/relay/RelaySessionFactoryTest.java
+++ b/java/test/org/openqa/selenium/grid/node/relay/RelaySessionFactoryTest.java
@@ -20,14 +20,29 @@ package org.openqa.selenium.grid.node.relay;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.grid.data.CreateSessionRequest;
+import org.openqa.selenium.grid.node.ActiveSession;
+import org.openqa.selenium.grid.testing.PassthroughHttpClient;
+import org.openqa.selenium.internal.Either;
+import org.openqa.selenium.remote.Dialect;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.http.Route;
+import org.openqa.selenium.remote.tracing.DefaultTestTracer;
+import org.openqa.selenium.remote.tracing.Tracer;
 
 public class RelaySessionFactoryTest {
 
-  // Add the following test method to the `RelaySessionFactoryTest` class
   @Test
   public void testFilterRelayCapabilities() {
     Capabilities capabilitiesWithApp =
@@ -68,5 +83,144 @@ public class RelaySessionFactoryTest {
     assertThat(capabilitiesWithAppPackage.getCapability("browserName")).isEqualTo(null);
     assertThat(capabilitiesWithBundleId.getCapability("browserName")).isEqualTo(null);
     assertThat(capabilitiesWithoutApp.getCapability("browserName")).isEqualTo("chrome");
+  }
+
+  @Test
+  void stereotypeSePrefixedCapsAreMergedIntoSession() {
+    String fakeSessionId = UUID.randomUUID().toString();
+
+    // The remote (e.g. Appium) only returns basic caps — no se: prefixed caps
+    Map<String, Object> responsePayload =
+        Map.of(
+            "value",
+            Map.of(
+                "sessionId",
+                fakeSessionId,
+                "capabilities",
+                Map.of(
+                    "browserName", "chrome",
+                    "platformName", "android")));
+
+    Route route =
+        Route.post("/session")
+            .to(
+                () ->
+                    req -> {
+                      HttpResponse response = new HttpResponse();
+                      response.setStatus(200);
+                      response.setContent(Contents.asJson(responsePayload));
+                      return response;
+                    });
+
+    PassthroughHttpClient.Factory clientFactory = new PassthroughHttpClient.Factory(route);
+    Tracer tracer = DefaultTestTracer.createTracer();
+
+    // Stereotype includes se: prefixed capabilities
+    Capabilities stereotype =
+        new ImmutableCapabilities(
+            "browserName", "chrome",
+            "platformName", "android",
+            "appium:deviceName", "emulator",
+            "se:downloadsEnabled", true,
+            "se:vncLocalAddress", "ws://10.0.0.1:7900");
+
+    RelaySessionFactory factory =
+        new RelaySessionFactory(
+            tracer,
+            clientFactory,
+            Duration.ofSeconds(300),
+            URI.create("http://localhost:4723"),
+            null,
+            "",
+            stereotype);
+
+    // Client request does NOT include se: caps — just the basics
+    Capabilities requestCaps =
+        new ImmutableCapabilities(
+            "browserName", "chrome",
+            "platformName", "android",
+            "appium:deviceName", "emulator");
+
+    CreateSessionRequest sessionRequest =
+        new CreateSessionRequest(Set.of(Dialect.W3C), requestCaps, Map.of());
+
+    Either<WebDriverException, ActiveSession> result = factory.apply(sessionRequest);
+
+    assertThat(result.isRight()).isTrue();
+    ActiveSession session = result.right();
+    Capabilities sessionCaps = session.getCapabilities();
+
+    // se: prefixed caps from stereotype must be present in session capabilities
+    assertThat(sessionCaps.getCapability("se:downloadsEnabled")).isEqualTo(true);
+    assertThat(sessionCaps.getCapability("se:vncLocalAddress")).isEqualTo("ws://10.0.0.1:7900");
+    // Standard caps from remote response must also be present
+    assertThat(sessionCaps.getCapability("browserName")).isEqualTo("chrome");
+    assertThat(sessionCaps.getCapability("platformName").toString())
+        .isEqualToIgnoringCase("android");
+  }
+
+  @Test
+  void stereotypeSePrefixedCapsAreNotOverriddenByRemoteResponse() {
+    String fakeSessionId = UUID.randomUUID().toString();
+
+    // Remote returns its own se:downloadsEnabled value
+    Map<String, Object> responsePayload =
+        Map.of(
+            "value",
+            Map.of(
+                "sessionId",
+                fakeSessionId,
+                "capabilities",
+                Map.of(
+                    "browserName", "chrome",
+                    "platformName", "android",
+                    "se:downloadsEnabled", false)));
+
+    Route route =
+        Route.post("/session")
+            .to(
+                () ->
+                    req -> {
+                      HttpResponse response = new HttpResponse();
+                      response.setStatus(200);
+                      response.setContent(Contents.asJson(responsePayload));
+                      return response;
+                    });
+
+    PassthroughHttpClient.Factory clientFactory = new PassthroughHttpClient.Factory(route);
+    Tracer tracer = DefaultTestTracer.createTracer();
+
+    Capabilities stereotype =
+        new ImmutableCapabilities(
+            "browserName", "chrome",
+            "platformName", "android",
+            "se:downloadsEnabled", true);
+
+    RelaySessionFactory factory =
+        new RelaySessionFactory(
+            tracer,
+            clientFactory,
+            Duration.ofSeconds(300),
+            URI.create("http://localhost:4723"),
+            null,
+            "",
+            stereotype);
+
+    Capabilities requestCaps =
+        new ImmutableCapabilities(
+            "browserName", "chrome",
+            "platformName", "android");
+
+    CreateSessionRequest sessionRequest =
+        new CreateSessionRequest(Set.of(Dialect.W3C), requestCaps, Map.of());
+
+    Either<WebDriverException, ActiveSession> result = factory.apply(sessionRequest);
+
+    assertThat(result.isRight()).isTrue();
+    ActiveSession session = result.right();
+    Capabilities sessionCaps = session.getCapabilities();
+
+    // Remote response value should win over stereotype (merge overlays remote on top)
+    assertThat(sessionCaps.getCapability("se:downloadsEnabled")).isEqualTo(false);
   }
 }


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?                                                                                                                                                                                                           
  - Fix regression where `se:` prefixed capabilities (e.g. `se:downloadsEnabled`, `se:vncLocalAddress`) from the relay stereotype config were no longer included in session responses
  - The capabilities.merge(filteredStereotype) line was accidentally removed in #15537 when refactoring the browserName removal for Appium mobile apps
  - Add unit tests to verify stereotype `se:` caps flow through to the session and that remote response values take precedence over stereotype values

Background
- In commit 4cacd4a05b, the Appium browserName filtering was refactored from inline code to the filterRelayCapabilities() method. During that refactoring, the line capabilities = capabilities.merge(filteredStereotype)
   was removed, which was responsible for merging stereotype capabilities into the request before session creation.
- This caused relay nodes in 4.36+ to lose any `se:` prefixed capabilities that were configured in the stereotype but not explicitly sent by the client (e.g. se:downloadsEnabled, se:vncLocalAddress).


### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
