### PR TITLE
[py] Update test to check it's an integer rather than a value

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_browser_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_browser_tests.py
@@ -90,8 +90,8 @@ def test_get_client_windows(driver):
     assert window_info.get_width() > 0
     assert window_info.get_height() > 0
     assert isinstance(window_info.is_active(), bool)
-    assert window_info.get_x() >= 0
-    assert window_info.get_y() >= 0
+    assert isinstance(window_info.get_x(), int)
+    assert isinstance(window_info.get_y(), int)
 
 
 def test_raises_exception_when_removing_default_user_context(driver):


### PR DESCRIPTION
On 2nd monitors if tests run on the secondary monitor and it is left of the primary monitor x and y will return negative which is allowed. This will also handle tests running on a different desktop which is supported but undefined in the spec

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Fixes a test

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->

- Bug fix (backwards compatible)

