### PR TITLE
[bidi] Convert RemoteValue to IDictionary

### DIFF
--- a/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
@@ -167,6 +167,11 @@ public abstract record RemoteValue
 
             foreach (var pair in remoteValues)
             {
+                if (pair.Count != 2)
+                {
+                    throw new FormatException($"Expected a pair of RemoteValues for dictionary entry, but got {pair.Count} values.");
+                }
+
                 var convertedKey = convertKeyMethod.Invoke(pair[0], null)!;
                 var convertedValue = convertValueMethod.Invoke(pair[1], null);
                 dict.Add(convertedKey, convertedValue);

--- a/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemoteValue.cs
@@ -98,6 +98,10 @@ public abstract record RemoteValue
                 => ConvertRemoteValuesToArray<TResult>(a.Value, t.GetElementType()!),
             (ArrayRemoteValue a, Type t) when t.IsGenericType && t.IsAssignableFrom(typeof(List<>).MakeGenericType(t.GetGenericArguments()[0]))
                 => ConvertRemoteValuesToGenericList<TResult>(a.Value, typeof(List<>).MakeGenericType(t.GetGenericArguments()[0])),
+            (MapRemoteValue m, Type t) when t.IsGenericType && t.GetGenericArguments().Length == 2 && t.IsAssignableFrom(typeof(Dictionary<,>).MakeGenericType(t.GetGenericArguments()))
+                => ConvertRemoteValuesToDictionary<TResult>(m.Value, typeof(Dictionary<,>).MakeGenericType(t.GetGenericArguments())),
+            (ObjectRemoteValue o, Type t) when t.IsGenericType && t.GetGenericArguments().Length == 2 && t.IsAssignableFrom(typeof(Dictionary<,>).MakeGenericType(t.GetGenericArguments()))
+                => ConvertRemoteValuesToDictionary<TResult>(o.Value, typeof(Dictionary<,>).MakeGenericType(t.GetGenericArguments())),
 
             (_, Type t) when Nullable.GetUnderlyingType(t) is { } underlying
                 => ConvertToNullable<TResult>(underlying),
@@ -149,6 +153,27 @@ public abstract record RemoteValue
         }
 
         return (TResult)list;
+    }
+
+    private static TResult ConvertRemoteValuesToDictionary<TResult>(IReadOnlyList<IReadOnlyList<RemoteValue>>? remoteValues, Type dictionaryType)
+    {
+        var typeArgs = dictionaryType.GetGenericArguments();
+        var dict = (System.Collections.IDictionary)Activator.CreateInstance(dictionaryType)!;
+
+        if (remoteValues is not null)
+        {
+            var convertKeyMethod = typeof(RemoteValue).GetMethod(nameof(ConvertTo))!.MakeGenericMethod(typeArgs[0]);
+            var convertValueMethod = typeof(RemoteValue).GetMethod(nameof(ConvertTo))!.MakeGenericMethod(typeArgs[1]);
+
+            foreach (var pair in remoteValues)
+            {
+                var convertedKey = convertKeyMethod.Invoke(pair[0], null)!;
+                var convertedValue = convertValueMethod.Invoke(pair[1], null);
+                dict.Add(convertedKey, convertedValue);
+            }
+        }
+
+        return (TResult)dict;
     }
 }
 

--- a/dotnet/test/common/BiDi/Script/RemoteValueConversionTests.cs
+++ b/dotnet/test/common/BiDi/Script/RemoteValueConversionTests.cs
@@ -286,4 +286,76 @@ internal class RemoteValueConversionTests
             Assert.That(value, Is.Empty);
         }
     }
+
+    [Test]
+    public void CanConvertMapRemoteValueToDictionary()
+    {
+        MapRemoteValue arg = new()
+        {
+            Value =
+            [
+                [new StringRemoteValue("key1"), new NumberRemoteValue(1)],
+                [new StringRemoteValue("key2"), new NumberRemoteValue(2)],
+            ]
+        };
+
+        AssertValue(arg.ConvertTo<Dictionary<string, int>>());
+        AssertValue(arg.ConvertTo<IDictionary<string, int>>());
+
+        static void AssertValue(IDictionary<string, int> value)
+        {
+            Assert.That(value, Has.Count.EqualTo(2));
+            Assert.That(value["key1"], Is.EqualTo(1));
+            Assert.That(value["key2"], Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public void CanConvertEmptyMapRemoteValueToDictionary()
+    {
+        MapRemoteValue arg = new();
+
+        AssertValue(arg.ConvertTo<Dictionary<string, int>>());
+
+        static void AssertValue(IDictionary<string, int> value)
+        {
+            Assert.That(value, Is.Empty);
+        }
+    }
+
+    [Test]
+    public void CanConvertObjectRemoteValueToDictionary()
+    {
+        ObjectRemoteValue arg = new()
+        {
+            Value =
+            [
+                [new StringRemoteValue("a"), new BooleanRemoteValue(true)],
+                [new StringRemoteValue("b"), new BooleanRemoteValue(false)],
+            ]
+        };
+
+        AssertValue(arg.ConvertTo<Dictionary<string, bool>>());
+        AssertValue(arg.ConvertTo<IDictionary<string, bool>>());
+
+        static void AssertValue(IDictionary<string, bool> value)
+        {
+            Assert.That(value, Has.Count.EqualTo(2));
+            Assert.That(value["a"], Is.True);
+            Assert.That(value["b"], Is.False);
+        }
+    }
+
+    [Test]
+    public void CanConvertEmptyObjectRemoteValueToDictionary()
+    {
+        ObjectRemoteValue arg = new();
+
+        AssertValue(arg.ConvertTo<Dictionary<string, string>>());
+
+        static void AssertValue(IDictionary<string, string> value)
+        {
+            Assert.That(value, Is.Empty);
+        }
+    }
 }


### PR DESCRIPTION
Adds support for converting `MapRemoteValue` and `ObjectRemoteValue` instances to generic dictionary types in the BiDi Script RemoteValue system. The changes include new conversion logic and comprehensive tests to ensure correct behavior for both populated and empty remote values.

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/16719

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
