### PR TITLE
[java] make the signature change in `ExecuteMethod` backward compatible

### DIFF
--- a/java/src/org/openqa/selenium/chromium/AddHasCasting.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasCasting.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.chromium;
 
 import static java.util.Collections.emptyList;
-import static java.util.Objects.requireNonNullElse;
 
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,7 @@ public abstract class AddHasCasting
     return new HasCasting() {
       @Override
       public List<Map<String, String>> getCastSinks() {
-        return requireNonNullElse(executeMethod.execute(GET_CAST_SINKS, null), emptyList());
+        return executeMethod.execute(GET_CAST_SINKS, null, emptyList());
       }
 
       @Override

--- a/java/src/org/openqa/selenium/chromium/AddHasCasting.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasCasting.java
@@ -81,7 +81,7 @@ public abstract class AddHasCasting
 
       @Override
       public String getCastIssueMessage() {
-        return executeMethod.executeRequired(GET_CAST_ISSUE_MESSAGE, null).toString();
+        return executeMethod.execute(GET_CAST_ISSUE_MESSAGE).toString();
       }
 
       @Override

--- a/java/src/org/openqa/selenium/chromium/AddHasCdp.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasCdp.java
@@ -51,8 +51,7 @@ public abstract class AddHasCdp implements AugmenterProvider<HasCdp>, Additional
       Require.nonNull("Command name", commandName);
       Require.nonNull("Parameters", parameters);
 
-      return executeMethod.executeRequired(
-          EXECUTE_CDP, Map.of("cmd", commandName, "params", parameters));
+      return executeMethod.executeAs(EXECUTE_CDP, Map.of("cmd", commandName, "params", parameters));
     };
   }
 }

--- a/java/src/org/openqa/selenium/chromium/AddHasNetworkConditions.java
+++ b/java/src/org/openqa/selenium/chromium/AddHasNetworkConditions.java
@@ -75,8 +75,7 @@ public class AddHasNetworkConditions
     return new HasNetworkConditions() {
       @Override
       public ChromiumNetworkConditions getNetworkConditions() {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> result = executeMethod.executeRequired(GET_NETWORK_CONDITIONS, null);
+        Map<String, Object> result = executeMethod.execute(GET_NETWORK_CONDITIONS);
         return new ChromiumNetworkConditions()
             .setOffline((Boolean) result.getOrDefault(OFFLINE, false))
             .setLatency(Duration.ofMillis((Long) result.getOrDefault(LATENCY, 0)))

--- a/java/src/org/openqa/selenium/firefox/AddHasContext.java
+++ b/java/src/org/openqa/selenium/firefox/AddHasContext.java
@@ -69,7 +69,7 @@ public class AddHasContext implements AugmenterProvider<HasContext>, AdditionalH
 
       @Override
       public FirefoxCommandContext getContext() {
-        String context = executeMethod.executeRequired(GET_CONTEXT, null);
+        String context = executeMethod.execute(GET_CONTEXT);
         return FirefoxCommandContext.fromString(context);
       }
     };

--- a/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
+++ b/java/src/org/openqa/selenium/firefox/AddHasExtensions.java
@@ -95,7 +95,7 @@ public class AddHasExtensions implements AugmenterProvider<HasExtensions>, Addit
           throw new InvalidArgumentException(path + " is an invalid path", e);
         }
 
-        return executeMethod.executeRequired(
+        return executeMethod.executeAs(
             INSTALL_EXTENSION, Map.of("addon", encoded, "temporary", temporary));
       }
 

