### PR TITLE
[rb] Fix failing firefox beta tests for browser context

### DIFF
--- a/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
@@ -87,46 +87,49 @@ module Selenium
             reset_driver!(unhandled_prompt_behavior: :ignore)
           end
 
-          it 'accepts users prompts without text' do
+          it 'accepts user prompts without text' do
             browsing_context = described_class.new(bridge)
 
             driver.navigate.to url_for('alerts.html')
             window = driver.window_handle
-            prompt_opened = false
+            prompt_opened = Queue.new
             bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
-            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened.push(true) }
             driver.find_element(id: 'alert').click
-            wait.until { prompt_opened }
+            wait.until { !prompt_opened.empty? }
             browsing_context.handle_user_prompt(window, accept: true)
+            wait_for_no_alert
 
             expect(driver.title).to eq('Testing Alerts')
           end
 
-          it 'accepts users prompts with text' do
+          it 'accepts user prompts with text' do
             browsing_context = described_class.new(bridge)
             driver.navigate.to url_for('alerts.html')
             window = driver.window_handle
-            prompt_opened = false
+            prompt_opened = Queue.new
             bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
-            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened.push(true) }
             driver.find_element(id: 'prompt').click
-            wait.until { prompt_opened }
+            wait.until { !prompt_opened.empty? }
             browsing_context.handle_user_prompt(window, accept: true, text: 'Hello, world!')
+            wait_for_no_alert
 
             expect(driver.title).to eq('Testing Alerts')
           end
 
-          it 'rejects users prompts' do
+          it 'rejects user prompts' do
             browsing_context = described_class.new(bridge)
             driver.navigate.to url_for('alerts.html')
             window = driver.window_handle
-            prompt_opened = false
+            prompt_opened = Queue.new
             bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
-            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened.push(true) }
             driver.find_element(id: 'alert').click
-            wait.until { prompt_opened }
+            wait.until { !prompt_opened.empty? }
 
             browsing_context.handle_user_prompt(window, accept: false)
+            wait_for_no_alert
 
             expect(driver.title).to eq('Testing Alerts')
           end

--- a/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
@@ -81,47 +81,55 @@ module Selenium
           expect(driver.execute_script('return window.devicePixelRatio')).to eq(2.0)
         end
 
-        it 'accepts users prompts without text',
-           except: {browser: %i[edge chrome],
-                    reason: 'https://github.com/GoogleChromeLabs/chromium-bidi/issues/3281'} do
-          browsing_context = described_class.new(bridge)
+        context 'user prompts', except: {browser: %i[edge chrome],
+                                          reason: 'https://github.com/GoogleChromeLabs/chromium-bidi/issues/3281'} do
+          before do
+            reset_driver!(unhandled_prompt_behavior: :ignore)
+          end
 
-          driver.navigate.to url_for('alerts.html')
-          driver.find_element(id: 'alert').click
-          wait_for_alert
-          window = driver.window_handles.first
-          browsing_context.handle_user_prompt(window, accept: true)
-          wait_for_no_alert
+          it 'accepts users prompts without text' do
+            browsing_context = described_class.new(bridge)
 
-          expect(driver.title).to eq('Testing Alerts')
-        end
+            driver.navigate.to url_for('alerts.html')
+            window = driver.window_handle
+            prompt_opened = false
+            bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            driver.find_element(id: 'alert').click
+            wait.until { prompt_opened }
+            browsing_context.handle_user_prompt(window, accept: true)
 
-        it 'accepts users prompts with text',
-           except: {browser: %i[edge chrome],
-                    reason: 'https://github.com/GoogleChromeLabs/chromium-bidi/issues/3281'} do
-          browsing_context = described_class.new(bridge)
-          driver.navigate.to url_for('alerts.html')
-          driver.find_element(id: 'prompt').click
-          wait_for_alert
-          window = driver.window_handles.first
-          browsing_context.handle_user_prompt(window, accept: true, text: 'Hello, world!')
-          wait_for_no_alert
+            expect(driver.title).to eq('Testing Alerts')
+          end
 
-          expect(driver.title).to eq('Testing Alerts')
-        end
+          it 'accepts users prompts with text' do
+            browsing_context = described_class.new(bridge)
+            driver.navigate.to url_for('alerts.html')
+            window = driver.window_handle
+            prompt_opened = false
+            bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            driver.find_element(id: 'prompt').click
+            wait.until { prompt_opened }
+            browsing_context.handle_user_prompt(window, accept: true, text: 'Hello, world!')
 
-        it 'rejects users prompts', except: {browser: %i[edge chrome],
-                                             reason: 'https://github.com/GoogleChromeLabs/chromium-bidi/issues/3281'} do
-          browsing_context = described_class.new(bridge)
-          driver.navigate.to url_for('alerts.html')
-          driver.find_element(id: 'alert').click
-          wait_for_alert
-          window = driver.window_handles.first
+            expect(driver.title).to eq('Testing Alerts')
+          end
 
-          browsing_context.handle_user_prompt(window, accept: false)
-          wait_for_no_alert
+          it 'rejects users prompts' do
+            browsing_context = described_class.new(bridge)
+            driver.navigate.to url_for('alerts.html')
+            window = driver.window_handle
+            prompt_opened = false
+            bridge.bidi.session.subscribe('browsingContext.userPromptOpened')
+            bridge.bidi.add_callback('browsingContext.userPromptOpened') { prompt_opened = true }
+            driver.find_element(id: 'alert').click
+            wait.until { prompt_opened }
 
-          expect(driver.title).to eq('Testing Alerts')
+            browsing_context.handle_user_prompt(window, accept: false)
+
+            expect(driver.title).to eq('Testing Alerts')
+          end
         end
 
         it 'activates a browser context' do

--- a/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
+++ b/rb/spec/integration/selenium/webdriver/bidi/browsing_context_spec.rb
@@ -81,8 +81,7 @@ module Selenium
           expect(driver.execute_script('return window.devicePixelRatio')).to eq(2.0)
         end
 
-        context 'user prompts', except: {browser: %i[edge chrome],
-                                          reason: 'https://github.com/GoogleChromeLabs/chromium-bidi/issues/3281'} do
+        context 'with user prompts' do
           before do
             reset_driver!(unhandled_prompt_behavior: :ignore)
           end


### PR DESCRIPTION
### 🔗 Related Issues
I made this pr #17188, and I keep getting Firefox Beta errors

### 💥 What does this PR do?
I'm trying to use event subscription that is natively BiDi for the test instead of alert and see if this fixes the errors

### 🔧 Implementation Notes
I think using the dismiss alert action was messing with the handle user prompt from bidi

### 🔄 Types of changes
- Bug fix (backwards compatible)
