### PR TITLE
[grid] Router WebSocket handle dropped close frames, idle disconnects, high-latency proxying

### DIFF
--- a/java/src/org/openqa/selenium/grid/router/BUILD.bazel
+++ b/java/src/org/openqa/selenium/grid/router/BUILD.bazel
@@ -21,9 +21,12 @@ java_library(
         "//java/src/org/openqa/selenium/grid/sessionqueue",
         "//java/src/org/openqa/selenium/grid/web",
         "//java/src/org/openqa/selenium/json",
+        "//java/src/org/openqa/selenium/netty/server",
         "//java/src/org/openqa/selenium/remote",
         "//java/src/org/openqa/selenium/status",
         artifact("com.google.guava:guava"),
+        artifact("io.netty:netty-codec-http"),
+        artifact("io.netty:netty-transport"),
         artifact("org.jspecify:jspecify"),
     ],
 )

--- a/java/src/org/openqa/selenium/grid/router/ProxyWebsocketsIntoGrid.java
+++ b/java/src/org/openqa/selenium/grid/router/ProxyWebsocketsIntoGrid.java
@@ -19,9 +19,16 @@ package org.openqa.selenium.grid.router;
 
 import static org.openqa.selenium.remote.http.HttpMethod.GET;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -29,6 +36,8 @@ import java.util.logging.Logger;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.grid.sessionmap.SessionMap;
 import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.netty.server.PostUpgradeHook;
+import org.openqa.selenium.netty.server.WebSocketFrameProxy;
 import org.openqa.selenium.remote.HttpSessionId;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.http.BinaryMessage;
@@ -40,6 +49,16 @@ import org.openqa.selenium.remote.http.Message;
 import org.openqa.selenium.remote.http.TextMessage;
 import org.openqa.selenium.remote.http.WebSocket;
 
+/**
+ * Proxies WebSocket connections from the Router to a Grid node.
+ *
+ * <p>After the Netty-side upgrade handshake completes ({@link PostUpgradeHook}), the pipeline is
+ * simplified: {@code MessageInboundConverter}, {@code MessageOutboundConverter}, and {@code
+ * WebSocketMessageHandler} are replaced by a {@link WebSocketFrameProxy} that forwards {@link
+ * io.netty.handler.codec.http.websocketx.WebSocketFrame} objects directly to the node-side {@link
+ * WebSocket}. This eliminates one intermediate object allocation and one executor-task submission
+ * per frame in each direction.
+ */
 public class ProxyWebsocketsIntoGrid
     implements BiFunction<String, Consumer<Message>, Optional<Consumer<Message>>> {
 
@@ -63,65 +82,211 @@ public class ProxyWebsocketsIntoGrid
       return Optional.empty();
     }
 
+    URI sessionUri;
     try {
-      URI sessionUri = sessions.getUri(sessionId.get());
-
-      HttpClient client =
-          clientFactory.createClient(ClientConfig.defaultConfig().baseUri(sessionUri));
-      try {
-        WebSocket upstream =
-            client.openSocket(new HttpRequest(GET, uri), new ForwardingListener(downstream));
-
-        return Optional.of(
-            (msg) -> {
-              try {
-                upstream.send(msg);
-              } finally {
-                if (msg instanceof CloseMessage) {
-                  try {
-                    client.close();
-                  } catch (Exception e) {
-                    LOG.log(Level.WARNING, "Failed to shutdown the client of " + sessionUri, e);
-                  }
-                }
-              }
-            });
-      } catch (Exception e) {
-        LOG.log(Level.WARNING, "Connecting to upstream websocket failed", e);
-        client.close();
-        return Optional.empty();
-      }
+      sessionUri = sessions.getUri(sessionId.get());
     } catch (NoSuchSessionException e) {
       LOG.warning("Attempt to connect to non-existent session: " + uri);
       return Optional.empty();
     }
+
+    AtomicBoolean upstreamClosing = new AtomicBoolean(false);
+    // Holds the client channel once onUpgradeComplete fires; used by DirectForwardingListener
+    // to write frames without going through MessageOutboundConverter.
+    AtomicReference<Channel> clientChannelRef = new AtomicReference<>();
+
+    HttpClient client =
+        clientFactory.createClient(ClientConfig.defaultConfig().baseUri(sessionUri));
+    try {
+      WebSocket upstream =
+          client.openSocket(
+              new HttpRequest(GET, uri),
+              new DirectForwardingListener(downstream, clientChannelRef, upstreamClosing, client));
+
+      return Optional.of(
+          new FrameProxyConsumer(upstream, client, clientChannelRef, upstreamClosing));
+
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Connecting to upstream websocket failed", e);
+      client.close();
+      return Optional.empty();
+    }
   }
 
