### PR TITLE
[dotnet] [bidi] Add disposed guard

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -27,6 +27,7 @@ namespace OpenQA.Selenium.BiDi;
 public sealed class BiDi : IBiDi
 {
     private readonly ConcurrentDictionary<Type, Module> _modules = new();
+    private bool _disposed;
 
     private Broker Broker { get; set; } = null!;
 
@@ -83,6 +84,13 @@ public sealed class BiDi : IBiDi
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
         await Broker.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
```
await bidi.DisposeAsync();
await bidi.DisposeAsync(); // works
```

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/17153

### 💥 What does this PR do?
This pull request introduces a minor improvement to the disposal logic in the `BiDi` class to prevent multiple disposals. The main change is the addition of an `_disposed` flag to ensure that the `DisposeAsync` method only runs its logic once.

### 🔧 Implementation Notes
Not yet thread-safe, unnecessary?

### 🔄 Types of changes
- Bug fix (backwards compatible)
