### PR TITLE
[dotnet] Stop/Dispose driver service asynchronously

### DIFF
--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -176,7 +176,7 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
         {
             try
             {
-                service.Dispose();
+                await service.DisposeAsync().ConfigureAwait(false);
             }
             catch
             {

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -449,6 +449,14 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
                 _logger.Debug($"Shutdown request was cancelled: {ex.Message}");
             }
         }
+        catch (Exception ex)
+        {
+            // Catch any unexpected exceptions to prevent unobserved task exceptions
+            if (_logger.IsEnabled(LogEventLevel.Debug))
+            {
+                _logger.Debug($"Unexpected error during shutdown signal: {ex.Message}");
+            }
+        }
     }
 
     private void TryKillProcess(Process process)

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -386,6 +386,10 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
 
             TryKillProcess(process);
         }
+        catch (InvalidOperationException)
+        {
+            // Process already exited or is in an invalid state, which is acceptable during shutdown
+        }
         finally
         {
             process.Dispose();
@@ -395,6 +399,12 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
 
     private static async Task WaitForProcessExitAsync(Process process, CancellationToken cancellationToken)
     {
+        // Early exit if process already exited
+        if (process.HasExited)
+        {
+            return;
+        }
+
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         void OnProcessExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
@@ -404,6 +414,7 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
             process.EnableRaisingEvents = true;
             process.Exited += OnProcessExited;
 
+            // Check again after attaching handler to avoid race condition
             if (process.HasExited)
             {
                 return;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -328,45 +328,99 @@ public abstract class DriverService : IDisposable
     {
         if (this.IsRunning)
         {
-            this.driverServiceProcess.EnableRaisingEvents = true;
+            var process = this.driverServiceProcess; // Capture reference to avoid race condition
+            process.EnableRaisingEvents = true;
 
             TaskCompletionSource<bool> stopCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            this.driverServiceProcess.Exited += ProcessExitedHandler;
+            process.Exited += ProcessExitedHandler;
 
             void ProcessExitedHandler(object? sender, EventArgs e)
             {
                 stopCompletionSource.TrySetResult(true);
             }
 
-            _ = ShutdownSignalAsync();
-
             try
             {
-                await stopCompletionSource.Task.ConfigureAwait(false);
+                // Fire and forget the shutdown signal
+                _ = ShutdownSignalAsync(process);
+
+                // Wait for process to exit or timeout
+                Task delayTask = Task.Delay(this.TerminationTimeout);
+                var completedTask = await Task.WhenAny(
+                    stopCompletionSource.Task,
+                    delayTask
+                ).ConfigureAwait(false);
+
+                if (completedTask == delayTask)
+                {
+                    // Timeout occurred, force kill the process if it's still running
+                    if (_logger.IsEnabled(LogEventLevel.Warn))
+                    {
+                        _logger.Warn($"Driver service did not exit within {this.TerminationTimeout.TotalSeconds} seconds. Forcing termination.");
+                    }
+
+                    if (!process.HasExited)
+                    {
+                        try
+                        {
+                            process.Kill();
+                            // Wait a short time for the process to exit after kill
+                            await Task.WhenAny(
+                                stopCompletionSource.Task,
+                                Task.Delay(TimeSpan.FromSeconds(1))
+                            ).ConfigureAwait(false);
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // Process may have already exited
+                        }
+                    }
+                }
             }
             finally
             {
-                this.driverServiceProcess.Exited -= ProcessExitedHandler;
+                process.Exited -= ProcessExitedHandler;
 
-                this.driverServiceProcess.Dispose();
+                process.Dispose();
                 this.driverServiceProcess = null;
             }
 
-            async Task ShutdownSignalAsync()
+            async Task ShutdownSignalAsync(Process targetProcess)
             {
-                if (HasShutdown)
+                try
                 {
-                    Uri shutdownUrl = new(this.ServiceUrl, "/shutdown");
-                    using var httpClient = new HttpClient()
+                    if (HasShutdown)
                     {
-                        Timeout = this.TerminationTimeout
-                    };
-                    using var response = await httpClient.GetAsync(shutdownUrl);
+                        Uri shutdownUrl = new(this.ServiceUrl, "/shutdown");
+                        using var httpClient = new HttpClient()
+                        {
+                            Timeout = this.TerminationTimeout
+                        };
+                        using var _ = await httpClient.GetAsync(shutdownUrl).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        targetProcess.Kill();
+                    }
                 }
-                else
+                catch (HttpRequestException ex)
                 {
-                    this.driverServiceProcess.Kill();
+                    if (_logger.IsEnabled(LogEventLevel.Debug))
+                    {
+                        _logger.Debug($"Failed to send shutdown signal to driver service: {ex.Message}");
+                    }
+                }
+                catch (OperationCanceledException ex)
+                {
+                    if (_logger.IsEnabled(LogEventLevel.Debug))
+                    {
+                        _logger.Debug($"Shutdown request to driver service timed out: {ex.Message}");
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process may have already exited when trying to kill
                 }
             }
         }

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -360,102 +360,111 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
 
     private async ValueTask StopAsync()
     {
-        if (this.IsRunning)
+        if (!this.IsRunning)
         {
-            var process = this.driverServiceProcess; // Capture reference to avoid race condition
+            return;
+        }
+
+        var process = this.driverServiceProcess;
+        using var timeoutCts = new CancellationTokenSource(this.TerminationTimeout);
+
+        try
+        {
+            // Send graceful shutdown signal
+            _ = SendShutdownSignalAsync(process, timeoutCts.Token);
+
+            // Wait for process to exit
+            await WaitForProcessExitAsync(process, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout occurred, force kill
+            if (_logger.IsEnabled(LogEventLevel.Warn))
+            {
+                _logger.Warn($"Driver service did not exit within {this.TerminationTimeout.TotalSeconds} seconds. Forcing termination.");
+            }
+
+            TryKillProcess(process);
+        }
+        finally
+        {
+            process.Dispose();
+            this.driverServiceProcess = null;
+        }
+    }
+
+    private static async Task WaitForProcessExitAsync(Process process, CancellationToken cancellationToken)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnProcessExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
+
+        try
+        {
             process.EnableRaisingEvents = true;
+            process.Exited += OnProcessExited;
 
-            TaskCompletionSource<bool> stopCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            process.Exited += ProcessExitedHandler;
-
-            void ProcessExitedHandler(object? sender, EventArgs e)
+            if (process.HasExited)
             {
-                stopCompletionSource.TrySetResult(true);
+                return;
             }
 
-            try
+            using (cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken)))
             {
-                // Fire and forget the shutdown signal
-                _ = ShutdownSignalAsync(process);
-
-                // Wait for process to exit or timeout
-                Task delayTask = Task.Delay(this.TerminationTimeout);
-                var completedTask = await Task.WhenAny(
-                    stopCompletionSource.Task,
-                    delayTask
-                ).ConfigureAwait(false);
-
-                if (completedTask == delayTask)
-                {
-                    // Timeout occurred, force kill the process if it's still running
-                    if (_logger.IsEnabled(LogEventLevel.Warn))
-                    {
-                        _logger.Warn($"Driver service did not exit within {this.TerminationTimeout.TotalSeconds} seconds. Forcing termination.");
-                    }
-
-                    if (!process.HasExited)
-                    {
-                        try
-                        {
-                            process.Kill();
-                            // Wait a short time for the process to exit after kill
-                            await Task.WhenAny(
-                                stopCompletionSource.Task,
-                                Task.Delay(TimeSpan.FromSeconds(1))
-                            ).ConfigureAwait(false);
-                        }
-                        catch (InvalidOperationException)
-                        {
-                            // Process may have already exited
-                        }
-                    }
-                }
+                await tcs.Task.ConfigureAwait(false);
             }
-            finally
-            {
-                process.Exited -= ProcessExitedHandler;
+        }
+        finally
+        {
+            process.Exited -= OnProcessExited;
+        }
+    }
 
-                process.Dispose();
-                this.driverServiceProcess = null;
+    private async Task SendShutdownSignalAsync(Process process, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (HasShutdown)
+            {
+                Uri shutdownUrl = new(this.ServiceUrl, "/shutdown");
+                using var httpClient = new HttpClient();
+                using var _ = await httpClient.GetAsync(shutdownUrl, cancellationToken).ConfigureAwait(false);
             }
-
-            async Task ShutdownSignalAsync(Process targetProcess)
+            else
             {
-                try
-                {
-                    if (HasShutdown)
-                    {
-                        Uri shutdownUrl = new(this.ServiceUrl, "/shutdown");
-                        using var httpClient = new HttpClient()
-                        {
-                            Timeout = this.TerminationTimeout
-                        };
-                        using var _ = await httpClient.GetAsync(shutdownUrl).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        targetProcess.Kill();
-                    }
-                }
-                catch (HttpRequestException ex)
-                {
-                    if (_logger.IsEnabled(LogEventLevel.Debug))
-                    {
-                        _logger.Debug($"Failed to send shutdown signal to driver service: {ex.Message}");
-                    }
-                }
-                catch (OperationCanceledException ex)
-                {
-                    if (_logger.IsEnabled(LogEventLevel.Debug))
-                    {
-                        _logger.Debug($"Shutdown request to driver service timed out: {ex.Message}");
-                    }
-                }
-                catch (InvalidOperationException)
-                {
-                    // Process may have already exited when trying to kill
-                }
+                TryKillProcess(process);
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            if (_logger.IsEnabled(LogEventLevel.Debug))
+            {
+                _logger.Debug($"Failed to send shutdown signal: {ex.Message}");
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            if (_logger.IsEnabled(LogEventLevel.Debug))
+            {
+                _logger.Debug($"Shutdown request was cancelled: {ex.Message}");
+            }
+        }
+    }
+
+    private void TryKillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill();
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            if (_logger.IsEnabled(LogEventLevel.Debug))
+            {
+                _logger.Debug($"Failed to kill process: {ex.Message}");
             }
         }
     }

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -270,7 +270,7 @@ public abstract class DriverService : IDisposable
         {
             if (disposing)
             {
-                this.Stop();
+                this.StopAsync().GetAwaiter().GetResult();
 
                 if (EnableProcessRedirection && this.driverServiceProcess is not null)
                 {
@@ -324,58 +324,51 @@ public abstract class DriverService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Stops the DriverService.
-    /// </summary>
-    private void Stop()
+    private async ValueTask StopAsync()
     {
         if (this.IsRunning)
         {
-            if (this.HasShutdown)
+            this.driverServiceProcess.EnableRaisingEvents = true;
+
+            TaskCompletionSource<bool> stopCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            this.driverServiceProcess.Exited += ProcessExitedHandler;
+
+            void ProcessExitedHandler(object? sender, EventArgs e)
             {
-                Uri shutdownUrl = new Uri(this.ServiceUrl, "/shutdown");
-                DateTime timeout = DateTime.Now.Add(this.TerminationTimeout);
-                using (var httpClient = new HttpClient())
-                {
-                    httpClient.DefaultRequestHeaders.ConnectionClose = true;
-
-                    while (this.IsRunning && DateTime.Now < timeout)
-                    {
-                        try
-                        {
-                            // Issue the shutdown HTTP request, then wait a short while for
-                            // the process to have exited. If the process hasn't yet exited,
-                            // we'll retry. We wait for exit here, since catching the exception
-                            // for a failed HTTP request due to a closed socket is particularly
-                            // expensive.
-                            using (var response = Task.Run(async () => await httpClient.GetAsync(shutdownUrl)).GetAwaiter().GetResult())
-                            {
-
-                            }
-
-                            this.driverServiceProcess.WaitForExit(3000);
-                        }
-                        catch (Exception ex) when (ex is HttpRequestException || ex is TimeoutException)
-                        {
-                        }
-                    }
-                }
+                stopCompletionSource.TrySetResult(true);
             }
 
-            // If at this point, the process still hasn't exited, wait for one
-            // last-ditch time, then, if it still hasn't exited, kill it. Note
-            // that falling into this branch of code should be exceedingly rare.
-            if (this.IsRunning)
+            _ = ShutdownSignalAsync();
+
+            try
             {
-                this.driverServiceProcess.WaitForExit(Convert.ToInt32(this.TerminationTimeout.TotalMilliseconds));
-                if (!this.driverServiceProcess.HasExited)
+                await stopCompletionSource.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                this.driverServiceProcess.Exited -= ProcessExitedHandler;
+
+                this.driverServiceProcess.Dispose();
+                this.driverServiceProcess = null;
+            }
+
+            async Task ShutdownSignalAsync()
+            {
+                if (HasShutdown)
+                {
+                    Uri shutdownUrl = new(this.ServiceUrl, "/shutdown");
+                    using var httpClient = new HttpClient()
+                    {
+                        Timeout = this.TerminationTimeout
+                    };
+                    using var response = await httpClient.GetAsync(shutdownUrl);
+                }
+                else
                 {
                     this.driverServiceProcess.Kill();
                 }
             }
-
-            this.driverServiceProcess.Dispose();
-            this.driverServiceProcess = null;
         }
     }
 

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -280,13 +280,13 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
         {
             if (disposing)
             {
-                this.StopAsync().GetAwaiter().GetResult();
-
                 if (EnableProcessRedirection && this.driverServiceProcess is not null)
                 {
                     this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
                     this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
                 }
+
+                this.StopAsync().GetAwaiter().GetResult();
             }
 
             this.isDisposed = true;
@@ -304,13 +304,13 @@ public abstract class DriverService : IDisposable, IAsyncDisposable
         {
             if (disposing)
             {
-                await this.StopAsync().ConfigureAwait(false);
-
                 if (EnableProcessRedirection && this.driverServiceProcess is not null)
                 {
                     this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
                     this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
                 }
+
+                await this.StopAsync().ConfigureAwait(false);
             }
 
             this.isDisposed = true;

--- a/dotnet/src/webdriver/DriverService.cs
+++ b/dotnet/src/webdriver/DriverService.cs
@@ -27,7 +27,7 @@ namespace OpenQA.Selenium;
 /// <summary>
 /// Exposes the service provided by a native WebDriver server executable.
 /// </summary>
-public abstract class DriverService : IDisposable
+public abstract class DriverService : IDisposable, IAsyncDisposable
 {
     private static readonly ILogger _logger = Log.GetLogger<DriverService>();
     private bool isDisposed;
@@ -182,6 +182,16 @@ public abstract class DriverService : IDisposable
     }
 
     /// <summary>
+    /// Asynchronously releases all resources associated with this <see cref="DriverService"/>.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous dispose operation.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        await this.DisposeAsync(true).ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
     /// Starts the driver service if it is not already running.
     /// </summary>
     /// <exception cref="InvalidOperationException">If the driver service path is specified but the driver service executable name is not.</exception>
@@ -271,6 +281,30 @@ public abstract class DriverService : IDisposable
             if (disposing)
             {
                 this.StopAsync().GetAwaiter().GetResult();
+
+                if (EnableProcessRedirection && this.driverServiceProcess is not null)
+                {
+                    this.driverServiceProcess.OutputDataReceived -= this.OnDriverProcessDataReceived;
+                    this.driverServiceProcess.ErrorDataReceived -= this.OnDriverProcessDataReceived;
+                }
+            }
+
+            this.isDisposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously releases all resources associated with this <see cref="DriverService"/>.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> if the DisposeAsync method was explicitly called; otherwise, <see langword="false"/>.</param>
+    /// <returns>A task that represents the asynchronous dispose operation.</returns>
+    protected virtual async ValueTask DisposeAsync(bool disposing)
+    {
+        if (!this.isDisposed)
+        {
+            if (disposing)
+            {
+                await this.StopAsync().ConfigureAwait(false);
 
                 if (EnableProcessRedirection && this.driverServiceProcess is not null)
                 {

--- a/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
+++ b/dotnet/src/webdriver/Firefox/FirefoxDriver.cs
@@ -229,7 +229,7 @@ public class FirefoxDriver : WebDriver
         {
             try
             {
-                service.Dispose();
+                await service.DisposeAsync().ConfigureAwait(false);
             }
             catch
             {

--- a/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
+++ b/dotnet/src/webdriver/IE/InternetExplorerDriver.cs
@@ -186,7 +186,7 @@ public class InternetExplorerDriver : WebDriver
         {
             try
             {
-                service.Dispose();
+                await service.DisposeAsync().ConfigureAwait(false);
             }
             catch
             {

--- a/dotnet/src/webdriver/Safari/SafariDriver.cs
+++ b/dotnet/src/webdriver/Safari/SafariDriver.cs
@@ -191,7 +191,7 @@ public class SafariDriver : WebDriver
         {
             try
             {
-                service.Dispose();
+                await service.DisposeAsync().ConfigureAwait(false);
             }
             catch
             {


### PR DESCRIPTION
Currently:
```csharp
using var service = new ...
```

Additionally:
```csharp
await using var service = new ...
```

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/17086 and https://github.com/SeleniumHQ/selenium/issues/14067

### 💥 What does this PR do?
Introduces asynchronous disposal support for `DriverService` and updates all driver implementations to use the new async disposal pattern. The main focus is to improve resource management and shutdown reliability for WebDriver services by making the shutdown process asynchronous and more robust.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
