### PR TITLE
[dotnet] [bidi] Cache BrowsingContext/UserContext per session

### DIFF
--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
@@ -42,7 +42,7 @@ internal class BrowserUserContextConverter(IBiDi bidi) : JsonConverter<UserConte
             sessionCache.Clear();
         }
 
-        return sessionCache.GetOrAdd(id!, key => new UserContext(key) { BiDi = bidi });
+        return sessionCache.GetOrAdd(id!, key => new UserContext(bidi, key));
     }
 
     public override void Write(Utf8JsonWriter writer, UserContext value, JsonSerializerOptions options)

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
@@ -17,6 +17,8 @@
 // under the License.
 // </copyright>
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Browser;
@@ -25,11 +27,15 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowserUserContextConverter(IBiDi bidi) : JsonConverter<UserContext>
 {
+    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, UserContext>> s_cache = [];
+
     public override UserContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var id = reader.GetString();
 
-        return new UserContext(id!) { BiDi = bidi };
+        var sessionCache = s_cache.GetValue(bidi, _ => new ConcurrentDictionary<string, UserContext>());
+
+        return sessionCache.GetOrAdd(id!, key => new UserContext(key) { BiDi = bidi });
     }
 
     public override void Write(Utf8JsonWriter writer, UserContext value, JsonSerializerOptions options)

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
@@ -27,8 +27,6 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowserUserContextConverter(IBiDi bidi) : JsonConverter<UserContext>
 {
-    private const int MaxCacheSize = 1_000;
-
     private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, UserContext>> s_cache = new();
 
     public override UserContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -36,11 +34,6 @@ internal class BrowserUserContextConverter(IBiDi bidi) : JsonConverter<UserConte
         var id = reader.GetString();
 
         var sessionCache = s_cache.GetValue(bidi, _ => new ConcurrentDictionary<string, UserContext>());
-
-        if (sessionCache.Count >= MaxCacheSize)
-        {
-            sessionCache.Clear();
-        }
 
         return sessionCache.GetOrAdd(id!, key => new UserContext(bidi, key));
     }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowserUserContextConverter.cs
@@ -27,13 +27,20 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowserUserContextConverter(IBiDi bidi) : JsonConverter<UserContext>
 {
-    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, UserContext>> s_cache = [];
+    private const int MaxCacheSize = 1_000;
+
+    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, UserContext>> s_cache = new();
 
     public override UserContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var id = reader.GetString();
 
         var sessionCache = s_cache.GetValue(bidi, _ => new ConcurrentDictionary<string, UserContext>());
+
+        if (sessionCache.Count >= MaxCacheSize)
+        {
+            sessionCache.Clear();
+        }
 
         return sessionCache.GetOrAdd(id!, key => new UserContext(key) { BiDi = bidi });
     }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
@@ -26,7 +26,9 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingContext.BrowsingContext>
 {
-    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, BrowsingContext.BrowsingContext>> s_cache = [];
+    private const int MaxCacheSize = 1_000;
+
+    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, BrowsingContext.BrowsingContext>> s_cache = new();
 
     private readonly IBiDi _bidi = bidi;
 
@@ -35,6 +37,11 @@ internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingCont
         var id = reader.GetString();
 
         var sessionCache = s_cache.GetValue(_bidi, _ => new ConcurrentDictionary<string, BrowsingContext.BrowsingContext>());
+
+        if (sessionCache.Count >= MaxCacheSize)
+        {
+            sessionCache.Clear();
+        }
 
         return sessionCache.GetOrAdd(id!, key => new BrowsingContext.BrowsingContext(_bidi, key));
     }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
@@ -26,8 +26,6 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingContext.BrowsingContext>
 {
-    private const int MaxCacheSize = 1_000;
-
     private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, BrowsingContext.BrowsingContext>> s_cache = new();
 
     public override BrowsingContext.BrowsingContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -35,11 +33,6 @@ internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingCont
         var id = reader.GetString();
 
         var sessionCache = s_cache.GetValue(bidi, _ => new ConcurrentDictionary<string, BrowsingContext.BrowsingContext>());
-
-        if (sessionCache.Count >= MaxCacheSize)
-        {
-            sessionCache.Clear();
-        }
 
         return sessionCache.GetOrAdd(id!, key => new BrowsingContext.BrowsingContext(bidi, key));
     }

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
@@ -30,20 +30,18 @@ internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingCont
 
     private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, BrowsingContext.BrowsingContext>> s_cache = new();
 
-    private readonly IBiDi _bidi = bidi;
-
     public override BrowsingContext.BrowsingContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var id = reader.GetString();
 
-        var sessionCache = s_cache.GetValue(_bidi, _ => new ConcurrentDictionary<string, BrowsingContext.BrowsingContext>());
+        var sessionCache = s_cache.GetValue(bidi, _ => new ConcurrentDictionary<string, BrowsingContext.BrowsingContext>());
 
         if (sessionCache.Count >= MaxCacheSize)
         {
             sessionCache.Clear();
         }
 
-        return sessionCache.GetOrAdd(id!, key => new BrowsingContext.BrowsingContext(_bidi, key));
+        return sessionCache.GetOrAdd(id!, key => new BrowsingContext.BrowsingContext(bidi, key));
     }
 
     public override void Write(Utf8JsonWriter writer, BrowsingContext.BrowsingContext value, JsonSerializerOptions options)

--- a/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/BrowsingContextConverter.cs
@@ -17,6 +17,8 @@
 // under the License.
 // </copyright>
 
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -24,13 +26,17 @@ namespace OpenQA.Selenium.BiDi.Json.Converters;
 
 internal class BrowsingContextConverter(IBiDi bidi) : JsonConverter<BrowsingContext.BrowsingContext>
 {
+    private static readonly ConditionalWeakTable<IBiDi, ConcurrentDictionary<string, BrowsingContext.BrowsingContext>> s_cache = [];
+
     private readonly IBiDi _bidi = bidi;
 
     public override BrowsingContext.BrowsingContext? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var id = reader.GetString();
 
-        return new BrowsingContext.BrowsingContext(id!) { BiDi = _bidi };
+        var sessionCache = s_cache.GetValue(_bidi, _ => new ConcurrentDictionary<string, BrowsingContext.BrowsingContext>());
+
+        return sessionCache.GetOrAdd(id!, key => new BrowsingContext.BrowsingContext(_bidi, key));
     }
 
     public override void Write(Utf8JsonWriter writer, BrowsingContext.BrowsingContext value, JsonSerializerOptions options)


### PR DESCRIPTION
This pull request iIimproving performance and ensuring object reuse for the same context IDs within a BiDi session. The main changes are the addition of a static cache using `ConditionalWeakTable` and `ConcurrentDictionary` in both converters.

These changes help prevent duplicate context objects and may improve memory usage and performance when deserializing contexts repeatedly in the same session.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
