### PR TITLE
[dotnet] [bidi] Hide url required for websocket only

### DIFF
--- a/dotnet/src/webdriver/BiDi/BiDi.cs
+++ b/dotnet/src/webdriver/BiDi/BiDi.cs
@@ -53,12 +53,14 @@ public sealed class BiDi : IBiDi
 
     public Emulation.IEmulationModule Emulation => AsModule<Emulation.EmulationModule>();
 
-    public static async Task<IBiDi> ConnectAsync(string url, Action<BiDiOptionsBuilder>? configure = null, CancellationToken cancellationToken = default)
+    public static async Task<IBiDi> ConnectAsync(Action<BiDiOptionsBuilder> configure, CancellationToken cancellationToken = default)
     {
-        BiDiOptionsBuilder builder = new();
-        configure?.Invoke(builder);
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
 
-        var transport = await builder.TransportFactory(new Uri(url), cancellationToken).ConfigureAwait(false);
+        BiDiOptionsBuilder builder = new();
+        configure(builder);
+
+        var transport = await builder.TransportFactory(cancellationToken).ConfigureAwait(false);
 
         BiDi bidi = new();
 

--- a/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
+++ b/dotnet/src/webdriver/BiDi/BiDiOptionsBuilder.cs
@@ -27,22 +27,21 @@ namespace OpenQA.Selenium.BiDi;
 /// </summary>
 public sealed class BiDiOptionsBuilder
 {
-    internal Func<Uri, CancellationToken, Task<ITransport>> TransportFactory { get; private set; }
-        = (uri, ct) => WebSocketTransport.ConnectAsync(uri, null, ct);
+    private Func<CancellationToken, Task<ITransport>>? _transportFactory;
 
     /// <summary>
-    /// Configures the BiDi connection to use a WebSocket transport.
+    /// Configures the BiDi connection to use a WebSocket transport with the specified URL.
     /// </summary>
-    /// <remarks>
-    /// WebSocket is the default transport; calling this method is only necessary
-    /// when you need to customize the underlying <see cref="ClientWebSocketOptions"/>
-    /// (e.g., to set headers, proxy, or certificates).
-    /// </remarks>
+    /// <param name="url">The WebSocket URL to connect to.</param>
     /// <param name="configure">An optional action to configure the <see cref="ClientWebSocketOptions"/> before connecting.</param>
     /// <returns>The current <see cref="BiDiOptionsBuilder"/> instance for chaining.</returns>
-    public BiDiOptionsBuilder UseWebSocket(Action<ClientWebSocketOptions>? configure = null)
+    public BiDiOptionsBuilder UseWebSocket(string url, Action<ClientWebSocketOptions>? configure = null)
     {
-        TransportFactory = (uri, ct) => WebSocketTransport.ConnectAsync(uri, configure, ct);
+        var uri = new Uri(url);
+        _transportFactory = ct => WebSocketTransport.ConnectAsync(uri, configure, ct);
         return this;
     }
+
+    internal Func<CancellationToken, Task<ITransport>> TransportFactory
+        => _transportFactory ?? throw new BiDiException("Transport is not configured. Call UseWebSocket(url) on BiDiOptionsBuilder.");
 }

--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -34,7 +34,10 @@ public static class WebDriverExtensions
 
         if (webSocketUrl is null) throw new BiDiException("The driver is not compatible with bidirectional protocol or \"webSocketUrl\" not enabled in driver options.");
 
-        var bidi = await BiDi.ConnectAsync(webSocketUrl, configure, cancellationToken).ConfigureAwait(false);
+        var bidi = await BiDi.ConnectAsync(options =>
+        {
+            options.UseWebSocket(webSocketUrl);
+        }, cancellationToken).ConfigureAwait(false);
 
         return bidi;
     }

--- a/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
+++ b/dotnet/src/webdriver/BiDi/WebDriver.Extensions.cs
@@ -37,6 +37,7 @@ public static class WebDriverExtensions
         var bidi = await BiDi.ConnectAsync(options =>
         {
             options.UseWebSocket(webSocketUrl);
+            configure?.Invoke(options);
         }, cancellationToken).ConfigureAwait(false);
 
         return bidi;


### PR DESCRIPTION
This pull request refactors the BiDi connection setup in the .NET WebDriver codebase to simplify and clarify how transports are configured. The most significant changes revolve around making the transport configuration explicit and removing implicit URL handling, which improves usability and error handling.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
