### PR TITLE
[java] Guard against NPE in Platform.extractFromSysProperty

### DIFF
--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -428,9 +428,10 @@ public enum Platform {
    * @return the most likely platform based on given operating system name and version
    */
   public static Platform extractFromSysProperty(String osName, String osVersion) {
-    osName = osName == null ? "" : osName;
+    osName = requireNonNullOrElse(osName, "");
+    osVersion = requireNonNullOrElse(osVersion, "");
     osName = osName.toLowerCase(Locale.ENGLISH);
-    osVersion = osVersion == null ? "" : osVersion;
+
     // os.name for android is linux
     if ("dalvik".equalsIgnoreCase(System.getProperty("java.vm.name"))) {
       return Platform.ANDROID;

--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -415,7 +415,7 @@ public enum Platform {
    * @return the most likely platform based on given operating system name
    */
   public static Platform extractFromSysProperty(String osName) {
-    return extractFromSysProperty(osName, System.getProperty("os.version"));
+    return extractFromSysProperty(osName, System.getProperty("os.version", ""));
   }
 
   /**
@@ -428,7 +428,9 @@ public enum Platform {
    * @return the most likely platform based on given operating system name and version
    */
   public static Platform extractFromSysProperty(String osName, String osVersion) {
+    osName = osName == null ? "" : osName;
     osName = osName.toLowerCase(Locale.ENGLISH);
+    osVersion = osVersion == null ? "" : osVersion;
     // os.name for android is linux
     if ("dalvik".equalsIgnoreCase(System.getProperty("java.vm.name"))) {
       return Platform.ANDROID;

--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium;
 
+import static java.util.Objects.requireNonNullElse;
+
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -428,8 +430,8 @@ public enum Platform {
    * @return the most likely platform based on given operating system name and version
    */
   public static Platform extractFromSysProperty(String osName, String osVersion) {
-    osName = requireNonNullOrElse(osName, "");
-    osVersion = requireNonNullOrElse(osVersion, "");
+    osName = requireNonNullElse(osName, "");
+    osVersion = requireNonNullElse(osVersion, "");
     osName = osName.toLowerCase(Locale.ENGLISH);
 
     // os.name for android is linux


### PR DESCRIPTION
### 💥 What does this PR do?

Prevents a possible `NullPointerException` in  
`Platform.extractFromSysProperty(String osName, String osVersion)`.

Previously:

- `osName` and `osVersion` were assumed to be non-null
- Calls such as `osVersion.equals("6.2")` could throw `NullPointerException`
- The public 2-argument method could receive `null` directly from callers

This PR makes the method defensive against null inputs.

---

### 🔧 Implementation Notes

The following changes were made:

1. Normalize `osName` and `osVersion` using `Objects.requireNonNullElse`:

   ```java
   osName = requireNonNullElse(osName, "");
   osVersion = requireNonNullElse(osVersion, "");
   osName = osName.toLowerCase(Locale.ENGLISH);
   ```

2. Provide a safe default when reading the system property:

   ```java
   System.getProperty("os.version", "")
   ```

These changes ensure:

- No NPE when null is passed to the public 2-argument method
- No NPE during version comparisons
- Existing platform detection logic remains unchanged

---

### 💡 Additional Considerations

- Backwards compatible change
- No modification to detection heuristics
- Default behavior continues to fall back to `UNIX` when no match is found
- Improves defensive robustness for external callers

---

### 🔄 Types of changes

- Bug fix (backwards compatible)