### PR TITLE
[py] Add in rules to agents around python 3.10+

### DIFF
--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -1,18 +1,26 @@
 <!-- Guidance for AI agents working in Selenium Python Bindings -->
 
 ## Code location
+
 - Package: `py/selenium/`
 - Remote/transport: `py/selenium/webdriver/remote/`
 
 ## Common commands
+
 - Build: `bazel build //py/...`
 
 ## Testing
-See `py/TESTING.md`
+
+Run tests via `bazel test //py/...`. See `/AGENTS.md` for toolchain details.
+
+## Testing
+
+Run tests via `bazel test //py:test-{browser}` or `bazel test //py:test-{browser}-bidi`, where `{browser}` is the target browser (e.g., `chrome`, `firefox`, `edge`). See `/AGENTS.md` for toolchain details.
 
 ## Code conventions
 
 ### Logging
+
 ```python
 logger = logging.getLogger(__name__)
 
@@ -22,6 +30,7 @@ logger.debug("diagnostic: request payload for debugging")
 ```
 
 ### Deprecation
+
 ```python
 warnings.warn(
     "old_method is deprecated, use new_method instead",
@@ -31,34 +40,41 @@ warnings.warn(
 ```
 
 ### Type hints
+
 Type hints are used throughout; add type annotations to new code
 
 Use union notation (`|`) instead of `Optional`:
+
 ```python
 # Preferred
 def method(param: str | None) -> int | None:
     pass
 
 # Avoid
+from typing import Optional
 def method(param: Optional[str]) -> Optional[int]:
     pass
 ```
 
 ### Python version
+
 Code must work with Python 3.10 or later. Use modern syntax features available in 3.10+.
 
 See the **Type hints** section for guidance on preferred type annotation syntax (including unions).
-When running tests or code in the terminal, explicitly use `python3.10` or later:
-```bash
-# Use explicitly
-python3.10 -c "..."
-python3.11 -c "..."
 
-# Avoid relying on `python3` as it may be 3.9 or earlier
+For testing: use `bazel test //py/...` which employs a hermetic Python 3.10+ toolchain (see `/AGENTS.md`).
+
+For ad-hoc scripts, check your Python version locally before running:
+
+```bash
+python --version
+# Ensure you have 3.10+; on macOS/Linux use python3.10+ or on Windows py -3.10
 ```
 
 ### Documentation
+
 Use Google-style docstrings:
+
 ```python
 def method(param: str) -> bool:
     """Brief description.

--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -45,10 +45,9 @@ def method(param: Optional[str]) -> Optional[int]:
 ```
 
 ### Python version
-Code must work with Python 3.10 or later. Use modern syntax features available in 3.10+:
-- Use `|` for union types instead of `Union[]`
-- Use `X | None` instead of `Optional[X]`
+Code must work with Python 3.10 or later. Use modern syntax features available in 3.10+.
 
+See the **Type hints** section for guidance on preferred type annotation syntax (including unions).
 When running tests or code in the terminal, explicitly use `python3.10` or later:
 ```bash
 # Use explicitly

--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -33,6 +33,31 @@ warnings.warn(
 ### Type hints
 Type hints are used throughout; add type annotations to new code
 
+Use union notation (`|`) instead of `Optional`:
+```python
+# Preferred
+def method(param: str | None) -> int | None:
+    pass
+
+# Avoid
+def method(param: Optional[str]) -> Optional[int]:
+    pass
+```
+
+### Python version
+Code must work with Python 3.10 or later. Use modern syntax features available in 3.10+:
+- Use `|` for union types instead of `Union[]`
+- Use `X | None` instead of `Optional[X]`
+
+When running tests or code in the terminal, explicitly use `python3.10` or later:
+```bash
+# Use explicitly
+python3.10 -c "..."
+python3.11 -c "..."
+
+# Avoid relying on `python3` as it may be 3.9 or earlier
+```
+
 ### Documentation
 Use Google-style docstrings:
 ```python


### PR DESCRIPTION
This tells the agent to favour union types instead of notation. Also telling it to explicitly check the python version locally when running things in the terminal

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Updates the rules for agents that are working on this code base in the python part of the tree

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->
Nope

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)

