### PR TITLE
[java] Enhance ScriptKey.toString() and mask script content in UnpinnedScriptKey

### DIFF
--- a/java/src/org/openqa/selenium/ScriptKey.java
+++ b/java/src/org/openqa/selenium/ScriptKey.java
@@ -34,6 +34,11 @@ public class ScriptKey {
   }
 
   @Override
+  public String toString() {
+    return identifier;
+  }
+
+  @Override
   public boolean equals(@Nullable Object o) {
     if (!(o instanceof ScriptKey)) {
       return false;

--- a/java/src/org/openqa/selenium/UnpinnedScriptKey.java
+++ b/java/src/org/openqa/selenium/UnpinnedScriptKey.java
@@ -118,6 +118,6 @@ public class UnpinnedScriptKey extends ScriptKey {
     // Avoid dumping raw JavaScript into logs: in UnpinnedScriptKey the identifier is the script.
     return String.format(
         "UnpinnedScriptKey{handle=%s, scriptId=%s, length=%d}",
-        scriptHandle, scriptId, script.length());
+        scriptHandle, Objects.toString(scriptId, "unset"), script.length());
   }
 }

--- a/java/src/org/openqa/selenium/UnpinnedScriptKey.java
+++ b/java/src/org/openqa/selenium/UnpinnedScriptKey.java
@@ -112,4 +112,12 @@ public class UnpinnedScriptKey extends ScriptKey {
   public int hashCode() {
     return Objects.hash(super.hashCode(), script);
   }
+
+  @Override
+  public String toString() {
+    // Avoid dumping raw JavaScript into logs: in UnpinnedScriptKey the identifier is the script.
+    return String.format(
+        "UnpinnedScriptKey{handle=%s, scriptId=%s, length=%d}",
+        scriptHandle, scriptId, script.length());
+  }
 }

--- a/java/src/org/openqa/selenium/UnpinnedScriptKey.java
+++ b/java/src/org/openqa/selenium/UnpinnedScriptKey.java
@@ -116,8 +116,13 @@ public class UnpinnedScriptKey extends ScriptKey {
   @Override
   public String toString() {
     // Avoid dumping raw JavaScript into logs: in UnpinnedScriptKey the identifier is the script.
-    return String.format(
-        "UnpinnedScriptKey{handle=%s, scriptId=%s, length=%d}",
-        scriptHandle, Objects.toString(scriptId, "unset"), script.length());
+    return "UnpinnedScriptKey{"
+        + "scriptHash="
+        + script.hashCode()
+        + ", scriptId="
+        + Objects.toString(scriptId, "unset")
+        + ", length="
+        + script.length()
+        + "}";
   }
 }

--- a/java/test/org/openqa/selenium/ScriptKeyTest.java
+++ b/java/test/org/openqa/selenium/ScriptKeyTest.java
@@ -1,0 +1,33 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.openqa.selenium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ScriptKeyTest {
+  @Test
+  void hasToStringEqualToIdentifier() {
+    assertThat(new ScriptKey("xxx")).hasToString("xxx");
+  }
+
+  @Test
+  void hasToStringWorksForEmptyIdentifier() {
+    assertThat(new ScriptKey("")).hasToString("");
+  }
+}

--- a/java/test/org/openqa/selenium/UnpinnedScriptKeyTest.java
+++ b/java/test/org/openqa/selenium/UnpinnedScriptKeyTest.java
@@ -32,14 +32,14 @@ class UnpinnedScriptKeyTest {
   }
 
   @Test
-  void toStringContainsHandleAndScriptIdWhenPresent() {
+  void toStringContainsScriptIdWhenPresent() {
     UnpinnedScriptKey key = new UnpinnedScriptKey("return 1;");
     key.setScriptId("script-99");
 
     String value = key.toString();
 
     assertThat(value).contains("UnpinnedScriptKey{");
-    assertThat(value).contains("handle=");
     assertThat(value).contains("scriptId=script-99");
+    assertThat(value).contains("length=");
   }
 }

--- a/java/test/org/openqa/selenium/UnpinnedScriptKeyTest.java
+++ b/java/test/org/openqa/selenium/UnpinnedScriptKeyTest.java
@@ -1,0 +1,45 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UnpinnedScriptKeyTest {
+
+  @Test
+  void toStringDoesNotExposeRawScript() {
+    String script = "return 'SECRET_TOKEN';";
+    UnpinnedScriptKey key = new UnpinnedScriptKey(script);
+
+    assertThat(key.toString()).doesNotContain(script);
+  }
+
+  @Test
+  void toStringContainsHandleAndScriptIdWhenPresent() {
+    UnpinnedScriptKey key = new UnpinnedScriptKey("return 1;");
+    key.setScriptId("script-99");
+
+    String value = key.toString();
+
+    assertThat(value).contains("UnpinnedScriptKey{");
+    assertThat(value).contains("handle=");
+    assertThat(value).contains("scriptId=script-99");
+  }
+}


### PR DESCRIPTION
### 💥 What does this PR do?
Overrides `toString()` in `org.openqa.selenium.ScriptKey` to return the underlying identifier instead of relying on the default `Object.toString()` implementation.

Previously, logging or printing a `ScriptKey` instance produced output such as:

```
org.openqa.selenium.ScriptKey@6d06d69c
```

This output is not helpful for debugging. Since `ScriptKey` represents an identifier wrapper, its string representation should reflect that identifier directly.

After this change, printing a `ScriptKey` will produce:

```
my-script-id
```

Additionally, `UnpinnedScriptKey` now overrides `toString()` to prevent exposing the full JavaScript source in logs. Since `UnpinnedScriptKey` internally stores the raw script as its identifier, returning it directly could result in large log output or unintended disclosure. The override ensures a safe, concise debug representation without leaking script content.

This improves debugging clarity while avoiding potential log bloat or sensitive script exposure.

---

### 🔧 Implementation Notes
- Implemented `toString()` in `ScriptKey` to return the `identifier` field.
- Overrode `toString()` in `UnpinnedScriptKey` to avoid logging raw script content.
- No changes were made to `equals()` or `hashCode()`.
- JSON serialization via `toJson()` and `fromJson()` remains unaffected.
- No functional behavior changes were introduced.

---

### 💡 Additional Considerations
- This is a non-breaking change.
- Prevents potential script leakage in logs for `UnpinnedScriptKey`.
- Improves overall debugging readability without altering API behavior.

---

### 🔄 Types of changes
- New feature (non-breaking change which adds functionality)