### PR TITLE
[java] specify nullability in other java packages

### DIFF
--- a/java/src/org/openqa/selenium/Architecture.java
+++ b/java/src/org/openqa/selenium/Architecture.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium;
 
 import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the known architectures used in WebDriver. It attempts to smooth over some of Java's
@@ -121,7 +122,7 @@ public enum Architecture {
    * @return the most likely architecture based on the given architecture name
    * @throws UnsupportedOperationException if the architecture given is unknown or unsupported
    */
-  public static Architecture extractFromSysProperty(String arch) {
+  public static Architecture extractFromSysProperty(@Nullable String arch) {
     if (arch != null) {
       arch = arch.toLowerCase(Locale.ENGLISH);
     }

--- a/java/src/org/openqa/selenium/BuildInfo.java
+++ b/java/src/org/openqa/selenium/BuildInfo.java
@@ -21,20 +21,25 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 /** Reads information about how the current application was built. */
 public class BuildInfo {
+  private static final Logger LOG = Logger.getLogger(BuildInfo.class.getName());
 
   private static final Properties BUILD_PROPERTIES = loadBuildProperties();
 
   private static Properties loadBuildProperties() {
     Properties properties = new Properties();
 
-    URL resource = BuildInfo.class.getResource("/META-INF/selenium-build.properties");
-    try (InputStream is = resource.openStream()) {
-      properties.load(is);
-    } catch (IOException | NullPointerException ignored) {
-      // Do nothing
+    String file = "/META-INF/selenium-build.properties";
+    URL resource = BuildInfo.class.getResource(file);
+    if (resource != null) {
+      try (InputStream is = resource.openStream()) {
+        properties.load(is);
+      } catch (IOException ignored) {
+        LOG.warning(() -> "Failed to read build info from " + file);
+      }
     }
 
     return properties;

--- a/java/src/org/openqa/selenium/Cookie.java
+++ b/java/src/org/openqa/selenium/Cookie.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.internal.Require;
 
 public class Cookie implements Serializable {
   private static final long serialVersionUID = 4115876353625612383L;
@@ -214,10 +215,9 @@ public class Cookie implements Serializable {
   }
 
   public void validate() {
-    if (name == null || name.isEmpty() || value == null || path == null) {
-      throw new IllegalArgumentException(
-          "Required attributes are not set or " + "any non-null attribute set to null");
-    }
+    Require.nonEmpty("Name", name);
+    Require.nonNull("Value", value);
+    Require.nonNull("Path", path);
 
     if (name.indexOf(';') != -1) {
       throw new IllegalArgumentException("Cookie names cannot contain a ';': " + name);

--- a/java/src/org/openqa/selenium/DeviceRotation.java
+++ b/java/src/org/openqa/selenium/DeviceRotation.java
@@ -19,6 +19,7 @@ package org.openqa.selenium;
 
 import java.util.Map;
 import java.util.Objects;
+import org.openqa.selenium.internal.Require;
 
 /**
  * Defines an object which represents the three dimensional plane and how a device can be rotated
@@ -46,7 +47,8 @@ public class DeviceRotation {
    * and z respectively: x : xVal y : yVal z : zVal
    */
   public DeviceRotation(Map<String, Number> map) {
-    if (map == null || !map.containsKey("x") || !map.containsKey("y") || !map.containsKey("z")) {
+    Require.nonNull("Map", map);
+    if (!map.containsKey("x") || !map.containsKey("y") || !map.containsKey("z")) {
       throw new IllegalArgumentException(
           "Could not initialize DeviceRotation with map given: " + map);
     }

--- a/java/src/org/openqa/selenium/InvalidCookieDomainException.java
+++ b/java/src/org/openqa/selenium/InvalidCookieDomainException.java
@@ -17,8 +17,6 @@
 
 package org.openqa.selenium;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Thrown when attempting to add a cookie under a different domain than the current URL.
  *
@@ -27,15 +25,15 @@ import org.jspecify.annotations.Nullable;
 public class InvalidCookieDomainException extends WebDriverException {
   public InvalidCookieDomainException() {}
 
-  public InvalidCookieDomainException(@Nullable String message) {
+  public InvalidCookieDomainException(String message) {
     super(message);
   }
 
-  public InvalidCookieDomainException(@Nullable Throwable cause) {
+  public InvalidCookieDomainException(Throwable cause) {
     super(cause);
   }
 
-  public InvalidCookieDomainException(@Nullable String message, @Nullable Throwable cause) {
+  public InvalidCookieDomainException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/java/src/org/openqa/selenium/Platform.java
+++ b/java/src/org/openqa/selenium/Platform.java
@@ -53,7 +53,7 @@ public enum Platform {
    */
   XP("Windows Server 2003", "xp", "windows", "winnt", "windows_nt", "windows nt") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -66,7 +66,7 @@ public enum Platform {
   /** For versions of Windows that "feel like" Windows Vista. */
   VISTA("windows vista", "Windows Server 2008") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -78,7 +78,7 @@ public enum Platform {
 
   WIN7("windows 7", "win7") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -91,7 +91,7 @@ public enum Platform {
   /** For versions of Windows that "feel like" Windows 8. */
   WIN8("Windows Server 2012", "windows 8", "win8") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -103,7 +103,7 @@ public enum Platform {
 
   WIN8_1("windows 8.1", "win8.1") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -115,7 +115,7 @@ public enum Platform {
 
   WIN10("windows 10", "win10") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -127,7 +127,7 @@ public enum Platform {
 
   WIN11("windows 11", "win11") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return WINDOWS;
     }
 
@@ -151,7 +151,7 @@ public enum Platform {
 
   SNOW_LEOPARD("snow leopard", "os x 10.6", "macos 10.6") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -163,7 +163,7 @@ public enum Platform {
 
   MOUNTAIN_LION("mountain lion", "os x 10.8", "macos 10.8") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -175,7 +175,7 @@ public enum Platform {
 
   MAVERICKS("mavericks", "os x 10.9", "macos 10.9") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -187,7 +187,7 @@ public enum Platform {
 
   YOSEMITE("yosemite", "os x 10.10", "macos 10.10") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -199,7 +199,7 @@ public enum Platform {
 
   EL_CAPITAN("el capitan", "os x 10.11", "macos 10.11") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -211,7 +211,7 @@ public enum Platform {
 
   SIERRA("sierra", "os x 10.12", "macos 10.12") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -223,7 +223,7 @@ public enum Platform {
 
   HIGH_SIERRA("high sierra", "os x 10.13", "macos 10.13") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -235,7 +235,7 @@ public enum Platform {
 
   MOJAVE("mojave", "os x 10.14", "macos 10.14") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -247,7 +247,7 @@ public enum Platform {
 
   CATALINA("catalina", "os x 10.15", "macos 10.15") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -259,7 +259,7 @@ public enum Platform {
 
   BIG_SUR("big sur", "os x 11.0", "macos 11.0") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -271,7 +271,7 @@ public enum Platform {
 
   MONTEREY("monterey", "os x 12.0", "macos 12.0") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -283,7 +283,7 @@ public enum Platform {
 
   VENTURA("ventura", "os x 13.0", "macos 13.0") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -295,7 +295,7 @@ public enum Platform {
 
   SONOMA("sonoma", "os x 14.0", "macos 14.0") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -307,7 +307,7 @@ public enum Platform {
 
   SEQUOIA("sequoia", "os x 15.0", "macos 15.0") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return MAC;
     }
 
@@ -327,7 +327,7 @@ public enum Platform {
 
   LINUX("linux") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return UNIX;
     }
 
@@ -354,7 +354,7 @@ public enum Platform {
   /** Never returned, but can be used to request a browser running on any operating system. */
   ANY("") {
     @Override
-    public @Nullable Platform family() {
+    public Platform family() {
       return ANY;
     }
 

--- a/java/src/org/openqa/selenium/SharedCapabilitiesMethods.java
+++ b/java/src/org/openqa/selenium/SharedCapabilitiesMethods.java
@@ -24,6 +24,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.logging.LogLevelMapping;
 import org.openqa.selenium.logging.LoggingPreferences;
 
@@ -84,7 +85,7 @@ class SharedCapabilitiesMethods {
     return "Capabilities " + abbreviate(seen, caps.asMap());
   }
 
-  private static String abbreviate(Map<Object, String> seen, Object stringify) {
+  private static String abbreviate(Map<Object, String> seen, @Nullable Object stringify) {
     if (stringify == null) {
       return "null";
     }

--- a/java/src/org/openqa/selenium/UnableToSetCookieException.java
+++ b/java/src/org/openqa/selenium/UnableToSetCookieException.java
@@ -17,8 +17,6 @@
 
 package org.openqa.selenium;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Thrown when a driver fails to set a cookie.
  *
@@ -27,15 +25,15 @@ import org.jspecify.annotations.Nullable;
 public class UnableToSetCookieException extends WebDriverException {
   public UnableToSetCookieException() {}
 
-  public UnableToSetCookieException(@Nullable String message) {
+  public UnableToSetCookieException(String message) {
     super(message);
   }
 
-  public UnableToSetCookieException(@Nullable Throwable cause) {
+  public UnableToSetCookieException(Throwable cause) {
     super(cause);
   }
 
-  public UnableToSetCookieException(@Nullable String message, @Nullable Throwable cause) {
+  public UnableToSetCookieException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/java/src/org/openqa/selenium/UnhandledAlertException.java
+++ b/java/src/org/openqa/selenium/UnhandledAlertException.java
@@ -20,16 +20,17 @@ package org.openqa.selenium;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public class UnhandledAlertException extends WebDriverException {
 
-  private final String alertText;
+  @Nullable private final String alertText;
 
   public UnhandledAlertException(String message) {
     this(message, null);
   }
 
-  public UnhandledAlertException(String message, String alertText) {
+  public UnhandledAlertException(String message, @Nullable String alertText) {
     super(message + ": " + alertText);
     this.alertText = alertText;
   }
@@ -37,14 +38,15 @@ public class UnhandledAlertException extends WebDriverException {
   /**
    * @return the text of the unhandled alert.
    */
+  @Nullable
   public String getAlertText() {
     return alertText;
   }
 
   // Used for serialising. Some of the drivers return the alert text like this.
   @Beta
-  public Map<String, String> getAlert() {
-    HashMap<String, String> toReturn = new HashMap<>();
+  public Map<String, @Nullable String> getAlert() {
+    HashMap<String, @Nullable String> toReturn = new HashMap<>();
     toReturn.put("text", getAlertText());
     return Collections.unmodifiableMap(toReturn);
   }

--- a/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
+++ b/java/src/org/openqa/selenium/chromium/ChromiumDriver.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.BuildInfo;
 import org.openqa.selenium.Capabilities;
@@ -277,6 +278,7 @@ public class ChromiumDriver extends RemoteWebDriver
   }
 
   @Override
+  @NullMarked
   public <X> void onLogEvent(EventType<X> kind) {
     Require.nonNull("Event type", kind);
     kind.initializeListener(this);

--- a/java/src/org/openqa/selenium/concurrent/Lazy.java
+++ b/java/src/org/openqa/selenium/concurrent/Lazy.java
@@ -20,12 +20,12 @@ package org.openqa.selenium.concurrent;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
-public class Lazy<T> {
+public final class Lazy<T> {
 
-  @Nullable private volatile T value;
+  private final Object lock = new Object();
+  private volatile @Nullable T value;
   private final Supplier<T> supplier;
 
   private Lazy(Supplier<T> supplier) {
@@ -33,14 +33,18 @@ public class Lazy<T> {
   }
 
   public Optional<T> getIfInitialized() {
-    return Optional.ofNullable(value);
+    return value == null ? Optional.empty() : Optional.ofNullable(value);
   }
 
   public T get() {
     if (value == null) {
-      synchronized (this) {
+      synchronized (lock) {
         if (value == null) {
-          value = supplier.get();
+          try {
+            value = supplier.get();
+          } catch (Exception e) {
+            throw new InitializationException(e);
+          }
         }
       }
     }
@@ -49,5 +53,16 @@ public class Lazy<T> {
 
   public static <T> Lazy<T> lazy(Supplier<T> supplier) {
     return new Lazy<>(supplier);
+  }
+
+  @FunctionalInterface
+  public interface Supplier<T> {
+    T get() throws Exception;
+  }
+
+  public static class InitializationException extends RuntimeException {
+    public InitializationException(Exception cause) {
+      super(cause);
+    }
   }
 }

--- a/java/src/org/openqa/selenium/events/BUILD.bazel
+++ b/java/src/org/openqa/selenium/events/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//java:defs.bzl", "java_library")
+load("//java:defs.bzl", "artifact", "java_library")
 
 java_library(
     name = "events",
@@ -13,5 +13,6 @@ java_library(
         "//java/src/org/openqa/selenium:core",
         "//java/src/org/openqa/selenium/json",
         "//java/src/org/openqa/selenium/status",
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/events/local/BUILD.bazel
+++ b/java/src/org/openqa/selenium/events/local/BUILD.bazel
@@ -15,5 +15,6 @@ java_library(
         "//java/src/org/openqa/selenium/events",
         "//java/src/org/openqa/selenium/grid/config",
         artifact("com.google.guava:guava"),
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/events/local/package-info.java
+++ b/java/src/org/openqa/selenium/events/local/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.events.local;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/events/package-info.java
+++ b/java/src/org/openqa/selenium/events/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.events;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/events/zeromq/BUILD.bazel
+++ b/java/src/org/openqa/selenium/events/zeromq/BUILD.bazel
@@ -20,5 +20,6 @@ java_library(
         artifact("com.google.guava:guava"),
         artifact("dev.failsafe:failsafe"),
         artifact("org.zeromq:jeromq"),
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
+++ b/java/src/org/openqa/selenium/events/zeromq/UnboundZmqEventBus.java
@@ -72,9 +72,8 @@ class UnboundZmqEventBus implements EventBus {
   private final Queue<UUID> recentMessages = EvictingQueue.create(128);
   private final String encodedSecret;
   private final ZMQ.Poller poller;
-
-  private ZMQ.Socket pub;
-  private ZMQ.Socket sub;
+  private final ZMQ.Socket pub;
+  private final ZMQ.Socket sub;
 
   UnboundZmqEventBus(
       ZContext context,
@@ -136,20 +135,26 @@ class UnboundZmqEventBus implements EventBus {
             .build();
 
     // Access to the zmq socket is safe here: no threads.
-    Failsafe.with(retryPolicy)
-        .run(
-            () -> {
-              sub = context.createSocket(SocketType.SUB);
-              sub.setIPv6(isSubAddressIPv6(publishConnection));
-              ZmqUtils.configureHeartbeat(sub, heartbeatPeriod, "SUB");
-              sub.connect(publishConnection);
-              sub.subscribe(new byte[0]);
+    ZMQ.Socket[] pubSub =
+        Failsafe.with(retryPolicy)
+            .get(
+                () -> {
+                  ZMQ.Socket sub = context.createSocket(SocketType.SUB);
+                  sub.setIPv6(isSubAddressIPv6(publishConnection));
+                  ZmqUtils.configureHeartbeat(sub, heartbeatPeriod, "SUB");
+                  sub.connect(publishConnection);
+                  sub.subscribe(new byte[0]);
 
-              pub = context.createSocket(SocketType.PUB);
-              pub.setIPv6(isSubAddressIPv6(subscribeConnection));
-              ZmqUtils.configureHeartbeat(pub, heartbeatPeriod, "PUB");
-              pub.connect(subscribeConnection);
-            });
+                  ZMQ.Socket pub = context.createSocket(SocketType.PUB);
+                  pub.setIPv6(isSubAddressIPv6(subscribeConnection));
+                  ZmqUtils.configureHeartbeat(pub, heartbeatPeriod, "PUB");
+                  pub.connect(subscribeConnection);
+
+                  return new ZMQ.Socket[] {pub, sub};
+                });
+    this.pub = pubSub[0];
+    this.sub = pubSub[1];
+
     // Connections are already established
     this.poller = context.createPoller(1);
     this.poller.register(Objects.requireNonNull(sub), ZMQ.Poller.POLLIN);
@@ -227,13 +232,8 @@ class UnboundZmqEventBus implements EventBus {
     ExecutorServices.shutdownGracefully(
         "Event Bus Listener Notifier", listenerNotificationExecutor);
     poller.close();
-
-    if (sub != null) {
-      sub.close();
-    }
-    if (pub != null) {
-      pub.close();
-    }
+    sub.close();
+    pub.close();
   }
 
   private class PollingRunnable implements Runnable {

--- a/java/src/org/openqa/selenium/events/zeromq/ZeroMqEventBus.java
+++ b/java/src/org/openqa/selenium/events/zeromq/ZeroMqEventBus.java
@@ -146,6 +146,7 @@ public class ZeroMqEventBus {
       this.data = data;
     }
 
+    @SuppressWarnings("DataFlowIssue")
     private static RejectedEvent fromJson(JsonInput input) {
       EventName name = null;
       Object data = null;

--- a/java/src/org/openqa/selenium/events/zeromq/package-info.java
+++ b/java/src/org/openqa/selenium/events/zeromq/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.events.zeromq;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/src/org/openqa/selenium/interactions/Actions.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.IntConsumer;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -46,7 +45,6 @@ import org.openqa.selenium.internal.Require;
  *
  * <p>Call {@link #perform()} at the end of the method chain to actually perform the actions.
  */
-@NullMarked
 public class Actions {
 
   private final WebDriver driver;
@@ -57,7 +55,7 @@ public class Actions {
   private @Nullable PointerInput activePointer;
   private @Nullable KeyInput activeKeyboard;
   private @Nullable WheelInput activeWheel;
-  private Duration actionDuration;
+  private final Duration actionDuration;
 
   public Actions(WebDriver driver) {
     this(driver, Duration.ofMillis(250));
@@ -155,9 +153,7 @@ public class Actions {
   }
 
   private Actions sendKeysInTicks(CharSequence... keys) {
-    if (keys == null) {
-      throw new IllegalArgumentException("Keys should be a not null CharSequence");
-    }
+    Require.nonNull("Keys", keys, "should be a not null CharSequence");
     for (CharSequence key : keys) {
       key.codePoints()
           .forEach(

--- a/java/src/org/openqa/selenium/interactions/Coordinates.java
+++ b/java/src/org/openqa/selenium/interactions/Coordinates.java
@@ -17,14 +17,12 @@
 
 package org.openqa.selenium.interactions;
 
-import org.jspecify.annotations.NullMarked;
 import org.openqa.selenium.Point;
 
 /**
  * Provides coordinates of an element for advanced interactions. Note that some coordinates (such as
  * screen coordinates) are evaluated lazily since the element may have to be scrolled into view.
  */
-@NullMarked
 public interface Coordinates {
 
   /**

--- a/java/src/org/openqa/selenium/interactions/Encodable.java
+++ b/java/src/org/openqa/selenium/interactions/Encodable.java
@@ -18,14 +18,13 @@
 package org.openqa.selenium.interactions;
 
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This interface allows a custom {@link Interaction} to be JSON encoded for the W3C wire format. It
  * should not normally be exposed or used by user-facing APIs. Instead, these should traffic in the
  * {@link Interaction} interface.
  */
-@NullMarked
 public interface Encodable {
-  Map<String, Object> encode();
+  Map<String, @Nullable Object> encode();
 }

--- a/java/src/org/openqa/selenium/interactions/InputSource.java
+++ b/java/src/org/openqa/selenium/interactions/InputSource.java
@@ -17,13 +17,10 @@
 
 package org.openqa.selenium.interactions;
 
-import org.jspecify.annotations.NullMarked;
-
 /**
  * Models an <a href="https://www.w3.org/TR/webdriver/#dfn-input-source">input source</a> as defined
  * and used by the W3C WebDriver spec.
  */
-@NullMarked
 public interface InputSource {
   SourceType getInputType();
 

--- a/java/src/org/openqa/selenium/interactions/Interaction.java
+++ b/java/src/org/openqa/selenium/interactions/Interaction.java
@@ -19,13 +19,10 @@ package org.openqa.selenium.interactions;
 
 import static java.util.Objects.requireNonNull;
 
-import org.jspecify.annotations.NullMarked;
-
 /**
  * Used as the basis of {@link Sequence}s for the W3C WebDriver spec <a
  * href="https://www.w3.org/TR/webdriver/#actions">Action commands</a>.
  */
-@NullMarked
 public abstract class Interaction {
 
   private final InputSource source;

--- a/java/src/org/openqa/selenium/interactions/Interactive.java
+++ b/java/src/org/openqa/selenium/interactions/Interactive.java
@@ -18,13 +18,11 @@
 package org.openqa.selenium.interactions;
 
 import java.util.Collection;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Indicates that a class can be used with the W3C WebDriver <a
  * href="https://www.w3.org/TR/webdriver/#actions">Actions commands</a>.
  */
-@NullMarked
 public interface Interactive {
   void perform(Collection<Sequence> actions);
 

--- a/java/src/org/openqa/selenium/interactions/KeyInput.java
+++ b/java/src/org/openqa/selenium/interactions/KeyInput.java
@@ -21,13 +21,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Models a <a href="https://www.w3.org/TR/webdriver/#dfn-key-input-source">key input source</a>.
  */
-@NullMarked
 public class KeyInput implements InputSource, Encodable {
 
   private final String name;
@@ -55,8 +53,8 @@ public class KeyInput implements InputSource, Encodable {
   }
 
   @Override
-  public Map<String, Object> encode() {
-    Map<String, Object> toReturn = new HashMap<>();
+  public Map<String, @Nullable Object> encode() {
+    Map<String, @Nullable Object> toReturn = new HashMap<>();
 
     toReturn.put("type", getInputType().getType());
     toReturn.put("id", name);

--- a/java/src/org/openqa/selenium/interactions/Locatable.java
+++ b/java/src/org/openqa/selenium/interactions/Locatable.java
@@ -17,9 +17,6 @@
 
 package org.openqa.selenium.interactions;
 
-import org.jspecify.annotations.NullMarked;
-
-@NullMarked
 public interface Locatable {
   Coordinates getCoordinates();
 }

--- a/java/src/org/openqa/selenium/interactions/MoveTargetOutOfBoundsException.java
+++ b/java/src/org/openqa/selenium/interactions/MoveTargetOutOfBoundsException.java
@@ -17,7 +17,6 @@
 
 package org.openqa.selenium.interactions;
 
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebDriverException;
 
@@ -25,7 +24,6 @@ import org.openqa.selenium.WebDriverException;
  * Indicates that the target provided to the actions move() method is invalid - outside of the size
  * of the window.
  */
-@NullMarked
 public class MoveTargetOutOfBoundsException extends WebDriverException {
   public MoveTargetOutOfBoundsException(@Nullable String message) {
     super(message);

--- a/java/src/org/openqa/selenium/interactions/Pause.java
+++ b/java/src/org/openqa/selenium/interactions/Pause.java
@@ -22,10 +22,8 @@ import static org.openqa.selenium.internal.Require.nonNegative;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 
 /** Indicates that a given {@link InputSource} should pause for a given duration. */
-@NullMarked
 public class Pause extends Interaction implements Encodable {
 
   private final Duration duration;

--- a/java/src/org/openqa/selenium/interactions/PointerInput.java
+++ b/java/src/org/openqa/selenium/interactions/PointerInput.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
@@ -35,7 +34,6 @@ import org.openqa.selenium.internal.Require;
  * Models a <a href="https://www.w3.org/TR/webdriver/#dfn-pointer-input-source">pointer input
  * source</a>.
  */
-@NullMarked
 public class PointerInput implements InputSource, Encodable {
 
   private final Kind kind;
@@ -57,8 +55,8 @@ public class PointerInput implements InputSource, Encodable {
   }
 
   @Override
-  public Map<String, Object> encode() {
-    Map<String, Object> toReturn = new HashMap<>();
+  public Map<String, @Nullable Object> encode() {
+    Map<String, @Nullable Object> toReturn = new HashMap<>();
 
     toReturn.put("type", getInputType().getType());
     toReturn.put("id", name);

--- a/java/src/org/openqa/selenium/interactions/Sequence.java
+++ b/java/src/org/openqa/selenium/interactions/Sequence.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A sequence of action objects for a given {@link InputSource} for use with the W3C <a
@@ -31,7 +31,6 @@ import org.jspecify.annotations.NullMarked;
  * Interaction}s, with the first item in each sequence being executed at the same time, then the
  * second, and so on, until all interactions in all sequences have been executed.
  */
-@NullMarked
 public class Sequence implements Encodable {
 
   private final List<Encodable> actions = new LinkedList<>();
@@ -66,12 +65,12 @@ public class Sequence implements Encodable {
   }
 
   @Override
-  public Map<String, Object> encode() {
-    Map<String, Object> toReturn = new HashMap<>(((Encodable) device).encode());
+  public Map<String, @Nullable Object> encode() {
+    Map<String, @Nullable Object> toReturn = new HashMap<>(((Encodable) device).encode());
 
-    List<Map<String, Object>> encodedActions = new LinkedList<>();
+    List<Map<String, @Nullable Object>> encodedActions = new LinkedList<>();
     for (Encodable action : actions) {
-      Map<String, Object> encodedAction = new HashMap<>(action.encode());
+      Map<String, @Nullable Object> encodedAction = new HashMap<>(action.encode());
       encodedActions.add(encodedAction);
     }
     toReturn.put("actions", encodedActions);
@@ -79,7 +78,7 @@ public class Sequence implements Encodable {
     return toReturn;
   }
 
-  public Map<String, Object> toJson() {
+  public Map<String, @Nullable Object> toJson() {
     return encode();
   }
 

--- a/java/src/org/openqa/selenium/interactions/SourceType.java
+++ b/java/src/org/openqa/selenium/interactions/SourceType.java
@@ -17,11 +17,9 @@
 
 package org.openqa.selenium.interactions;
 
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** One of the allowing types for an {@link InputSource}. */
-@NullMarked
 public enum SourceType {
   KEY("key"),
   NONE(null),

--- a/java/src/org/openqa/selenium/interactions/WheelInput.java
+++ b/java/src/org/openqa/selenium/interactions/WheelInput.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
@@ -35,7 +34,6 @@ import org.openqa.selenium.internal.Require;
  * Models a <a href="https://www.w3.org/TR/webdriver/#dfn-wheel-input-source">wheel input
  * source</a>.
  */
-@NullMarked
 public class WheelInput implements InputSource, Encodable {
 
   private final String name;
@@ -65,8 +63,8 @@ public class WheelInput implements InputSource, Encodable {
   }
 
   @Override
-  public Map<String, Object> encode() {
-    Map<String, Object> toReturn = new HashMap<>();
+  public Map<String, @Nullable Object> encode() {
+    Map<String, @Nullable Object> toReturn = new HashMap<>();
 
     toReturn.put("type", getInputType().getType());
     toReturn.put("id", this.name);

--- a/java/src/org/openqa/selenium/interactions/package-info.java
+++ b/java/src/org/openqa/selenium/interactions/package-info.java
@@ -15,26 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+@NullMarked
 package org.openqa.selenium.interactions;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.openqa.selenium.internal.Require;
-
-/** An action for aggregating actions and triggering all of them at the same time. */
-public class CompositeAction implements Action {
-
-  private final List<Action> actionsList = new ArrayList<>();
-
-  @Override
-  public void perform() {
-    for (Action action : actionsList) {
-      action.perform();
-    }
-  }
-
-  public CompositeAction addAction(Action action) {
-    actionsList.add(Require.nonNull("Action", action));
-    return this;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/internal/Require.java
+++ b/java/src/org/openqa/selenium/internal/Require.java
@@ -211,6 +211,14 @@ public final class Require {
     return arg;
   }
 
+  public static String nonEmpty(String argName, @Nullable String arg) {
+    nonNull(argName, arg);
+    if (arg.isEmpty()) {
+      throw new IllegalArgumentException(String.format(MUST_NOT_BE_EMPTY, argName));
+    }
+    return arg;
+  }
+
   public static void stateCondition(boolean state, String message, Object... args) {
     if (!state) {
       throw new IllegalStateException(String.format(message, args));

--- a/java/src/org/openqa/selenium/logging/CompositeLocalLogs.java
+++ b/java/src/org/openqa/selenium/logging/CompositeLocalLogs.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.logging;
 
 import java.util.Set;
 import java.util.TreeSet;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * LocalLogs implementation that holds two other local logs. NOTE: The two local logs are not equal.
@@ -42,6 +43,7 @@ class CompositeLocalLogs extends LocalLogs {
   }
 
   @Override
+  @NullMarked
   public LogEntries get(String logType) {
     if (predefinedTypeLogger.getAvailableLogTypes().contains(logType)) {
       return predefinedTypeLogger.get(logType);

--- a/java/src/org/openqa/selenium/logging/HandlerBasedLocalLogs.java
+++ b/java/src/org/openqa/selenium/logging/HandlerBasedLocalLogs.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.logging;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * LocalLogs instance that extracts entries from a logging handler.
@@ -39,6 +40,7 @@ class HandlerBasedLocalLogs extends LocalLogs {
   }
 
   @Override
+  @NullMarked
   public LogEntries get(String logType) {
     if (LogType.CLIENT.equals(logType) && logTypesToInclude.contains(logType)) {
       Collection<LogEntry> entries = loggingHandler.getRecords();

--- a/java/src/org/openqa/selenium/logging/LocalLogs.java
+++ b/java/src/org/openqa/selenium/logging/LocalLogs.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.logging;
 
 import java.util.Collections;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Stores and retrieves logs in-process (i.e. without any RPCs).
@@ -32,6 +33,7 @@ public abstract class LocalLogs implements Logs {
   private static final LocalLogs NULL_LOGGER =
       new LocalLogs() {
         @Override
+        @NullMarked
         public LogEntries get(String logType) {
           return new LogEntries(Collections.emptyList());
         }
@@ -79,6 +81,7 @@ public abstract class LocalLogs implements Logs {
   protected LocalLogs() {}
 
   @Override
+  @NullMarked
   public abstract LogEntries get(String logType);
 
   public abstract void addEntry(String logType, LogEntry entry);

--- a/java/src/org/openqa/selenium/logging/SessionLogs.java
+++ b/java/src/org/openqa/selenium/logging/SessionLogs.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.internal.Require;
 
@@ -44,7 +45,7 @@ public class SessionLogs {
     this.logTypeToEntriesMap = new HashMap<>();
   }
 
-  public LogEntries getLogs(String logType) {
+  public LogEntries getLogs(@Nullable String logType) {
     if (logType == null || !logTypeToEntriesMap.containsKey(logType)) {
       return new LogEntries(Collections.emptyList());
     }

--- a/java/src/org/openqa/selenium/logging/StoringLocalLogs.java
+++ b/java/src/org/openqa/selenium/logging/StoringLocalLogs.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * LocalLogs instance that has its own storage. This should be used for explicit storing of logs,
@@ -40,6 +41,7 @@ class StoringLocalLogs extends LocalLogs {
   }
 
   @Override
+  @NullMarked
   public LogEntries get(String logType) {
     return new LogEntries(getLocalLogs(logType));
   }

--- a/java/src/org/openqa/selenium/logging/package-info.java
+++ b/java/src/org/openqa/selenium/logging/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.logging;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/logging/profiler/package-info.java
+++ b/java/src/org/openqa/selenium/logging/profiler/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.logging.profiler;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/netty/server/BUILD.bazel
+++ b/java/src/org/openqa/selenium/netty/server/BUILD.bazel
@@ -27,5 +27,6 @@ java_library(
         artifact("io.netty:netty-handler"),
         artifact("io.netty:netty-transport"),
         artifact("org.bouncycastle:bcpkix-jdk18on"),
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/netty/server/NettyServer.java
+++ b/java/src/org/openqa/selenium/netty/server/NettyServer.java
@@ -45,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.net.ssl.SSLException;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.grid.server.BaseServerOptions;
 import org.openqa.selenium.grid.server.Server;
 import org.openqa.selenium.internal.Require;
@@ -63,11 +64,11 @@ public class NettyServer implements Server<NettyServer> {
   private final URL externalUrl;
   private final HttpHandler handler;
   private final BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> websocketHandler;
-  private final SslContext sslCtx;
+  private final @Nullable SslContext sslCtx;
   private final boolean allowCors;
-  private final Function<String, Optional<URI>> tcpTunnelResolver;
+  private final @Nullable Function<String, Optional<URI>> tcpTunnelResolver;
 
-  private Channel channel;
+  @Nullable private Channel channel;
 
   public NettyServer(BaseServerOptions options, HttpHandler handler) {
     this(options, handler, (str, sink) -> Optional.empty());
@@ -94,7 +95,7 @@ public class NettyServer implements Server<NettyServer> {
       BaseServerOptions options,
       HttpHandler handler,
       BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> websocketHandler,
-      Function<String, Optional<URI>> tcpTunnelResolver) {
+      @Nullable Function<String, Optional<URI>> tcpTunnelResolver) {
     Require.nonNull("Server options", options);
     Require.nonNull("Handler", handler);
     this.websocketHandler = Require.nonNull("Factory for websocket connections", websocketHandler);

--- a/java/src/org/openqa/selenium/netty/server/RequestConverter.java
+++ b/java/src/org/openqa/selenium/netty/server/RequestConverter.java
@@ -39,6 +39,7 @@ import io.netty.util.ReferenceCountUtil;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Debug;
 import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.HttpMethod;
@@ -51,9 +52,9 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
   private static final Logger LOG = Logger.getLogger(RequestConverter.class.getName());
   private static final Set<io.netty.handler.codec.http.HttpMethod> SUPPORTED_METHODS =
       Set.of(DELETE, GET, POST, OPTIONS);
-  private volatile FileBackedOutputStream buffer;
+  private volatile @Nullable FileBackedOutputStream buffer;
   private final AtomicLong length = new AtomicLong();
-  private volatile HttpRequest request;
+  private volatile @Nullable HttpRequest request;
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
@@ -131,6 +132,7 @@ class RequestConverter extends SimpleChannelInboundHandler<HttpObject> {
     super.channelInactive(ctx);
   }
 
+  @Nullable
   private HttpRequest createRequest(
       ChannelHandlerContext ctx, io.netty.handler.codec.http.HttpRequest nettyRequest) {
 

--- a/java/src/org/openqa/selenium/netty/server/SeleniumHttpInitializer.java
+++ b/java/src/org/openqa/selenium/netty/server/SeleniumHttpInitializer.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.Message;
@@ -40,9 +41,9 @@ class SeleniumHttpInitializer extends ChannelInitializer<SocketChannel> {
       AttributeKey.newInstance("se-ws-handler");
   private final HttpHandler seleniumHandler;
   private final BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> webSocketHandler;
-  private final SslContext sslCtx;
+  private final @Nullable SslContext sslCtx;
   private final boolean allowCors;
-  private final Function<String, Optional<URI>> tcpTunnelResolver;
+  private final @Nullable Function<String, Optional<URI>> tcpTunnelResolver;
 
   SeleniumHttpInitializer(
       SslContext sslCtx,
@@ -53,11 +54,11 @@ class SeleniumHttpInitializer extends ChannelInitializer<SocketChannel> {
   }
 
   SeleniumHttpInitializer(
-      SslContext sslCtx,
+      @Nullable SslContext sslCtx,
       HttpHandler seleniumHandler,
       BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> webSocketHandler,
       boolean allowCors,
-      Function<String, Optional<URI>> tcpTunnelResolver) {
+      @Nullable Function<String, Optional<URI>> tcpTunnelResolver) {
     this.sslCtx = sslCtx;
     this.seleniumHandler = Require.nonNull("HTTP handler", seleniumHandler);
     this.webSocketHandler = Require.nonNull("WebSocket handler", webSocketHandler);

--- a/java/src/org/openqa/selenium/netty/server/TcpUpgradeTunnelHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/TcpUpgradeTunnelHandler.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium.netty.server;
 
+import static org.openqa.selenium.concurrent.Lazy.lazy;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -50,6 +52,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLException;
+import org.openqa.selenium.concurrent.Lazy;
 
 /**
  * Netty handler placed in the server pipeline before {@link WebSocketUpgradeHandler}. When it sees
@@ -75,7 +78,7 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
    * certificates are trusted because Grid nodes commonly use self-signed certificates for internal
    * cluster communication. The external client↔Router TLS boundary is separate and unaffected.
    */
-  private static volatile SslContext clientSslContext;
+  private static final Lazy<SslContext> clientSslContext = lazy(() -> buildClientSslContext());
 
   private final Function<String, Optional<URI>> nodeUriResolver;
 
@@ -122,8 +125,8 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
     SslContext nodeSslCtx = null;
     if (useTls) {
       try {
-        nodeSslCtx = buildClientSslContext();
-      } catch (SSLException e) {
+        nodeSslCtx = clientSslContext.get();
+      } catch (Lazy.InitializationException e) {
         LOG.log(
             Level.WARNING,
             "Failed to build SSL context for HTTPS node at "
@@ -131,7 +134,7 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
                 + ":"
                 + port
                 + ", falling back to WebSocket handler",
-            e);
+            e.getCause());
         clientChannel.config().setAutoRead(true);
         ctx.fireChannelRead(req);
         return;
@@ -192,20 +195,10 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
   }
 
   private static SslContext buildClientSslContext() throws SSLException {
-    if (clientSslContext == null) {
-      synchronized (TcpUpgradeTunnelHandler.class) {
-        if (clientSslContext == null) {
-          // InsecureTrustManagerFactory is appropriate here: Grid nodes commonly use self-signed
-          // certificates for intra-cluster communication, and the trust boundary that matters to
-          // end users is the client↔Router TLS connection, not this Router↔Node hop.
-          clientSslContext =
-              SslContextBuilder.forClient()
-                  .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                  .build();
-        }
-      }
-    }
-    return clientSslContext;
+    // InsecureTrustManagerFactory is appropriate here: Grid nodes commonly use self-signed
+    // certificates for intra-cluster communication, and the trust boundary that matters to
+    // end users is the client↔Router TLS connection, not this Router↔Node hop.
+    return SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
   }
 
   // ---------------------------------------------------------------------------

--- a/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
@@ -54,6 +54,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.remote.http.CloseMessage;
 import org.openqa.selenium.remote.http.Message;
@@ -67,7 +68,7 @@ class WebSocketUpgradeHandler extends ChannelInboundHandlerAdapter {
   private static final Logger LOG = Logger.getLogger(WebSocketUpgradeHandler.class.getName());
   private final AttributeKey<Consumer<Message>> key;
   private final BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> factory;
-  private WebSocketServerHandshaker handshaker;
+  private @Nullable WebSocketServerHandshaker handshaker;
 
   public WebSocketUpgradeHandler(
       AttributeKey<Consumer<Message>> key,

--- a/java/src/org/openqa/selenium/netty/server/package-info.java
+++ b/java/src/org/openqa/selenium/netty/server/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.netty.server;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/redis/BUILD.bazel
+++ b/java/src/org/openqa/selenium/redis/BUILD.bazel
@@ -15,5 +15,6 @@ java_library(
         artifact("io.lettuce:lettuce-core"),
         artifact("org.jboss.marshalling:jboss-marshalling"),
         artifact("org.redisson:redisson"),
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/redis/GridRedisClient.java
+++ b/java/src/org/openqa/selenium/redis/GridRedisClient.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.grid.data.Availability;
 import org.openqa.selenium.grid.data.NodeId;
 import org.openqa.selenium.grid.data.NodeStatus;
@@ -71,6 +72,7 @@ public class GridRedisClient implements Closeable {
     return connection.sync().mget(keys);
   }
 
+  @Nullable
   public String get(String key) {
     return connection.sync().get(key);
   }
@@ -159,8 +161,9 @@ public class GridRedisClient implements Closeable {
 
   public Set<NodeStatus> getNodes(Set<NodeId> nodeIds) {
     return nodeIds.stream()
-        .filter(nodeId -> getNode(nodeId).isPresent())
-        .map(nodeId -> getNode(nodeId).get())
+        .map(nodeId -> getNode(nodeId))
+        .filter(nodeStatus -> nodeStatus.isPresent())
+        .map(nodeStatus -> nodeStatus.get())
         .collect(Collectors.toSet());
   }
 

--- a/java/src/org/openqa/selenium/redis/package-info.java
+++ b/java/src/org/openqa/selenium/redis/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.redis;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/remote/AddHasLogEvents.java
+++ b/java/src/org/openqa/selenium/remote/AddHasLogEvents.java
@@ -22,6 +22,7 @@ import static org.openqa.selenium.remote.Browser.EDGE;
 import static org.openqa.selenium.remote.Browser.OPERA;
 
 import java.util.function.Predicate;
+import org.jspecify.annotations.NullMarked;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.devtools.HasDevTools;
@@ -47,6 +48,7 @@ public class AddHasLogEvents implements AugmenterProvider<HasLogEvents> {
   public HasLogEvents getImplementation(Capabilities capabilities, ExecuteMethod executeMethod) {
     return new HasLogEvents() {
       @Override
+      @NullMarked
       public <X> void onLogEvent(EventType<X> kind) {
         if (((RemoteExecuteMethod) executeMethod).getWrappedDriver() instanceof HasDevTools) {
           WebDriver driver = ((RemoteExecuteMethod) executeMethod).getWrappedDriver();

--- a/java/src/org/openqa/selenium/remote/RemoteLogs.java
+++ b/java/src/org/openqa/selenium/remote/RemoteLogs.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.UnsupportedCommandException;
@@ -67,6 +68,7 @@ public class RemoteLogs implements Logs {
   }
 
   @Override
+  @NullMarked
   @SuppressWarnings("deprecation")
   public LogEntries get(String logType) {
     if (LogType.CLIENT.equals(logType)) {

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -707,6 +707,7 @@ public class RemoteWebDriver
     execute(DriverCommand.CLEAR_ACTIONS_STATE);
   }
 
+  @NullMarked
   @Override
   public VirtualAuthenticator addVirtualAuthenticator(VirtualAuthenticatorOptions options) {
     String authenticatorId =
@@ -714,6 +715,7 @@ public class RemoteWebDriver
     return new RemoteVirtualAuthenticator(authenticatorId);
   }
 
+  @NullMarked
   @Override
   public void removeVirtualAuthenticator(VirtualAuthenticator authenticator) {
     execute(
@@ -1379,6 +1381,7 @@ public class RemoteWebDriver
       return id;
     }
 
+    @NullMarked
     @Override
     public void addCredential(Credential credential) {
       execute(
@@ -1397,11 +1400,13 @@ public class RemoteWebDriver
       return response.stream().map(Credential::fromMap).collect(Collectors.toList());
     }
 
+    @NullMarked
     @Override
     public void removeCredential(byte[] credentialId) {
       removeCredential(Base64.getUrlEncoder().encodeToString(credentialId));
     }
 
+    @NullMarked
     @Override
     public void removeCredential(String credentialId) {
       execute(

--- a/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -47,6 +47,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.AcceptedW3CCapabilityKeys;
 import org.openqa.selenium.Alert;
@@ -696,6 +697,7 @@ public class RemoteWebDriver
   }
 
   @Override
+  @NullMarked
   public void perform(Collection<Sequence> actions) {
     execute(DriverCommand.ACTIONS(actions));
   }

--- a/java/src/org/openqa/selenium/status/BUILD.bazel
+++ b/java/src/org/openqa/selenium/status/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//java:defs.bzl", "java_library")
 
 java_library(
@@ -6,5 +7,8 @@ java_library(
     visibility = [
         "//java/src/org/openqa/selenium:__subpackages__",
         "//java/test/org/openqa/selenium:__subpackages__",
+    ],
+    deps = [
+        artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/status/package-info.java
+++ b/java/src/org/openqa/selenium/status/package-info.java
@@ -1,0 +1,21 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@NullMarked
+package org.openqa.selenium.status;
+
+import org.jspecify.annotations.NullMarked;

--- a/java/src/org/openqa/selenium/virtualauthenticator/Credential.java
+++ b/java/src/org/openqa/selenium/virtualauthenticator/Credential.java
@@ -23,7 +23,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 
@@ -33,7 +32,6 @@ import org.openqa.selenium.internal.Require;
  * @see <a
  *     href="https://w3c.github.io/webauthn/#credential-parameters">https://w3c.github.io/webauthn/#credential-parameters</a>
  */
-@NullMarked
 public class Credential {
 
   private final byte[] id;
@@ -121,7 +119,7 @@ public class Credential {
 
   public Map<String, @Nullable Object> toMap() {
     Base64.Encoder encoder = Base64.getUrlEncoder();
-    Map<String, Object> map = new HashMap<>();
+    Map<String, @Nullable Object> map = new HashMap<>();
     map.put("credentialId", encoder.encodeToString(id));
     map.put("isResidentCredential", isResidentCredential);
     map.put("rpId", rpId);

--- a/java/src/org/openqa/selenium/virtualauthenticator/VirtualAuthenticator.java
+++ b/java/src/org/openqa/selenium/virtualauthenticator/VirtualAuthenticator.java
@@ -18,10 +18,8 @@
 package org.openqa.selenium.virtualauthenticator;
 
 import java.util.List;
-import org.jspecify.annotations.NullMarked;
 
 /** Represents a virtual authenticator. */
-@NullMarked
 public interface VirtualAuthenticator {
 
   /**

--- a/java/src/org/openqa/selenium/virtualauthenticator/VirtualAuthenticatorOptions.java
+++ b/java/src/org/openqa/selenium/virtualauthenticator/VirtualAuthenticatorOptions.java
@@ -18,7 +18,6 @@
 package org.openqa.selenium.virtualauthenticator;
 
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Options for the creation of virtual authenticators.
@@ -26,7 +25,6 @@ import org.jspecify.annotations.NullMarked;
  * @see <a
  *     href="https://w3c.github.io/webauthn/#sctn-automation">https://w3c.github.io/webauthn/#sctn-automation</a>
  */
-@NullMarked
 public class VirtualAuthenticatorOptions {
 
   public enum Protocol {

--- a/java/src/org/openqa/selenium/virtualauthenticator/package-info.java
+++ b/java/src/org/openqa/selenium/virtualauthenticator/package-info.java
@@ -15,20 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+@NullMarked
 package org.openqa.selenium.virtualauthenticator;
 
-/** Interface implemented by each driver that allows access to the virtual authenticator API. */
-public interface HasVirtualAuthenticator {
-  /**
-   * Adds a virtual authenticator with the given options.
-   *
-   * @return the new virtual authenticator.
-   */
-  VirtualAuthenticator addVirtualAuthenticator(VirtualAuthenticatorOptions options);
-
-  /**
-   * Removes a previously added virtual authenticator. The authenticator is no longer valid after
-   * removal, so no methods may be called.
-   */
-  void removeVirtualAuthenticator(VirtualAuthenticator authenticator);
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/test/org/openqa/selenium/BUILD.bazel
+++ b/java/test/org/openqa/selenium/BUILD.bazel
@@ -35,6 +35,7 @@ java_test_suite(
         artifact("com.google.guava:guava"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.mockito:mockito-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )
 
@@ -52,6 +53,7 @@ java_library(
         "//java/src/org/openqa/selenium/support",
         artifact("com.google.guava:guava"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )
 
@@ -86,5 +88,6 @@ java_selenium_test_suite(
         artifact("io.netty:netty-transport"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
+        artifact("org.jspecify:jspecify"),
     ] + JUNIT5_DEPS,
 )

--- a/java/test/org/openqa/selenium/StubDriver.java
+++ b/java/test/org/openqa/selenium/StubDriver.java
@@ -19,10 +19,14 @@ package org.openqa.selenium;
 
 import java.util.List;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.logging.Logs;
 
 public class StubDriver implements WebDriver, JavascriptExecutor {
 
+  @NullMarked
   @Override
   public void get(String url) {
     throw new UnsupportedOperationException("get");
@@ -38,11 +42,13 @@ public class StubDriver implements WebDriver, JavascriptExecutor {
     throw new UnsupportedOperationException("getTitle");
   }
 
+  @NullMarked
   @Override
   public List<WebElement> findElements(By by) {
     throw new UnsupportedOperationException("findElements");
   }
 
+  @NullMarked
   @Override
   public WebElement findElement(By by) {
     throw new UnsupportedOperationException("findElement");
@@ -92,13 +98,15 @@ public class StubDriver implements WebDriver, JavascriptExecutor {
     throw new UnsupportedOperationException("logs");
   }
 
+  @Nullable
   @Override
-  public Object executeScript(String script, Object... args) {
+  public Object executeScript(@NonNull String script, @Nullable Object @NonNull ... args) {
     throw new UnsupportedOperationException("executeScript");
   }
 
+  @Nullable
   @Override
-  public Object executeAsyncScript(String script, Object... args) {
+  public Object executeAsyncScript(@NonNull String script, @Nullable Object @NonNull ... args) {
     throw new UnsupportedOperationException("executeAsyncScript");
   }
 }

--- a/java/test/org/openqa/selenium/WrappedWebElement.java
+++ b/java/test/org/openqa/selenium/WrappedWebElement.java
@@ -18,11 +18,13 @@
 package org.openqa.selenium;
 
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A WebElement that wraps another WebElement, for purposes of testing that JSON converters
  * serialized wrapped elements correctly.
  */
+@NullMarked
 public class WrappedWebElement implements WebElement, WrapsElement {
 
   private final WebElement wrappedElement;


### PR DESCRIPTION
### 🔗 Related Issues
Partially implements https://github.com/SeleniumHQ/selenium/issues/14291

### 💥 What does this PR do?

Adds JSpecify nullability annotations to other packages:
* `org.openqa.selenium.events.*`
* `org.openqa.selenium.interactions.*`
* `org.openqa.selenium.netty.*`
* `org.openqa.selenium.redis.*`
* `org.openqa.selenium.status.*`
* `org.openqa.selenium.virtualauthenticator.*`


### 🔄 Types of changes
- Cleanup (formatting, renaming)
