### PR TITLE
[java] Keys: enforce CharSequence contract in charAt()

### DIFF
--- a/java/src/org/openqa/selenium/Keys.java
+++ b/java/src/org/openqa/selenium/Keys.java
@@ -140,10 +140,10 @@ public enum Keys implements CharSequence {
 
   @Override
   public char charAt(int index) {
-    if (index == 0) {
-      return keyCode;
+    if (index != 0) {
+      throw new IndexOutOfBoundsException("Index: " + index + ", Length: 1");
     }
-    return 0;
+    return keyCode;
   }
 
   @Override

--- a/java/test/org/openqa/selenium/KeysTest.java
+++ b/java/test/org/openqa/selenium/KeysTest.java
@@ -35,8 +35,10 @@ class KeysTest {
   }
 
   @Test
-  void charAtOtherPositionReturnsZero() {
-    assertThat(Keys.LEFT.charAt(10)).isEqualTo((char) 0);
+  void charAtOtherPositionThrows() {
+
+    assertThatExceptionOfType(IndexOutOfBoundsException.class)
+        .isThrownBy(() -> Keys.LEFT.charAt(10));
   }
 
   @Test


### PR DESCRIPTION
### 💥 What does this PR do?

Updates `Keys.charAt(int index)` to validate the index and throw 
`IndexOutOfBoundsException` when the index is not `0`.

Previously, the method returned the null character (`'\u0000'`) for any
index other than `0`, which silently violated the `CharSequence` contract.

This change ensures:

- `length()` returns `1`
- `charAt(0)` returns the key code
- `charAt(index != 0)` throws `IndexOutOfBoundsException`

This aligns the implementation with expected `CharSequence` behavior.

---

### 🔧 Implementation Notes

`Keys` represents a single Unicode PUA character. Since its length is
always `1`, only index `0` is valid.

Instead of returning `'\u0000'` for invalid indexes (which can mask bugs
and produce incorrect comparisons), the method now explicitly throws
`IndexOutOfBoundsException`.

Alternative considered:
- Keeping the previous behavior (returning `'\u0000'`) — rejected because
  it silently hides incorrect usage and breaks contract expectations.

---

### 💡 Additional Considerations

- No behavioral change for valid usage (`charAt(0)`).
- Improves correctness when used in string comparisons or iteration.
- No impact on `toString()`, `subSequence()`, or `chord()` behavior.

---

### 🔄 Types of changes

- Bug fix (backwards compatible)