### PR TITLE
[ruby] fix linter error in `./go authors` script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,9 @@ task ios_driver: 'appium:build'
 desc 'Update AUTHORS file'
 task :authors do
   puts 'Updating AUTHORS file'
-  sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS ; cat AUTHORS) | sort -uf > AUTHORS.tmp && mv AUTHORS.tmp AUTHORS"
+  sh "(git log --use-mailmap --format='%aN <%aE>' ; " \
+     'cat .OLD_AUTHORS ; cat AUTHORS) | ' \
+     'sort -uf > AUTHORS.tmp && mv AUTHORS.tmp AUTHORS'
 end
 
 # Example: `./go release_updates selenium-4.31.0 early-stable`


### PR DESCRIPTION
Ruby linter complained about too long line. Had to split it. Hope the backslash works in all environments.


### 🔗 Related Issues
Build failure sample:
https://github.com/SeleniumHQ/selenium/actions/runs/22319716311/job/64575771271?pr=17130

```ruby

Offenses:

Rakefile:99:121: C: Layout/LineLength: Line is too long. [135/120]
  sh "(git log --use-mailmap --format='%aN <%aE>' ; cat .OLD_AUTHORS ; cat AUTHORS) | sort -uf > AUTHORS.tmp && mv AUTHORS.tmp AUTHORS"
                                                                                                                        ^^^^^^^^^^^^^^^

295 files inspected, 1 offense detected
/home/runner/work/selenium/selenium/rake_tasks/bazel.rb:57:in `execute'
/home/runner/work/selenium/selenium/rake_tasks/ruby.rake:152:in `block in <main>'
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
Tasks: TOP => rb:lint
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```

### 💥 What does this PR do?
Splits too long line in ruby script into 3 shorter lines.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
