### PR TITLE
[dotnet] Start ChromeDriver asynchronously

### DIFF
--- a/dotnet/src/webdriver/Chrome/ChromeDriver.cs
+++ b/dotnet/src/webdriver/Chrome/ChromeDriver.cs
@@ -158,6 +158,61 @@ public class ChromeDriver : ChromiumDriver
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ChromeDriver"/> class using the specified command executor and options.
+    /// </summary>
+    /// <param name="commandExecutor">The <see cref="ICommandExecutor"/> to use for executing commands.</param>
+    /// <param name="options">The <see cref="ChromeOptions"/> to use for this driver.</param>
+    /// <param name="autoStartSession">Whether to automatically start the session.</param>
+    protected ChromeDriver(ICommandExecutor commandExecutor, ChromeOptions options, bool autoStartSession)
+        : base(commandExecutor, options, autoStartSession)
+    {
+        if (autoStartSession)
+        {
+            this.AddCustomChromeCommands();
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously creates and starts a new instance of the <see cref="ChromeDriver"/> class with default options.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the initialized <see cref="ChromeDriver"/>.</returns>
+    public static Task<ChromeDriver> StartAsync()
+    {
+        return StartAsync(new ChromeOptions());
+    }
+
+    /// <summary>
+    /// Asynchronously creates and starts a new instance of the <see cref="ChromeDriver"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The <see cref="ChromeOptions"/> to be used with the Chrome driver.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the initialized <see cref="ChromeDriver"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="options"/> is <see langword="null"/>.</exception>
+    public static async Task<ChromeDriver> StartAsync(ChromeOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options), "Chrome options must not be null");
+        }
+
+        ChromeDriverService service = ChromeDriverService.CreateDefaultService();
+        ICommandExecutor executor = await GenerateDriverServiceCommandExecutorAsync(service, options, DefaultCommandTimeout).ConfigureAwait(false);
+
+        ChromeDriver driver = new(executor, options, autoStartSession: false);
+        driver.AddCustomChromeCommands();
+
+        try
+        {
+            await driver.StartSessionAsync(options.ToCapabilities()).ConfigureAwait(false);
+            return driver;
+        }
+        catch
+        {
+            driver.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Gets a read-only dictionary of the custom WebDriver commands defined for ChromeDriver.
     /// The keys of the dictionary are the names assigned to the command; the values are the
     /// <see cref="CommandInfo"/> objects describing the command behavior.

--- a/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
+++ b/dotnet/src/webdriver/Chromium/ChromiumDriver.cs
@@ -133,6 +133,20 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ChromiumDriver"/> class using the specified command executor and options.
+    /// </summary>
+    /// <param name="commandExecutor">The <see cref="ICommandExecutor"/> to use for executing commands.</param>
+    /// <param name="options">The <see cref="ChromiumOptions"/> to be used with the ChromiumDriver.</param>
+    /// <param name="autoStartSession">Whether to automatically start the session.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">If the Chromium options capability name is <see langword="null"/>.</exception>
+    protected ChromiumDriver(ICommandExecutor commandExecutor, ChromiumOptions options, bool autoStartSession)
+        : base(commandExecutor, ConvertOptionsToCapabilities(options), autoStartSession)
+    {
+        this.optionsCapabilityName = options.CapabilityName ?? throw new ArgumentException("No chromium options capability name specified", nameof(options));
+    }
+
+    /// <summary>
     /// Gets the dictionary of custom Chromium commands registered with the driver.
     /// </summary>
     protected static IReadOnlyDictionary<string, CommandInfo> ChromiumCustomCommands => new ReadOnlyDictionary<string, CommandInfo>(chromiumCustomCommands);
@@ -144,7 +158,15 @@ public class ChromiumDriver : WebDriver, ISupportsLogs, IDevTools
             .GetAwaiter().GetResult();
     }
 
