### PR TITLE
[grid] Fix Distributor thread exhaustion in node health-check cycle

### DIFF
--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -29,6 +29,7 @@ import static org.openqa.selenium.remote.tracing.Tags.EXCEPTION;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.time.Duration;
@@ -38,7 +39,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -182,7 +186,6 @@ public class LocalDistributor extends Distributor implements Closeable {
         new LocalNodeRegistry(
             tracer,
             bus,
-            newSessionThreadPoolSize,
             this.clientFactory,
             this.registrationSecret,
             this.healthcheckInterval,
@@ -191,14 +194,19 @@ public class LocalDistributor extends Distributor implements Closeable {
             this.purgeDeadNodesService);
 
     sessionCreatorExecutor =
-        Executors.newFixedThreadPool(
+        new ThreadPoolExecutor(
             newSessionThreadPoolSize,
+            newSessionThreadPoolSize,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(newSessionThreadPoolSize),
             r -> {
               Thread thread = new Thread(r);
               thread.setName("Local Distributor - Session Creation");
               thread.setDaemon(true);
               return thread;
-            });
+            },
+            new ThreadPoolExecutor.CallerRunsPolicy());
 
     NewSessionRunnable newSessionRunnable = new NewSessionRunnable();
 
@@ -515,10 +523,15 @@ public class LocalDistributor extends Distributor implements Closeable {
   @Override
   public void close() {
     LOG.info("Shutting down Distributor executor service");
-    shutdownGracefully("Local Distributor - Purge Dead Nodes", purgeDeadNodesService);
-    shutdownGracefully("Local Distributor - Node Health Check", nodeHealthCheckService);
     shutdownGracefully("Local Distributor - New Session Queue", newSessionService);
     shutdownGracefully("Local Distributor - Session Creation", sessionCreatorExecutor);
+    shutdownGracefully("Local Distributor - Node Health Check", nodeHealthCheckService);
+    shutdownGracefully("Local Distributor - Purge Dead Nodes", purgeDeadNodesService);
+    try {
+      nodeRegistry.close();
+    } catch (IOException e) {
+      LOG.log(Level.WARNING, "Unable to close node registry cleanly", e);
+    }
   }
 
   private class NewSessionRunnable implements Runnable {
@@ -554,7 +567,16 @@ public class LocalDistributor extends Distributor implements Closeable {
         if (!stereotypes.isEmpty()) {
           List<SessionRequest> matchingRequests = sessionQueue.getNextAvailable(stereotypes);
           matchingRequests.forEach(
-              req -> sessionCreatorExecutor.execute(() -> handleNewSessionRequest(req)));
+              req -> {
+                try {
+                  sessionCreatorExecutor.execute(() -> handleNewSessionRequest(req));
+                } catch (RejectedExecutionException e) {
+                  LOG.log(
+                      getDebugLogLevel(),
+                      "Dropping session creation task while shutting down distributor",
+                      e);
+                }
+              });
         }
       }
 

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -199,14 +199,14 @@ public class LocalDistributor extends Distributor implements Closeable {
             newSessionThreadPoolSize,
             0L,
             TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(newSessionThreadPoolSize),
+            new LinkedBlockingQueue<>(),
             r -> {
               Thread thread = new Thread(r);
               thread.setName("Local Distributor - Session Creation");
               thread.setDaemon(true);
               return thread;
             },
-            new ThreadPoolExecutor.CallerRunsPolicy());
+            new ThreadPoolExecutor.AbortPolicy());
 
     NewSessionRunnable newSessionRunnable = new NewSessionRunnable();
 

--- a/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
+++ b/java/src/org/openqa/selenium/grid/distributor/local/LocalNodeRegistry.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.grid.distributor.local;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.openqa.selenium.concurrent.ExecutorServices.shutdownGracefully;
 import static org.openqa.selenium.grid.data.Availability.DOWN;
 import static org.openqa.selenium.grid.data.Availability.DRAINING;
 import static org.openqa.selenium.grid.data.Availability.UP;
@@ -34,8 +35,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -88,12 +92,11 @@ public class LocalNodeRegistry implements NodeRegistry {
   private final ExecutorService nodeHealthCheckExecutor;
   private final Duration purgeNodesInterval;
   private final ScheduledExecutorService purgeDeadNodesService;
-  private final int newSessionThreadPoolSize;
+  private final AtomicBoolean healthChecksInProgress = new AtomicBoolean(false);
 
   public LocalNodeRegistry(
       Tracer tracer,
       EventBus bus,
-      int newSessionThreadPoolSize,
       HttpClient.Factory clientFactory,
       Secret registrationSecret,
       Duration healthcheckInterval,
@@ -109,7 +112,6 @@ public class LocalNodeRegistry implements NodeRegistry {
         Require.nonNull("Node health check service", nodeHealthCheckService);
     this.purgeNodesInterval = Require.nonNull("Purge nodes interval", purgeNodesInterval);
     this.purgeDeadNodesService = Require.nonNull("Purge dead nodes service", purgeDeadNodesService);
-    this.newSessionThreadPoolSize = newSessionThreadPoolSize;
 
     this.model = new LocalGridModel(bus);
     this.nodes = new ConcurrentHashMap<>();
@@ -138,9 +140,10 @@ public class LocalNodeRegistry implements NodeRegistry {
         healthcheckInterval.toMillis(),
         TimeUnit.MILLISECONDS);
 
+    // Health checks are I/O-bound; a cached pool spawns one thread per active check and
+    // reuses idle threads, giving each cycle a single concurrent pass over all nodes.
     this.nodeHealthCheckExecutor =
-        Executors.newFixedThreadPool(
-            this.newSessionThreadPoolSize,
+        Executors.newCachedThreadPool(
             r -> {
               Thread t = new Thread(r);
               t.setName("node-health-check-" + t.getId());
@@ -305,6 +308,11 @@ public class LocalNodeRegistry implements NodeRegistry {
 
   @Override
   public void runHealthChecks() {
+    if (!healthChecksInProgress.compareAndSet(false, true)) {
+      LOG.log(getDebugLogLevel(), "Skipping health checks because previous cycle is still running");
+      return;
+    }
+
     Map<NodeId, Runnable> nodeHealthChecks;
     Lock readLock = this.lock.readLock();
     readLock.lock();
@@ -314,18 +322,40 @@ public class LocalNodeRegistry implements NodeRegistry {
       readLock.unlock();
     }
 
-    if (nodeHealthChecks.isEmpty()) {
-      return;
+    try {
+      if (nodeHealthChecks.isEmpty()) {
+        return;
+      }
+
+      List<Future<?>> futures = new ArrayList<>(nodeHealthChecks.size());
+      nodeHealthChecks.forEach(
+          (nodeId, check) -> {
+            try {
+              futures.add(nodeHealthCheckExecutor.submit(() -> runHealthCheck(nodeId, check)));
+            } catch (RejectedExecutionException e) {
+              LOG.log(
+                  getDebugLogLevel(),
+                  String.format(
+                      "Unable to schedule health check for node %s, running in caller thread",
+                      nodeId),
+                  e);
+              runHealthCheck(nodeId, check);
+            }
+          });
+
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        } catch (Exception e) {
+          LOG.log(getDebugLogLevel(), "Error waiting for health check execution", e);
+        }
+      }
+    } finally {
+      healthChecksInProgress.set(false);
     }
-
-    List<Runnable> checks = new ArrayList<>(nodeHealthChecks.values());
-    int total = checks.size();
-
-    // Large deployments: process in parallel batches with controlled concurrency
-    int batchSize = Math.max(10, total / 10);
-
-    List<List<Runnable>> batches = partition(checks, batchSize);
-    processBatchesInParallel(batches);
   }
 
   @Override
@@ -417,40 +447,12 @@ public class LocalNodeRegistry implements NodeRegistry {
     }
   }
 
-  private void processBatchesInParallel(List<List<Runnable>> batches) {
-    if (batches.isEmpty()) {
-      return;
+  private void runHealthCheck(NodeId nodeId, Runnable check) {
+    try {
+      check.run();
+    } catch (Throwable t) {
+      LOG.log(getDebugLogLevel(), "Health check execution failed for node " + nodeId, t);
     }
-
-    // Process all batches with controlled parallelism
-    batches.forEach(
-        batch ->
-            nodeHealthCheckExecutor.submit(
-                () ->
-                    batch.parallelStream()
-                        .forEach(
-                            r -> {
-                              try {
-                                r.run();
-                              } catch (Throwable t) {
-                                LOG.log(
-                                    getDebugLogLevel(),
-                                    "Health check execution failed in batch",
-                                    t);
-                              }
-                            })));
-  }
-
-  private static List<List<Runnable>> partition(List<Runnable> list, int size) {
-    List<List<Runnable>> batches = new ArrayList<>();
-    if (list.isEmpty() || size <= 0) {
-      return batches;
-    }
-    for (int i = 0; i < list.size(); i += size) {
-      int end = Math.min(i + size, list.size());
-      batches.add(new ArrayList<>(list.subList(i, end)));
-    }
-    return batches;
   }
 
   private Runnable asRunnableHealthCheck(Node node) {
@@ -581,6 +583,7 @@ public class LocalNodeRegistry implements NodeRegistry {
   @Override
   public void close() {
     LOG.info("Shutting down LocalNodeRegistry");
+    shutdownGracefully("Local Distributor - Node Health Check Worker", nodeHealthCheckExecutor);
     Lock writeLock = lock.writeLock();
     writeLock.lock();
     try {

--- a/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -76,8 +76,8 @@ public class RemoteNode extends Node implements Closeable {
   // Health checks only need /status to respond quickly; no need for the full session timeout.
   static final Duration HEALTH_CHECK_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
   static final Duration HEALTH_CHECK_READ_TIMEOUT = Duration.ofSeconds(30);
-  private final HttpHandler client;
-  private final HttpHandler healthCheckClient;
+  private final HttpClient client;
+  private final HttpClient healthCheckClient;
   private final URI externalUri;
   private final Set<Capabilities> capabilities;
   private final HealthCheck healthCheck;
@@ -327,8 +327,8 @@ public class RemoteNode extends Node implements Closeable {
 
   @Override
   public void close() {
-    ((HttpClient) this.client).close();
-    ((HttpClient) this.healthCheckClient).close();
+    this.client.close();
+    this.healthCheckClient.close();
   }
 
   private class RemoteCheck implements HealthCheck {

--- a/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -73,7 +73,11 @@ import org.openqa.selenium.remote.tracing.Tracer;
 public class RemoteNode extends Node implements Closeable {
 
   public static final Json JSON = new Json();
+  // Health checks only need /status to respond quickly; no need for the full session timeout.
+  static final Duration HEALTH_CHECK_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
+  static final Duration HEALTH_CHECK_READ_TIMEOUT = Duration.ofSeconds(30);
   private final HttpHandler client;
+  private final HttpHandler healthCheckClient;
   private final URI externalUri;
   private final Set<Capabilities> capabilities;
   private final HealthCheck healthCheck;
@@ -93,7 +97,14 @@ public class RemoteNode extends Node implements Closeable {
 
     ClientConfig clientConfig =
         defaultConfig().readTimeout(this.getSessionTimeout()).baseUrl(fromUri(externalUri));
-    this.client = Require.nonNull("HTTP client factory", clientFactory).createClient(clientConfig);
+    HttpClient.Factory factory = Require.nonNull("HTTP client factory", clientFactory);
+    this.client = factory.createClient(clientConfig);
+
+    this.healthCheckClient =
+        factory.createClient(
+            clientConfig
+                .connectionTimeout(HEALTH_CHECK_CONNECTION_TIMEOUT)
+                .readTimeout(HEALTH_CHECK_READ_TIMEOUT));
 
     this.healthCheck = new RemoteCheck();
 
@@ -251,10 +262,14 @@ public class RemoteNode extends Node implements Closeable {
 
   @Override
   public NodeStatus getStatus() {
+    return getStatus(client);
+  }
+
+  private NodeStatus getStatus(HttpHandler handler) {
     HttpRequest req = new HttpRequest(GET, "/status");
     HttpTracing.inject(tracer, tracer.getCurrentContext(), req);
 
-    HttpResponse res = client.execute(req);
+    HttpResponse res = handler.execute(req);
 
     try (Reader reader = reader(res);
         JsonInput in = JSON.newInput(reader)) {
@@ -312,14 +327,15 @@ public class RemoteNode extends Node implements Closeable {
 
   @Override
   public void close() {
-    ((HttpClient) (this.client)).close();
+    ((HttpClient) this.client).close();
+    ((HttpClient) this.healthCheckClient).close();
   }
 
   private class RemoteCheck implements HealthCheck {
     @Override
     public Result check() {
       try {
-        NodeStatus status = getStatus();
+        NodeStatus status = getStatus(healthCheckClient);
 
         if (status.getNodeId() != null && !Objects.equals(getId(), status.getNodeId())) {
           // ensure the original RemoteNode stays DOWN when it has been restarted and registered

--- a/java/test/org/openqa/selenium/grid/distributor/local/LocalNodeRegistryTest.java
+++ b/java/test/org/openqa/selenium/grid/distributor/local/LocalNodeRegistryTest.java
@@ -1,0 +1,295 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.distributor.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.grid.data.Availability.UP;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.events.EventBus;
+import org.openqa.selenium.events.local.GuavaEventBus;
+import org.openqa.selenium.grid.data.CreateSessionRequest;
+import org.openqa.selenium.grid.data.CreateSessionResponse;
+import org.openqa.selenium.grid.data.NodeId;
+import org.openqa.selenium.grid.data.NodeStatus;
+import org.openqa.selenium.grid.data.Session;
+import org.openqa.selenium.grid.node.HealthCheck;
+import org.openqa.selenium.grid.node.Node;
+import org.openqa.selenium.grid.security.Secret;
+import org.openqa.selenium.internal.Either;
+import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.tracing.DefaultTestTracer;
+import org.openqa.selenium.remote.tracing.Tracer;
+
+class LocalNodeRegistryTest {
+
+  private final Secret registrationSecret = new Secret("bavarian smoked");
+  private Tracer tracer;
+  private EventBus bus;
+  private ScheduledExecutorService nodeHealthCheckService;
+  private ScheduledExecutorService purgeDeadNodesService;
+  private LocalNodeRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    tracer = DefaultTestTracer.createTracer();
+    bus = new GuavaEventBus();
+    nodeHealthCheckService = Executors.newSingleThreadScheduledExecutor();
+    purgeDeadNodesService = Executors.newSingleThreadScheduledExecutor();
+    registry =
+        new LocalNodeRegistry(
+            tracer,
+            bus,
+            config -> {
+              throw new UnsupportedOperationException("Not used by this test");
+            },
+            registrationSecret,
+            Duration.ofHours(1),
+            nodeHealthCheckService,
+            Duration.ZERO,
+            purgeDeadNodesService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (registry != null) {
+      registry.close();
+    }
+    if (nodeHealthCheckService != null) {
+      nodeHealthCheckService.shutdownNow();
+    }
+    if (purgeDeadNodesService != null) {
+      purgeDeadNodesService.shutdownNow();
+    }
+    if (bus != null) {
+      bus.close();
+    }
+  }
+
+  @Test
+  void shouldNotRunOverlappingHealthChecks() throws Exception {
+    AtomicInteger checksRun = new AtomicInteger(0);
+    CountDownLatch checkStarted = new CountDownLatch(1);
+    CountDownLatch releaseCheck = new CountDownLatch(1);
+    NodeId nodeId = new NodeId(UUID.randomUUID());
+
+    Node node =
+        new TestNode(
+            tracer,
+            nodeId,
+            URI.create("http://example:4444"),
+            registrationSecret,
+            () -> {
+              checksRun.incrementAndGet();
+              checkStarted.countDown();
+              try {
+                releaseCheck.await(2, TimeUnit.SECONDS);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return new HealthCheck.Result(UP, "ok");
+            });
+    registry.add(node);
+
+    ExecutorService runner = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> firstRun = runner.submit(registry::runHealthChecks);
+
+      assertThat(checkStarted.await(2, TimeUnit.SECONDS)).isTrue();
+      registry.runHealthChecks();
+      assertThat(checksRun.get()).isEqualTo(1);
+
+      releaseCheck.countDown();
+      firstRun.get(2, TimeUnit.SECONDS);
+    } finally {
+      runner.shutdownNow();
+    }
+  }
+
+  @Test
+  void shouldRunHealthChecksForMultipleNodesConcurrently() throws Exception {
+    // Each check parks on a shared latch to prove that all 3 run concurrently — one thread
+    // per node via the cached pool — rather than queuing behind a fixed-size pool.
+    int nodeCount = 3;
+    CountDownLatch allStarted = new CountDownLatch(nodeCount);
+    CountDownLatch releaseAll = new CountDownLatch(1);
+
+    for (int i = 0; i < nodeCount; i++) {
+      NodeId nodeId = new NodeId(UUID.randomUUID());
+      Node node =
+          new TestNode(
+              tracer,
+              nodeId,
+              URI.create("http://example" + i + ":4444"),
+              registrationSecret,
+              () -> {
+                allStarted.countDown();
+                try {
+                  // Block until all checks have started, confirming concurrent execution.
+                  assertThat(releaseAll.await(5, TimeUnit.SECONDS)).isTrue();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                return new HealthCheck.Result(UP, "ok");
+              });
+      registry.add(node);
+    }
+
+    ExecutorService runner = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> healthCheckFuture = runner.submit(registry::runHealthChecks);
+
+      // All 3 checks must start before any single one finishes — proving concurrent execution.
+      assertThat(allStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      releaseAll.countDown();
+      healthCheckFuture.get(5, TimeUnit.SECONDS);
+    } finally {
+      runner.shutdownNow();
+    }
+  }
+
+  @Test
+  void closeShouldShutdownNodeHealthCheckWorkerPool() throws Exception {
+    ExecutorService nodeHealthCheckExecutor = getNodeHealthCheckExecutor(registry);
+    assertThat(nodeHealthCheckExecutor.isShutdown()).isFalse();
+
+    registry.close();
+
+    assertThat(nodeHealthCheckExecutor.isShutdown()).isTrue();
+  }
+
+  private static ExecutorService getNodeHealthCheckExecutor(LocalNodeRegistry registry)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field field = LocalNodeRegistry.class.getDeclaredField("nodeHealthCheckExecutor");
+    field.setAccessible(true);
+    return (ExecutorService) field.get(registry);
+  }
+
+  private static class TestNode extends Node {
+
+    private final NodeStatus status;
+    private final HealthCheck healthCheck;
+
+    TestNode(
+        Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, HealthCheck healthCheck) {
+      super(tracer, nodeId, uri, registrationSecret, Duration.ofSeconds(5));
+      this.healthCheck = healthCheck;
+      this.status =
+          new NodeStatus(
+              nodeId,
+              uri,
+              1,
+              Set.of(),
+              UP,
+              Duration.ofSeconds(5),
+              Duration.ofSeconds(5),
+              "test",
+              Map.of("name", "test", "arch", "test", "version", "test"));
+    }
+
+    @Override
+    public Either<WebDriverException, CreateSessionResponse> newSession(
+        CreateSessionRequest sessionRequest) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse executeWebDriverCommand(HttpRequest req) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Session getSession(SessionId id) throws NoSuchSessionException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse uploadFile(HttpRequest req, SessionId id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse downloadFile(HttpRequest req, SessionId id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void stop(SessionId id) throws NoSuchSessionException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSessionOwner(SessionId id) {
+      return false;
+    }
+
+    @Override
+    public boolean tryAcquireConnection(SessionId id) {
+      return false;
+    }
+
+    @Override
+    public void releaseConnection(SessionId id) {}
+
+    @Override
+    public boolean isSupporting(Capabilities capabilities) {
+      return true;
+    }
+
+    @Override
+    public NodeStatus getStatus() {
+      return status;
+    }
+
+    @Override
+    public HealthCheck getHealthCheck() {
+      return healthCheck;
+    }
+
+    @Override
+    public void drain() {
+      draining.set(true);
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/3077

### 💥 What does this PR do?
  - RemoteNode used the session timeout (default 300 s) as the read timeout for `/status` health-check pings. A single hung node blocked a thread for 5 minutes. Fixed by giving health checks a dedicated HttpClient
  With 5 connection timeout and 30s read timeout, derived from the main client config are inherited.
  - LocalNodeRegistry's fixed-size thread pool queued excess checks behind busy threads, meaning cycles over many nodes ran in serial rounds. Fixed by switching to a cached thread pool, which spawns one thread
  per active check and reuses idle ones — all N checks run in a single concurrent pass.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
