### PR TITLE
[dotnet] Refactor waiting until driver service is initialized

### DIFF
--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -172,42 +172,6 @@ public abstract class DriverService : IDisposable
         Environment.GetEnvironmentVariable("SE_DEBUG") is not null;
 
     /// <summary>
-    /// Gets a value indicating whether the service is responding to HTTP requests.
-    /// </summary>
-    protected virtual bool IsInitialized
-    {
-        get
-        {
-            bool isInitialized = false;
-
-            try
-            {
-                using (var httpClient = new HttpClient())
-                {
-                    httpClient.DefaultRequestHeaders.ConnectionClose = true;
-                    httpClient.Timeout = TimeSpan.FromSeconds(5);
-
-                    Uri serviceHealthUri = new Uri(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
-                    using (var response = Task.Run(async () => await httpClient.GetAsync(serviceHealthUri)).GetAwaiter().GetResult())
-                    {
-                        // Checking the response from the 'status' end point. Note that we are simply checking
-                        // that the HTTP status returned is a 200 status, and that the response has the correct
-                        // Content-Type header. A more sophisticated check would parse the JSON response and
-                        // validate its values. At the moment we do not do this more sophisticated check.
-                        isInitialized = response.StatusCode == HttpStatusCode.OK && response.Content.Headers.ContentType is { MediaType: string mediaType } && mediaType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase);
-                    }
-                }
-            }
-            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
-            {
-                // Do nothing. The exception is expected, meaning driver service is not initialized.
-            }
-
-            return isInitialized;
-        }
-    }
-
-    /// <summary>
     /// Releases all resources associated with this <see cref="DriverService"/>.
     /// </summary>
     public void Dispose()
@@ -267,7 +231,7 @@ public abstract class DriverService : IDisposable
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
 
-        bool serviceAvailable = this.WaitForServiceInitialization();
+        bool serviceAvailable = this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
 
         DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
         this.OnDriverProcessStarted(processStartedEventArgs);
@@ -404,26 +368,44 @@ public abstract class DriverService : IDisposable
     }
 
     /// <summary>
-    /// Waits until a the service is initialized, or the timeout set
+    /// Waits until the service is initialized, or the timeout set
     /// by the <see cref="InitializationTimeout"/> property is reached.
     /// </summary>
     /// <returns><see langword="true"/> if the service is properly started and receiving HTTP requests;
     /// otherwise; <see langword="false"/>.</returns>
