### PR TITLE
[py] Add return type annotation to execute_script and execute_async_script

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -506,7 +506,7 @@ class WebDriver(BaseWebDriver):
         """
         return list(self.pinned_scripts)
 
-    def execute_script(self, script: str, *args) -> dict[str, Any]:
+    def execute_script(self, script: str, *args) -> Any:
         """Synchronously Executes JavaScript in the current window/frame.
 
         Args:

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -531,7 +531,7 @@ class WebDriver(BaseWebDriver):
 
         return self.execute(command, {"script": script, "args": converted_args})["value"]
 
-    def execute_async_script(self, script: str, *args) -> dict:
+    def execute_async_script(self, script: str, *args) -> Any:
         """Asynchronously Executes JavaScript in the current window/frame.
 
         Args:

--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -506,7 +506,7 @@ class WebDriver(BaseWebDriver):
         """
         return list(self.pinned_scripts)
 
-    def execute_script(self, script: str, *args):
+    def execute_script(self, script: str, *args) -> dict[str, Any]:
         """Synchronously Executes JavaScript in the current window/frame.
 
         Args:


### PR DESCRIPTION
## Summary
- Add `-> Any` return type annotation to `WebDriver.execute_script`
- Add `-> Any` return type annotation to `WebDriver.execute_async_script`


## Motivation
`execute_script` returns the result of the executed JavaScript, which can be any type (string, number, bool, list, dict, None, WebElement, etc.). Adding an `Any` return type annotation improves IDE support and documents this behavior.

## Test plan
- No behavioral changes; annotation-only change