### PR TITLE
[java] Fluent setters in few classes like `PrintOptions` etc.

### DIFF
--- a/java/src/org/openqa/selenium/chromium/AddHasNetworkConditions.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasNetworkConditions.java
@@ -17,7 +17,12 @@
 
 package org.openqa.selenium.chromium;
 
+import static java.util.Objects.requireNonNull;
 import static org.openqa.selenium.chromium.ChromiumDriver.IS_CHROMIUM_BROWSER;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.DOWNLOAD_THROUGHPUT;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.LATENCY;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.OFFLINE;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.UPLOAD_THROUGHPUT;
 
 import com.google.auto.service.AutoService;
 import java.time.Duration;
@@ -73,19 +78,14 @@ public class AddHasNetworkConditions
       public ChromiumNetworkConditions getNetworkConditions() {
         @SuppressWarnings("unchecked")
         Map<String, Object> result =
-            (Map<String, Object>) executeMethod.execute(GET_NETWORK_CONDITIONS, null);
-        ChromiumNetworkConditions networkConditions = new ChromiumNetworkConditions();
-        networkConditions.setOffline(
-            (Boolean) result.getOrDefault(ChromiumNetworkConditions.OFFLINE, false));
-        networkConditions.setLatency(
-            Duration.ofMillis((Long) result.getOrDefault(ChromiumNetworkConditions.LATENCY, 0)));
-        networkConditions.setDownloadThroughput(
-            ((Number) result.getOrDefault(ChromiumNetworkConditions.DOWNLOAD_THROUGHPUT, -1))
-                .intValue());
-        networkConditions.setUploadThroughput(
-            ((Number) result.getOrDefault(ChromiumNetworkConditions.UPLOAD_THROUGHPUT, -1))
-                .intValue());
-        return networkConditions;
+            (Map<String, Object>)
+                requireNonNull(executeMethod.execute(GET_NETWORK_CONDITIONS, null));
+        return new ChromiumNetworkConditions()
+            .setOffline((Boolean) result.getOrDefault(OFFLINE, false))
+            .setLatency(Duration.ofMillis((Long) result.getOrDefault(LATENCY, 0)))
+            .setDownloadThroughput(
+                ((Number) result.getOrDefault(DOWNLOAD_THROUGHPUT, -1)).intValue())
+            .setUploadThroughput(((Number) result.getOrDefault(UPLOAD_THROUGHPUT, -1)).intValue());
       }
 
       @Override
@@ -94,13 +94,13 @@ public class AddHasNetworkConditions
 
         Map<String, Object> conditions =
             Map.of(
-                ChromiumNetworkConditions.OFFLINE,
+                OFFLINE,
                 networkConditions.getOffline(),
-                ChromiumNetworkConditions.LATENCY,
+                LATENCY,
                 networkConditions.getLatency().toMillis(),
-                ChromiumNetworkConditions.DOWNLOAD_THROUGHPUT,
+                DOWNLOAD_THROUGHPUT,
                 networkConditions.getDownloadThroughput(),
-                ChromiumNetworkConditions.UPLOAD_THROUGHPUT,
+                UPLOAD_THROUGHPUT,
                 networkConditions.getUploadThroughput());
         executeMethod.execute(SET_NETWORK_CONDITIONS, Map.of("network_conditions", conditions));
       }

