### PR TITLE
[java] Improve screenshot error message

### DIFF
--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -82,25 +82,24 @@ public interface OutputType<T> {
           return save(data);
         }
 
-       private File save(byte[] data) {
-         Path tmpFilePath = null;
-         try {
-          tmpFilePath = Files.createTempFile("screenshot", ".png");
-          Files.write(tmpFilePath, data);
-            } catch (IOException e) {
-             String pathInfo = (tmpFilePath != null)
-              ? tmpFilePath.toAbsolutePath().toString()
-              : "temporary file could not be created";
+        private File save(byte[] data) {
+          Path tmpFilePath = null;
+          try {
+            tmpFilePath = Files.createTempFile("screenshot", ".png");
+            Files.write(tmpFilePath, data);
+          } catch (IOException e) {
+            String pathInfo =
+                (tmpFilePath != null)
+                    ? tmpFilePath.toAbsolutePath().toString()
+                    : "temporary file could not be created";
 
             throw new WebDriverException(
-         "Failed to create or write screenshot to temporary file: " + pathInfo,
-         e);
-           }
+                "Failed to create or write screenshot to temporary file: " + pathInfo, e);
+          }
 
-         File tmpFile = tmpFilePath.toFile();
-         tmpFile.deleteOnExit();
-         return tmpFile;
-
+          File tmpFile = tmpFilePath.toFile();
+          tmpFile.deleteOnExit();
+          return tmpFile;
         }
 
         public String toString() {

--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -13,7 +13,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
-// under the License.
 
 package org.openqa.selenium;
 
@@ -82,16 +81,25 @@ public interface OutputType<T> {
           return save(data);
         }
 
-        private File save(byte[] data) {
-          try {
-            Path tmpFilePath = Files.createTempFile("screenshot", ".png");
-            File tmpFile = tmpFilePath.toFile();
-            tmpFile.deleteOnExit();
-            Files.write(tmpFilePath, data);
-            return tmpFile;
-          } catch (IOException e) {
-            throw new WebDriverException(e);
-          }
+       private File save(byte[] data) {
+         Path tmpFilePath = null;
+         try {
+          tmpFilePath = Files.createTempFile("screenshot", ".png");
+          Files.write(tmpFilePath, data);
+            } catch (IOException e) {
+             String pathInfo = (tmpFilePath != null)
+              ? tmpFilePath.toAbsolutePath().toString()
+              : "temporary file could not be created";
+
+            throw new WebDriverException(
+         "Failed to create or write screenshot to temporary file: " + pathInfo,
+         e);
+           }
+
+         File tmpFile = tmpFilePath.toFile();
+         tmpFile.deleteOnExit();
+         return tmpFile;
+
         }
 
         public String toString() {

--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -13,6 +13,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
+// under the License.
 
 package org.openqa.selenium;
 

--- a/java/src/org/openqa/selenium/OutputType.java
+++ b/java/src/org/openqa/selenium/OutputType.java
@@ -83,23 +83,30 @@ public interface OutputType<T> {
         }
 
         private File save(byte[] data) {
-          Path tmpFilePath = null;
+          Path tmpFilePath = createScreenshotFile();
           try {
-            tmpFilePath = Files.createTempFile("screenshot", ".png");
             Files.write(tmpFilePath, data);
           } catch (IOException e) {
-            String pathInfo =
-                (tmpFilePath != null)
-                    ? tmpFilePath.toAbsolutePath().toString()
-                    : "temporary file could not be created";
-
             throw new WebDriverException(
-                "Failed to create or write screenshot to temporary file: " + pathInfo, e);
+                "Failed to create or write screenshot to temporary file: "
+                    + tmpFilePath.toAbsolutePath().toString(),
+                e);
           }
 
           File tmpFile = tmpFilePath.toFile();
           tmpFile.deleteOnExit();
           return tmpFile;
+        }
+
+        private Path createScreenshotFile() {
+          try {
+            return Files.createTempFile("screenshot", ".png");
+          } catch (IOException e) {
+            throw new WebDriverException(
+                "Failed to create or write screenshot to temporary file: "
+                    + "temporary file could not be created",
+                e);
+          }
         }
 
         public String toString() {


### PR DESCRIPTION
### 💥 What does this PR do?
Improves the diagnostic information included in the `WebDriverException`
thrown when creating or writing the temporary screenshot file fails in
`OutputType.FILE`.

The original `IOException` is preserved as the cause.

### 🔧 Implementation Notes
- Keeps behavior unchanged except for the exception message in failure cases.
- Includes the temp file path (when available) to make debugging file-system
  failures easier.

### 💡 Additional Considerations
- No public API changes.
- No behavioral changes in success cases.
- This change only affects the error message when an `IOException` occurs.

### 🔄 Types of changes
- Bug fix (backwards compatible)
- Cleanup (formatting, renaming)