### PR TITLE
[java] remove `@Nullable` from return value for `ExpectedConditions` that never return null

### DIFF
--- a/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
+++ b/java/src/org/openqa/selenium/support/ui/ExpectedConditions.java
@@ -247,8 +247,8 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> visibilityOfAllElementsLocatedBy(
       final By locator) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
-      private int indexOfInvisibleElement;
+    return new ExpectedCondition<>() {
+      private int indexOfInvisibleElement = -1;
       private @Nullable WebElement invisibleElement;
 
       @Override
@@ -304,8 +304,8 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> visibilityOfAllElements(
       final List<WebElement> elements) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
-      private int indexOfInvisibleElement;
+    return new ExpectedCondition<>() {
+      private int indexOfInvisibleElement = -1;
       private @Nullable WebElement invisibleElement;
 
       @Override
@@ -345,7 +345,7 @@ public class ExpectedConditions {
    * @return the (same) WebElement once it is visible
    */
   public static ExpectedCondition<@Nullable WebElement> visibilityOf(final WebElement element) {
-    return new ExpectedCondition<@Nullable WebElement>() {
+    return new ExpectedCondition<>() {
       @Override
       public @Nullable WebElement apply(WebDriver driver) {
         return elementIfVisible(element);
@@ -373,7 +373,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> presenceOfAllElementsLocatedBy(
       final By locator) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       @Override
       public @Nullable List<WebElement> apply(WebDriver driver) {
         List<WebElement> elements = driver.findElements(locator);
@@ -596,7 +596,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable WebDriver> frameToBeAvailableAndSwitchToIt(
       final By locator) {
-    return new ExpectedCondition<@Nullable WebDriver>() {
+    return new ExpectedCondition<>() {
       private @Nullable NotFoundException error;
 
       @Override
@@ -660,7 +660,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable WebDriver> frameToBeAvailableAndSwitchToIt(
       final WebElement frame) {
-    return new ExpectedCondition<@Nullable WebDriver>() {
+    return new ExpectedCondition<>() {
       private @Nullable NoSuchFrameException error;
 
       @Override
@@ -850,7 +850,7 @@ public class ExpectedConditions {
    * @return the result of the provided condition
    */
   public static <T> ExpectedCondition<@Nullable T> refreshed(final ExpectedCondition<T> condition) {
-    return new ExpectedCondition<@Nullable T>() {
+    return new ExpectedCondition<>() {
       @Override
       public @Nullable T apply(WebDriver driver) {
         try {
@@ -934,7 +934,7 @@ public class ExpectedConditions {
   }
 
   public static ExpectedCondition<@Nullable Alert> alertIsPresent() {
-    return new ExpectedCondition<@Nullable Alert>() {
+    return new ExpectedCondition<>() {
       @Override
       public @Nullable Alert apply(WebDriver driver) {
         try {
@@ -953,7 +953,7 @@ public class ExpectedConditions {
 
   public static ExpectedCondition<Boolean> numberOfWindowsToBe(final int expectedNumberOfWindows) {
     return new ExpectedCondition<>() {
-      private int actualNumberOfWindows;
+      private int actualNumberOfWindows = -1;
       private @Nullable WebDriverException error;
 
       @Override
@@ -1136,7 +1136,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> numberOfElementsToBeMoreThan(
       final By locator, final Integer expectedNumber) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       private Integer actualNumber = 0;
 
       @Override
@@ -1165,7 +1165,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> numberOfElementsToBeLessThan(
       final By locator, final Integer number) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       private Integer currentNumber = 0;
 
       @Override
@@ -1193,7 +1193,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> numberOfElementsToBe(
       final By locator, final Integer expectedNumberOfElements) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       private Integer actualNumberOfElements = -1;
 
       @Override
@@ -1414,7 +1414,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> visibilityOfNestedElementsLocatedBy(
       final By parent, final By childLocator) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       private int indexOfInvisibleElement = -1;
       private @Nullable WebElement invisibleChild;
 
@@ -1465,7 +1465,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> visibilityOfNestedElementsLocatedBy(
       final WebElement element, final By childLocator) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
       private int indexOfInvisibleElement = -1;
       private @Nullable WebElement invisibleChild;
 
@@ -1575,7 +1575,7 @@ public class ExpectedConditions {
    */
   public static ExpectedCondition<@Nullable List<WebElement>> presenceOfNestedElementsLocatedBy(
       final By parent, final By childLocator) {
-    return new ExpectedCondition<@Nullable List<WebElement>>() {
+    return new ExpectedCondition<>() {
 
       @Override
       public @Nullable List<WebElement> apply(WebDriver driver) {
@@ -1610,7 +1610,7 @@ public class ExpectedConditions {
   public static ExpectedCondition<Boolean> invisibilityOfAllElements(
       final List<WebElement> elements) {
     return new ExpectedCondition<>() {
-      private int indexOfVisibleElement;
+      private int indexOfVisibleElement = -1;
       private @Nullable WebElement visibleElement;
 
       @Override
@@ -1808,7 +1808,7 @@ public class ExpectedConditions {
    * @return object once JavaScript executes without errors
    */
   public static ExpectedCondition<@Nullable Object> jsReturnsValue(final String javaScript) {
-    return new ExpectedCondition<@Nullable Object>() {
+    return new ExpectedCondition<>() {
       private @Nullable WebDriverException error;
 
       @Override

--- a/java/src/org/openqa/selenium/support/ui/FluentWait.java
+++ b/java/src/org/openqa/selenium/support/ui/FluentWait.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
@@ -200,7 +201,7 @@ public class FluentWait<T> implements Wait<T> {
    * @throws TimeoutException If the timeout expires.
    */
   @Override
-  public <V> V until(Function<? super T, @Nullable V> isTrue) {
+  public <V extends @Nullable Object> @NonNull V until(Function<? super T, ? extends V> isTrue) {
     Instant end = clock.instant().plus(timeout);
 
     Throwable lastException;

--- a/java/src/org/openqa/selenium/support/ui/Wait.java
+++ b/java/src/org/openqa/selenium/support/ui/Wait.java
@@ -18,6 +18,8 @@
 package org.openqa.selenium.support.ui;
 
 import java.util.function.Function;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A generic interface for waiting until a condition is true or not null. The condition may take a
@@ -36,9 +38,9 @@ public interface Wait<F> {
    * implementor may throw whatever is idiomatic for a given test infrastructure (e.g. JUnit4 would
    * throw {@link AssertionError}).
    *
-   * @param <T> the return type of the method, which must not be Void
+   * @param <V> the return type of the method, which must not be Void
    * @param isTrue the parameter to pass to the {@link ExpectedCondition}
    * @return truthy value from the isTrue condition
    */
-  <T> T until(Function<? super F, T> isTrue);
+  <V extends @Nullable Object> @NonNull V until(Function<? super F, ? extends V> isTrue);
 }


### PR DESCRIPTION
### 🔗 Related Issues
Fixes #17122

### 💥 What does this PR do?
1. Removes `@Nullable` annotation from several return value for `ExpectedConditions` that never return null
2. Marks <V> type of Function both nullable and non-nullable (using a crazy trick `<V extends @Nullable Object>`).

### 🔧 Implementation Notes
1. Some implementations of `ExpectedConditions` can return null. 
3. But expression `wait.until(ExpectedConditions.visibilityOf(...))` never returns null. It either returns Object or true, or throws `TimeoutException`.

### 💡 Additional Considerations
Probably we should create a test suite in Kotlin, so that nullability problems arise earlier. 

### 🔄 Types of changes
- Bug fix
- Breaking change (fix or feature that would cause existing functionality to change)


### Backward incompatible change #1

Signature of public method `Wait.until` and `FluentWait.until` was changed.

Before:
```java
  @Override
  public <V> V until(Function<? super T, @Nullable V> isTrue) { ... }
```

After:
```java
  @Override
  public <V extends @Nullable Object> @NonNull V until(Function<? super T, ? extends V> isTrue) { ... }
```

### Backward incompatible change #2

Built-in conditions `ExpectedConditions.*` now return non-nullable value. 