--- a/java/src/org/openqa/selenium/chromium/ChromiumNetworkConditions.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumNetworkConditions.java
@@ -31,6 +31,10 @@ public class ChromiumNetworkConditions {
   private int downloadThroughput = -1;
   private int uploadThroughput = -1;
 
+  public static ChromiumNetworkConditions withLatency(Duration latency) {
+    return new ChromiumNetworkConditions().setLatency(latency);
+  }
+
   /**
    * @return whether network is simulated to be offline.
    */
@@ -43,8 +47,9 @@ public class ChromiumNetworkConditions {
    *
    * @param offline when set to true, network is simulated to be offline.
    */
-  public void setOffline(boolean offline) {
+  public ChromiumNetworkConditions setOffline(boolean offline) {
     this.offline = offline;
+    return this;
   }
 
   /**
@@ -61,8 +66,9 @@ public class ChromiumNetworkConditions {
    *
    * @param latency amount of latency, typically a Duration of milliseconds.
    */
-  public void setLatency(Duration latency) {
+  public ChromiumNetworkConditions setLatency(Duration latency) {
     this.latency = latency;
+    return this;
   }
 
   /**
@@ -79,8 +85,9 @@ public class ChromiumNetworkConditions {
    *
    * @param downloadThroughput throughput in kb/second
    */
-  public void setDownloadThroughput(int downloadThroughput) {
+  public ChromiumNetworkConditions setDownloadThroughput(int downloadThroughput) {
     this.downloadThroughput = downloadThroughput;
+    return this;
   }
 
   /**
@@ -97,7 +104,8 @@ public class ChromiumNetworkConditions {
    *
    * @param uploadThroughput throughput in kb/second
    */
-  public void setUploadThroughput(int uploadThroughput) {
+  public ChromiumNetworkConditions setUploadThroughput(int uploadThroughput) {
     this.uploadThroughput = uploadThroughput;
+    return this;
   }
 }

--- a/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxOptions.java
@@ -67,6 +67,11 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     addPreference("remote.active-protocols", 1);
   }
 
+  public FirefoxOptions(FirefoxProfile profile) {
+    this();
+    setProfile(profile);
+  }
+
   public FirefoxOptions(Capabilities source) {
     // We need to initialize all our own fields before calling.
     this();
@@ -176,7 +181,7 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     }
   }
 
-  public FirefoxOptions setProfile(FirefoxProfile profile) {
+  public final FirefoxOptions setProfile(FirefoxProfile profile) {
     Require.nonNull("Profile", profile);
 
     try {
@@ -220,6 +225,14 @@ public class FirefoxOptions extends AbstractDriverOptions<FirefoxOptions> {
     newPrefs.put(key, value);
 
     return setFirefoxOption(Keys.PREFS, Collections.unmodifiableMap(newPrefs));
+  }
+
+  Map<String, Object> prefs() {
+    return getOption(Keys.PREFS);
+  }
+
+  String profile() {
+    return getOption(Keys.PROFILE);
   }
 
   public FirefoxOptions setLogLevel(FirefoxDriverLogLevel logLevel) {

--- a/java/src/org/openqa/selenium/firefox/FirefoxProfile.java
+++ b/java/src/org/openqa/selenium/firefox/FirefoxProfile.java
@@ -177,8 +177,9 @@ public class FirefoxProfile {
     return name;
   }
 
-  public void setPreference(String key, Object value) {
+  public FirefoxProfile setPreference(String key, Object value) {
     additionalPrefs.setPreference(key, value);
+    return this;
   }
 
   protected Preferences getAdditionalPreferences() {
@@ -256,8 +257,9 @@ public class FirefoxProfile {
    *
    * @param loadNoFocusLib Whether to always load the no focus library.
    */
-  public void setAlwaysLoadNoFocusLib(boolean loadNoFocusLib) {
+  public FirefoxProfile setAlwaysLoadNoFocusLib(boolean loadNoFocusLib) {
     this.loadNoFocusLib = loadNoFocusLib;
+    return this;
   }
 
   /**
@@ -266,8 +268,9 @@ public class FirefoxProfile {
    *
    * @param acceptUntrustedSsl Whether untrusted SSL certificates should be accepted.
    */
-  public void setAcceptUntrustedCertificates(boolean acceptUntrustedSsl) {
+  public FirefoxProfile setAcceptUntrustedCertificates(boolean acceptUntrustedSsl) {
     this.acceptUntrustedCerts = acceptUntrustedSsl;
+    return this;
   }
 
   /**
@@ -284,8 +287,9 @@ public class FirefoxProfile {
    *
    * @param untrustedIssuer whether to assume untrusted issuer or not.
    */
-  public void setAssumeUntrustedCertificateIssuer(boolean untrustedIssuer) {
+  public FirefoxProfile setAssumeUntrustedCertificateIssuer(boolean untrustedIssuer) {
     this.untrustedCertIssuer = untrustedIssuer;
+    return this;
   }
 
   public void clean(File profileDir) {

--- a/java/src/org/openqa/selenium/firefox/Preferences.java
+++ b/java/src/org/openqa/selenium/firefox/Preferences.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.firefox;
 
+import static java.util.Collections.unmodifiableMap;
 import static org.openqa.selenium.json.Json.MAP_TYPE;
 
 import java.io.BufferedReader;
@@ -32,18 +33,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.Json;
 
 class Preferences {
-
-  /**
-   * The maximum amount of time scripts should be permitted to run. The user may increase this
-   * timeout, but may not set it below the default value.
-   */
-  private static final String MAX_SCRIPT_RUN_TIME_KEY = "dom.max_script_run_time";
-
-  private static final int DEFAULT_MAX_SCRIPT_RUN_TIME = 30;
 
   /**
    * This pattern is used to parse preferences in user.js. It is intended to match all preference
@@ -56,7 +48,6 @@ class Preferences {
   private static final Pattern PREFERENCE_PATTERN =
       Pattern.compile("user_pref\\(\"([^\"]+)\", (\"?.+?\"?)\\);");
 
-  private final Map<String, Object> immutablePrefs = new HashMap<>();
   private final Map<String, Object> allPrefs = new HashMap<>();
 
   public Preferences() {}
@@ -87,6 +78,10 @@ class Preferences {
     }
   }
 
+  Map<String, Object> asMap() {
+    return unmodifiableMap(allPrefs);
+  }
+
   private void readUserPrefs(File userPrefs) {
     try (Reader reader = Files.newBufferedReader(userPrefs.toPath(), Charset.defaultCharset())) {
       readPreferences(reader);
@@ -111,7 +106,6 @@ class Preferences {
               value = ((Long) value).intValue();
             }
             setPreference(key, value);
-            immutablePrefs.put(key, value);
           });
 
       Map<String, Object> mutable = (Map<String, Object>) map.get("mutable");
@@ -122,7 +116,7 @@ class Preferences {
     }
   }
 
-  public void setPreference(String key, Object value) {
+  public Preferences setPreference(String key, Object value) {
     if (value instanceof String) {
       if (isStringified((String) value)) {
         throw new IllegalArgumentException(
@@ -134,6 +128,7 @@ class Preferences {
     } else {
       allPrefs.put(key, value);
     }
+    return this;
   }
 
   private void readPreferences(Reader reader) throws IOException {
@@ -196,35 +191,5 @@ class Preferences {
     // Assume we a string is stringified (i.e. wrapped in " ") when
     // the first character == " and the last character == "
     return value.startsWith("\"") && value.endsWith("\"");
-  }
-
-  private void checkPreference(String key, Object value) {
-    Require.nonNull("Key", key);
-    Require.nonNull("Value", value);
-    Require.stateCondition(
-        !immutablePrefs.containsKey(key)
-            || (immutablePrefs.containsKey(key) && value.equals(immutablePrefs.get(key))),
-        "Preference %s may not be overridden: frozen value=%s, requested value=%s",
-        key,
-        immutablePrefs.get(key),
-        value);
-    if (MAX_SCRIPT_RUN_TIME_KEY.equals(key)) {
-      int n;
-      if (value instanceof String) {
-        n = Integer.parseInt((String) value);
-      } else if (value instanceof Integer) {
-        n = (Integer) value;
-      } else {
-        throw new IllegalStateException(
-            String.format(
-                "%s value must be a number: %s",
-                MAX_SCRIPT_RUN_TIME_KEY, value.getClass().getName()));
-      }
-      Require.stateCondition(
-          n == 0 || n >= DEFAULT_MAX_SCRIPT_RUN_TIME,
-          "%s must be == 0 || >= %s",
-          MAX_SCRIPT_RUN_TIME_KEY,
-          DEFAULT_MAX_SCRIPT_RUN_TIME);
-    }
   }
 }

--- a/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
+++ b/java/src/org/openqa/selenium/grid/log/LoggingOptions.java
@@ -83,7 +83,7 @@ public class LoggingOptions {
     return config.get(LOGGING_SECTION, "log-encoding").orElse(null);
   }
 
-  public void setLoggingLevel() {
+  public LoggingOptions setLoggingLevel() {
     String configLevel = config.get(LOGGING_SECTION, "log-level").orElse(DEFAULT_LOG_LEVEL);
     if (Debug.isDebugAll()) {
       System.err.println(
@@ -105,6 +105,7 @@ public class LoggingOptions {
                   + DEFAULT_LOG_LEVELS)
           .printStackTrace();
     }
+    return this;
   }
 
   public Tracer getTracer() {

--- a/java/src/org/openqa/selenium/manager/SeleniumManagerOutput.java
+++ b/java/src/org/openqa/selenium/manager/SeleniumManagerOutput.java
@@ -32,16 +32,18 @@ public class SeleniumManagerOutput {
     return logs;
   }
 
-  public void setLogs(List<Log> logs) {
+  public SeleniumManagerOutput setLogs(List<Log> logs) {
     this.logs = logs;
+    return this;
   }
 
   public Result getResult() {
     return result;
   }
 
-  public void setResult(Result result) {
+  public SeleniumManagerOutput setResult(Result result) {
     this.result = result;
+    return this;
   }
 
   public static class Log {

--- a/java/src/org/openqa/selenium/print/PrintOptions.java
+++ b/java/src/org/openqa/selenium/print/PrintOptions.java
@@ -55,15 +55,16 @@ public class PrintOptions {
     return this.orientation;
   }
 
-  public void setOrientation(Orientation orientation) {
+  public PrintOptions setOrientation(Orientation orientation) {
     this.orientation = Require.nonNull("orientation", orientation);
+    return this;
   }
 
   public String @Nullable [] getPageRanges() {
     return this.pageRanges;
   }
 
-  public void setPageRanges(String firstRange, String... ranges) {
+  public PrintOptions setPageRanges(String firstRange, String... ranges) {
     Require.nonNull("pageRanges", firstRange);
     this.pageRanges =
         new String[ranges.length + 1]; // Need to add all ranges and the initial range too.
@@ -71,26 +72,30 @@ public class PrintOptions {
     this.pageRanges[0] = firstRange;
 
     if (ranges.length > 0) System.arraycopy(ranges, 0, this.pageRanges, 1, ranges.length);
+    return this;
   }
 
-  public void setPageRanges(List<String> ranges) {
+  public PrintOptions setPageRanges(List<String> ranges) {
     this.pageRanges = new String[ranges.size()];
     this.pageRanges = ranges.toArray(this.pageRanges);
+    return this;
   }
 
-  public void setBackground(boolean background) {
+  public PrintOptions setBackground(boolean background) {
     this.background = Require.nonNull("background", background);
+    return this;
   }
 
   public boolean getBackground() {
     return this.background;
   }
 
-  public void setScale(double scale) {
+  public PrintOptions setScale(double scale) {
     if (scale < 0.1 || scale > 2) {
       throw new IllegalArgumentException("Scale value should be between 0.1 and 2");
     }
     this.scale = scale;
+    return this;
   }
 
   public double getScale() {
@@ -101,16 +106,19 @@ public class PrintOptions {
     return this.shrinkToFit;
   }
 
-  public void setShrinkToFit(boolean value) {
+  public PrintOptions setShrinkToFit(boolean value) {
     this.shrinkToFit = Require.nonNull("value", value);
+    return this;
   }
 
-  public void setPageSize(PageSize pageSize) {
+  public PrintOptions setPageSize(PageSize pageSize) {
     this.pageSize = Require.nonNull("pageSize", pageSize);
+    return this;
   }
 
-  public void setPageMargin(PageMargin margin) {
+  public PrintOptions setPageMargin(PageMargin margin) {
     this.pageMargin = Require.nonNull("margin", margin);
+    return this;
   }
 
   public PageSize getPageSize() {

--- a/java/src/org/openqa/selenium/remote/DesiredCapabilities.java
+++ b/java/src/org/openqa/selenium/remote/DesiredCapabilities.java
@@ -55,16 +55,19 @@ public class DesiredCapabilities extends MutableCapabilities {
     }
   }
 
-  public void setBrowserName(String browserName) {
+  public DesiredCapabilities setBrowserName(String browserName) {
     setCapability(BROWSER_NAME, browserName);
+    return this;
   }
 
-  public void setVersion(String version) {
+  public DesiredCapabilities setVersion(String version) {
     setCapability(BROWSER_VERSION, version);
+    return this;
   }
 
-  public void setPlatform(Platform platform) {
+  public DesiredCapabilities setPlatform(Platform platform) {
     setCapability(PLATFORM_NAME, platform);
+    return this;
   }
 
   public boolean acceptInsecureCerts() {
@@ -79,8 +82,9 @@ public class DesiredCapabilities extends MutableCapabilities {
     return true;
   }
 
-  public void setAcceptInsecureCerts(boolean acceptInsecureCerts) {
+  public DesiredCapabilities setAcceptInsecureCerts(boolean acceptInsecureCerts) {
     setCapability(ACCEPT_INSECURE_CERTS, acceptInsecureCerts);
+    return this;
   }
 
   /**

--- a/java/src/org/openqa/selenium/remote/ErrorHandler.java
+++ b/java/src/org/openqa/selenium/remote/ErrorHandler.java
@@ -74,8 +74,9 @@ public class ErrorHandler {
     return includeServerErrors;
   }
 
-  public void setIncludeServerErrors(boolean includeServerErrors) {
+  public ErrorHandler setIncludeServerErrors(boolean includeServerErrors) {
     this.includeServerErrors = includeServerErrors;
+    return this;
   }
 
   @SuppressWarnings("unchecked")

--- a/java/test/org/openqa/selenium/PrintPageTest.java
+++ b/java/test/org/openqa/selenium/PrintPageTest.java
@@ -53,8 +53,7 @@ class PrintPageTest extends JupiterTestBase {
   @Test
   @Ignore(value = CHROME)
   public void canPrintTwoPages() {
-    PrintOptions printOptions = new PrintOptions();
-    printOptions.setPageRanges("1-2");
+    PrintOptions printOptions = new PrintOptions().setPageRanges("1-2");
 
     Pdf pdf = printer.print(printOptions);
     assertThat(pdf.getContent()).contains(MAGIC_STRING);
@@ -64,12 +63,11 @@ class PrintPageTest extends JupiterTestBase {
   @Test
   @Ignore(value = CHROME)
   public void canPrintWithValidParams() {
-    PrintOptions printOptions = new PrintOptions();
-    PageSize pageSize = new PageSize();
-
-    printOptions.setPageRanges("1-2");
-    printOptions.setOrientation(PrintOptions.Orientation.LANDSCAPE);
-    printOptions.setPageSize(pageSize);
+    PrintOptions printOptions =
+        new PrintOptions()
+            .setPageRanges("1-2")
+            .setOrientation(PrintOptions.Orientation.LANDSCAPE)
+            .setPageSize(new PageSize());
 
     Pdf pdf = printer.print(printOptions);
     assertThat(pdf.getContent()).contains(MAGIC_STRING);

--- a/java/test/org/openqa/selenium/WebScriptExecuteTest.java
+++ b/java/test/org/openqa/selenium/WebScriptExecuteTest.java
@@ -280,9 +280,6 @@ class WebScriptExecuteTest extends JupiterTestBase {
 
   @Test
   void canExecuteScriptWithObjectArgument() {
-
-    PrintOptions options = new PrintOptions();
-
     RemoteValue value =
         ((RemoteWebDriver) driver)
             .script()
@@ -293,7 +290,7 @@ class WebScriptExecuteTest extends JupiterTestBase {
                     + "                    Object.prototype.toString.call(arg));\n"
                     + "            return arg;\n"
                     + "        }}",
-                options);
+                new PrintOptions());
 
     assertThat(value.getType()).isEqualTo("object");
 

--- a/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
+++ b/java/test/org/openqa/selenium/bidi/browsingcontext/BrowsingContextTest.java
@@ -523,11 +523,9 @@ class BrowsingContextTest extends JupiterTestBase {
   @NeedsFreshDriver
   void canPrintPage() {
     BrowsingContext browsingContext = new BrowsingContext(driver, driver.getWindowHandle());
-
     driver.get(appServer.whereIs("formPage.html"));
-    PrintOptions printOptions = new PrintOptions();
 
-    String printPage = browsingContext.print(printOptions);
+    String printPage = browsingContext.print(new PrintOptions());
 
     assertThat(printPage).isNotEmpty();
     // Comparing expected PDF is a hard problem.

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
@@ -17,9 +17,11 @@
 
 package org.openqa.selenium.chrome;
 
+import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.withLatency;
 import static org.openqa.selenium.testing.drivers.Browser.CHROME;
 
 import java.time.Duration;
@@ -33,7 +35,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.chromium.HasCasting;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.chromium.HasNetworkConditions;
@@ -64,10 +65,9 @@ class ChromeDriverFunctionalTest extends JupiterTestBase {
   @NoDriverBeforeTest
   public void builderOverridesDefaultChromeOptions() {
     ChromeOptions options = (ChromeOptions) CHROME.getCapabilities();
-    options.setImplicitWaitTimeout(Duration.ofMillis(1));
+    options.setImplicitWaitTimeout(ofMillis(1));
     localDriver = ChromeDriver.builder().oneOf(options).build();
-    assertThat(localDriver.manage().timeouts().getImplicitWaitTimeout())
-        .isEqualTo(Duration.ofMillis(1));
+    assertThat(localDriver.manage().timeouts().getImplicitWaitTimeout()).isEqualTo(ofMillis(1));
   }
 
   @Test
@@ -171,11 +171,9 @@ class ChromeDriverFunctionalTest extends JupiterTestBase {
   void canManageNetworkConditions() {
     HasNetworkConditions conditions = (HasNetworkConditions) driver;
 
-    ChromiumNetworkConditions networkConditions = new ChromiumNetworkConditions();
-    networkConditions.setLatency(Duration.ofMillis(200));
+    conditions.setNetworkConditions(withLatency(ofMillis(200)));
 
-    conditions.setNetworkConditions(networkConditions);
-    assertThat(conditions.getNetworkConditions().getLatency()).isEqualTo(Duration.ofMillis(200));
+    assertThat(conditions.getNetworkConditions().getLatency()).isEqualTo(ofMillis(200));
 
     conditions.deleteNetworkConditions();
 

--- a/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/edge/EdgeDriverFunctionalTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.openqa.selenium.chromium.ChromiumNetworkConditions.withLatency;
 import static org.openqa.selenium.testing.drivers.Browser.EDGE;
 
 import java.time.Duration;
@@ -33,7 +34,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.chromium.HasCasting;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.chromium.HasNetworkConditions;
@@ -167,10 +167,8 @@ class EdgeDriverFunctionalTest extends JupiterTestBase {
   void canManageNetworkConditions() {
     HasNetworkConditions conditions = (HasNetworkConditions) driver;
 
-    ChromiumNetworkConditions networkConditions = new ChromiumNetworkConditions();
-    networkConditions.setLatency(Duration.ofMillis(200));
+    conditions.setNetworkConditions(withLatency(Duration.ofMillis(200)));
 
-    conditions.setNetworkConditions(networkConditions);
     assertThat(conditions.getNetworkConditions().getLatency()).isEqualTo(Duration.ofMillis(200));
 
     conditions.deleteNetworkConditions();

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverPreferenceTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverPreferenceTest.java
@@ -39,9 +39,10 @@ class FirefoxDriverPreferenceTest extends JupiterTestBase {
   @Test
   @NoDriverBeforeTest
   public void canStartDriverWithSpecifiedProfile() {
-    FirefoxProfile profile = new FirefoxProfile();
-    profile.setPreference("browser.startup.page", 1);
-    profile.setPreference("browser.startup.homepage", pages.xhtmlTestPage);
+    FirefoxProfile profile =
+        new FirefoxProfile()
+            .setPreference("browser.startup.page", 1)
+            .setPreference("browser.startup.homepage", pages.xhtmlTestPage);
 
     localDriver = new WebDriverBuilder().get(getDefaultOptions().setProfile(profile));
 

--- a/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxDriverTest.java
@@ -141,7 +141,7 @@ class FirefoxDriverTest extends JupiterTestBase {
     FirefoxProfile profile = new ProfilesIni().getProfile("default");
     assumeTrue(profile != null);
 
-    localDriver = new WebDriverBuilder().get(new FirefoxOptions().setProfile(profile));
+    localDriver = new WebDriverBuilder().get(new FirefoxOptions(profile));
   }
 
   @Test

--- a/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
+++ b/java/test/org/openqa/selenium/firefox/FirefoxOptionsTest.java
@@ -56,6 +56,26 @@ import org.openqa.selenium.testing.TestUtilities;
 class FirefoxOptionsTest {
 
   @Test
+  void defaultConstructor() {
+    FirefoxOptions options = new FirefoxOptions();
+
+    assertThat(options.getBrowserName()).isEqualTo("firefox");
+    assertThat(options.getCapability(ACCEPT_INSECURE_CERTS)).isEqualTo(true);
+    assertThat(options.prefs()).containsExactly(Map.entry("remote.active-protocols", 1));
+    assertThat(options.profile()).isNull();
+  }
+
+  @Test
+  void constructorWithProfile() {
+    FirefoxOptions options = new FirefoxOptions(new FirefoxProfile().setPreference("foo", "bar"));
+
+    assertThat(options.getBrowserName()).isEqualTo("firefox");
+    assertThat(options.getCapability(ACCEPT_INSECURE_CERTS)).isEqualTo(true);
+    assertThat(options.prefs()).containsExactly(Map.entry("remote.active-protocols", 1));
+    assertThat(options.profile()).isBase64();
+  }
+
+  @Test
   void canInitFirefoxOptionsWithCapabilities() {
     FirefoxOptions options =
         new FirefoxOptions(
@@ -138,8 +158,7 @@ class FirefoxOptionsTest {
     String key = "browser.startup.homepage";
     String value = "about:robots";
 
-    FirefoxProfile profile = new FirefoxProfile();
-    profile.setPreference(key, value);
+    FirefoxProfile profile = new FirefoxProfile().setPreference(key, value);
 
     FirefoxOptions options = new FirefoxOptions();
     options.setProfile(profile);
@@ -311,11 +330,7 @@ class FirefoxOptionsTest {
     String key = "browser.startup.homepage";
     String value = "about:robots";
 
-    FirefoxProfile profile = new FirefoxProfile();
-    profile.setPreference(key, value);
-
-    options.setProfile(profile);
-
+    options.setProfile(new FirefoxProfile().setPreference(key, value));
     options.setLogLevel(DEBUG);
 
     File binary = TestUtilities.createTmpFile("binary");
@@ -383,8 +398,7 @@ class FirefoxOptionsTest {
     String key = "browser.startup.homepage";
     String value = "about:robots";
 
-    FirefoxProfile profile = new FirefoxProfile();
-    profile.setPreference(key, value);
+    FirefoxProfile profile = new FirefoxProfile().setPreference(key, value);
 
     File binary = TestUtilities.createTmpFile("binary");
 

--- a/java/test/org/openqa/selenium/firefox/PreferencesTest.java
+++ b/java/test/org/openqa/selenium/firefox/PreferencesTest.java
@@ -17,10 +17,12 @@
 
 package org.openqa.selenium.firefox;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -120,7 +122,21 @@ class PreferencesTest {
 
     preferences.setPreference("frozen.pref", true);
 
-    assertThat(preferences.getPreference("frozen.pref")).isEqualTo(true);
+    assertThat(preferences.asMap()).containsExactly(Map.entry("frozen.pref", true));
+  }
+
+  @Test
+  void canUseFluentSetter() {
+    Preferences preferences =
+        new Preferences()
+            .setPreference("one", true)
+            .setPreference("two", 2)
+            .setPreference("three", "3.0")
+            .setPreference("four", asList(1, 2, 3));
+
+    assertThat(preferences.asMap())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of("one", true, "two", 2, "three", "3.0", "four", asList(1, 2, 3)));
   }
 
   private boolean canSet(Preferences pref, String value) {

--- a/java/test/org/openqa/selenium/print/PageSizeTest.java
+++ b/java/test/org/openqa/selenium/print/PageSizeTest.java
@@ -19,19 +19,11 @@ package org.openqa.selenium.print;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("UnitTests")
 class PageSizeTest {
-
-  private PrintOptions printOptions;
-
-  @BeforeEach
-  void setUp() {
-    printOptions = new PrintOptions();
-  }
 
   @Test
   void setsDefaultHeightWidth() {
@@ -42,30 +34,25 @@ class PageSizeTest {
 
   @Test
   void verifiesPageSizeA4() {
-
-    printOptions.setPageSize(PageSize.ISO_A4);
-    assertThat(printOptions.getPageSize().getHeight()).isEqualTo(29.7);
-    assertThat(printOptions.getPageSize().getWidth()).isEqualTo(21.0);
+    assertThat(PageSize.ISO_A4.getHeight()).isEqualTo(29.7);
+    assertThat(PageSize.ISO_A4.getWidth()).isEqualTo(21.0);
   }
 
   @Test
   void verifiesPageSizeLegal() {
-    printOptions.setPageSize(PageSize.US_LEGAL);
-    assertThat(printOptions.getPageSize().getHeight()).isEqualTo(35.56);
-    assertThat(printOptions.getPageSize().getWidth()).isEqualTo(21.59);
+    assertThat(PageSize.US_LEGAL.getHeight()).isEqualTo(35.56);
+    assertThat(PageSize.US_LEGAL.getWidth()).isEqualTo(21.59);
   }
 
   @Test
   void verifiesPageSizeLetter() {
-    printOptions.setPageSize(PageSize.US_LETTER);
-    assertThat(printOptions.getPageSize().getHeight()).isEqualTo(27.94);
-    assertThat(printOptions.getPageSize().getWidth()).isEqualTo(21.59);
+    assertThat(PageSize.US_LETTER.getHeight()).isEqualTo(27.94);
+    assertThat(PageSize.US_LETTER.getWidth()).isEqualTo(21.59);
   }
 
   @Test
   void verifiesPageSizeTabloid() {
-    printOptions.setPageSize(PageSize.ANSI_TABLOID);
-    assertThat(printOptions.getPageSize().getHeight()).isEqualTo(43.18);
-    assertThat(printOptions.getPageSize().getWidth()).isEqualTo(27.94);
+    assertThat(PageSize.ANSI_TABLOID.getHeight()).isEqualTo(43.18);
+    assertThat(PageSize.ANSI_TABLOID.getWidth()).isEqualTo(27.94);
   }
 }

--- a/java/test/org/openqa/selenium/print/PrintOptionsTest.java
+++ b/java/test/org/openqa/selenium/print/PrintOptionsTest.java
@@ -39,11 +39,8 @@ class PrintOptionsTest {
 
   @Test
   void setsValuesAsPassed() {
-    PrintOptions printOptions = new PrintOptions();
-
-    printOptions.setBackground(true);
-    printOptions.setScale(1.5);
-    printOptions.setShrinkToFit(false);
+    PrintOptions printOptions =
+        new PrintOptions().setBackground(true).setScale(1.5).setShrinkToFit(false);
 
     assertThat(printOptions.getScale()).isEqualTo(1.5);
     assertThat(printOptions.getBackground()).isTrue();
@@ -66,14 +63,12 @@ class PrintOptionsTest {
 
     Map<String, Object> map = printOptions.toMap();
     assertThat(map).hasSize(7);
-    assertThat(map).containsKey("page");
-    assertThat(map).containsKey("orientation");
-    assertThat(map).containsKey("scale");
-    assertThat(map).containsKey("shrinkToFit");
-    assertThat(map).containsKey("background");
-    assertThat(map).containsKey("pageRanges");
-    assertThat(map).containsKey("margin");
-    assertThat(map.get("margin")).asInstanceOf(MAP).hasSize(4);
-    assertThat(map.get("page")).asInstanceOf(MAP).hasSize(2);
+    assertThat(map)
+        .containsOnlyKeys(
+            "page", "orientation", "scale", "shrinkToFit", "background", "pageRanges", "margin");
+    assertThat(map.get("margin"))
+        .asInstanceOf(MAP)
+        .containsOnlyKeys("top", "left", "bottom", "right");
+    assertThat(map.get("page")).asInstanceOf(MAP).containsOnlyKeys("width", "height");
   }
 }

--- a/java/test/org/openqa/selenium/remote/DesiredCapabilitiesTest.java
+++ b/java/test/org/openqa/selenium/remote/DesiredCapabilitiesTest.java
@@ -18,6 +18,12 @@
 package org.openqa.selenium.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.Platform.ANDROID;
+import static org.openqa.selenium.Platform.WINDOWS;
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
+import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,9 +38,52 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 class DesiredCapabilitiesTest {
 
   @Test
+  void defaultConstructor() {
+    DesiredCapabilities capabilities = new DesiredCapabilities();
+    assertThat(capabilities.asMap()).isEmpty();
+  }
+
+  @Test
+  void constructorWithMap() {
+    DesiredCapabilities capabilities = new DesiredCapabilities(Map.of("foo", 8));
+    assertThat(capabilities.asMap()).containsExactly(Map.entry("foo", 8));
+  }
+
+  @Test
+  void constructorWithBrowserVersion() {
+    DesiredCapabilities capabilities = new DesiredCapabilities("firefox", "2.0", WINDOWS);
+    assertThat(capabilities.asMap())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                BROWSER_VERSION, "2.0",
+                BROWSER_NAME, "firefox",
+                PLATFORM_NAME, WINDOWS));
+  }
+
+  @Test
+  void fluentSetters() {
+    DesiredCapabilities capabilities =
+        new DesiredCapabilities()
+            .setBrowserName("edge")
+            .setVersion("3.0")
+            .setPlatform(ANDROID)
+            .setAcceptInsecureCerts(true);
+    assertThat(capabilities.asMap())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                BROWSER_VERSION,
+                "3.0",
+                BROWSER_NAME,
+                "edge",
+                PLATFORM_NAME,
+                ANDROID,
+                ACCEPT_INSECURE_CERTS,
+                true));
+  }
+
+  @Test
   void testAddingTheSameCapabilityToAMapTwiceShouldResultInOneEntry() {
-    Map<org.openqa.selenium.Capabilities, Class<? extends WebDriver>> capabilitiesToDriver =
-        new ConcurrentHashMap<>();
+    Map<Capabilities, Class<? extends WebDriver>> capabilitiesToDriver = new ConcurrentHashMap<>();
 
     capabilitiesToDriver.put(new FirefoxOptions(), WebDriver.class);
     capabilitiesToDriver.put(new FirefoxOptions(), RemoteWebDriver.class);

--- a/java/test/org/openqa/selenium/remote/ErrorHandlerTest.java
+++ b/java/test/org/openqa/selenium/remote/ErrorHandlerTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.InvalidCookieDomainException;
@@ -49,7 +48,7 @@ import org.openqa.selenium.json.Json;
 @Tag("UnitTests")
 @SuppressWarnings("removal")
 class ErrorHandlerTest {
-  private ErrorHandler handler;
+  private final ErrorHandler handler = new ErrorHandler().setIncludeServerErrors(true);
 
   private static void assertStackTracesEqual(
       StackTraceElement[] expected, StackTraceElement[] actual) {
@@ -66,12 +65,6 @@ class ErrorHandlerTest {
   private static Map<String, Object> toMap(Object o) {
     String rawJson = new Json().toJson(o);
     return new Json().toType(rawJson, Map.class);
-  }
-
-  @BeforeEach
-  public void setUp() {
-    handler = new ErrorHandler();
-    handler.setIncludeServerErrors(true);
   }
 
   @Test


### PR DESCRIPTION
### 🔗 Related Issues
none

### 💥 What does this PR do?
Makes some setters return `this`.  In other words, make these setter method "fluent" or "chainable".

This style allows calling multiple setters in a row, thus making code shorter/readable.

Also, added few unit-tests for uncovered constructors of `FirefoxOptions` etc.

### 🔧 Implementation Notes
I changed only a few less-critical classes (like `PrintOptions`), 
and didn't yet touch too widely used classes like `MutableCapabilities` which still has `void` setters.


### 🔄 Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)

This PR changes signatures of some setter methods. Formally, it's a breaking change - though, nothing should break in users' code.