### PR TITLE
[java] Fix javadoc for scrollToElement

### DIFF
--- a/java/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/src/org/openqa/selenium/interactions/Actions.java
@@ -216,11 +216,11 @@ public class Actions {
   }
 
   /**
-   * If the element is outside the viewport, scrolls the bottom of the element to the bottom of the
-   * viewport.
+   * Scrolls to the given element.
    *
-   * @param element Which element to scroll into the viewport.
+   * @param element Which element to scroll to.
    * @return A self reference.
+   * @throws MoveTargetOutOfBoundsException If the element is outside the viewport.
    */
   public Actions scrollToElement(WebElement element) {
     WheelInput.ScrollOrigin scrollOrigin = WheelInput.ScrollOrigin.fromElement(element);

--- a/java/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/src/org/openqa/selenium/interactions/Actions.java
@@ -216,9 +216,9 @@ public class Actions {
   }
 
   /**
-   * Scrolls to the given element.
+   * Scrolls at the location of an element.
    *
-   * @param element Which element to scroll to.
+   * @param element Which element to scroll.
    * @return A self reference.
    * @throws MoveTargetOutOfBoundsException if the element is outside the viewport.
    */

--- a/java/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/src/org/openqa/selenium/interactions/Actions.java
@@ -220,7 +220,7 @@ public class Actions {
    *
    * @param element Which element to scroll to.
    * @return A self reference.
-   * @throws MoveTargetOutOfBoundsException If the element is outside the viewport.
+   * @throws MoveTargetOutOfBoundsException if the element is outside the viewport.
    */
   public Actions scrollToElement(WebElement element) {
     WheelInput.ScrollOrigin scrollOrigin = WheelInput.ScrollOrigin.fromElement(element);


### PR DESCRIPTION
### 🔗 Related Issues

Fixes #17141

### 💥 What does this PR do?

This PR fixes the javadoc for `Actions.scrollToElement()`.

If element is outside of viewport, `MoveTargetOutOfBoundsException` is thrown.

### 🔄 Types of changes
- Bug fix (backwards compatible)
