### PR TITLE
[dotnet] [bidi] Properly handle websocket close handshake

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -269,6 +269,14 @@ internal sealed class Broker : IAsyncDisposable
                 _logger.Error($"Unhandled error occurred while receiving remote messages: {ex}");
             }
 
+            // Fail all pending commands, as the connection is likely broken if we failed to receive messages.
+            foreach (var pendingCommand in _pendingCommands.Values)
+            {
+                pendingCommand.TaskCompletionSource.TrySetException(ex);
+            }
+
+            _pendingCommands.Clear();
+
             throw;
         }
     }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -113,7 +113,7 @@ internal sealed class Broker : IAsyncDisposable
 
         _receiveMessagesCancellationTokenSource.Dispose();
 
-        _transport.Dispose();
+        await _transport.DisposeAsync().ConfigureAwait(false);
 
         GC.SuppressFinalize(this);
     }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -270,12 +270,13 @@ internal sealed class Broker : IAsyncDisposable
             }
 
             // Fail all pending commands, as the connection is likely broken if we failed to receive messages.
-            foreach (var pendingCommand in _pendingCommands.Values)
+            foreach (var id in _pendingCommands.Keys)
             {
-                pendingCommand.TaskCompletionSource.TrySetException(ex);
+                if (_pendingCommands.TryRemove(id, out var pendingCommand))
+                {
+                    pendingCommand.TaskCompletionSource.TrySetException(ex);
+                }
             }
-
-            _pendingCommands.Clear();
 
             throw;
         }

--- a/dotnet/src/webdriver/BiDi/ITransport.cs
+++ b/dotnet/src/webdriver/BiDi/ITransport.cs
@@ -19,7 +19,7 @@
 
 namespace OpenQA.Selenium.BiDi;
 
-interface ITransport : IDisposable
+interface ITransport : IAsyncDisposable
 {
     Task<byte[]> ReceiveAsync(CancellationToken cancellationToken);
 

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -69,7 +69,7 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
 
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
-                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken).ConfigureAwait(false);
+                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
 
                     throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
                         $"The remote end closed the WebSocket connection. Status: {_webSocket.CloseStatus}, Description: {_webSocket.CloseStatusDescription}");

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -67,6 +67,14 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport, IDispos
             {
                 result = await _webSocket.ReceiveAsync(segment, cancellationToken).ConfigureAwait(false);
 
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken).ConfigureAwait(false);
+
+                    throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
+                        $"The remote end closed the WebSocket connection. Status: {_webSocket.CloseStatus}, Description: {_webSocket.CloseStatusDescription}");
+                }
+
                 _sharedMemoryStream.Write(receiveBuffer, 0, result.Count);
             }
             while (!result.EndOfMessage);

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -72,7 +72,7 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
                     await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
 
                     throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
-                        $"The remote end closed the WebSocket connection. Status: {_webSocket.CloseStatus}, Description: {_webSocket.CloseStatusDescription}");
+                        $"The remote end closed the WebSocket connection. Status: {result.CloseStatus}, Description: {result.CloseStatusDescription}");
                 }
 
                 _sharedMemoryStream.Write(receiveBuffer, 0, result.Count);

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -24,7 +24,7 @@ using OpenQA.Selenium.Internal.Logging;
 
 namespace OpenQA.Selenium.BiDi;
 
-sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport, IDisposable
+sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
 {
     private readonly static ILogger _logger = Internal.Logging.Log.GetLogger<WebSocketTransport>();
 
@@ -115,26 +115,31 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport, IDispos
 
     private bool _disposed;
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+        if (_disposed) return;
 
-    private void Dispose(bool disposing)
-    {
-        if (_disposed)
+        if (_webSocket.State == WebSocketState.Open)
         {
-            return;
+            try
+            {
+                await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsEnabled(LogEventLevel.Warn))
+                {
+                    _logger.Warn($"Error closing WebSocket gracefully: {ex.Message}");
+                }
+            }
         }
 
-        if (disposing)
-        {
-            _webSocket.Dispose();
-            _sharedMemoryStream.Dispose();
-            _socketSendSemaphoreSlim.Dispose();
-        }
+        _webSocket.Dispose();
+        _sharedMemoryStream.Dispose();
+        _socketSendSemaphoreSlim.Dispose();
 
         _disposed = true;
+
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
More robust websocket handshake.

### 💥 What does this PR do?
Refactors the BiDi transport layer to improve resource management and error handling, particularly around asynchronous disposal and WebSocket connection failures. The main changes include switching to asynchronous disposal patterns and ensuring all pending commands are properly failed when the connection breaks.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
