### PR TITLE
[java] fix "or" condition

### DIFF
--- a/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -399,7 +399,7 @@ public class ExpectedConditions {
 
     return new ExpectedCondition<>() {
       private @Nullable String elementText;
-      private @Nullable StaleElementReferenceException error;
+      private @Nullable WebDriverException error;
 
       @Override
       public Boolean apply(WebDriver driver) {
@@ -408,7 +408,7 @@ public class ExpectedConditions {
         try {
           elementText = element.getText();
           return elementText.contains(text);
-        } catch (StaleElementReferenceException e) {
+        } catch (StaleElementReferenceException | NoSuchElementException e) {
           error = e;
           return false;
         }
@@ -481,7 +481,7 @@ public class ExpectedConditions {
 
     return new ExpectedCondition<>() {
       private @Nullable String actualValue;
-      private @Nullable StaleElementReferenceException error;
+      private @Nullable WebDriverException error;
 
       @Override
       public Boolean apply(WebDriver driver) {
@@ -490,7 +490,7 @@ public class ExpectedConditions {
         try {
           actualValue = element.getAttribute("value");
           return actualValue != null && actualValue.contains(expectedValue);
-        } catch (StaleElementReferenceException e) {
+        } catch (StaleElementReferenceException | NoSuchElementException e) {
           error = e;
           return false;
         }
@@ -825,7 +825,7 @@ public class ExpectedConditions {
           // Calling any method forces a staleness check
           element.isEnabled();
           return false;
-        } catch (StaleElementReferenceException expected) {
+        } catch (StaleElementReferenceException | NoSuchElementException expected) {
           return true;
         }
       }
@@ -855,7 +855,7 @@ public class ExpectedConditions {
       public @Nullable T apply(WebDriver driver) {
         try {
           return condition.apply(driver);
-        } catch (StaleElementReferenceException e) {
+        } catch (StaleElementReferenceException | NoSuchElementException e) {
           return null;
         }
       }
@@ -1677,15 +1677,21 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<Boolean> or(final ExpectedCondition<?>... conditions) {
     return new ExpectedCondition<>() {
+      @Nullable final Object[] results = new Object[conditions.length];
+
       @Override
       public Boolean apply(WebDriver driver) {
-        for (ExpectedCondition<?> condition : conditions) {
+        for (int i = 0; i != conditions.length; ++i) {
+          ExpectedCondition<?> condition = conditions[i];
+          results[i] = null;
           try {
             Object result = condition.apply(driver);
             if (Boolean.TRUE.equals(result) || result != null && !(result instanceof Boolean)) {
               return true;
             }
-          } catch (StaleElementReferenceException ignore) {
+            results[i] = result;
+          } catch (RuntimeException e) {
+            results[i] = e;
           }
         }
         return false;
@@ -1696,9 +1702,22 @@ public class ExpectedConditions {
         StringBuilder message =
             new StringBuilder("at least one condition to be valid:").append(lineSeparator());
         for (int i = 0; i < conditions.length; i++) {
-          message.append(i + 1).append(". ").append(conditions[i]).append(lineSeparator());
+          message
+              .append(i + 1)
+              .append(". ")
+              .append(conditions[i])
+              .append(resultAsString(results[i]))
+              .append(lineSeparator());
         }
         return message.toString();
+      }
+
+      private Object resultAsString(@Nullable Object result) {
+        return Boolean.FALSE.equals(result)
+            ? ""
+            : result instanceof WebDriverException
+                ? " (caused by: " + shortDescription((WebDriverException) result) + ")"
+                : " (actual: " + result + ")";
       }
     };
   }

--- a/java/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
+++ b/java/test/org/openqa/selenium/support/ui/ExpectedConditionsTest.java
@@ -966,8 +966,7 @@ final class ExpectedConditionsTest {
           .thenReturn("16pt")
           .thenReturn("17pt")
           .thenReturn("18pt");
-      when(mockElement.getText())
-          .thenThrow(new StaleElementReferenceException("Element disappeared"));
+      when(mockElement.getText()).thenThrow(new NoSuchElementException("Element disappeared"));
 
       assertThat(
               wait.until(
@@ -981,7 +980,7 @@ final class ExpectedConditionsTest {
     void whenAllThrow() {
       String attributeName = "test";
       when(mockElement.getAttribute(attributeName))
-          .thenThrow(new StaleElementReferenceException("Disappeared 1"));
+          .thenThrow(new NoSuchElementException("Disappeared 1"));
       when(mockElement.getCssValue(attributeName))
           .thenThrow(new StaleElementReferenceException("Disappeared 2"));
       when(mockElement.getText()).thenThrow(new StaleElementReferenceException("Disappeared 3"));
@@ -999,7 +998,8 @@ final class ExpectedConditionsTest {
                   + "1. element to have text \"test\", but..."
                   + " org.openqa.selenium.StaleElementReferenceException: Disappeared 3."
                   + lineSeparator()
-                  + "2. attribute or CSS value \"test\"=\"test\". Current value: \"null\".")
+                  + "2. attribute or CSS value \"test\"=\"test\". Current value: \"null\". (caused"
+                  + " by: org.openqa.selenium.NoSuchElementException: Disappeared 1)")
           .hasMessageContaining("tried for 1.1 seconds with 250 milliseconds interval");
     }
   }


### PR DESCRIPTION
We need to re-try in case of `NoSuchElementException`, not only `StaleElementReferenceException`.

@ammmze FYI

### 🔗 Related Issues
Fixes #17091

### 💥 What does this PR do?
1. Fixes `ExpectedConditions.or`: now it does re-try when some of conditions throws `NoSuchElementException`.
2. Improves the error message generated by `or` method (adds actual value or exception to every condition in `or`).

### 🔧 Implementation Notes
`NoSuchElementException` may be thrown by a page object because its @FindBy fields are lazy-initialized.


### 🔄 Types of changes
- Bug fix (backwards compatible)
