### PR TITLE
[dotnet] [bidi] Add UserContext in event args

### DIFF
--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
@@ -43,4 +43,4 @@ public enum ContextType
     Window
 }
 
-public sealed record CreateResult(BrowsingContext Context) : EmptyResult;
+public sealed record CreateResult(BrowsingContext Context, Browser.UserContext? UserContext) : EmptyResult;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/HistoryUpdatedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/HistoryUpdatedEventArgs.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record HistoryUpdatedEventArgs(BrowsingContext Context, DateTimeOffset Timestamp, string Url)
+public sealed record HistoryUpdatedEventArgs(BrowsingContext Context, DateTimeOffset Timestamp, string Url, Browser.UserContext? UserContext)
     : EventArgs;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/NavigationInfo.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/NavigationInfo.cs
@@ -21,5 +21,5 @@ using System;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record NavigationInfo(BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url)
+public sealed record NavigationInfo(BrowsingContext Context, Navigation? Navigation, DateTimeOffset Timestamp, string Url, Browser.UserContext? UserContext)
     : EventArgs, IBaseNavigationInfo;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptClosedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptClosedEventArgs.cs
@@ -19,5 +19,5 @@
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record UserPromptClosedEventArgs(BrowsingContext Context, bool Accepted, string? UserText)
+public sealed record UserPromptClosedEventArgs(BrowsingContext Context, bool Accepted, UserPromptType Type, Browser.UserContext? UserContext, string? UserText)
     : EventArgs;

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptOpenedEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/UserPromptOpenedEventArgs.cs
@@ -22,7 +22,7 @@ using OpenQA.Selenium.BiDi.Json.Converters;
 
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-public sealed record UserPromptOpenedEventArgs(BrowsingContext Context, Session.UserPromptHandlerType Handler, UserPromptType Type, string Message, string? DefaultValue)
+public sealed record UserPromptOpenedEventArgs(BrowsingContext Context, Session.UserPromptHandlerType Handler, string Message, UserPromptType Type, Browser.UserContext? UserContext, string? DefaultValue)
     : EventArgs;
 
 [JsonConverter(typeof(CamelCaseEnumConverter<UserPromptType>))]

--- a/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Input/FileDialogInfo.cs
@@ -19,5 +19,5 @@
 
 namespace OpenQA.Selenium.BiDi.Input;
 
-public sealed record FileDialogInfo(BrowsingContext.BrowsingContext Context, bool Multiple, Script.SharedReference? Element)
+public sealed record FileDialogInfo(BrowsingContext.BrowsingContext Context, Browser.UserContext? UserContext, bool Multiple, Script.SharedReference? Element)
     : EventArgs;

--- a/dotnet/src/webdriver/BiDi/Input/InputModule.cs
+++ b/dotnet/src/webdriver/BiDi/Input/InputModule.cs
@@ -65,6 +65,7 @@ public sealed class InputModule : Module
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
         jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));
 
         _jsonContext = new InputJsonSerializerContext(jsonSerializerOptions);

--- a/dotnet/src/webdriver/BiDi/Log/LogModule.cs
+++ b/dotnet/src/webdriver/BiDi/Log/LogModule.cs
@@ -43,6 +43,7 @@ public sealed class LogModule : Module
     protected override void Initialize(BiDi bidi, JsonSerializerOptions jsonSerializerOptions)
     {
         jsonSerializerOptions.Converters.Add(new BrowsingContextConverter(bidi));
+        jsonSerializerOptions.Converters.Add(new BrowserUserContextConverter(bidi));
         jsonSerializerOptions.Converters.Add(new RealmConverter(bidi));
         jsonSerializerOptions.Converters.Add(new InternalIdConverter(bidi));
         jsonSerializerOptions.Converters.Add(new HandleConverter(bidi));

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
@@ -38,6 +38,8 @@ public abstract record RealmInfo(Realm Realm, string Origin) : EventArgs;
 
 public sealed record WindowRealmInfo(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(Realm, Origin)
 {
+    public Browser.UserContext? UserContext { get; init; }
+    
     public string? Sandbox { get; init; }
 }
 

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
@@ -39,7 +39,7 @@ public abstract record RealmInfo(Realm Realm, string Origin) : EventArgs;
 public sealed record WindowRealmInfo(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(Realm, Origin)
 {
     public Browser.UserContext? UserContext { get; init; }
-    
+
     public string? Sandbox { get; init; }
 }
 

--- a/dotnet/src/webdriver/BiDi/Script/Source.cs
+++ b/dotnet/src/webdriver/BiDi/Script/Source.cs
@@ -22,4 +22,6 @@ namespace OpenQA.Selenium.BiDi.Script;
 public sealed record Source(Realm Realm)
 {
     public BrowsingContext.BrowsingContext? Context { get; init; }
+
+    public Browser.UserContext? UserContext { get; init; }
 }


### PR DESCRIPTION
Adds support for tracking and handling `UserContext` information across various BiDi (Browser Automation) event argument and info classes. The main focus is on ensuring that user context data is available in relevant event records, improving context-awareness throughout the WebDriver BiDi implementation.

### 💡 Additional Considerations
Optional for now, tracking https://github.com/w3c/webdriver-bidi/issues/1071

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
