### PR TITLE
[py][bidi]: skip `test_perform_actions_pointer_pen_type` for firefox

### DIFF
--- a/py/test/selenium/webdriver/common/bidi_input_tests.py
+++ b/py/test/selenium/webdriver/common/bidi_input_tests.py
@@ -529,6 +529,7 @@ def test_perform_actions_pointer_touch_type(driver, pages):
     assert button.get_attribute("value") == "Clicked"
 
 
+@pytest.mark.xfail_firefox
 def test_perform_actions_pointer_pen_type(driver, pages):
     """Test pointer actions with pen pointer type."""
     pages.load("javascriptPage.html")


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->
Skips the `test_perform_actions_pointer_pen_type` test for firefox as it is not yet implemented, returns error - 
`Error: Unimplemented pointerMove for pointerType pen`

WPT tests - https://wpt.fyi/results/webdriver/tests/bidi/input/perform_actions/pointer_pen.py?label=master&label=stable&product=firefox&product=chrome&product=edge&aligned

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Tests
