### PR TITLE
[dotnet] Apply selenium theme for docs

### DIFF
--- a/dotnet/docs/docfx.json
+++ b/dotnet/docs/docfx.json
@@ -48,7 +48,8 @@
     "output": "../../build/docs/api/dotnet",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "templates/selenium"
     ],
     "globalMetadata": {
       "_appName": "Selenium .NET API",

--- a/dotnet/docs/index.md
+++ b/dotnet/docs/index.md
@@ -5,5 +5,5 @@ layout: landingPage
 # Welcome to the Selenium .NET API Docs
 
 ## Modules
-- [Selenium.WebDriver](webdriver/OpenQA.Selenium.html)
-- [Selenium.Support](support/OpenQA.Selenium.Support.html)
+- [Selenium.WebDriver](webdriver/OpenQA.Selenium.yml)
+- [Selenium.Support](support/OpenQA.Selenium.Support.yml)

--- a/dotnet/docs/templates/selenium/public/main.css
+++ b/dotnet/docs/templates/selenium/public/main.css
@@ -1,0 +1,8 @@
+:root {
+  --bs-primary: #43b02a;
+  --bs-primary-rgb: 67, 176, 42;
+  --bs-link-color: #43b02a;
+  --bs-link-color-rgb: 67, 176, 42;
+  --bs-link-hover-color: #369022;
+  --bs-link-hover-color-rgb: 54, 144, 34;
+}


### PR DESCRIPTION
Green style.

### 💥 What does this PR do?
This pull request introduces a new custom template for the Selenium .NET API documentation and updates links on the landing page to use YAML files. The changes primarily focus on enhancing the documentation's appearance and navigation.

Documentation theming:

* Added the `templates/selenium` template to the `docfx.json` configuration, enabling the use of a custom Selenium-themed template for generated docs.
* Introduced a new CSS file `templates/selenium/public/main.css` with custom color variables to match Selenium branding.

Navigation improvements:

* Updated module links on the landing page (`index.md`) to reference `.yml` files instead of `.html`, improving navigation consistency with DocFX output.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