-  private static class ForwardingListener implements WebSocket.Listener {
-    private final Consumer<Message> downstream;
+  // ---------------------------------------------------------------------------
+  // Consumer returned to WebSocketUpgradeHandler — also implements PostUpgradeHook
+  // ---------------------------------------------------------------------------
 
-    public ForwardingListener(Consumer<Message> downstream) {
-      this.downstream = Objects.requireNonNull(downstream);
+  private static class FrameProxyConsumer implements Consumer<Message>, PostUpgradeHook {
+
+    private final WebSocket upstream;
+    private final HttpClient client;
+    private final AtomicReference<Channel> clientChannelRef;
+    private final AtomicBoolean upstreamClosing;
+
+    FrameProxyConsumer(
+        WebSocket upstream,
+        HttpClient client,
+        AtomicReference<Channel> clientChannelRef,
+        AtomicBoolean upstreamClosing) {
+      this.upstream = upstream;
+      this.client = client;
+      this.clientChannelRef = clientChannelRef;
+      this.upstreamClosing = upstreamClosing;
     }
 
+    /**
+     * Called by {@link org.openqa.selenium.netty.server.WebSocketUpgradeHandler} on the Netty IO
+     * thread after the client-side handshake completes. Install {@link WebSocketFrameProxy} and
+     * strip the three {@code Message}-layer handlers so subsequent data frames never pass through
+     * the full Selenium handler chain.
+     */
     @Override
-    public void onBinary(byte[] data) {
-      downstream.accept(new BinaryMessage(data));
+    public void onUpgradeComplete(ChannelHandlerContext ctx) {
+      Channel ch = ctx.channel();
+      clientChannelRef.set(ch);
+
+      WebSocketFrameProxy proxy = new WebSocketFrameProxy(upstream, upstreamClosing);
+      ChannelPipeline pipeline = ctx.pipeline();
+
+      // Insert the frame proxy just before the inbound Message converter so it intercepts
+      // WebSocketFrame objects first, then remove the three now-redundant handlers.
+      pipeline.addBefore("netty-to-se-messages", "frame-proxy", proxy);
+      removeIfPresent(pipeline, "netty-to-se-messages"); // MessageInboundConverter
+      removeIfPresent(pipeline, "se-to-netty-messages"); // MessageOutboundConverter
+      removeIfPresent(pipeline, "se-websocket-handler"); // WebSocketMessageHandler
     }
 
+    private static void removeIfPresent(ChannelPipeline pipeline, String name) {
+      if (pipeline.get(name) != null) {
+        pipeline.remove(name);
+      }
+    }
+
+    /**
+     * After pipeline rewiring this consumer is only called for {@link CloseMessage} (fired by
+     * {@link org.openqa.selenium.netty.server.WebSocketUpgradeHandler} on the close handshake).
+     * Data frames are handled directly by {@link WebSocketFrameProxy}.
+     */
     @Override
-    public void onClose(int code, String reason) {
-      downstream.accept(new CloseMessage(code, reason));
+    public void accept(Message msg) {
+      if (upstreamClosing.get()) {
+        if (msg instanceof CloseMessage) {
+          closeClient();
+        }
+        return;
+      }
+
+      try {
+        upstream.send(msg);
+      } catch (Exception e) {
+        LOG.log(
+            Level.FINE,
+            "Could not forward message to node WebSocket (connection likely closed)",
+            e);
+        closeClient();
+        return;
+      }
+
+      if (msg instanceof CloseMessage) {
+        closeClient();
+      }
+    }
+
+    private void closeClient() {
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOG.log(Level.WARNING, "Failed to close upstream client", e);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Listener for node → client messages (fast path via direct frame writes)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Writes node-side messages directly to the client {@link Channel} as Netty WebSocket frames,
+   * bypassing {@code MessageOutboundConverter}. Falls back to the {@code downstream} consumer
+   * before the client channel reference is set (i.e. before {@link
+   * PostUpgradeHook#onUpgradeComplete} fires, which is rare).
+   */
+  private static class DirectForwardingListener implements WebSocket.Listener {
+
+    private final Consumer<Message> fallbackDownstream;
+    private final AtomicReference<Channel> clientChannelRef;
+    private final AtomicBoolean upstreamClosing;
+    private final HttpClient client;
+
+    DirectForwardingListener(
+        Consumer<Message> fallbackDownstream,
+        AtomicReference<Channel> clientChannelRef,
+        AtomicBoolean upstreamClosing,
+        HttpClient client) {
+      this.fallbackDownstream = Objects.requireNonNull(fallbackDownstream);
+      this.clientChannelRef = Objects.requireNonNull(clientChannelRef);
+      this.upstreamClosing = Objects.requireNonNull(upstreamClosing);
+      this.client = Objects.requireNonNull(client);
     }
 
     @Override
     public void onText(CharSequence data) {
-      downstream.accept(new TextMessage(data));
+      Channel ch = clientChannelRef.get();
+      if (ch != null) {
+        // Fast path: write TextWebSocketFrame directly, skipping MessageOutboundConverter.
+        WebSocketFrameProxy.writeTextFrame(ch, data);
+      } else {
+        fallbackDownstream.accept(new TextMessage(data));
+      }
+    }
+
+    @Override
+    public void onBinary(byte[] data) {
+      Channel ch = clientChannelRef.get();
+      if (ch != null) {
+        // Fast path: write BinaryWebSocketFrame directly, skipping MessageOutboundConverter.
+        WebSocketFrameProxy.writeBinaryFrame(ch, data);
+      } else {
+        fallbackDownstream.accept(new BinaryMessage(data));
+      }
+    }
+
+    @Override
+    public void onClose(int code, String reason) {
+      upstreamClosing.set(true);
+      // After onUpgradeComplete the pipeline no longer contains MessageOutboundConverter, so
+      // writing a CloseMessage object via fallbackDownstream would fail to encode. Write the
+      // Netty frame directly once the client channel reference is available.
+      Channel ch = clientChannelRef.get();
+      if (ch != null && ch.isActive()) {
+        ch.writeAndFlush(new CloseWebSocketFrame(code, reason));
+      } else {
+        fallbackDownstream.accept(new CloseMessage(code, reason));
+      }
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOG.log(Level.FINE, "Failed to close client on upstream WebSocket close", e);
+      }
     }
 
     @Override
     public void onError(Throwable cause) {
+      upstreamClosing.set(true);
       LOG.log(Level.WARNING, "Error proxying websocket command", cause);
+      // Close the client channel so Playwright/BiDi clients see a clean disconnect rather than
+      // hanging until the next keepalive ping fires.
+      Channel ch = clientChannelRef.get();
+      if (ch != null && ch.isActive()) {
+        ch.writeAndFlush(new CloseWebSocketFrame(1011, "upstream error"))
+            .addListener(ChannelFutureListener.CLOSE);
+      }
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOG.log(Level.FINE, "Failed to close client after WebSocket error", e);
+      }
     }
   }
 }

--- a/java/src/org/openqa/selenium/grid/router/httpd/RouterFlags.java
+++ b/java/src/org/openqa/selenium/grid/router/httpd/RouterFlags.java
@@ -74,6 +74,18 @@ public class RouterFlags implements HasRoles {
   @ConfigValue(section = ROUTER_SECTION, name = "disable-ui", example = "true")
   public boolean disableUi = false;
 
+  @Parameter(
+      names = {"--tcp-tunnel"},
+      arity = 1,
+      description =
+          "Enable the transparent TCP tunnel for WebSocket connections (BiDi, CDP). "
+              + "When disabled, all WebSocket traffic is routed through ProxyWebsocketsIntoGrid "
+              + "instead of the direct byte-bridge. Disable for benchmarking the proxy path "
+              + "or in network topologies where the Router cannot open direct TCP connections "
+              + "to Nodes (e.g. Kubernetes port-forward setups).")
+  @ConfigValue(section = ROUTER_SECTION, name = "tcp-tunnel", example = "false")
+  public boolean tcpTunnel = true;
+
   @Override
   public Set<Role> getRoles() {
     return Collections.singleton(ROUTER_ROLE);

--- a/java/src/org/openqa/selenium/grid/router/httpd/RouterOptions.java
+++ b/java/src/org/openqa/selenium/grid/router/httpd/RouterOptions.java
@@ -51,4 +51,8 @@ public class RouterOptions {
   public boolean disableUi() {
     return config.get(ROUTER_SECTION, "disable-ui").map(Boolean::parseBoolean).orElse(false);
   }
+
+  public boolean tcpTunnel() {
+    return config.get(ROUTER_SECTION, "tcp-tunnel").map(Boolean::parseBoolean).orElse(true);
+  }
 }

--- a/java/src/org/openqa/selenium/grid/router/httpd/RouterServer.java
+++ b/java/src/org/openqa/selenium/grid/router/httpd/RouterServer.java
@@ -191,18 +191,22 @@ public class RouterServer extends TemplateGridServerCommand {
 
     // Resolve a request URI to the Node URI for direct TCP tunnelling of WebSocket connections.
     // Falls back to ProxyWebsocketsIntoGrid (the websocketHandler) when the session is not found.
+    // Passing null disables the tunnel entirely (--tcp-tunnel false), forcing all WebSocket traffic
+    // through ProxyWebsocketsIntoGrid — useful for benchmarking or restricted network topologies.
     Function<String, Optional<URI>> tcpTunnelResolver =
-        uri ->
-            HttpSessionId.getSessionId(uri)
-                .map(SessionId::new)
-                .flatMap(
-                    id -> {
-                      try {
-                        return Optional.of(sessions.getUri(id));
-                      } catch (NoSuchSessionException e) {
-                        return Optional.empty();
-                      }
-                    });
+        routerOptions.tcpTunnel()
+            ? uri ->
+                HttpSessionId.getSessionId(uri)
+                    .map(SessionId::new)
+                    .flatMap(
+                        id -> {
+                          try {
+                            return Optional.of(sessions.getUri(id));
+                          } catch (NoSuchSessionException e) {
+                            return Optional.empty();
+                          }
+                        })
+            : null;
 
     return new Handlers(
         routeWithLiveness,

--- a/java/src/org/openqa/selenium/netty/server/NettyServer.java
+++ b/java/src/org/openqa/selenium/netty/server/NettyServer.java
@@ -19,6 +19,7 @@ package org.openqa.selenium.netty.server;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
@@ -177,6 +178,10 @@ public class NettyServer implements Server<NettyServer> {
     b.group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)
         .handler(new LoggingHandler(LogLevel.DEBUG))
+        // OS-level TCP keepalive: kernel probes stale connections that the app cannot detect.
+        .childOption(ChannelOption.SO_KEEPALIVE, true)
+        // Disable Nagle: flush small frames (BiDi, CDP) immediately without buffering.
+        .childOption(ChannelOption.TCP_NODELAY, true)
         .childHandler(
             new SeleniumHttpInitializer(
                 sslCtx, handler, websocketHandler, allowCors, tcpTunnelResolver));

--- a/java/src/org/openqa/selenium/netty/server/PostUpgradeHook.java
+++ b/java/src/org/openqa/selenium/netty/server/PostUpgradeHook.java
@@ -1,0 +1,39 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.netty.server;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * Optional interface that a {@link java.util.function.Consumer} returned by a WebSocket handler
+ * factory may implement to receive a callback <em>after</em> the Netty-side WebSocket handshake has
+ * completed.
+ *
+ * <p>Implementing this hook allows the handler to rewire the Netty pipeline (e.g. replace the
+ * {@code Message}-layer handlers with a lighter-weight frame-level forwarder) once the channel is
+ * fully in WebSocket mode.
+ */
+public interface PostUpgradeHook {
+
+  /**
+   * Called on the Netty IO thread immediately after the {@link
+   * io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker} handshake future succeeds.
+   * The channel is now in WebSocket mode; callers may freely modify {@code ctx.pipeline()}.
+   */
+  void onUpgradeComplete(ChannelHandlerContext ctx);
+}

--- a/java/src/org/openqa/selenium/netty/server/TcpUpgradeTunnelHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/TcpUpgradeTunnelHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -39,9 +40,12 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.ReferenceCountUtil;
 import java.net.URI;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -139,6 +143,11 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
         new Bootstrap()
             .group(clientChannel.eventLoop())
             .channel(NioSocketChannel.class)
+            // Mirror the server-side socket options so both legs of the tunnel behave
+            // the same: SO_KEEPALIVE lets the OS probe stale connections, TCP_NODELAY
+            // flushes small CDP/BiDi frames without Nagle buffering.
+            .option(ChannelOption.SO_KEEPALIVE, true)
+            .option(ChannelOption.TCP_NODELAY, true)
             .handler(
                 new ChannelInitializer<SocketChannel>() {
                   @Override
@@ -303,6 +312,29 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
                     }
                   }
 
+                  // Install read-idle detection on both tunnel channels. The tunnel carries raw
+                  // WebSocket bytes (CDP / BiDi); application-level pings from the client (e.g.
+                  // Playwright's 30 s pings) flow through and reset the timer naturally. If no
+                  // bytes arrive for IDLE_TIMEOUT_SECONDS the upstream LB has silently dropped
+                  // the TCP connection — close both ends so the session slot is freed promptly.
+                  int idleSeconds = WebSocketKeepAliveHandler.PING_INTERVAL_SECONDS * 4;
+                  nodeChannel
+                      .pipeline()
+                      .addBefore(
+                          "tunnel",
+                          "node-idle",
+                          new IdleStateHandler(idleSeconds, 0, 0, TimeUnit.SECONDS));
+                  nodeChannel
+                      .pipeline()
+                      .addAfter(
+                          "node-idle", "node-idle-close", new IdleCloseHandler(clientChannel));
+                  cp.addBefore(
+                      "tunnel",
+                      "client-idle",
+                      new IdleStateHandler(idleSeconds, 0, 0, TimeUnit.SECONDS));
+                  cp.addAfter(
+                      "client-idle", "client-idle-close", new IdleCloseHandler(nodeChannel));
+
                   // Re-enable reads on the client now that the tunnel is live.
                   clientChannel.config().setAutoRead(true);
                 });
@@ -325,6 +357,39 @@ class TcpUpgradeTunnelHandler extends ChannelInboundHandlerAdapter {
       LOG.log(Level.WARNING, "Error during node upgrade handshake", cause);
       ctx.close();
       clientChannel.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idle-close handler shared by both legs of the tunnel
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Closes both tunnel channels when no bytes have been received on this channel for the configured
+   * read-idle window. This cleans up sessions where the intermediate load balancer silently dropped
+   * the TCP connection without sending a FIN or RST (common with AWS ALB, k8s ingress-nginx at
+   * their default 60 s idle timeout).
+   */
+  private static final class IdleCloseHandler extends ChannelInboundHandlerAdapter {
+
+    private final Channel peer;
+
+    IdleCloseHandler(Channel peer) {
+      this.peer = peer;
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+      if (evt instanceof IdleStateEvent) {
+        LOG.log(
+            Level.FINE,
+            "TCP tunnel read-idle timeout on {0}, closing both channels",
+            ctx.channel());
+        ctx.close();
+        peer.close();
+        return;
+      }
+      super.userEventTriggered(ctx, evt);
     }
   }
 }

--- a/java/src/org/openqa/selenium/netty/server/WebSocketFrameProxy.java
+++ b/java/src/org/openqa/selenium/netty/server/WebSocketFrameProxy.java
@@ -1,0 +1,166 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.netty.server;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openqa.selenium.remote.http.BinaryMessage;
+import org.openqa.selenium.remote.http.TextMessage;
+import org.openqa.selenium.remote.http.WebSocket;
+
+/**
+ * Installed in the client-side Netty pipeline by {@link
+ * org.openqa.selenium.grid.router.ProxyWebsocketsIntoGrid} after the WebSocket upgrade handshake
+ * completes on both sides. It replaces the {@link MessageInboundConverter} → {@link
+ * WebSocketMessageHandler} chain by forwarding {@link WebSocketFrame} objects directly to the
+ * node-side {@link WebSocket}, avoiding one intermediate {@code Message} allocation and one
+ * executor-task submission per frame.
+ *
+ * <p>The reverse direction (node → client) is handled by {@code DirectForwardingListener} inside
+ * {@code ProxyWebsocketsIntoGrid}, which writes {@link TextWebSocketFrame}/{@link
+ * BinaryWebSocketFrame} directly to the client {@link Channel}, bypassing {@link
+ * MessageOutboundConverter}.
+ *
+ * <p>Close frames are intentionally NOT handled here — they continue to flow through {@link
+ * WebSocketUpgradeHandler} which calls the registered {@code Consumer<Message>} with a {@link
+ * org.openqa.selenium.remote.http.CloseMessage} and runs the Netty-level close handshake.
+ *
+ * <p>This handler is not {@code @ChannelHandler.Sharable}: each connection gets its own instance so
+ * that the fragmentation accumulators are per-connection.
+ */
+public class WebSocketFrameProxy extends SimpleChannelInboundHandler<WebSocketFrame> {
+
+  private static final Logger LOG = Logger.getLogger(WebSocketFrameProxy.class.getName());
+
+  private final WebSocket upstream;
+  private final AtomicBoolean upstreamClosing;
+
+  // State for reassembling fragmented messages (mirrors MessageInboundConverter).
+  private enum Continuation {
+    Text,
+    Binary,
+    None
+  }
+
+  private Continuation next = Continuation.None;
+  private final StringBuilder textBuffer = new StringBuilder();
+  private final ByteArrayOutputStream binaryBuffer = new ByteArrayOutputStream();
+
+  public WebSocketFrameProxy(WebSocket upstream, AtomicBoolean upstreamClosing) {
+    super(true); // autoRelease: SimpleChannelInboundHandler releases each frame after read
+    this.upstream = upstream;
+    this.upstreamClosing = upstreamClosing;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, WebSocketFrame frame) {
+    if (upstreamClosing.get()) {
+      LOG.log(Level.FINE, "Dropping data frame: upstream WebSocket is closing");
+      return;
+    }
+
+    try {
+      forwardFrame(frame);
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Failed to forward WebSocket frame to node", e);
+      ctx.fireExceptionCaught(e);
+    }
+  }
+
+  private void forwardFrame(WebSocketFrame frame) {
+    if (frame instanceof TextWebSocketFrame) {
+      TextWebSocketFrame text = (TextWebSocketFrame) frame;
+      if (text.isFinalFragment()) {
+        upstream.send(new TextMessage(text.text()));
+      } else {
+        next = Continuation.Text;
+        textBuffer.append(text.text());
+      }
+
+    } else if (frame instanceof BinaryWebSocketFrame) {
+      BinaryWebSocketFrame binary = (BinaryWebSocketFrame) frame;
+      if (binary.isFinalFragment()) {
+        upstream.send(new BinaryMessage(binary.content().nioBuffer()));
+      } else {
+        next = Continuation.Binary;
+        try {
+          binary.content().readBytes(binaryBuffer, binary.content().readableBytes());
+        } catch (IOException e) {
+          throw new UncheckedIOException("failed to read binary frame", e);
+        }
+      }
+
+    } else if (frame instanceof ContinuationWebSocketFrame) {
+      ContinuationWebSocketFrame cont = (ContinuationWebSocketFrame) frame;
+      switch (next) {
+        case Text:
+          textBuffer.append(cont.text());
+          if (cont.isFinalFragment()) {
+            upstream.send(new TextMessage(textBuffer.toString()));
+            textBuffer.setLength(0);
+            next = Continuation.None;
+          }
+          break;
+        case Binary:
+          try {
+            cont.content().readBytes(binaryBuffer, cont.content().readableBytes());
+          } catch (IOException e) {
+            throw new UncheckedIOException("failed to read continuation frame", e);
+          }
+          if (cont.isFinalFragment()) {
+            upstream.send(new BinaryMessage(binaryBuffer.toByteArray()));
+            binaryBuffer.reset();
+            next = Continuation.None;
+          }
+          break;
+        default:
+          // CloseWebSocketFrame continuation or unknown — ignore.
+          break;
+      }
+    }
+    // CloseWebSocketFrame: handled by WebSocketUpgradeHandler → Consumer<CloseMessage>.
+  }
+
+  /**
+   * Called by the node-side {@code ForwardingListener} to write a text frame directly to the client
+   * channel, bypassing {@link MessageOutboundConverter}.
+   */
+  public static void writeTextFrame(Channel clientChannel, CharSequence text) {
+    clientChannel.writeAndFlush(new TextWebSocketFrame(text.toString()));
+  }
+
+  /**
+   * Called by the node-side {@code ForwardingListener} to write a binary frame directly to the
+   * client channel, bypassing {@link MessageOutboundConverter}.
+   */
+  public static void writeBinaryFrame(Channel clientChannel, byte[] data) {
+    clientChannel.writeAndFlush(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(data)));
+  }
+}

--- a/java/src/org/openqa/selenium/netty/server/WebSocketKeepAliveHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/WebSocketKeepAliveHandler.java
@@ -1,0 +1,69 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.netty.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Sends a WebSocket {@link PingWebSocketFrame} whenever no data has been written to the channel for
+ * {@link #PING_INTERVAL_SECONDS} seconds. This prevents cloud load balancers (AWS ALB default: 60
+ * s, GCP default: 600 s, k8s ingress-nginx default: 60 s) and NAT gateways from silently dropping
+ * idle TCP connections mid-session.
+ *
+ * <p>Must be placed in the pipeline immediately after an {@link
+ * io.netty.handler.timeout.IdleStateHandler} that is configured with a writer-idle timeout.
+ * Installed by {@link WebSocketUpgradeHandler} after the WebSocket handshake completes so that it
+ * only activates for WebSocket connections (never for plain HTTP request/response pairs).
+ *
+ * <p>Incoming {@link io.netty.handler.codec.http.websocketx.PongWebSocketFrame} responses are
+ * handled by {@link WebSocketUpgradeHandler} (which releases them). No additional handling is
+ * needed here.
+ */
+class WebSocketKeepAliveHandler extends ChannelInboundHandlerAdapter {
+
+  static final int PING_INTERVAL_SECONDS = 30;
+
+  private static final Logger LOG = Logger.getLogger(WebSocketKeepAliveHandler.class.getName());
+
+  @Override
+  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    if (evt instanceof IdleStateEvent && ((IdleStateEvent) evt).state() == IdleState.WRITER_IDLE) {
+      LOG.log(Level.FINE, "Sending WebSocket ping keepalive on {0}", ctx.channel());
+      ctx.writeAndFlush(new PingWebSocketFrame())
+          .addListener(
+              future -> {
+                if (!future.isSuccess()) {
+                  // Channel is gone; close it so the session slot is released.
+                  LOG.log(
+                      Level.FINE,
+                      "WebSocket ping failed on " + ctx.channel() + ", closing channel",
+                      future.cause());
+                  ctx.close();
+                }
+              });
+      return;
+    }
+    super.userEventTriggered(ctx, evt);
+  }
+}

--- a/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
+++ b/java/src/org/openqa/selenium/netty/server/WebSocketUpgradeHandler.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -43,10 +44,12 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -157,7 +160,27 @@ class WebSocketUpgradeHandler extends ChannelInboundHandlerAdapter {
                 if (!future.isSuccess()) {
                   ctx.fireExceptionCaught(future.cause());
                 } else {
-                  ctx.channel().attr(key).setIfAbsent(maybeHandler.get());
+                  Consumer<Message> handler = maybeHandler.get();
+                  ctx.channel().attr(key).setIfAbsent(handler);
+
+                  // Install application-level keepalive for all WebSocket connections.
+                  // Cloud LBs (AWS ALB: 60 s, k8s ingress-nginx: 60 s) silently drop idle
+                  // TCP connections; OS-level SO_KEEPALIVE alone is not enough because
+                  // most LBs ignore TCP keepalive probes. A WS ping every 30 s resets
+                  // the LB's idle timer at the application level.
+                  ChannelPipeline pipeline = ctx.pipeline();
+                  pipeline.addAfter(
+                      "ws-protocol",
+                      "ws-idle",
+                      new IdleStateHandler(
+                          0, WebSocketKeepAliveHandler.PING_INTERVAL_SECONDS, 0, TimeUnit.SECONDS));
+                  pipeline.addAfter("ws-idle", "ws-keepalive", new WebSocketKeepAliveHandler());
+
+                  // Allow the handler to rewire the pipeline now that the channel
+                  // is fully in WebSocket mode (HTTP codec no longer active).
+                  if (handler instanceof PostUpgradeHook) {
+                    ((PostUpgradeHook) handler).onUpgradeComplete(ctx);
+                  }
                 }
               });
     }

--- a/java/test/org/openqa/selenium/grid/router/TunnelWebsocketTest.java
+++ b/java/test/org/openqa/selenium/grid/router/TunnelWebsocketTest.java
@@ -67,6 +67,7 @@ import org.openqa.selenium.netty.server.NettyServer;
 import org.openqa.selenium.remote.HttpSessionId;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.remote.http.BinaryMessage;
+import org.openqa.selenium.remote.http.CloseMessage;
 import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.HttpRequest;
@@ -631,5 +632,256 @@ class TunnelWebsocketTest {
 
     distributor.close();
     bus.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // ProxyWebsocketsIntoGrid + WebSocketFrameProxy (fallback path) tests
+  //
+  // These tests deliberately omit the TCP tunnel resolver so TcpUpgradeTunnelHandler
+  // is NOT installed. Every WebSocket upgrade goes through ProxyWebsocketsIntoGrid
+  // which, after the Netty handshake, rewires the pipeline via WebSocketFrameProxy.
+  // ---------------------------------------------------------------------------
+
+  private Server<?> createProxyRouter() {
+    // 3-arg constructor: no tcpTunnelResolver → no TcpUpgradeTunnelHandler in the pipeline.
+    return new NettyServer(
+            new BaseServerOptions(emptyConfig),
+            nullHandler,
+            new ProxyWebsocketsIntoGrid(HttpClient.Factory.createDefault(), sessions))
+        .start();
+  }
+
+  @Test
+  void proxyPath_shouldForwardTextMessageToBackend()
+      throws URISyntaxException, InterruptedException {
+    AtomicReference<String> received = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+
+    backendServer = createEchoBackend("", latch, received);
+
+    SessionId id = new SessionId(UUID.randomUUID());
+    sessions.add(
+        new Session(
+            id,
+            backendServer.getUrl().toURI(),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now()));
+
+    tunnelServer = createProxyRouter();
+
+    HttpClient.Factory factory = HttpClient.Factory.createDefault();
+    try (WebSocket socket =
+        factory
+            .createClient(tunnelServer.getUrl())
+            .openSocket(
+                new HttpRequest(GET, "/session/" + id + "/bidi"), new WebSocket.Listener() {})) {
+
+      socket.sendText("proxy-hello");
+
+      assertThat(latch.await(5, SECONDS)).isTrue();
+      assertThat(received.get()).isEqualTo("proxy-hello");
+    }
+  }
+
+  @Test
+  void proxyPath_shouldForwardReplyFromBackendToClient()
+      throws URISyntaxException, InterruptedException {
+    backendServer = createEchoBackend("proxy-pong", new CountDownLatch(1), new AtomicReference<>());
+
+    SessionId id = new SessionId(UUID.randomUUID());
+    sessions.add(
+        new Session(
+            id,
+            backendServer.getUrl().toURI(),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now()));
+
+    tunnelServer = createProxyRouter();
+
+    HttpClient.Factory factory = HttpClient.Factory.createDefault();
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<String> reply = new AtomicReference<>();
+
+    try (WebSocket socket =
+        factory
+            .createClient(tunnelServer.getUrl())
+            .openSocket(
+                new HttpRequest(GET, "/session/" + id + "/bidi"),
+                new WebSocket.Listener() {
+                  @Override
+                  public void onText(CharSequence data) {
+                    reply.set(data.toString());
+                    latch.countDown();
+                  }
+                })) {
+
+      socket.sendText("proxy-ping");
+
+      assertThat(latch.await(5, SECONDS)).isTrue();
+      assertThat(reply.get()).isEqualTo("proxy-pong");
+    }
+  }
+
+  @Test
+  void proxyPath_shouldForwardBinaryMessages() throws URISyntaxException, InterruptedException {
+    byte[] payload = new byte[] {10, 20, 30, 40};
+
+    AtomicReference<byte[]> received = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+
+    backendServer =
+        new NettyServer(
+                new BaseServerOptions(emptyConfig),
+                nullHandler,
+                (uri, sink) ->
+                    Optional.of(
+                        msg -> {
+                          if (msg instanceof BinaryMessage) {
+                            received.set(((BinaryMessage) msg).data());
+                            latch.countDown();
+                          }
+                        }))
+            .start();
+
+    SessionId id = new SessionId(UUID.randomUUID());
+    sessions.add(
+        new Session(
+            id,
+            backendServer.getUrl().toURI(),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now()));
+
+    tunnelServer = createProxyRouter();
+
+    HttpClient.Factory factory = HttpClient.Factory.createDefault();
+    try (WebSocket socket =
+        factory
+            .createClient(tunnelServer.getUrl())
+            .openSocket(
+                new HttpRequest(GET, "/session/" + id + "/bidi"), new WebSocket.Listener() {})) {
+
+      socket.sendBinary(payload);
+
+      assertThat(latch.await(5, SECONDS)).isTrue();
+      assertThat(received.get()).isEqualTo(payload);
+    }
+  }
+
+  @Test
+  void proxyPath_shouldSupportMultipleMessagesAndBidirectionalFlow()
+      throws URISyntaxException, InterruptedException {
+    // Backend echoes every text message back with a ">" prefix to distinguish direction.
+    int messageCount = 5;
+    CountDownLatch backendLatch = new CountDownLatch(messageCount);
+    CountDownLatch clientLatch = new CountDownLatch(messageCount);
+
+    backendServer =
+        new NettyServer(
+                new BaseServerOptions(emptyConfig),
+                nullHandler,
+                (uri, sink) ->
+                    Optional.of(
+                        msg -> {
+                          if (msg instanceof TextMessage) {
+                            backendLatch.countDown();
+                            sink.accept(new TextMessage(">" + ((TextMessage) msg).text()));
+                          }
+                        }))
+            .start();
+
+    SessionId id = new SessionId(UUID.randomUUID());
+    sessions.add(
+        new Session(
+            id,
+            backendServer.getUrl().toURI(),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now()));
+
+    tunnelServer = createProxyRouter();
+
+    HttpClient.Factory factory = HttpClient.Factory.createDefault();
+    try (WebSocket socket =
+        factory
+            .createClient(tunnelServer.getUrl())
+            .openSocket(
+                new HttpRequest(GET, "/session/" + id + "/bidi"),
+                new WebSocket.Listener() {
+                  @Override
+                  public void onText(CharSequence data) {
+                    clientLatch.countDown();
+                  }
+                })) {
+
+      for (int i = 0; i < messageCount; i++) {
+        socket.sendText("msg-" + i);
+      }
+
+      assertThat(backendLatch.await(10, SECONDS)).as("backend received all messages").isTrue();
+      assertThat(clientLatch.await(10, SECONDS)).as("client received all replies").isTrue();
+    }
+  }
+
+  /**
+   * Regression test for node-initiated close in proxy path.
+   *
+   * <p>After the Netty pipeline is rewired by {@code WebSocketFrameProxy} (i.e. {@code
+   * MessageOutboundConverter} is removed), a close message sent by the backend must still reach the
+   * client as a proper WebSocket close frame — not silently dropped.
+   */
+  @Test
+  void proxyPath_shouldRelayNodeInitiatedClose() throws URISyntaxException, InterruptedException {
+    CountDownLatch closeLatch = new CountDownLatch(1);
+    AtomicReference<Integer> closeCode = new AtomicReference<>();
+
+    // Backend sends one text message, then immediately closes the connection.
+    backendServer =
+        new NettyServer(
+                new BaseServerOptions(emptyConfig),
+                nullHandler,
+                (uri, sink) ->
+                    Optional.of(
+                        msg -> {
+                          if (msg instanceof TextMessage) {
+                            sink.accept(new CloseMessage(1000, "done"));
+                          }
+                        }))
+            .start();
+
+    SessionId id = new SessionId(UUID.randomUUID());
+    sessions.add(
+        new Session(
+            id,
+            backendServer.getUrl().toURI(),
+            new ImmutableCapabilities(),
+            new ImmutableCapabilities(),
+            Instant.now()));
+
+    tunnelServer = createProxyRouter();
+
+    HttpClient.Factory factory = HttpClient.Factory.createDefault();
+    try (WebSocket socket =
+        factory
+            .createClient(tunnelServer.getUrl())
+            .openSocket(
+                new HttpRequest(GET, "/session/" + id + "/bidi"),
+                new WebSocket.Listener() {
+                  @Override
+                  public void onClose(int code, String reason) {
+                    closeCode.set(code);
+                    closeLatch.countDown();
+                  }
+                })) {
+
+      socket.sendText("trigger-close");
+
+      assertThat(closeLatch.await(5, SECONDS))
+          .as("client should receive close frame from node")
+          .isTrue();
+      assertThat(closeCode.get()).isEqualTo(1000);
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
Improve three user-visible problems with WebSocket connections (BiDi, CDP) routed through Selenium Grid:

  - **BiDi/CDP sessions hang after the browser crashes or the Node kills the session.** When the Node closed the WebSocket, the client was never notified — it would sit open until the next keepalive cycle (up to 30 s) rather than receiving a clean close.

  - **Cloud load balancers (AWS ALB, GCP, k8s ingress-nginx) silently drop idle WebSocket connections mid-session.** These LBs have a 60 s idle timeout and ignore OS-level TCP keepalives. Long-running Playwright or BiDi tests that go quiet for more than 60 s would have their connection dropped without any signal. Fixed by sending application-level WebSocket pings every 30 s.

  - **Every BiDi/CDP message was parsed and repackaged by the Router even though the Router has nothing to do with the message content.** This added latency and CPU overhead proportional to message rate. The Router now bridges the connection at the TCP level, removing itself from the data path entirely after the initial handshake. Falls back to the old message-proxying path for network topologies where a direct TCP connection to the Node is not possible (e.g. Kubernetes port-forward).


### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
