### PR TITLE
[dotnet] [bidi] Wait until events are dispatched when unsubscribing

### DIFF
--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -42,12 +42,10 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     private readonly Task _eventEmitterTask;
 
-    private static readonly TaskFactory _myTaskFactory = new(CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskContinuationOptions.None, TaskScheduler.Default);
-
     public EventDispatcher(Func<ISessionModule> sessionProvider)
     {
         _sessionProvider = sessionProvider;
-        _eventEmitterTask = _myTaskFactory.StartNew(ProcessEventsAwaiterAsync).Unwrap();
+        _eventEmitterTask = Task.Run(ProcessEventsAwaiterAsync);
     }
 
     public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -40,12 +40,12 @@ internal sealed class EventDispatcher : IAsyncDisposable
         SingleWriter = true
     });
 
-    private readonly Task _eventEmitterTask;
+    private readonly Task _processEventsTask;
 
     public EventDispatcher(Func<ISessionModule> sessionProvider)
     {
         _sessionProvider = sessionProvider;
-        _eventEmitterTask = Task.Run(ProcessEventsAsync);
+        _processEventsTask = Task.Run(ProcessEventsAsync);
     }
 
     public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
@@ -144,7 +144,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
     {
         _pendingEvents.Writer.Complete();
 
-        await _eventEmitterTask.ConfigureAwait(false);
+        await _processEventsTask.ConfigureAwait(false);
 
         GC.SuppressFinalize(this);
     }

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -34,7 +34,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     private readonly ConcurrentDictionary<string, EventRegistration> _events = new();
 
-    private readonly Channel<PendingEvent> _pendingEvents = Channel.CreateUnbounded<PendingEvent>(new()
+    private readonly Channel<EventItem> _pendingEvents = Channel.CreateUnbounded<EventItem>(new()
     {
         SingleReader = true,
         SingleWriter = true
@@ -57,7 +57,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
         var subscribeResult = await _sessionProvider().SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }, cancellationToken).ConfigureAwait(false);
 
-        registration.Handlers.Add(eventHandler);
+        registration.AddHandler(eventHandler);
 
         return new Subscription(subscribeResult.Subscription, this, eventHandler);
     }
@@ -67,7 +67,11 @@ internal sealed class EventDispatcher : IAsyncDisposable
         if (_events.TryGetValue(subscription.EventHandler.EventName, out var registration))
         {
             await _sessionProvider().UnsubscribeAsync([subscription.SubscriptionId], null, cancellationToken).ConfigureAwait(false);
-            registration.Handlers.Remove(subscription.EventHandler);
+
+            // Wait until all pending events for this method are dispatched
+            await registration.DrainAsync().ConfigureAwait(false);
+
+            registration.RemoveHandler(subscription.EventHandler);
         }
     }
 
