### PR TITLE
[dotnet] [bidi] Preserve configurable options pattern

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -57,7 +57,7 @@ public sealed class BiDi : IBiDi
         BiDiOptionsBuilder builder = new();
         configure?.Invoke(builder);
 
-        var transport = await WebSocketTransport.ConnectAsync(new Uri(url), builder.WebSocketConfigure, cancellationToken).ConfigureAwait(false);
+        var transport = await builder.TransportFactory(new Uri(url), cancellationToken).ConfigureAwait(false);
 
         BiDi bidi = new();
 

--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -52,10 +52,10 @@ public sealed class BiDi : IBiDi
 
     public Emulation.IEmulationModule Emulation => AsModule<Emulation.EmulationModule>();
 
-    public static async Task<IBiDi> ConnectAsync(string url, Action<BiDiOptions>? configure = null, CancellationToken cancellationToken = default)
+    public static async Task<IBiDi> ConnectAsync(string url, Action<BiDiOptionsBuilder>? configure = null, CancellationToken cancellationToken = default)
     {
-        BiDiOptions options = new();
-        configure?.Invoke(options);
+        BiDiOptionsBuilder builder = new();
+        configure?.Invoke(builder);
 
         var transport = await WebSocketTransport.ConnectAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -52,8 +52,11 @@ public sealed class BiDi : IBiDi
 
     public Emulation.IEmulationModule Emulation => AsModule<Emulation.EmulationModule>();
 
-    public static async Task<IBiDi> ConnectAsync(string url, BiDiOptions? options = null, CancellationToken cancellationToken = default)
+    public static async Task<IBiDi> ConnectAsync(string url, Action<BiDiOptions>? configure = null, CancellationToken cancellationToken = default)
     {
+        BiDiOptions options = new();
+        configure?.Invoke(options);
+
         var transport = await WebSocketTransport.ConnectAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
 
         BiDi bidi = new();

--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -57,7 +57,7 @@ public sealed class BiDi : IBiDi
         BiDiOptionsBuilder builder = new();
         configure?.Invoke(builder);
 
-        var transport = await WebSocketTransport.ConnectAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
+        var transport = await WebSocketTransport.ConnectAsync(new Uri(url), builder.WebSocketConfigure, cancellationToken).ConfigureAwait(false);
 
         BiDi bidi = new();
 

--- a/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
+++ b/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
@@ -17,8 +17,17 @@
 // under the License.
 // </copyright>
 
+using System.Net.WebSockets;
+
 namespace OpenQA.Selenium.BiDi;
 
 public sealed class BiDiOptionsBuilder
 {
+    internal Action<ClientWebSocketOptions>? WebSocketConfigure { get; private set; }
+
+    public BiDiOptionsBuilder UseWebSocket(Action<ClientWebSocketOptions> configure)
+    {
+        WebSocketConfigure = configure;
+        return this;
+    }
 }

--- a/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
+++ b/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
@@ -1,4 +1,4 @@
-// <copyright file="BiDiOptions.cs" company="Selenium Committers">
+// <copyright file="BiDiOptionsBuilder.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -19,6 +19,6 @@
 
 namespace OpenQA.Selenium.BiDi;
 
-public sealed class BiDiOptions
+public sealed class BiDiOptionsBuilder
 {
 }

--- a/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
+++ b/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
@@ -21,13 +21,28 @@ using System.Net.WebSockets;
 
 namespace OpenQA.Selenium.BiDi;
 
+/// <summary>
+/// Provides a fluent API for configuring BiDi connection options,
+/// such as the underlying transport mechanism.
+/// </summary>
 public sealed class BiDiOptionsBuilder
 {
-    internal Action<ClientWebSocketOptions>? WebSocketConfigure { get; private set; }
+    internal Func<Uri, CancellationToken, Task<ITransport>> TransportFactory { get; private set; }
+        = (uri, ct) => WebSocketTransport.ConnectAsync(uri, null, ct);
 
-    public BiDiOptionsBuilder UseWebSocket(Action<ClientWebSocketOptions> configure)
+    /// <summary>
+    /// Configures the BiDi connection to use a WebSocket transport.
+    /// </summary>
+    /// <remarks>
+    /// WebSocket is the default transport; calling this method is only necessary
+    /// when you need to customize the underlying <see cref="ClientWebSocketOptions"/>
+    /// (e.g., to set headers, proxy, or certificates).
+    /// </remarks>
+    /// <param name="configure">An optional action to configure the <see cref="ClientWebSocketOptions"/> before connecting.</param>
+    /// <returns>The current <see cref="BiDiOptionsBuilder"/> instance for chaining.</returns>
+    public BiDiOptionsBuilder UseWebSocket(Action<ClientWebSocketOptions>? configure = null)
     {
-        WebSocketConfigure = configure;
+        TransportFactory = (uri, ct) => WebSocketTransport.ConnectAsync(uri, configure, ct);
         return this;
     }
 }

--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -21,7 +21,7 @@ namespace OpenQA.Selenium.BiDi;
 
 public static class WebDriverExtensions
 {
-    public static async Task<IBiDi> AsBiDiAsync(this IWebDriver webDriver, Action<BiDiOptions>? configure = null, CancellationToken cancellationToken = default)
+    public static async Task<IBiDi> AsBiDiAsync(this IWebDriver webDriver, Action<BiDiOptionsBuilder>? configure = null, CancellationToken cancellationToken = default)
     {
         if (webDriver is null) throw new ArgumentNullException(nameof(webDriver));
 

--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -21,7 +21,7 @@ namespace OpenQA.Selenium.BiDi;
 
 public static class WebDriverExtensions
 {
-    public static async Task<IBiDi> AsBiDiAsync(this IWebDriver webDriver, BiDiOptions? options = null, CancellationToken cancellationToken = default)
+    public static async Task<IBiDi> AsBiDiAsync(this IWebDriver webDriver, Action<BiDiOptions>? configure = null, CancellationToken cancellationToken = default)
     {
         if (webDriver is null) throw new ArgumentNullException(nameof(webDriver));
 
@@ -34,7 +34,7 @@ public static class WebDriverExtensions
 
         if (webSocketUrl is null) throw new BiDiException("The driver is not compatible with bidirectional protocol or \"webSocketUrl\" not enabled in driver options.");
 
-        var bidi = await BiDi.ConnectAsync(webSocketUrl, options, cancellationToken).ConfigureAwait(false);
+        var bidi = await BiDi.ConnectAsync(webSocketUrl, configure, cancellationToken).ConfigureAwait(false);
 
         return bidi;
     }

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -32,9 +32,11 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
     private readonly SemaphoreSlim _socketSendSemaphoreSlim = new(1, 1);
     private readonly MemoryStream _sharedMemoryStream = new();
 
-    public static async Task<WebSocketTransport> ConnectAsync(Uri uri, CancellationToken cancellationToken)
+    public static async Task<WebSocketTransport> ConnectAsync(Uri uri, Action<ClientWebSocketOptions>? configure, CancellationToken cancellationToken)
     {
         ClientWebSocket webSocket = new();
+
+        configure?.Invoke(webSocket.Options);
 
         try
         {

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -32,7 +32,7 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
     private readonly SemaphoreSlim _socketSendSemaphoreSlim = new(1, 1);
     private readonly MemoryStream _sharedMemoryStream = new();
 
-    public static async Task<WebSocketTransport> ConnectAsync(Uri uri, Action<ClientWebSocketOptions>? configure, CancellationToken cancellationToken)
+    public static async Task<ITransport> ConnectAsync(Uri uri, Action<ClientWebSocketOptions>? configure, CancellationToken cancellationToken)
     {
         ClientWebSocket webSocket = new();
 

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -36,10 +36,10 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
     {
         ClientWebSocket webSocket = new();
 
-        configure?.Invoke(webSocket.Options);
-
         try
         {
+            configure?.Invoke(webSocket.Options);
+
             await webSocket.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception)


### PR DESCRIPTION
```
await BiDi.ConnectAsync(url, options => options.UseSomething());
```

### 💥 What does this PR do?
Updates the way `BiDiOptions` are configured when establishing a BiDi connection in the .NET WebDriver codebase. Instead of passing a `BiDiOptions` object directly, the API now accepts a configuration delegate, making it easier and more flexible to customize options inline.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