-    private static async Task<ICommandExecutor> GenerateDriverServiceCommandExecutorAsync(DriverService service, DriverOptions options, TimeSpan commandTimeout)
+    /// <summary>
+    /// Asynchronously generates a driver service command executor.
+    /// </summary>
+    /// <param name="service">The <see cref="DriverService"/> to use.</param>
+    /// <param name="options">The <see cref="DriverOptions"/> to be used with the driver.</param>
+    /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="ICommandExecutor"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="service"/> or <paramref name="options"/> are <see langword="null"/>.</exception>
+    protected static async Task<ICommandExecutor> GenerateDriverServiceCommandExecutorAsync(DriverService service, DriverOptions options, TimeSpan commandTimeout)
     {
         if (service is null)
         {

--- a/dotnet/src/webdriver/WebDriver.cs
+++ b/dotnet/src/webdriver/WebDriver.cs
@@ -48,6 +48,17 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     /// <param name="executor">The <see cref="ICommandExecutor"/> object used to execute commands.</param>
     /// <param name="capabilities">The <see cref="ICapabilities"/> object used to configure the driver session.</param>
     protected WebDriver(ICommandExecutor executor, ICapabilities capabilities)
+        : this(executor, capabilities, true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebDriver"/> class.
+    /// </summary>
+    /// <param name="executor">The <see cref="ICommandExecutor"/> object used to execute commands.</param>
+    /// <param name="capabilities">The <see cref="ICapabilities"/> object used to configure the driver session.</param>
+    /// <param name="autoStartSession">Whether to automatically start the driver session.</param>
+    protected WebDriver(ICommandExecutor executor, ICapabilities capabilities, bool autoStartSession)
     {
         this.CommandExecutor = executor;
         this.elementFactory = new WebElementFactory(this);
@@ -61,22 +72,25 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
             this.RegisterDriverCommand(DriverCommand.GetLog, new HttpCommandInfo(HttpCommandInfo.PostCommand, "/session/{sessionId}/se/log"), true);
         }
 
-        try
-        {
-            this.StartSession(capabilities);
-        }
-        catch (Exception)
+        if (autoStartSession)
         {
             try
             {
-                // Failed to start driver session, disposing of driver
-                this.Dispose();
+                this.StartSession(capabilities);
             }
-            catch
+            catch (Exception)
             {
-                // Ignore the clean-up exception. We'll propagate the original failure.
+                try
+                {
+                    // Failed to start driver session, disposing of driver
+                    this.Dispose();
+                }
+                catch
+                {
+                    // Ignore the clean-up exception. We'll propagate the original failure.
+                }
+                throw;
             }
-            throw;
         }
     }
 

--- a/dotnet/src/webdriver/WebDriver.cs
+++ b/dotnet/src/webdriver/WebDriver.cs
@@ -43,7 +43,7 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     private readonly List<string> registeredCommands = new List<string>();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="WebDriver"/> class.
+    /// Initializes a new instance of the <see cref="WebDriver"/> class and automatically starts the driver session.
     /// </summary>
     /// <param name="executor">The <see cref="ICommandExecutor"/> object used to execute commands.</param>
     /// <param name="capabilities">The <see cref="ICapabilities"/> object used to configure the driver session.</param>
@@ -53,11 +53,11 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="WebDriver"/> class.
+    /// Initializes a new instance of the <see cref="WebDriver"/> class with optional automatic session initialization.
     /// </summary>
     /// <param name="executor">The <see cref="ICommandExecutor"/> object used to execute commands.</param>
     /// <param name="capabilities">The <see cref="ICapabilities"/> object used to configure the driver session.</param>
-    /// <param name="autoStartSession">Whether to automatically start the driver session.</param>
+    /// <param name="autoStartSession">Whether to automatically start the driver session. When <see langword="true"/>, the session is started immediately; when <see langword="false"/>, the session must be started manually.</param>
     protected WebDriver(ICommandExecutor executor, ICapabilities capabilities, bool autoStartSession)
     {
         this.CommandExecutor = executor;

--- a/dotnet/src/webdriver/WebDriver.cs
+++ b/dotnet/src/webdriver/WebDriver.cs
@@ -88,7 +88,7 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     /// <summary>
     /// Gets the <see cref="ICapabilities"/> that the driver session was created with, which may be different from those requested.
     /// </summary>
-    public ICapabilities Capabilities { get; private set; }
+    public ICapabilities Capabilities { get; private set; } = null!;
 
     /// <summary>
     /// Gets or sets the URL the browser is currently displaying.
@@ -180,7 +180,7 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     /// <summary>
     /// Gets the <see cref="Selenium.SessionId"/> for the current session of this driver.
     /// </summary>
-    public SessionId SessionId { get; private set; }
+    public SessionId SessionId { get; private set; } = null!;
 
     /// <summary>
     /// Gets or sets the <see cref="IFileDetector"/> responsible for detecting
@@ -584,11 +584,20 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
     /// Starts a session with the driver
     /// </summary>
     /// <param name="capabilities">Capabilities of the browser</param>
-    [MemberNotNull(nameof(SessionId))]
-    [MemberNotNull(nameof(Capabilities))]
     protected void StartSession(ICapabilities capabilities)
     {
-        Dictionary<string, object?> parameters = new Dictionary<string, object?>();
+        Task.Run(() => this.StartSessionAsync(capabilities)).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Asynchronously starts a session with the driver.
+    /// </summary>
+    /// <param name="capabilities">Capabilities of the browser.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="WebDriverException">If the session cannot be started or the response is invalid.</exception>
+    protected async Task StartSessionAsync(ICapabilities capabilities)
+    {
+        Dictionary<string, object?> parameters = [];
 
         // If the object passed into the RemoteWebDriver constructor is a
         // RemoteSessionSettings object, it is expected that all intermediate
@@ -599,11 +608,12 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
         {
             Dictionary<string, object> matchCapabilities = this.GetCapabilitiesDictionary(capabilities);
 
-            List<object> firstMatchCapabilitiesList = new List<object>();
-            firstMatchCapabilitiesList.Add(matchCapabilities);
+            List<object> firstMatchCapabilitiesList = [matchCapabilities];
 
-            Dictionary<string, object> specCompliantCapabilitiesDictionary = new Dictionary<string, object>();
-            specCompliantCapabilitiesDictionary["firstMatch"] = firstMatchCapabilitiesList;
+            Dictionary<string, object> specCompliantCapabilitiesDictionary = new()
+            {
+                ["firstMatch"] = firstMatchCapabilitiesList
+            };
 
             parameters.Add("capabilities", specCompliantCapabilitiesDictionary);
         }
@@ -612,9 +622,10 @@ public class WebDriver : IWebDriver, ISearchContext, IJavaScriptExecutor, IFinds
             parameters.Add("capabilities", remoteSettings.ToDictionary());
         }
 
-        Response response = this.Execute(DriverCommand.NewSession, parameters);
+        Response response = await this.ExecuteAsync(DriverCommand.NewSession, parameters).ConfigureAwait(false);
 
         response.EnsureValueIsNotNull();
+
         if (response.Value is not Dictionary<string, object> rawCapabilities)
         {
             string errorMessage = string.Format(CultureInfo.InvariantCulture, "The new session command returned a value ('{0}') that is not a valid JSON object.", response.Value);


### PR DESCRIPTION
```csharp
var chrome = await ChromeDriver.StartAsync();

// or

var chrome = await ChromeDriver.StartAsync(new() { BrowserVersion = "145" });
```

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/17086 and https://github.com/SeleniumHQ/selenium/issues/14067

### 💥 What does this PR do?
Introduces asynchronous initialization support for the ChromeDriver and ChromiumDriver classes, refactors driver session startup logic to allow optional automatic session creation, and improves code clarity and safety with better nullability handling and modern C# syntax. The changes also add comprehensive documentation for new and existing APIs.

### 💡 Additional Considerations
Only overload which takes `ChromeOptions`. Others will come soon?

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
