### PR TITLE
[dotnet] [bidi] Parallel event handlers

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -128,8 +128,7 @@ internal sealed class Broker : IAsyncDisposable
         string? error = default;
         string? message = default;
         Utf8JsonReader resultReader = default;
-        int paramsStartIndex = 0;
-        int paramsEndIndex = 0;
+        Utf8JsonReader paramsReader = default;
 
         Utf8JsonReader reader = new(data);
         reader.Read(); // "{"
@@ -138,8 +137,6 @@ internal sealed class Broker : IAsyncDisposable
 
         while (reader.TokenType == JsonTokenType.PropertyName)
         {
-            bool isParams = false;
-
             if (reader.ValueTextEquals("id"u8))
             {
                 reader.Read();
@@ -165,8 +162,7 @@ internal sealed class Broker : IAsyncDisposable
             else if (reader.ValueTextEquals("params"u8))
             {
                 reader.Read();
-                paramsStartIndex = (int)reader.TokenStartIndex;
-                isParams = true;
+                paramsReader = reader; // snapshot
             }
             else if (reader.ValueTextEquals("error"u8))
             {
@@ -184,7 +180,6 @@ internal sealed class Broker : IAsyncDisposable
             }
 
             reader.Skip();
-            if (isParams) paramsEndIndex = (int)reader.BytesConsumed;
             reader.Read();
         }
 
@@ -223,8 +218,23 @@ internal sealed class Broker : IAsyncDisposable
 
             case TypeEvent:
                 if (method is null) throw new BiDiException($"The remote end responded with 'event' message type, but missed required 'method' property. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
-                var paramsJsonData = new ReadOnlyMemory<byte>(data, paramsStartIndex, paramsEndIndex - paramsStartIndex);
-                _eventDispatcher.EnqueueEvent(method, paramsJsonData, _bidi);
+
+                if (!_eventDispatcher.TryGetJsonTypeInfo(method, out var jsonTypeInfo))
+                {
+                    if (_logger.IsEnabled(LogEventLevel.Warn))
+                    {
+                        _logger.Warn($"Received BiDi event with method '{method}', but no event type mapping was found. Event will be ignored. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                    }
+
+                    break;
+                }
+
+                var eventArgs = JsonSerializer.Deserialize(ref paramsReader, jsonTypeInfo) as EventArgs
+                    ?? throw new BiDiException("Remote end returned null event args in the 'params' property.");
+
+                eventArgs.BiDi = _bidi;
+
+                _eventDispatcher.EnqueueEvent(method, eventArgs);
                 break;
 
             case TypeError:

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -34,6 +34,8 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     private readonly ConcurrentDictionary<string, EventRegistration> _eventRegistrations = new();
 
+    private readonly ConcurrentDictionary<Task, byte> _runningHandlers = new();
+
     private readonly Channel<PendingEvent> _pendingEvents = Channel.CreateUnbounded<PendingEvent>(new()
     {
         SingleReader = true,
@@ -81,23 +83,34 @@ internal sealed class EventDispatcher : IAsyncDisposable
         {
             while (reader.TryRead(out var result))
             {
-                try
+                if (_eventRegistrations.TryGetValue(result.Method, out var registration))
                 {
-                    if (_eventRegistrations.TryGetValue(result.Method, out var registration))
+                    foreach (var handler in registration.GetHandlers()) // copy-on-write array, safe to iterate
                     {
-                        foreach (var handler in registration.GetHandlers()) // copy-on-write array, safe to iterate
+                        var runningHandlerTask = InvokeHandlerAsync(handler, result.EventArgs);
+                        if (!runningHandlerTask.IsCompleted)
                         {
-                            await handler.InvokeAsync(result.EventArgs).ConfigureAwait(false);
+                            _runningHandlers.TryAdd(runningHandlerTask, 0);
+                            _ = runningHandlerTask.ContinueWith(static (t, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(t, out _),
+                                _runningHandlers, TaskContinuationOptions.ExecuteSynchronously);
                         }
                     }
                 }
-                catch (Exception ex)
-                {
-                    if (_logger.IsEnabled(LogEventLevel.Error))
-                    {
-                        _logger.Error($"Unhandled error processing BiDi event handler: {ex}");
-                    }
-                }
+            }
+        }
+    }
+
+    private async Task InvokeHandlerAsync(EventHandler handler, EventArgs eventArgs)
+    {
+        try
+        {
+            await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogEventLevel.Error))
+            {
+                _logger.Error($"Unhandled error processing BiDi event handler: {ex}");
             }
         }
     }
@@ -107,6 +120,8 @@ internal sealed class EventDispatcher : IAsyncDisposable
         _pendingEvents.Writer.Complete();
 
         await _eventEmitterTask.ConfigureAwait(false);
+
+        await Task.WhenAll(_runningHandlers.Keys).ConfigureAwait(false);
 
         GC.SuppressFinalize(this);
     }

--- a/dotnet/src/webdriver/BiDi/EventDispatcher.cs
+++ b/dotnet/src/webdriver/BiDi/EventDispatcher.cs
@@ -18,7 +18,7 @@
 // </copyright>
 
 using System.Collections.Concurrent;
-using System.Text.Json;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading.Channels;
 using OpenQA.Selenium.BiDi.Session;
@@ -32,7 +32,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     private readonly Func<ISessionModule> _sessionProvider;
 
-    private readonly ConcurrentDictionary<string, EventRegistration> _events = new();
+    private readonly ConcurrentDictionary<string, EventRegistration> _eventRegistrations = new();
 
     private readonly Channel<PendingEvent> _pendingEvents = Channel.CreateUnbounded<PendingEvent>(new()
     {
@@ -51,7 +51,7 @@ internal sealed class EventDispatcher : IAsyncDisposable
     public async Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
         where TEventArgs : EventArgs
     {
-        var registration = _events.GetOrAdd(eventName, _ => new EventRegistration(jsonTypeInfo));
+        var registration = _eventRegistrations.GetOrAdd(eventName, _ => new EventRegistration(jsonTypeInfo));
 
         var subscribeResult = await _sessionProvider().SubscribeAsync([eventName], new() { Contexts = options?.Contexts, UserContexts = options?.UserContexts }, cancellationToken).ConfigureAwait(false);
 
@@ -62,26 +62,16 @@ internal sealed class EventDispatcher : IAsyncDisposable
 
     public async ValueTask UnsubscribeAsync(Subscription subscription, CancellationToken cancellationToken)
     {
-        if (_events.TryGetValue(subscription.EventHandler.EventName, out var registration))
+        if (_eventRegistrations.TryGetValue(subscription.EventHandler.EventName, out var registration))
         {
             await _sessionProvider().UnsubscribeAsync([subscription.SubscriptionId], null, cancellationToken).ConfigureAwait(false);
             registration.RemoveHandler(subscription.EventHandler);
         }
     }
 
-    public void EnqueueEvent(string method, ReadOnlyMemory<byte> jsonUtf8Bytes, IBiDi bidi)
+    public void EnqueueEvent(string method, EventArgs eventArgs)
     {
-        if (_events.TryGetValue(method, out var registration) && registration.TypeInfo is not null)
-        {
-            _pendingEvents.Writer.TryWrite(new PendingEvent(method, jsonUtf8Bytes, bidi, registration.TypeInfo));
-        }
-        else
-        {
-            if (_logger.IsEnabled(LogEventLevel.Warn))
-            {
-                _logger.Warn($"Received BiDi event with method '{method}', but no event type mapping was found. Event will be ignored.");
-            }
-        }
+        _pendingEvents.Writer.TryWrite(new PendingEvent(method, eventArgs));
     }
 
     private async Task ProcessEventsAwaiterAsync()
@@ -93,15 +83,11 @@ internal sealed class EventDispatcher : IAsyncDisposable
             {
                 try
                 {
-                    if (_events.TryGetValue(result.Method, out var registration))
+                    if (_eventRegistrations.TryGetValue(result.Method, out var registration))
                     {
-                        // Deserialize on background thread instead of network thread (single parse)
-                        var eventArgs = (EventArgs)JsonSerializer.Deserialize(result.JsonUtf8Bytes.Span, result.TypeInfo)!;
-                        eventArgs.BiDi = result.BiDi;
-
                         foreach (var handler in registration.GetHandlers()) // copy-on-write array, safe to iterate
                         {
-                            await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
+                            await handler.InvokeAsync(result.EventArgs).ConfigureAwait(false);
                         }
                     }
                 }
@@ -125,7 +111,19 @@ internal sealed class EventDispatcher : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private readonly record struct PendingEvent(string Method, ReadOnlyMemory<byte> JsonUtf8Bytes, IBiDi BiDi, JsonTypeInfo TypeInfo);
+    public bool TryGetJsonTypeInfo(string eventName, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo)
+    {
+        if (_eventRegistrations.TryGetValue(eventName, out var registration))
+        {
+            jsonTypeInfo = registration.TypeInfo;
+            return true;
+        }
+
+        jsonTypeInfo = null;
+        return false;
+    }
+
+    private readonly record struct PendingEvent(string Method, EventArgs EventArgs);
 
     private sealed class EventRegistration(JsonTypeInfo typeInfo)
     {


### PR DESCRIPTION
Now all event handlers are executed in parallel, non blocking each others.

Why:
I have 100 tests, each test is executed in isolated `userContext` environment. Each test is executed in parallel sharing one single bidi connection. Each test wants to listen to network traffic (just an example). So, ideally any event handler should not block others, never.

Experiment:
I have executed this kind of simulation. Performance is great!

### 💥 What does this PR do?
This pull request introduces improvements to the event handling mechanism in the `EventDispatcher` class, focusing on better management of asynchronous event handler tasks and ensuring proper cleanup during disposal.

### 💡 Additional Considerations
It is still considerable to configure this behaviour.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
