### PR TITLE
[dotnet] [bidi] Receive readonly data from remote end

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -75,7 +75,7 @@ internal sealed class Broker : IAsyncDisposable
 
                 try
                 {
-                    ProcessReceivedMessage(data);
+                    ProcessReceivedMessage(data.Span);
                 }
                 catch (Exception ex)
                 {
@@ -196,7 +196,7 @@ internal sealed class Broker : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private void ProcessReceivedMessage(byte[]? data)
+    private void ProcessReceivedMessage(ReadOnlySpan<byte> data)
     {
         long? id = default;
         string? type = default;
@@ -206,7 +206,7 @@ internal sealed class Broker : IAsyncDisposable
         Utf8JsonReader resultReader = default;
         Utf8JsonReader paramsReader = default;
 
-        Utf8JsonReader reader = new(new ReadOnlySpan<byte>(data));
+        Utf8JsonReader reader = new(data);
         reader.Read();
 
         reader.Read(); // "{"

--- a/dotnet/src/webdriver/BiDi/ITransport.cs
+++ b/dotnet/src/webdriver/BiDi/ITransport.cs
@@ -23,7 +23,7 @@ interface ITransport : IDisposable
 {
     Task ConnectAsync(CancellationToken cancellationToken);
 
-    Task<byte[]> ReceiveAsync(CancellationToken cancellationToken);
+    Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken);
 
     Task SendAsync(byte[] data, CancellationToken cancellationToken);
 }

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -37,7 +37,7 @@ sealed class WebSocketTransport(Uri _uri) : ITransport, IDisposable
         await _webSocket.ConnectAsync(_uri, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<byte[]> ReceiveAsync(CancellationToken cancellationToken)
+    public async Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken)
     {
         var receiveBuffer = ArrayPool<byte>.Shared.Rent(1024 * 8);
 
@@ -57,11 +57,11 @@ sealed class WebSocketTransport(Uri _uri) : ITransport, IDisposable
             }
             while (!result.EndOfMessage);
 
-            byte[] data = _sharedMemoryStream.ToArray();
+            var data = new ReadOnlyMemory<byte>(_sharedMemoryStream.GetBuffer(), 0, (int)_sharedMemoryStream.Length);
 
             if (_logger.IsEnabled(LogEventLevel.Trace))
             {
-                _logger.Trace($"BiDi RCV <-- {Encoding.UTF8.GetString(data)}");
+                _logger.Trace($"BiDi RCV <-- {Encoding.UTF8.GetString(_sharedMemoryStream.GetBuffer(), 0, (int)_sharedMemoryStream.Length)}");
             }
 
             return data;


### PR DESCRIPTION
Refactors the way binary message data is handled in the BiDi WebDriver implementation, focusing on improving performance and memory usage by switching from `byte[]` to `ReadOnlyMemory<byte>` and `ReadOnlySpan<byte>`. The changes affect message reception, processing, and interface definitions.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