@@ -75,7 +79,8 @@ internal sealed class EventDispatcher : IAsyncDisposable
     {
         if (_events.TryGetValue(method, out var registration) && registration.TypeInfo is not null)
         {
-            _pendingEvents.Writer.TryWrite(new PendingEvent(method, jsonUtf8Bytes, bidi, registration.TypeInfo));
+            registration.IncrementPending();
+            _pendingEvents.Writer.TryWrite(new EventItem(jsonUtf8Bytes, bidi, registration));
         }
         else
         {
@@ -89,22 +94,20 @@ internal sealed class EventDispatcher : IAsyncDisposable
     private async Task ProcessEventsAwaiterAsync()
     {
         var reader = _pendingEvents.Reader;
+
         while (await reader.WaitToReadAsync().ConfigureAwait(false))
         {
-            while (reader.TryRead(out var result))
+            while (reader.TryRead(out var evt))
             {
                 try
                 {
-                    if (_events.TryGetValue(result.Method, out var registration))
-                    {
-                        // Deserialize on background thread instead of network thread (single parse)
-                        var eventArgs = (EventArgs)JsonSerializer.Deserialize(result.JsonUtf8Bytes.Span, result.TypeInfo)!;
-                        eventArgs.BiDi = result.BiDi;
+                    // Deserialize on background thread instead of network thread (single parse)
+                    var eventArgs = (EventArgs)JsonSerializer.Deserialize(evt.JsonUtf8Bytes.Span, evt.Registration.TypeInfo)!;
+                    eventArgs.BiDi = evt.BiDi;
 
-                        foreach (var handler in registration.Handlers.ToArray()) // copy handlers avoiding modified collection while iterating
-                        {
-                            await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
-                        }
+                    foreach (var handler in evt.Registration.GetHandlersSnapshot())
+                    {
+                        await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
@@ -113,6 +116,10 @@ internal sealed class EventDispatcher : IAsyncDisposable
                     {
                         _logger.Error($"Unhandled error processing BiDi event handler: {ex}");
                     }
+                }
+                finally
+                {
+                    evt.Registration.DecrementPending();
                 }
             }
         }
@@ -127,11 +134,64 @@ internal sealed class EventDispatcher : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private readonly record struct PendingEvent(string Method, ReadOnlyMemory<byte> JsonUtf8Bytes, IBiDi BiDi, JsonTypeInfo TypeInfo);
+    private sealed record EventItem(ReadOnlyMemory<byte> JsonUtf8Bytes, IBiDi BiDi, EventRegistration Registration);
 
     private sealed class EventRegistration(JsonTypeInfo typeInfo)
     {
+        private int _pendingCount;
+        private readonly object _drainLock = new();
+        private TaskCompletionSource<bool>? _drainTcs;
+        private readonly List<EventHandler> _handlers = [];
+
         public JsonTypeInfo TypeInfo { get; } = typeInfo;
-        public List<EventHandler> Handlers { get; } = [];
+
+        public void AddHandler(EventHandler handler)
+        {
+            lock (_drainLock) _handlers.Add(handler);
+        }
+
+        public void RemoveHandler(EventHandler handler)
+        {
+            lock (_drainLock) _handlers.Remove(handler);
+        }
+
+        public EventHandler[] GetHandlersSnapshot()
+        {
+            lock (_drainLock) return [.. _handlers];
+        }
+
+        public void IncrementPending() => Interlocked.Increment(ref _pendingCount);
+
+        public void DecrementPending()
+        {
+            if (Interlocked.Decrement(ref _pendingCount) == 0)
+            {
+                lock (_drainLock)
+                {
+                    _drainTcs?.TrySetResult(true);
+                    _drainTcs = null;
+                }
+            }
+        }
+
+        public ValueTask DrainAsync()
+        {
+            lock (_drainLock)
+            {
+                if (Volatile.Read(ref _pendingCount) == 0) return default;
+
+                _drainTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                // Double-check: count could have reached 0 between the check and setting TCS
+                if (Volatile.Read(ref _pendingCount) == 0)
+                {
+                    _drainTcs.TrySetResult(true);
+                    _drainTcs = null;
+                    return default;
+                }
+
+                return new ValueTask(_drainTcs.Task);
+            }
+        }
     }
 }

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -75,9 +75,14 @@ internal sealed class EventDispatcher : IAsyncDisposable
             await _sessionProvider().UnsubscribeAsync([subscription.SubscriptionId], null, cancellationToken).ConfigureAwait(false);
 
             // Wait until all pending events for this method are dispatched
-            await registration.DrainAsync(cancellationToken).ConfigureAwait(false);
-
-            registration.RemoveHandler(subscription.EventHandler);
+            try
+            {
+                await registration.DrainAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                registration.RemoveHandler(subscription.EventHandler);
+            }
         }
     }
 

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -79,7 +79,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
     {
         if (_events.TryGetValue(method, out var registration) && registration.TypeInfo is not null)
         {
-            registration.IncrementPending();
+            registration.IncrementEnqueued();
             _pendingEvents.Writer.TryWrite(new EventItem(jsonUtf8Bytes, bidi, registration));
         }
         else
@@ -101,25 +101,34 @@ internal sealed class EventDispatcher : IAsyncDisposable
             {
                 try
                 {
-                    // Deserialize on background thread instead of network thread (single parse)
                     var eventArgs = (EventArgs)JsonSerializer.Deserialize(evt.JsonUtf8Bytes.Span, evt.Registration.TypeInfo)!;
                     eventArgs.BiDi = evt.BiDi;
 
                     foreach (var handler in evt.Registration.GetHandlersSnapshot())
                     {
-                        await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
+                        try
+                        {
+                            await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (_logger.IsEnabled(LogEventLevel.Error))
+                            {
+                                _logger.Error($"Unhandled error processing BiDi event handler: {ex}");
+                            }
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
                     if (_logger.IsEnabled(LogEventLevel.Error))
                     {
-                        _logger.Error($"Unhandled error processing BiDi event handler: {ex}");
+                        _logger.Error($"Unhandled error deserializing BiDi event: {ex}");
                     }
                 }
                 finally
                 {
-                    evt.Registration.DecrementPending();
+                    evt.Registration.IncrementProcessed();
                 }
             }
         }
@@ -138,10 +147,11 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     private sealed class EventRegistration(JsonTypeInfo typeInfo)
     {
-        private int _pendingCount;
+        private long _enqueueSeq;
+        private long _processedSeq;
         private readonly object _drainLock = new();
-        private TaskCompletionSource<bool>? _drainTcs;
         private readonly List<EventHandler> _handlers = [];
+        private List<(long TargetSeq, TaskCompletionSource<bool> Tcs)>? _drainWaiters;
 
         public JsonTypeInfo TypeInfo { get; } = typeInfo;
 
@@ -160,37 +170,49 @@ internal sealed class EventDispatcher : IAsyncDisposable
             lock (_drainLock) return [.. _handlers];
         }
 
-        public void IncrementPending() => Interlocked.Increment(ref _pendingCount);
+        public void IncrementEnqueued() => Interlocked.Increment(ref _enqueueSeq);
 
-        public void DecrementPending()
+        public void IncrementProcessed()
         {
-            if (Interlocked.Decrement(ref _pendingCount) == 0)
+            var processed = Interlocked.Increment(ref _processedSeq);
+
+            lock (_drainLock)
             {
-                lock (_drainLock)
+                if (_drainWaiters is null) return;
+
+                for (var i = _drainWaiters.Count - 1; i >= 0; i--)
                 {
-                    _drainTcs?.TrySetResult(true);
-                    _drainTcs = null;
+                    if (_drainWaiters[i].TargetSeq <= processed)
+                    {
+                        _drainWaiters[i].Tcs.TrySetResult(true);
+                        _drainWaiters.RemoveAt(i);
+                    }
                 }
+
+                if (_drainWaiters.Count == 0) _drainWaiters = null;
             }
         }
 
-        public ValueTask DrainAsync()
+        public Task DrainAsync()
         {
             lock (_drainLock)
             {
-                if (Volatile.Read(ref _pendingCount) == 0) return default;
+                var target = Volatile.Read(ref _enqueueSeq);
+                if (Volatile.Read(ref _processedSeq) >= target) return Task.CompletedTask;
 
-                _drainTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _drainWaiters ??= [];
+                _drainWaiters.Add((target, tcs));
 
-                // Double-check: count could have reached 0 between the check and setting TCS
-                if (Volatile.Read(ref _pendingCount) == 0)
+                // Double-check: processing may have caught up between the read and adding the waiter
+                if (Volatile.Read(ref _processedSeq) >= target)
                 {
-                    _drainTcs.TrySetResult(true);
-                    _drainTcs = null;
-                    return default;
+                    _drainWaiters.Remove((target, tcs));
+                    if (_drainWaiters.Count == 0) _drainWaiters = null;
+                    return Task.CompletedTask;
                 }
 
-                return new ValueTask(_drainTcs.Task);
+                return tcs.Task;
             }
         }
     }

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -75,7 +75,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
             await _sessionProvider().UnsubscribeAsync([subscription.SubscriptionId], null, cancellationToken).ConfigureAwait(false);
 
             // Wait until all pending events for this method are dispatched
-            await registration.DrainAsync().ConfigureAwait(false);
+            await registration.DrainAsync(cancellationToken).ConfigureAwait(false);
 
             registration.RemoveHandler(subscription.EventHandler);
         }
@@ -199,7 +199,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
             }
         }
 
