### PR TITLE
[dotnet] Asynchronously start driver service (breaking change)

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -169,7 +169,7 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
 
         try
         {
-            service.Start();
+            await service.StartAsync().ConfigureAwait(false);
             return new DriverServiceCommandExecutor(service, commandTimeout);
         }
         catch

--- a/dotnet/src/webdriver/DriverFinder.cs
+++ b/dotnet/src/webdriver/DriverFinder.cs
@@ -40,13 +40,14 @@ public class DriverFinder(DriverOptions options)
     /// Gets the path to the browser driver executable.
     /// Discovers the driver path on first call using Selenium Manager.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the full path to the driver executable.</returns>
     /// <exception cref="NoSuchDriverException">When browser name is not specified or driver/browser cannot be found.</exception>
-    public async ValueTask<string> GetDriverPathAsync()
+    public async ValueTask<string> GetDriverPathAsync(CancellationToken cancellationToken = default)
     {
         if (_driverPath is null)
         {
-            await DiscoverBinaryPathsAsync().ConfigureAwait(false);
+            await DiscoverBinaryPathsAsync(cancellationToken).ConfigureAwait(false);
         }
 
         return _driverPath!;
@@ -56,19 +57,20 @@ public class DriverFinder(DriverOptions options)
     /// Gets the path to the browser binary.
     /// Discovers the browser path on first call using Selenium Manager.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the full path to the browser binary.</returns>
     /// <exception cref="NoSuchDriverException">When browser name is not specified or driver/browser cannot be found.</exception>
-    public async ValueTask<string> GetBrowserPathAsync()
+    public async ValueTask<string> GetBrowserPathAsync(CancellationToken cancellationToken = default)
     {
         if (_browserPath is null)
         {
-            await DiscoverBinaryPathsAsync().ConfigureAwait(false);
+            await DiscoverBinaryPathsAsync(cancellationToken).ConfigureAwait(false);
         }
 
         return _browserPath!;
     }
 
-    private async ValueTask DiscoverBinaryPathsAsync()
+    private async ValueTask DiscoverBinaryPathsAsync(CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(options.BrowserName))
         {
@@ -80,7 +82,7 @@ public class DriverFinder(DriverOptions options)
             BrowserVersion = options.BrowserVersion,
             BrowserPath = options.BinaryLocation,
             Proxy = options.Proxy?.SslProxy ?? options.Proxy?.HttpProxy
-        }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         string driverPath = smResult.DriverPath;
         string browserPath = smResult.BrowserPath;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -184,6 +184,17 @@ public abstract class DriverService : IDisposable
     /// <summary>
     /// Starts the driver service if it is not already running.
     /// </summary>
+    /// <exception cref="InvalidOperationException">If the driver service path is specified but the driver service executable name is not.</exception>
+    /// <exception cref="WebDriverException">If the service fails to initialize within the timeout period or exits unexpectedly.</exception>
+    [Obsolete("Use StartAsync(CancellationToken) instead. This method will be removed in a future release (4.43).")]
+    public void Start()
+    {
+        this.StartAsync().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Starts the driver service if it is not already running.
+    /// </summary>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous start operation.</returns>
     /// <exception cref="InvalidOperationException">If the driver service path is specified but the driver service executable name is not.</exception>

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -182,10 +182,15 @@ public abstract class DriverService : IDisposable
     }
 
     /// <summary>
-    /// Starts the DriverService if it is not already running.
+    /// Starts the driver service if it is not already running.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous start operation.</returns>
+    /// <exception cref="InvalidOperationException">If the driver service path is specified but the driver service executable name is not.</exception>
+    /// <exception cref="WebDriverException">If the service fails to initialize within the timeout period or exits unexpectedly.</exception>
+    /// <exception cref="OperationCanceledException">If the operation is cancelled via the cancellation token.</exception>
     [MemberNotNull(nameof(driverServiceProcess))]
-    public void Start()
+    public async ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
         if (this.driverServiceProcess != null)
         {
@@ -206,7 +211,7 @@ public abstract class DriverService : IDisposable
         else
         {
             var driverFinder = new DriverFinder(this.GetDefaultDriverOptions());
-            var driverPath = Task.Run(async () => await driverFinder.GetDriverPathAsync()).GetAwaiter().GetResult();
+            var driverPath = await driverFinder.GetDriverPathAsync(cancellationToken).ConfigureAwait(false);
             this.driverServiceProcess.StartInfo.FileName = driverPath;
         }
 
@@ -232,7 +237,7 @@ public abstract class DriverService : IDisposable
         this.driverServiceProcess.BeginOutputReadLine();
         this.driverServiceProcess.BeginErrorReadLine();
 
-        this.WaitForServiceInitializationAsync().GetAwaiter().GetResult();
+        await this.WaitForServiceInitializationAsync(cancellationToken).ConfigureAwait(false);
 
         DriverProcessStartedEventArgs processStartedEventArgs = new DriverProcessStartedEventArgs(this.driverServiceProcess);
         this.OnDriverProcessStarted(processStartedEventArgs);

--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -222,7 +222,7 @@ public class FirefoxDriver : WebDriver
 
         try
         {
-            service.Start();
+            await service.StartAsync().ConfigureAwait(false);
             return new DriverServiceCommandExecutor(service, commandTimeout);
         }
         catch

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -179,7 +179,7 @@ public class InternetExplorerDriver : WebDriver
 
         try
         {
-            service.Start();
+            await service.StartAsync().ConfigureAwait(false);
             return new DriverServiceCommandExecutor(service, commandTimeout);
         }
         catch

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -184,7 +184,7 @@ public class SafariDriver : WebDriver
 
         try
         {
-            service.Start();
+            await service.StartAsync().ConfigureAwait(false);
             return new DriverServiceCommandExecutor(service, commandTimeout);
         }
         catch


### PR DESCRIPTION
Before:

```csharp
var service = ChromeDriverService.CreateDefaultService();
service.Start();
```

After:
```csharp
var service = ChromeDriverService.CreateDefaultService();
await service.StartAsync();
```

Intentionally changed method signature (breaking change). I expect only 0.01% of users are affected. Even Appium, who inherits this class, doesn't use this method :)

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/17086

### 💥 What does this PR do?
Refactors the driver service startup process to be fully asynchronous and to support cancellation via `CancellationToken`. The main changes include updating the driver service start methods to be asynchronous, propagating cancellation tokens throughout the driver discovery and startup process, and updating related method signatures and documentation accordingly.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- Breaking change (fix or feature that would cause existing functionality to change)