--- a/java/src/org/openqa/selenium/remote/ExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/ExecuteMethod.java
@@ -40,16 +40,30 @@ public interface ExecuteMethod {
    */
   @Nullable Object execute(String commandName, @Nullable Map<String, ?> parameters);
 
-  default <T> T execute(String commandName, @Nullable Map<String, ?> parameters, T defaultValue) {
-    return requireNonNullElse(executeOptional(commandName, parameters), defaultValue);
-  }
-
+  /**
+   * Execute the given command and return the default value if the command return null.
+   * @return non-nullable value of type T.
+   */
   @SuppressWarnings("unchecked")
-  default @Nullable <T> T executeOptional(String commandName, @Nullable Map<String, ?> parameters) {
-    return (T) execute(commandName, parameters);
+  default <T> T execute(String commandName, @Nullable Map<String, ?> parameters, T defaultValue) {
+    return (T) requireNonNullElse(execute(commandName, parameters), defaultValue);
   }
 
-  default <T> T executeRequired(String commandName, @Nullable Map<String, ?> parameters) {
-    return requireNonNull(executeOptional(commandName, parameters));
+  /**
+   * Execute the given command and cast the returned value to T.
+   * @return non-nullable value of type T.
+   */
+  @SuppressWarnings("unchecked")
+  default <T> T executeAs(String commandName, @Nullable Map<String, ?> parameters) {
+    return (T) requireNonNull(execute(commandName, parameters));
+  }
+
+  /**
+   * Execute the given command without parameters and cast the returned value to T.
+   * @return non-nullable value of type T.
+   */
+  @SuppressWarnings("unchecked")
+  default <T> T execute(String commandName) {
+    return (T) requireNonNull(execute(commandName, null));
   }
 }

--- a/java/src/org/openqa/selenium/remote/ExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/ExecuteMethod.java
@@ -42,6 +42,7 @@ public interface ExecuteMethod {
 
   /**
    * Execute the given command and return the default value if the command return null.
+   *
    * @return non-nullable value of type T.
    */
   @SuppressWarnings("unchecked")
@@ -51,6 +52,7 @@ public interface ExecuteMethod {
 
   /**
    * Execute the given command and cast the returned value to T.
+   *
    * @return non-nullable value of type T.
    */
   @SuppressWarnings("unchecked")
@@ -60,6 +62,7 @@ public interface ExecuteMethod {
 
   /**
    * Execute the given command without parameters and cast the returned value to T.
+   *
    * @return non-nullable value of type T.
    */
   @SuppressWarnings("unchecked")

--- a/java/src/org/openqa/selenium/remote/ExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/ExecuteMethod.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.remote;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
@@ -37,9 +38,18 @@ public interface ExecuteMethod {
    * @param parameters The parameters to execute that command with
    * @return The result of {@link Response#getValue()}.
    */
-  @Nullable <T> T execute(String commandName, @Nullable Map<String, ?> parameters);
+  @Nullable Object execute(String commandName, @Nullable Map<String, ?> parameters);
+
+  default <T> T execute(String commandName, @Nullable Map<String, ?> parameters, T defaultValue) {
+    return requireNonNullElse(executeOptional(commandName, parameters), defaultValue);
+  }
+
+  @SuppressWarnings("unchecked")
+  default @Nullable <T> T executeOptional(String commandName, @Nullable Map<String, ?> parameters) {
+    return (T) execute(commandName, parameters);
+  }
 
   default <T> T executeRequired(String commandName, @Nullable Map<String, ?> parameters) {
-    return requireNonNull(execute(commandName, parameters));
+    return requireNonNull(executeOptional(commandName, parameters));
   }
 }

--- a/java/src/org/openqa/selenium/remote/FedCmDialogImpl.java
+++ b/java/src/org/openqa/selenium/remote/FedCmDialogImpl.java
@@ -46,7 +46,7 @@ class FedCmDialogImpl implements FederatedCredentialManagementDialog {
   @Nullable
   @Override
   public String getDialogType() {
-    return executeMethod.executeOptional(DriverCommand.GET_FEDCM_DIALOG_TYPE, null);
+    return (String) executeMethod.execute(DriverCommand.GET_FEDCM_DIALOG_TYPE, null);
   }
 
   @Override
@@ -58,21 +58,20 @@ class FedCmDialogImpl implements FederatedCredentialManagementDialog {
   @Nullable
   @Override
   public String getTitle() {
-    Map<String, String> result = executeMethod.executeRequired(DriverCommand.GET_FEDCM_TITLE, null);
+    Map<String, String> result = executeMethod.execute(DriverCommand.GET_FEDCM_TITLE);
     return result.get("title");
   }
 
   @Nullable
   @Override
   public String getSubtitle() {
-    Map<String, String> result = executeMethod.executeRequired(DriverCommand.GET_FEDCM_TITLE, null);
+    Map<String, String> result = executeMethod.execute(DriverCommand.GET_FEDCM_TITLE);
     return result.get("subtitle");
   }
 
   @Override
   public List<FederatedCredentialManagementAccount> getAccounts() {
-    List<Map<String, String>> accounts =
-        executeMethod.executeRequired(DriverCommand.GET_ACCOUNTS, null);
+    List<Map<String, String>> accounts = executeMethod.execute(DriverCommand.GET_ACCOUNTS);
 
     return accounts.stream()
         .map(map -> new FederatedCredentialManagementAccount(map))

--- a/java/src/org/openqa/selenium/remote/FedCmDialogImpl.java
+++ b/java/src/org/openqa/selenium/remote/FedCmDialogImpl.java
@@ -46,7 +46,7 @@ class FedCmDialogImpl implements FederatedCredentialManagementDialog {
   @Nullable
   @Override
   public String getDialogType() {
-    return executeMethod.execute(DriverCommand.GET_FEDCM_DIALOG_TYPE, null);
+    return executeMethod.executeOptional(DriverCommand.GET_FEDCM_DIALOG_TYPE, null);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/remote/LocalExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/LocalExecuteMethod.java
@@ -26,7 +26,7 @@ import org.openqa.selenium.WebDriverException;
 class LocalExecuteMethod implements ExecuteMethod {
   @Nullable
   @Override
-  public <T> T execute(String commandName, @Nullable Map<String, ?> parameters) {
+  public Object execute(String commandName, @Nullable Map<String, ?> parameters) {
     throw new WebDriverException("Cannot execute remote command: " + commandName);
   }
 }

--- a/java/src/org/openqa/selenium/remote/RemoteExecuteMethod.java
+++ b/java/src/org/openqa/selenium/remote/RemoteExecuteMethod.java
@@ -31,9 +31,8 @@ public class RemoteExecuteMethod implements ExecuteMethod, WrapsDriver {
     this.driver = Require.nonNull("Remote WebDriver", driver);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public @Nullable <T> T execute(String commandName, @Nullable Map<String, ?> parameters) {
+  public @Nullable Object execute(String commandName, @Nullable Map<String, ?> parameters) {
     Response response;
 
     if (parameters == null || parameters.isEmpty()) {
@@ -42,7 +41,7 @@ public class RemoteExecuteMethod implements ExecuteMethod, WrapsDriver {
       response = driver.execute(commandName, parameters);
     }
 
-    return (T) response.getValue();
+    return response.getValue();
   }
 
   @Override

--- a/java/src/org/openqa/selenium/remote/RemoteLogs.java
+++ b/java/src/org/openqa/selenium/remote/RemoteLogs.java
@@ -149,8 +149,7 @@ public class RemoteLogs implements Logs {
 
   @Override
   public Set<String> getAvailableLogTypes() {
-    List<String> rawList =
-        executeMethod.executeRequired(DriverCommand.GET_AVAILABLE_LOG_TYPES, null);
+    List<String> rawList = executeMethod.execute(DriverCommand.GET_AVAILABLE_LOG_TYPES);
     Set<String> builder = new LinkedHashSet<>();
     builder.addAll(rawList);
     builder.addAll(getAvailableLocalLogs());

--- a/java/src/org/openqa/selenium/safari/AddHasPermissions.java
+++ b/java/src/org/openqa/selenium/safari/AddHasPermissions.java
@@ -67,7 +67,7 @@ public class AddHasPermissions
 
       @Override
       public Map<String, Boolean> getPermissions() {
-        Map<?, ?> resultMap = executeMethod.executeRequired(GET_PERMISSIONS, null);
+        Map<?, ?> resultMap = executeMethod.execute(GET_PERMISSIONS);
 
         Map<String, Boolean> permissionMap = new HashMap<>();
         for (Map.Entry<?, ?> entry : resultMap.entrySet()) {

--- a/java/test/org/openqa/selenium/remote/RemoteLogsTest.java
+++ b/java/test/org/openqa/selenium/remote/RemoteLogsTest.java
@@ -133,7 +133,7 @@ class RemoteLogsTest {
   @Test
   void canGetAvailableLogTypes() {
     List<String> remoteAvailableLogTypes = List.of(LogType.PROFILER, LogType.SERVER);
-    when(executeMethod.executeRequired(DriverCommand.GET_AVAILABLE_LOG_TYPES, null))
+    when(executeMethod.execute(DriverCommand.GET_AVAILABLE_LOG_TYPES))
         .thenReturn(remoteAvailableLogTypes);
 
     Set<String> localAvailableLogTypes = Set.of(LogType.PROFILER, LogType.CLIENT);


### PR DESCRIPTION
... to avoid too many changes e.g. in Appium project (its has own implementation `AppiumExecutionMethod`).

In PR #17152, I changed signature of `ExecuteMethod.execute()` - and later realized that it breaks backward compatibility in Appium.

### 🔗 Related Issues

This all is part of nullability migration https://github.com/SeleniumHQ/selenium/issues/14291

### 💥 What does this PR do?
Reverts signature of `ExecuteMethod.execute()` to the initial state.

### 🔧 Implementation Notes
For convenience, I added few "default" methods to `ExecuteMethod` that call the old `execute()` and cast the result to nullable or non-nullable type.


### 🔄 Types of changes
- Bug fix (backwards compatible)