-        public Task DrainAsync()
+        public Task DrainAsync(CancellationToken cancellationToken)
         {
             lock (_drainLock)
             {
@@ -218,7 +218,13 @@ internal sealed class EventDispatcher : IAsyncDisposable
                     return Task.CompletedTask;
                 }
 
-                return tcs.Task;
+                if (!cancellationToken.CanBeCanceled) return tcs.Task;
+
+                return tcs.Task.ContinueWith(
+                    static _ => { },
+                    cancellationToken,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default);
             }
         }
     }

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -55,11 +55,19 @@ internal sealed class EventDispatcher : IAsyncDisposable
     {
         var registration = _events.GetOrAdd(eventName, _ => new EventRegistration(jsonTypeInfo));
 
-        var subscribeResult = await _sessionProvider().SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }, cancellationToken).ConfigureAwait(false);
-
         registration.AddHandler(eventHandler);
 
-        return new Subscription(subscribeResult.Subscription, this, eventHandler);
+        try
+        {
+            var subscribeResult = await _sessionProvider().SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }, cancellationToken).ConfigureAwait(false);
+
+            return new Subscription(subscribeResult.Subscription, this, eventHandler);
+        }
+        catch
+        {
+            registration.RemoveHandler(eventHandler);
+            throw;
+        }
     }
 
     public async ValueTask UnsubscribeAsync(Subscription subscription, CancellationToken cancellationToken)

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -85,8 +85,17 @@ internal sealed class EventDispatcher : IAsyncDisposable
     {
         if (_events.TryGetValue(method, out var registration))
         {
-            registration.IncrementEnqueued();
-            _pendingEvents.Writer.TryWrite(new EventItem(jsonUtf8Bytes, bidi, registration));
+            if (_pendingEvents.Writer.TryWrite(new EventItem(jsonUtf8Bytes, bidi, registration)))
+            {
+                registration.IncrementEnqueued();
+            }
+            else
+            {
+                if (_logger.IsEnabled(LogEventLevel.Warn))
+                {
+                    _logger.Warn($"Failed to enqueue BiDi event with method '{method}' for processing. Event will be ignored.");
+                }
+            }
         }
         else
         {

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -45,7 +45,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
     public EventDispatcher(Func<ISessionModule> sessionProvider)
     {
         _sessionProvider = sessionProvider;
-        _eventEmitterTask = Task.Run(ProcessEventsAwaiterAsync);
+        _eventEmitterTask = Task.Run(ProcessEventsAsync);
     }
 
     public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
@@ -97,7 +97,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
         }
     }
 
-    private async Task ProcessEventsAwaiterAsync()
+    private async Task ProcessEventsAsync()
     {
         var reader = _pendingEvents.Reader;
 

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -85,7 +85,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     public void EnqueueEvent(string method, ReadOnlyMemory<byte> jsonUtf8Bytes, IBiDi bidi)
     {
-        if (_events.TryGetValue(method, out var registration) && registration.TypeInfo is not null)
+        if (_events.TryGetValue(method, out var registration))
         {
             registration.IncrementEnqueued();
             _pendingEvents.Writer.TryWrite(new EventItem(jsonUtf8Bytes, bidi, registration));


### PR DESCRIPTION

### 🔗 Related Issues
Fix https://github.com/SeleniumHQ/selenium/issues/16574

### 💥 What does this PR do?
Refactors the event dispatching mechanism in the `EventDispatcher` class to improve thread safety, reliability, and event handler management. The changes introduce a new `EventItem` structure, enhance handler registration/removal, and ensure that all pending events are processed before unsubscribing handlers. Error handling and concurrency controls have also been improved.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
