### PR TITLE
[dotnet] Fix start/quit implementation on incorrect level

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -167,6 +167,8 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
             options.BrowserVersion = null;
         }
 
+        service.Start();
+
         return new DriverServiceCommandExecutor(service, commandTimeout);
     }
 

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -167,9 +167,24 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
             options.BrowserVersion = null;
         }
 
-        service.Start();
+        try
+        {
+            service.Start();
+            return new DriverServiceCommandExecutor(service, commandTimeout);
+        }
+        catch
+        {
+            try
+            {
+                service.Dispose();
+            }
+            catch
+            {
+                // Ignore exceptions thrown while disposing the service to preserve the original exception.
+            }
 
-        return new DriverServiceCommandExecutor(service, commandTimeout);
+            throw;
+        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -227,7 +227,15 @@ public class FirefoxDriver : WebDriver
         }
         catch
         {
-            service.Dispose();
+            try
+            {
+                service.Dispose();
+            }
+            catch
+            {
+                // Ignore exceptions thrown while disposing the service to preserve the original exception.
+            }
+
             throw;
         }
     }

--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -220,6 +220,8 @@ public class FirefoxDriver : WebDriver
             options.BrowserVersion = null;
         }
 
+        service.Start();
+
         return new DriverServiceCommandExecutor(service, commandTimeout);
     }
 

--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -220,9 +220,16 @@ public class FirefoxDriver : WebDriver
             options.BrowserVersion = null;
         }
 
-        service.Start();
-
-        return new DriverServiceCommandExecutor(service, commandTimeout);
+        try
+        {
+            service.Start();
+            return new DriverServiceCommandExecutor(service, commandTimeout);
+        }
+        catch
+        {
+            service.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -177,9 +177,16 @@ public class InternetExplorerDriver : WebDriver
             service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
         }
 
-        service.Start();
-
-        return new DriverServiceCommandExecutor(service, commandTimeout);
+        try
+        {
+            service.Start();
+            return new DriverServiceCommandExecutor(service, commandTimeout);
+        }
+        catch
+        {
+            service.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -177,6 +177,8 @@ public class InternetExplorerDriver : WebDriver
             service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
         }
 
+        service.Start();
+
         return new DriverServiceCommandExecutor(service, commandTimeout);
     }
 

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -184,7 +184,15 @@ public class InternetExplorerDriver : WebDriver
         }
         catch
         {
-            service.Dispose();
+            try
+            {
+                service.Dispose();
+            }
+            catch
+            {
+                // Ignore exceptions thrown while disposing the service to preserve the original exception.
+            }
+
             throw;
         }
     }

--- a/dotnet/src/webdriver/Remote/DriverServiceCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/DriverServiceCommandExecutor.cs
@@ -111,28 +111,6 @@ public class DriverServiceCommandExecutor : ICommandExecutor
         }
 
         return await this.HttpExecutor.ExecuteAsync(commandToExecute).ConfigureAwait(false);
-
-        Response toReturn;
-        if (commandToExecute.Name == DriverCommand.NewSession)
-        {
-            this.service.Start();
-        }
-
-        // Use a try-catch block to catch exceptions for the Quit
-        // command, so that we can get the finally block.
-        try
-        {
-            toReturn = await this.HttpExecutor.ExecuteAsync(commandToExecute).ConfigureAwait(false);
-        }
-        finally
-        {
-            if (commandToExecute.Name == DriverCommand.Quit)
-            {
-                this.Dispose();
-            }
-        }
-
-        return toReturn;
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/Remote/DriverServiceCommandExecutor.cs
+++ b/dotnet/src/webdriver/Remote/DriverServiceCommandExecutor.cs
@@ -110,6 +110,8 @@ public class DriverServiceCommandExecutor : ICommandExecutor
             throw new ArgumentNullException(nameof(commandToExecute), "Command to execute cannot be null");
         }
 
+        return await this.HttpExecutor.ExecuteAsync(commandToExecute).ConfigureAwait(false);
+
         Response toReturn;
         if (commandToExecute.Name == DriverCommand.NewSession)
         {

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -182,6 +182,8 @@ public class SafariDriver : WebDriver
             service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
         }
 
+        service.Start();
+
         return new DriverServiceCommandExecutor(service, commandTimeout);
     }
 

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -189,7 +189,15 @@ public class SafariDriver : WebDriver
         }
         catch
         {
-            service.Dispose();
+            try
+            {
+                service.Dispose();
+            }
+            catch
+            {
+                // Ignore exceptions thrown while disposing the service to preserve the original exception.
+            }
+
             throw;
         }
     }

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -182,9 +182,16 @@ public class SafariDriver : WebDriver
             service.DriverServiceExecutableName = Path.GetFileName(fullServicePath);
         }
 
-        service.Start();
-
-        return new DriverServiceCommandExecutor(service, commandTimeout);
+        try
+        {
+            service.Start();
+            return new DriverServiceCommandExecutor(service, commandTimeout);
+        }
+        catch
+        {
+            service.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/WebDriver.cs
+++ b/dotnet/src/webdriver/WebDriver.cs
@@ -50,6 +50,16 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     protected WebDriver(ICommandExecutor executor, ICapabilities capabilities)
     {
         this.CommandExecutor = executor;
+        this.elementFactory = new WebElementFactory(this);
+        this.registeredCommands.AddRange(DriverCommand.KnownCommands);
+
+        if (this is ISupportsLogs)
+        {
+            // Only add the legacy log commands if the driver supports
+            // retrieving the logs via the extension end points.
+            this.RegisterDriverCommand(DriverCommand.GetAvailableLogTypes, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/se/log/types"), true);
+            this.RegisterDriverCommand(DriverCommand.GetLog, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log"), true);
+        }
 
         try
         {
@@ -60,24 +70,13 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
             try
             {
                 // Failed to start driver session, disposing of driver
-                this.Quit();
+                this.Dispose();
             }
             catch
             {
                 // Ignore the clean-up exception. We'll propagate the original failure.
             }
             throw;
-        }
-
-        this.elementFactory = new WebElementFactory(this);
-        this.registeredCommands.AddRange(DriverCommand.KnownCommands);
-
-        if (this is ISupportsLogs)
-        {
-            // Only add the legacy log commands if the driver supports
-            // retrieving the logs via the extension end points.
-            this.RegisterDriverCommand(DriverCommand.GetAvailableLogTypes, new HttpCommandInfo(HttpCommandInfo.GetCommand, "/session/{sessionId}/se/log/types"), true);
-            this.RegisterDriverCommand(DriverCommand.GetLog, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log"), true);
         }
     }
 


### PR DESCRIPTION
Previously `DriverServiceCommandExecutor` was responsible for starting and disposing upstream object. This is bad! 10 years :)

Now `WebDriver` takes its responsibility, managing `DriverService` lifecycle.

### 💥 What does this PR do?
Refactors how driver services are started and disposed in the .NET WebDriver implementations, and also improves the initialization logic in the `WebDriver` base class. The main focus is on ensuring that driver services are started safely with proper exception handling and that resources are correctly disposed of in error scenarios. Additionally, it streamlines command registration and element factory initialization in the `WebDriver` class.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
