### PR TITLE
[grid] Fix WebSocket connection counter leaks in ProxyNodeWebsockets

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
+++ b/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
@@ -102,34 +102,44 @@ public class ProxyNodeWebsockets
       return Optional.empty();
     }
 
-    Session session = node.getSession(id);
-    Capabilities caps = session.getCapabilities();
-    LOG.fine("Scanning for endpoint: " + caps);
+    try {
+      Session session = node.getSession(id);
+      Capabilities caps = session.getCapabilities();
+      LOG.fine("Scanning for endpoint: " + caps);
 
-    // Used by the ForwardingListener to notify the node that the session is still active
-    Consumer<SessionId> sessionConsumer = node::isSessionOwner;
+      // Used by the ForwardingListener to notify the node that the session is still active
+      Consumer<SessionId> sessionConsumer = node::isSessionOwner;
 
-    if (bidiMatch != null) {
-      return findBiDiEndpoint(downstream, caps, sessionConsumer, id);
-    }
+      Optional<Consumer<Message>> endpoint;
+      if (bidiMatch != null) {
+        endpoint = findBiDiEndpoint(downstream, caps, sessionConsumer, id);
+      } else if (vncMatch != null) {
+        // Passing a fake consumer to the ForwardingListener to avoid sending a session notification
+        // when VNC is used.
+        sessionConsumer = fakeConsumer -> {};
+        endpoint = findVncEndpoint(downstream, caps, sessionConsumer, id);
+      } else if (fwdMatch != null) {
+        // This match happens when a user wants to do CDP over Dynamic Grid
+        LOG.info("Matched endpoint where CDP connection is being forwarded");
+        endpoint = findCdpEndpoint(downstream, caps, sessionConsumer, id);
+      } else if (caps.getCapabilityNames().contains("se:forwardCdp")) {
+        LOG.info("Found endpoint where CDP connection needs to be forwarded");
+        endpoint = findForwardCdpEndpoint(downstream, caps, sessionConsumer, id);
+      } else {
+        endpoint = findCdpEndpoint(downstream, caps, sessionConsumer, id);
+      }
 
-    if (vncMatch != null) {
-      // Passing a fake consumer to the ForwardingListener to avoid sending a session notification
-      // when VNC is used.
-      sessionConsumer = fakeConsumer -> {};
-      return findVncEndpoint(downstream, caps, sessionConsumer, id);
-    }
+      // If no endpoint could be established the connection slot must be released;
+      if (endpoint.isEmpty()) {
+        node.releaseConnection(id);
+      }
 
-    // This match happens when a user wants to do CDP over Dynamic Grid
-    if (fwdMatch != null) {
-      LOG.info("Matched endpoint where CDP connection is being forwarded");
-      return findCdpEndpoint(downstream, caps, sessionConsumer, id);
+      return endpoint;
+    } catch (Exception e) {
+      node.releaseConnection(id);
+      LOG.log(Level.WARNING, "Failed to establish WebSocket endpoint for session " + id, e);
+      return Optional.empty();
     }
-    if (caps.getCapabilityNames().contains("se:forwardCdp")) {
-      LOG.info("Found endpoint where CDP connection needs to be forwarded");
-      return findForwardCdpEndpoint(downstream, caps, sessionConsumer, id);
-    }
-    return findCdpEndpoint(downstream, caps, sessionConsumer, id);
   }
 
   private Optional<Consumer<Message>> findCdpEndpoint(
@@ -213,6 +223,10 @@ public class ProxyNodeWebsockets
       Consumer<SessionId> sessionConsumer,
       SessionId sessionId) {
     String vncLocalAddress = (String) caps.getCapability("se:vncLocalAddress");
+    if (vncLocalAddress == null) {
+      LOG.warning("No VNC endpoint address in capabilities");
+      return Optional.empty();
+    }
     Optional<URI> vncUri;
     try {
       vncUri = Optional.of(new URI(vncLocalAddress));
@@ -264,7 +278,6 @@ public class ProxyNodeWebsockets
       };
     } catch (Exception e) {
       LOG.log(Level.WARNING, "Connecting to upstream websocket failed", e);
-      node.releaseConnection(sessionId);
       client.close();
       throw e;
     }
