### PR TITLE
[dotnet] [bidi] Unregister cancelled commands

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -147,10 +147,14 @@ internal sealed class Broker : IAsyncDisposable
         var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
         cts.CancelAfter(timeout);
 
-        cts.Token.Register(() => tcs.TrySetCanceled(cts.Token));
+        using var ctsRegistration = cts.Token.Register(() =>
+        {
+            tcs.TrySetCanceled(cts.Token);
+            _pendingCommands.TryRemove(command.Id, out _);
+        });
+        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
         var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
         _pendingCommands[command.Id] = commandInfo;
-        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
 
         await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -83,7 +83,15 @@ internal sealed class Broker : IAsyncDisposable
             _pendingCommands.TryRemove(command.Id, out _);
         });
 
-        await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
+        try
+        {
+            await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            _pendingCommands.TryRemove(command.Id, out _);
+            throw;
+        }
 
         return (TResult)await tcs.Task.ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -118,7 +118,7 @@ internal sealed class Broker : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private void ProcessReceivedMessage(byte[]? data)
+    private void ProcessReceivedMessage(byte[] data)
     {
         long? id = default;
         string? type = default;
@@ -216,13 +216,13 @@ internal sealed class Broker : IAsyncDisposable
                 break;
 
             case "event":
-                if (method is null) throw new BiDiException("The remote end responded with 'event' message type, but missed required 'method' property.");
+                if (method is null) throw new BiDiException($"The remote end responded with 'event' message type, but missed required 'method' property. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
                 var paramsJsonData = new ReadOnlyMemory<byte>(data, (int)paramsStartIndex, (int)(paramsEndIndex - paramsStartIndex));
                 _eventDispatcher.EnqueueEvent(method, paramsJsonData, _bidi);
                 break;
 
             case "error":
-                if (id is null) throw new BiDiException("The remote end responded with 'error' message type, but missed required 'id' property.");
+                if (id is null) throw new BiDiException($"The remote end responded with 'error' message type, but missed required 'id' property. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
 
                 if (_pendingCommands.TryGetValue(id.Value, out var errorCommand))
                 {
@@ -233,7 +233,7 @@ internal sealed class Broker : IAsyncDisposable
                 {
                     if (_logger.IsEnabled(LogEventLevel.Warn))
                     {
-                        _logger.Warn($"The remote end responded with 'error' message type, but no pending command with id {id} was found.");
+                        _logger.Warn($"The remote end responded with 'error' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
                     }
                 }
 

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -147,14 +147,15 @@ internal sealed class Broker : IAsyncDisposable
         var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
         cts.CancelAfter(timeout);
 
+        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
+        var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
+        _pendingCommands[command.Id] = commandInfo;
+
         using var ctsRegistration = cts.Token.Register(() =>
         {
             tcs.TrySetCanceled(cts.Token);
             _pendingCommands.TryRemove(command.Id, out _);
         });
-        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
-        var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
-        _pendingCommands[command.Id] = commandInfo;
 
         await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -73,10 +73,15 @@ internal sealed class Broker : IAsyncDisposable
         var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
         cts.CancelAfter(timeout);
 
-        cts.Token.Register(() => tcs.TrySetCanceled(cts.Token));
+        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
         var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
         _pendingCommands[command.Id] = commandInfo;
-        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
+
+        using var ctsRegistration = cts.Token.Register(() =>
+        {
+            tcs.TrySetCanceled(cts.Token);
+            _pendingCommands.TryRemove(command.Id, out _);
+        });
 
         await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
 
@@ -194,7 +199,10 @@ internal sealed class Broker : IAsyncDisposable
                 }
                 else
                 {
-                    throw new BiDiException($"The remote end responded with 'success' message type, but no pending command with id {id} was found.");
+                    if (_logger.IsEnabled(LogEventLevel.Warn))
+                    {
+                        _logger.Warn($"The remote end responded with 'success' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                    }
                 }
 
                 break;
@@ -215,7 +223,10 @@ internal sealed class Broker : IAsyncDisposable
                 }
                 else
                 {
-                    throw new BiDiException($"The remote end responded with 'error' message type, but no pending command with id {id} was found.");
+                    if (_logger.IsEnabled(LogEventLevel.Warn))
+                    {
+                        _logger.Warn($"The remote end responded with 'error' message type, but no pending command with id {id} was found.");
+                    }
                 }
 
                 break;


### PR DESCRIPTION
Refines the command execution logic in the `Broker` class to improve resource management and prevent memory leaks when commands are canceled. The main change ensures that canceled commands are properly removed from the `_pendingCommands` dictionary.

### 🔄 Types of changes
- Bug fix (backwards compatible)