-    private bool WaitForServiceInitialization()
+    private async Task<bool> WaitForServiceInitializationAsync()
     {
-        bool isInitialized = false;
         DateTime timeout = DateTime.Now.Add(this.InitializationTimeout);
-        while (!isInitialized && DateTime.Now < timeout)
+        
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.ConnectionClose = true;
+        httpClient.Timeout = TimeSpan.FromSeconds(5);
+        
+        Uri serviceHealthUri = new Uri(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
+        
+        while (DateTime.Now < timeout)
         {
             // If the driver service process has exited, we can exit early.
             if (!this.IsRunning)
             {
-                break;
+                return false;
             }
 
-            isInitialized = this.IsInitialized;
+            try
+            {
+                using var response = await httpClient.GetAsync(serviceHealthUri).ConfigureAwait(false);
+                
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
+            {
+                // The exception is expected, meaning driver service is not yet initialized.
+            }
+
+            // Avoid busy-waiting by introducing a small delay between polling attempts.
+            await Task.Delay(100).ConfigureAwait(false);
         }
 
-        return isInitialized;
+        return false;
     }
 }

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -374,9 +374,8 @@ public abstract class DriverService : IDisposable
         
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.ConnectionClose = true;
-        httpClient.Timeout = TimeSpan.FromSeconds(5);
         
-        Uri serviceHealthUri = new Uri(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
+        Uri serviceHealthUri = new(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
 
         try
         {
@@ -394,18 +393,20 @@ public abstract class DriverService : IDisposable
                 {
                     using var response = await httpClient.GetAsync(serviceHealthUri, linkedCts.Token).ConfigureAwait(false);
                     
+                    // TODO: Consider checking the content of the response to ensure that the service is fully initialized
+                    // and ready to accept commands, rather than just checking for a successful status code.
                     if (response.IsSuccessStatusCode)
                     {
                         return;
                     }
                 }
-                catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
+                catch (Exception ex) when (ex is HttpRequestException)
                 {
                     // The exception is expected, meaning driver service is not yet initialized.
                 }
 
                 // Avoid busy-waiting by introducing a small delay between polling attempts.
-                await Task.Delay(100, linkedCts.Token).ConfigureAwait(false);
+                await Task.Delay(50, linkedCts.Token).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -232,10 +232,10 @@ public abstract class DriverService : IDisposable
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
 
+        this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
+
         DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
         this.OnDriverProcessStarted(processStartedEventArgs);
-
-        this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -20,7 +20,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Net;
 
 namespace OpenQA.Selenium;
 
@@ -231,15 +230,10 @@ public abstract class DriverService : IDisposable
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
 
-        bool serviceAvailable = this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
-
         DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
         this.OnDriverProcessStarted(processStartedEventArgs);
 
-        if (!serviceAvailable)
-        {
-            throw new WebDriverException($"Cannot start the driver service on {this.ServiceUrl}");
-        }
+        this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -371,41 +365,52 @@ public abstract class DriverService : IDisposable
     /// Waits until the service is initialized, or the timeout set
     /// by the <see cref="InitializationTimeout"/> property is reached.
     /// </summary>
-    /// <returns><see langword="true"/> if the service is properly started and receiving HTTP requests;
-    /// otherwise; <see langword="false"/>.</returns>
-    private async Task<bool> WaitForServiceInitializationAsync()
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the service to initialize.</param>
+    /// <exception cref="WebDriverException">If the service fails to start within the timeout period.</exception>
+    private async Task WaitForServiceInitializationAsync(CancellationToken cancellationToken = default)
     {
-        DateTime timeout = DateTime.Now.Add(this.InitializationTimeout);
+        using var timeoutCts = new CancellationTokenSource(this.InitializationTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.ConnectionClose = true;
         httpClient.Timeout = TimeSpan.FromSeconds(5);
         
         Uri serviceHealthUri = new Uri(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
-        
-        while (DateTime.Now < timeout)
+
+        try
         {
-            // If the driver service process has exited, we can exit early.
-            if (!this.IsRunning)
+            while (true)
             {
-                return false;
-            }
+                linkedCts.Token.ThrowIfCancellationRequested();
 
-            try
-            {
-                using var response = await httpClient.GetAsync(serviceHealthUri).ConfigureAwait(false);
-                
-                return response.IsSuccessStatusCode;
-            }
-            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
-            {
-                // The exception is expected, meaning driver service is not yet initialized.
-            }
+                // If the driver service process has exited, we can exit early.
+                if (!this.IsRunning)
+                {
+                    throw new WebDriverException($"Cannot start the driver service on {this.ServiceUrl}");
+                }
 
-            // Avoid busy-waiting by introducing a small delay between polling attempts.
-            await Task.Delay(100).ConfigureAwait(false);
+                try
+                {
+                    using var response = await httpClient.GetAsync(serviceHealthUri, linkedCts.Token).ConfigureAwait(false);
+                    
+                    if (response.IsSuccessStatusCode)
+                    {
+                        return;
+                    }
+                }
+                catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
+                {
+                    // The exception is expected, meaning driver service is not yet initialized.
+                }
+
+                // Avoid busy-waiting by introducing a small delay between polling attempts.
+                await Task.Delay(100, linkedCts.Token).ConfigureAwait(false);
+            }
         }
-
-        return false;
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw new WebDriverException($"Cannot start the driver service on {this.ServiceUrl}");
+        }
     }
 }

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -20,6 +20,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using OpenQA.Selenium.Internal.Logging;
 
 namespace OpenQA.Selenium;
 
@@ -28,6 +29,7 @@ namespace OpenQA.Selenium;
 /// </summary>
 public abstract class DriverService : IDisposable
 {
+    private static readonly ILogger _logger = Log.GetLogger<DriverService>();
     private bool isDisposed;
     private Process? driverServiceProcess;
 
@@ -371,10 +373,10 @@ public abstract class DriverService : IDisposable
     {
         using var timeoutCts = new CancellationTokenSource(this.InitializationTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-        
+
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.ConnectionClose = true;
-        
+
         Uri serviceHealthUri = new(this.ServiceUrl, new Uri(DriverCommand.Status, UriKind.Relative));
 
         try
@@ -386,21 +388,25 @@ public abstract class DriverService : IDisposable
                 // If the driver service process has exited, we can exit early.
                 if (!this.IsRunning)
                 {
-                    throw new WebDriverException($"Cannot start the driver service on {this.ServiceUrl}");
+                    throw new WebDriverException($"Driver service process exited unexpectedly before initialization completed. Service URL: {this.ServiceUrl}");
                 }
 
                 try
                 {
                     using var response = await httpClient.GetAsync(serviceHealthUri, linkedCts.Token).ConfigureAwait(false);
-                    
+
                     // TODO: Consider checking the content of the response to ensure that the service is fully initialized
                     // and ready to accept commands, rather than just checking for a successful status code.
                     if (response.IsSuccessStatusCode)
                     {
+                        if (_logger.IsEnabled(LogEventLevel.Debug))
+                        {
+                            _logger.Debug($"Driver service initialized successfully and ready to accept commands at {this.ServiceUrl}");
+                        }
                         return;
                     }
                 }
-                catch (Exception ex) when (ex is HttpRequestException)
+                catch (HttpRequestException)
                 {
                     // The exception is expected, meaning driver service is not yet initialized.
                 }
@@ -411,7 +417,7 @@ public abstract class DriverService : IDisposable
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
-            throw new WebDriverException($"Cannot start the driver service on {this.ServiceUrl}");
+            throw new WebDriverException($"Timed out waiting for driver service to initialize after {this.InitializationTimeout.TotalSeconds} seconds. Service URL: {this.ServiceUrl}");
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/17086

### 💥 What does this PR do?
This pull request refactors the driver service initialization logic in `DriverService.cs` to use modern async patterns and improves logging and error handling. The main focus is on replacing the old synchronous polling method with an asynchronous approach, removing redundant code, and integrating structured logging.

These changes modernize the service startup process, improve maintainability, and provide better diagnostics in failure scenarios.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
- Breaking change (fix or feature that would cause existing functionality to change)
