### PR TITLE
[py] Use Self as return type of __enter__ in remote.WebDriver

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -32,6 +32,8 @@ from contextlib import asynccontextmanager, contextmanager
 from importlib import import_module
 from typing import Any, cast
 
+from typing_extensions import Self
+
 from selenium.common.exceptions import (
     InvalidArgumentException,
     JavascriptException,
@@ -287,7 +289,7 @@ class WebDriver(BaseWebDriver):
     def __repr__(self) -> str:
         return f'<{type(self).__module__}.{type(self).__name__} (session="{self.session_id}")>'
 
-    def __enter__(self) -> "WebDriver":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(


### PR DESCRIPTION
### 🔗 Related Issues

Fixes #17169

### 💥 What does this PR do?

change the return type of `s.w.remote.webdriver.WebDriver.__enter__` from `s.w.remote.webdriver.WebDriver` to `Self`.
as a result, `drv.get_log` in the following code can be resolved as expected.

```
with selenium.webdriver.chrome.webdriver.WebDriver() as drv:
    reveal_type(drv.get_log)
```

### 🔧 Implementation Notes

since selenium currently supports Python 3.10, i used `typing_extensions.Self` instead of `typing.Self`.

### 💡 Additional Considerations

### 🔄 Types of changes

- Bug fix (backwards compatible)