@@ -313,6 +326,9 @@ public class ProxyNodeWebsockets
     @Override
     public void onError(Throwable cause) {
       LOG.log(Level.WARNING, "Error proxying websocket command", cause);
+      if (connectionReleased.compareAndSet(false, true)) {
+        node.releaseConnection(sessionId);
+      }
     }
   }
 }

--- a/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
+++ b/java/src/org/openqa/selenium/grid/node/ProxyNodeWebsockets.java
@@ -223,7 +223,7 @@ public class ProxyNodeWebsockets
       Consumer<SessionId> sessionConsumer,
       SessionId sessionId) {
     String vncLocalAddress = (String) caps.getCapability("se:vncLocalAddress");
-    if (vncLocalAddress == null) {
+    if (vncLocalAddress == null || vncLocalAddress.trim().isEmpty()) {
       LOG.warning("No VNC endpoint address in capabilities");
       return Optional.empty();
     }

--- a/java/test/org/openqa/selenium/grid/node/ProxyNodeWebsocketsTest.java
+++ b/java/test/org/openqa/selenium/grid/node/ProxyNodeWebsocketsTest.java
@@ -1,0 +1,406 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.grid.data.CreateSessionRequest;
+import org.openqa.selenium.grid.data.CreateSessionResponse;
+import org.openqa.selenium.grid.data.NodeId;
+import org.openqa.selenium.grid.data.NodeStatus;
+import org.openqa.selenium.grid.data.Session;
+import org.openqa.selenium.grid.security.Secret;
+import org.openqa.selenium.internal.Either;
+import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.remote.http.HttpClient;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.http.Message;
+import org.openqa.selenium.remote.http.WebSocket;
+import org.openqa.selenium.remote.tracing.DefaultTestTracer;
+
+class ProxyNodeWebsocketsTest {
+
+  private static final Secret SECRET = new Secret("test");
+
+  /**
+   * Regression test for counter leak: if tryAcquireConnection succeeds but no WebSocket endpoint
+   * can be established, releaseConnection must be called so the slot is returned to the counter.
+   * Without the fix, the counter climbs on every failed attempt until it reaches the configured
+   * limit, blocking all future connections regardless of how high the limit is set.
+   */
+  @Test
+  void shouldReleaseConnectionSlotWhenNoEndpointCanBeEstablished() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // Capabilities with no CDP endpoint caps (no goog:chromeOptions / ms:edgeOptions) so that
+    // findCdpEndpoint iterates over all known caps, finds nothing, and returns Optional.empty().
+    Session session =
+        new Session(
+            sessionId,
+            URI.create("http://localhost:4444"),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now());
+
+    Node node = new CountingStubNode(sessionId, session, acquireCount, releaseCount);
+
+    // clientFactory is never reached because endpoint discovery fails before createWsEndPoint.
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/cdp", msg -> {});
+
+    assertThat(result).isEmpty();
+    assertThat(acquireCount.get()).isEqualTo(1);
+    // The fix: slot must be released so the counter does not leak.
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotReleaseConnectionSlotWhenLimitAlreadyReached() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // Node reports the connection limit is already reached.
+    Node node =
+        new CountingStubNode(sessionId, null, new AtomicInteger(), releaseCount) {
+          @Override
+          public boolean tryAcquireConnection(SessionId id) {
+            return false;
+          }
+        };
+
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/cdp", msg -> {});
+
+    assertThat(result).isEmpty();
+    // Nothing was acquired, so nothing should be released.
+    assertThat(releaseCount.get()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldReleaseConnectionSlotWhenGetSessionThrows() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // getSession throws so no endpoint is ever reached; the slot must still be released.
+    Node node =
+        new CountingStubNode(sessionId, null, acquireCount, releaseCount) {
+          @Override
+          public Session getSession(SessionId id) {
+            throw new NoSuchSessionException("session gone");
+          }
+        };
+
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/cdp", msg -> {});
+
+    assertThat(result).isEmpty();
+    assertThat(acquireCount.get()).isEqualTo(1);
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldReleaseConnectionSlotWhenBiDiUriIsInvalid() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // An invalid se:gridWebSocketUrl causes URISyntaxException in findBiDiEndpoint, which
+    // returns Optional.empty() — the slot must still be released.
+    Session session =
+        new Session(
+            sessionId,
+            URI.create("http://localhost:4444"),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities("se:gridWebSocketUrl", "not a valid uri"),
+            Instant.now());
+
+    Node node = new CountingStubNode(sessionId, session, acquireCount, releaseCount);
+
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/bidi", msg -> {});
+
+    assertThat(result).isEmpty();
+    assertThat(acquireCount.get()).isEqualTo(1);
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  /**
+   * Fix 3: se:vncLocalAddress capability absent from caps. Before the fix, {@code new URI(null)}
+   * threw NullPointerException which was not caught by the URISyntaxException handler, bypassing
+   * the endpoint.isEmpty() release guard and leaking the slot.
+   */
+  @Test
+  void shouldReleaseConnectionSlotWhenVncAddressIsNull() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // No se:vncLocalAddress in caps → getCapability returns null → was NPE before the fix.
+    Session session =
+        new Session(
+            sessionId,
+            URI.create("http://localhost:4444"),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now());
+
+    Node node = new CountingStubNode(sessionId, session, acquireCount, releaseCount);
+
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/vnc", msg -> {});
+
+    assertThat(result).isEmpty();
+    assertThat(acquireCount.get()).isEqualTo(1);
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldReleaseConnectionSlotWhenVncUriIsInvalid() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    Session session =
+        new Session(
+            sessionId,
+            URI.create("http://localhost:4444"),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities("se:vncLocalAddress", "not a valid uri %%"),
+            Instant.now());
+
+    Node node = new CountingStubNode(sessionId, session, acquireCount, releaseCount);
+
+    ProxyNodeWebsockets proxy =
+        new ProxyNodeWebsockets(config -> null, node, /* gridSubPath= */ "");
+
+    Optional<Consumer<Message>> result =
+        proxy.apply("/session/" + sessionId + "/se/vnc", msg -> {});
+
+    assertThat(result).isEmpty();
+    assertThat(acquireCount.get()).isEqualTo(1);
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  /**
+   * Fix 4: ForwardingListener.onError must release the connection slot in case the WebSocket
+   * implementation does not call onClose after an error. Without the fix the slot leaks permanently
+   * when only onError fires.
+   */
+  @Test
+  void shouldReleaseConnectionSlotWhenWebSocketOnErrorFires() {
+    SessionId sessionId = new SessionId(UUID.randomUUID());
+    AtomicInteger acquireCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+
+    // se:gridWebSocketUrl present and valid so findBiDiEndpoint reaches createWsEndPoint.
+    Session session =
+        new Session(
+            sessionId,
+            URI.create("http://localhost:4444"),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities("se:gridWebSocketUrl", "ws://localhost:9222/devtools"),
+            Instant.now());
+
+    Node node = new CountingStubNode(sessionId, session, acquireCount, releaseCount);
+
+    // Simulates a WebSocket implementation that fires onError without a subsequent onClose.
+    HttpClient.Factory clientFactory =
+        config ->
+            new HttpClient() {
+              @Override
+              public HttpResponse execute(HttpRequest req) {
+                return new HttpResponse();
+              }
+
+              @Override
+              public WebSocket openSocket(HttpRequest req, WebSocket.Listener listener) {
+                listener.onError(new RuntimeException("network error — no onClose follows"));
+                // Return a no-op WebSocket handle; the connection has already errored.
+                return new WebSocket() {
+                  @Override
+                  public WebSocket send(Message message) {
+                    return this;
+                  }
+
+                  @Override
+                  public void close() {}
+                };
+              }
+
+              @Override
+              public <T>
+                  java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>>
+                      sendAsyncNative(
+                          java.net.http.HttpRequest request,
+                          java.net.http.HttpResponse.BodyHandler<T> handler) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public <T> java.net.http.HttpResponse<T> sendNative(
+                  java.net.http.HttpRequest request,
+                  java.net.http.HttpResponse.BodyHandler<T> handler) {
+                throw new UnsupportedOperationException();
+              }
+            };
+
+    ProxyNodeWebsockets proxy = new ProxyNodeWebsockets(clientFactory, node, /* gridSubPath= */ "");
+
+    proxy.apply("/session/" + sessionId + "/se/bidi", msg -> {});
+
+    assertThat(acquireCount.get()).isEqualTo(1);
+    // Slot must be released via onError even though onClose was never called.
+    assertThat(releaseCount.get()).isEqualTo(1);
+  }
+
+  /** Minimal Node stub that counts tryAcquireConnection / releaseConnection calls. */
+  private abstract static class StubNode extends Node {
+
+    StubNode(NodeId nodeId, URI uri) {
+      super(DefaultTestTracer.createTracer(), nodeId, uri, SECRET, Duration.ofSeconds(30));
+    }
+
+    @Override
+    public Either<WebDriverException, CreateSessionResponse> newSession(
+        CreateSessionRequest sessionRequest) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse executeWebDriverCommand(HttpRequest req) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Session getSession(SessionId id) throws NoSuchSessionException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse uploadFile(HttpRequest req, SessionId id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpResponse downloadFile(HttpRequest req, SessionId id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void stop(SessionId id) throws NoSuchSessionException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSupporting(Capabilities capabilities) {
+      return false;
+    }
+
+    @Override
+    public NodeStatus getStatus() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HealthCheck getHealthCheck() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void drain() {
+      draining.set(true);
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+  }
+
+  private static class CountingStubNode extends StubNode {
+
+    private final SessionId ownedSession;
+    private final Session session;
+    private final AtomicInteger acquireCount;
+    private final AtomicInteger releaseCount;
+
+    CountingStubNode(
+        SessionId ownedSession,
+        Session session,
+        AtomicInteger acquireCount,
+        AtomicInteger releaseCount) {
+      super(new NodeId(UUID.randomUUID()), URI.create("http://localhost:5555"));
+      this.ownedSession = ownedSession;
+      this.session = session;
+      this.acquireCount = acquireCount;
+      this.releaseCount = releaseCount;
+    }
+
+    @Override
+    public boolean isSessionOwner(SessionId id) {
+      return ownedSession.equals(id);
+    }
+
+    @Override
+    public boolean tryAcquireConnection(SessionId id) {
+      acquireCount.incrementAndGet();
+      return true;
+    }
+
+    @Override
+    public void releaseConnection(SessionId id) {
+      releaseCount.incrementAndGet();
+    }
+
+    @Override
+    public Session getSession(SessionId id) {
+      return session;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes #17089
> I am still seeing the warning:
“Too many websocket connections initiated by ”
To troubleshoot this, I also set --connection-limit-per-session to 5000, but the warning still appears. In addition, the node is rejecting the WebSocket connection and returning a 400 Bad Request error.

### 💥 What does this PR do?
  `tryAcquireConnection` increments a per-session counter to enforce `--connection-limit-per-session`, but several code paths missed to call `releaseConnection`, causing the counter to climb permanently. Users would see 
  `Too many websocket connections initiated by <id>` on every new CDP/BiDi/VNC request, even with a high limit configured.

Leak paths fixed:

  - No endpoint found - apply() now collects all endpoint-finder results into a single Optional and calls releaseConnection when it is empty, covering CDP, BiDi, VNC, and forward-CDP paths uniformly.
  - Exception after acquire — getSession throwing NoSuchSessionException (session evicted between isSessionOwner and getSession) or findCdpEndpoint rethrowing an I/O error both bypassed the release guard. The
  post-acquire block is now wrapped in try/catch that always releases.
  - Null VNC address — caps.getCapability("se:vncLocalAddress") returns null when absent; new URI(null) throws NullPointerException which the existing URISyntaxException catch did not cover. Added an explicit
  null check before the URI constructor.
  - onError without onClose — ForwardingListener.onError now releases the slot using the existing AtomicBoolean guard, covering WebSocket implementations that do not guarantee onClose after an error.



### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
