### PR TITLE
[dotnet] [bidi] ~Zero allocation per command/event

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -35,7 +35,6 @@ internal sealed class Broker : IAsyncDisposable
     private readonly IBiDi _bidi;
 
     private readonly ConcurrentDictionary<long, CommandInfo> _pendingCommands = new();
-    private readonly ReceiveBufferWriter _receiveBufferWriter = new();
 
     private long _currentCommandId;
 
@@ -278,26 +277,28 @@ internal sealed class Broker : IAsyncDisposable
 
     private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
     {
+        using var receiveBufferWriter = new PooledBufferWriter();
+
         try
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                _receiveBufferWriter.Reset();
+                receiveBufferWriter.Reset();
 
-                await _transport.ReceiveAsync(_receiveBufferWriter, cancellationToken).ConfigureAwait(false);
+                await _transport.ReceiveAsync(receiveBufferWriter, cancellationToken).ConfigureAwait(false);
 
                 if (_logger.IsEnabled(LogEventLevel.Trace))
                 {
 #if NET8_0_OR_GREATER
-                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(_receiveBufferWriter.WrittenMemory.Span)}");
+                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(receiveBufferWriter.WrittenMemory.Span)}");
 #else
-                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(_receiveBufferWriter.WrittenMemory.ToArray())}");
+                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(receiveBufferWriter.WrittenMemory.ToArray())}");
 #endif
                 }
 
                 try
                 {
-                    ProcessReceivedMessage(_receiveBufferWriter.WrittenMemory);
+                    ProcessReceivedMessage(receiveBufferWriter.WrittenMemory);
                 }
                 catch (Exception ex)
                 {
@@ -330,14 +331,27 @@ internal sealed class Broker : IAsyncDisposable
 
     private readonly record struct CommandInfo(TaskCompletionSource<EmptyResult> TaskCompletionSource, JsonTypeInfo JsonResultTypeInfo);
 
-    private sealed class ReceiveBufferWriter : IBufferWriter<byte>
+    private sealed class PooledBufferWriter : IBufferWriter<byte>, IDisposable
     {
-        private byte[] _buffer = new byte[1024 * 8];
+        private const int DefaultBufferSize = 1024 * 8;
+
+        private byte[]? _buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         private int _written;
 
         public ReadOnlyMemory<byte> WrittenMemory => new(_buffer, 0, _written);
 
-        public void Reset() => _written = 0;
+        public void Reset()
+        {
+            var buffer = _buffer ?? throw new ObjectDisposedException(nameof(PooledBufferWriter));
+
+            if (buffer.Length > DefaultBufferSize)
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+                _buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            }
+
+            _written = 0;
+        }
 
         public void Advance(int count) => _written += count;
 
@@ -355,12 +369,29 @@ internal sealed class Broker : IAsyncDisposable
 
         private void EnsureCapacity(int sizeHint)
         {
-            if (sizeHint <= 0) sizeHint = _buffer.Length - _written;
-            if (sizeHint <= 0) sizeHint = _buffer.Length;
+            var buffer = _buffer ?? throw new ObjectDisposedException(nameof(PooledBufferWriter));
 
-            if (_written + sizeHint > _buffer.Length)
+            if (sizeHint <= 0) sizeHint = buffer.Length - _written;
+            if (sizeHint <= 0) sizeHint = buffer.Length;
+
+            if (_written + sizeHint > buffer.Length)
             {
-                Array.Resize(ref _buffer, Math.Max(_buffer.Length * 2, _written + sizeHint));
+                var newSize = Math.Max(buffer.Length * 2, _written + sizeHint);
+                var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+                buffer.AsSpan(0, _written).CopyTo(newBuffer);
+                ArrayPool<byte>.Shared.Return(buffer);
+                _buffer = newBuffer;
+            }
+        }
+
+        public void Dispose()
+        {
+            var buffer = _buffer;
+
+            if (buffer is not null)
+            {
+                _buffer = null;
+                ArrayPool<byte>.Shared.Return(buffer);
             }
         }
     }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -72,7 +72,13 @@ internal sealed class Broker : IAsyncDisposable
         var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
         cts.CancelAfter(timeout);
 
-        var data = JsonSerializer.SerializeToUtf8Bytes(command, jsonCommandTypeInfo);
+        using var sendBuffer = new PooledBufferWriter();
+
+        using (var writer = new Utf8JsonWriter((IBufferWriter<byte>)sendBuffer))
+        {
+            JsonSerializer.Serialize(writer, command, jsonCommandTypeInfo);
+        }
+
         var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
         _pendingCommands[command.Id] = commandInfo;
 
@@ -87,13 +93,13 @@ internal sealed class Broker : IAsyncDisposable
             if (_logger.IsEnabled(LogEventLevel.Trace))
             {
 #if NET8_0_OR_GREATER
-                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(data.AsSpan())}");
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.Span)}");
 #else
-                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(data)}");
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.ToArray())}");
 #endif
             }
 
-            await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
+            await _transport.SendAsync(sendBuffer.WrittenMemory, cts.Token).ConfigureAwait(false);
         }
         catch
         {

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -126,7 +126,7 @@ internal sealed class Broker : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private void ProcessReceivedMessage(ReadOnlyMemory<byte> data)
+    private void ProcessReceivedMessage(ReadOnlySpan<byte> data)
     {
         const int TypeSuccess = 1;
         const int TypeEvent = 2;
@@ -140,7 +140,7 @@ internal sealed class Broker : IAsyncDisposable
         Utf8JsonReader resultReader = default;
         Utf8JsonReader paramsReader = default;
 
-        Utf8JsonReader reader = new(data.Span);
+        Utf8JsonReader reader = new(data);
         reader.Read(); // "{"
 
         reader.Read();
@@ -298,7 +298,7 @@ internal sealed class Broker : IAsyncDisposable
 
                 try
                 {
-                    ProcessReceivedMessage(receiveBufferWriter.WrittenMemory);
+                    ProcessReceivedMessage(receiveBufferWriter.WrittenMemory.Span);
                 }
                 catch (Exception ex)
                 {

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -48,7 +48,7 @@ internal sealed class Broker : IAsyncDisposable
         _eventDispatcher = new EventDispatcher(sessionProvider);
 
         _receiveMessagesCancellationTokenSource = new CancellationTokenSource();
-        _receivingMessageTask = Task.Run(() => ReceiveMessagesAsync(_receiveMessagesCancellationTokenSource.Token));
+        _receivingMessageTask = Task.Run(() => ReceiveMessagesLoopAsync(_receiveMessagesCancellationTokenSource.Token));
     }
 
     public Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
@@ -275,7 +275,7 @@ internal sealed class Broker : IAsyncDisposable
         }
     }
 
-    private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
+    private async Task ReceiveMessagesLoopAsync(CancellationToken cancellationToken)
     {
         using var receiveBufferWriter = new PooledBufferWriter();
 

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -74,7 +74,7 @@ internal sealed class Broker : IAsyncDisposable
 
         using var sendBuffer = new PooledBufferWriter();
 
-        using (var writer = new Utf8JsonWriter((IBufferWriter<byte>)sendBuffer))
+        using (var writer = new Utf8JsonWriter(sendBuffer))
         {
             JsonSerializer.Serialize(writer, command, jsonCommandTypeInfo);
         }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -17,6 +17,7 @@
 // under the License.
 // </copyright>
 
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -34,6 +35,7 @@ internal sealed class Broker : IAsyncDisposable
     private readonly IBiDi _bidi;
 
     private readonly ConcurrentDictionary<long, CommandInfo> _pendingCommands = new();
+    private readonly ReceiveBufferWriter _receiveBufferWriter = new();
 
     private long _currentCommandId;
 
@@ -83,6 +85,15 @@ internal sealed class Broker : IAsyncDisposable
 
         try
         {
+            if (_logger.IsEnabled(LogEventLevel.Trace))
+            {
+#if NET8_0_OR_GREATER
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(data.AsSpan())}");
+#else
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(data)}");
+#endif
+            }
+
             await _transport.SendAsync(data, cts.Token).ConfigureAwait(false);
         }
         catch
@@ -116,7 +127,7 @@ internal sealed class Broker : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private void ProcessReceivedMessage(byte[] data)
+    private void ProcessReceivedMessage(ReadOnlyMemory<byte> data)
     {
         const int TypeSuccess = 1;
         const int TypeEvent = 2;
@@ -130,7 +141,7 @@ internal sealed class Broker : IAsyncDisposable
         Utf8JsonReader resultReader = default;
         Utf8JsonReader paramsReader = default;
 
-        Utf8JsonReader reader = new(data);
+        Utf8JsonReader reader = new(data.Span);
         reader.Read(); // "{"
 
         reader.Read();
@@ -210,20 +221,20 @@ internal sealed class Broker : IAsyncDisposable
                 {
                     if (_logger.IsEnabled(LogEventLevel.Warn))
                     {
-                        _logger.Warn($"The remote end responded with 'success' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                        _logger.Warn($"The remote end responded with 'success' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
                     }
                 }
 
                 break;
 
             case TypeEvent:
-                if (method is null) throw new BiDiException($"The remote end responded with 'event' message type, but missed required 'method' property. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                if (method is null) throw new BiDiException($"The remote end responded with 'event' message type, but missed required 'method' property. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
 
                 if (!_eventDispatcher.TryGetJsonTypeInfo(method, out var jsonTypeInfo))
                 {
                     if (_logger.IsEnabled(LogEventLevel.Warn))
                     {
-                        _logger.Warn($"Received BiDi event with method '{method}', but no event type mapping was found. Event will be ignored. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                        _logger.Warn($"Received BiDi event with method '{method}', but no event type mapping was found. Event will be ignored. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
                     }
 
                     break;
@@ -238,7 +249,7 @@ internal sealed class Broker : IAsyncDisposable
                 break;
 
             case TypeError:
-                if (id is null) throw new BiDiException($"The remote end responded with 'error' message type, but missed required 'id' property. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                if (id is null) throw new BiDiException($"The remote end responded with 'error' message type, but missed required 'id' property. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
 
                 if (_pendingCommands.TryGetValue(id.Value, out var errorCommand))
                 {
@@ -249,7 +260,7 @@ internal sealed class Broker : IAsyncDisposable
                 {
                     if (_logger.IsEnabled(LogEventLevel.Warn))
                     {
-                        _logger.Warn($"The remote end responded with 'error' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                        _logger.Warn($"The remote end responded with 'error' message type, but no pending command with id {id} was found. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
                     }
                 }
 
@@ -258,7 +269,7 @@ internal sealed class Broker : IAsyncDisposable
             default:
                 if (_logger.IsEnabled(LogEventLevel.Warn))
                 {
-                    _logger.Warn($"The remote end responded with unknown message type. Message content: {System.Text.Encoding.UTF8.GetString(data)}");
+                    _logger.Warn($"The remote end responded with unknown message type. Message content: {System.Text.Encoding.UTF8.GetString(data.ToArray())}");
                 }
 
                 break;
@@ -271,11 +282,22 @@ internal sealed class Broker : IAsyncDisposable
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var data = await _transport.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                _receiveBufferWriter.Reset();
+
+                await _transport.ReceiveAsync(_receiveBufferWriter, cancellationToken).ConfigureAwait(false);
+
+                if (_logger.IsEnabled(LogEventLevel.Trace))
+                {
+#if NET8_0_OR_GREATER
+                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(_receiveBufferWriter.WrittenMemory.Span)}");
+#else
+                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(_receiveBufferWriter.WrittenMemory.ToArray())}");
+#endif
+                }
 
                 try
                 {
-                    ProcessReceivedMessage(data);
+                    ProcessReceivedMessage(_receiveBufferWriter.WrittenMemory);
                 }
                 catch (Exception ex)
                 {
@@ -307,4 +329,39 @@ internal sealed class Broker : IAsyncDisposable
     }
 
     private readonly record struct CommandInfo(TaskCompletionSource<EmptyResult> TaskCompletionSource, JsonTypeInfo JsonResultTypeInfo);
+
+    private sealed class ReceiveBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] _buffer = new byte[1024 * 8];
+        private int _written;
+
+        public ReadOnlyMemory<byte> WrittenMemory => new(_buffer, 0, _written);
+
+        public void Reset() => _written = 0;
+
+        public void Advance(int count) => _written += count;
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsMemory(_written);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsSpan(_written);
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            if (sizeHint <= 0) sizeHint = _buffer.Length - _written;
+            if (sizeHint <= 0) sizeHint = _buffer.Length;
+
+            if (_written + sizeHint > _buffer.Length)
+            {
+                Array.Resize(ref _buffer, Math.Max(_buffer.Length * 2, _written + sizeHint));
+            }
+        }
+    }
 }

--- a/dotnet/src/webdriver/BiDi/ITransport.cs
+++ b/dotnet/src/webdriver/BiDi/ITransport.cs
@@ -17,11 +17,13 @@
 // under the License.
 // </copyright>
 
+using System.Buffers;
+
 namespace OpenQA.Selenium.BiDi;
 
 interface ITransport : IAsyncDisposable
 {
-    Task<byte[]> ReceiveAsync(CancellationToken cancellationToken);
+    Task ReceiveAsync(IBufferWriter<byte> writer, CancellationToken cancellationToken);
 
-    ValueTask SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken);
+    Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken);
 }

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -19,7 +19,6 @@
 
 using System.Buffers;
 using System.Net.WebSockets;
-using System.Text;
 using OpenQA.Selenium.Internal.Logging;
 
 namespace OpenQA.Selenium.BiDi;
@@ -27,10 +26,8 @@ namespace OpenQA.Selenium.BiDi;
 sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
 {
     private readonly static ILogger _logger = Internal.Logging.Log.GetLogger<WebSocketTransport>();
-
     private readonly ClientWebSocket _webSocket = webSocket;
     private readonly SemaphoreSlim _socketSendSemaphoreSlim = new(1, 1);
-    private readonly MemoryStream _sharedMemoryStream = new();
 
     public static async Task<ITransport> ConnectAsync(Uri uri, Action<ClientWebSocketOptions>? configure, CancellationToken cancellationToken)
     {
@@ -53,71 +50,46 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
         return webSocketTransport;
     }
 
-    public async Task<byte[]> ReceiveAsync(CancellationToken cancellationToken)
+    public async Task ReceiveAsync(IBufferWriter<byte> writer, CancellationToken cancellationToken)
     {
-        var receiveBuffer = ArrayPool<byte>.Shared.Rent(1024 * 8);
+        WebSocketReceiveResult result;
 
-        try
+        do
         {
-            _sharedMemoryStream.SetLength(0);
+            var memory = writer.GetMemory();
 
-            ArraySegment<byte> segment = new(receiveBuffer);
-
-            WebSocketReceiveResult result;
-
-            do
+            if (!System.Runtime.InteropServices.MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment))
             {
-                result = await _webSocket.ReceiveAsync(segment, cancellationToken).ConfigureAwait(false);
-
-                if (result.MessageType == WebSocketMessageType.Close)
-                {
-                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
-
-                    throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
-                        $"The remote end closed the WebSocket connection. Status: {result.CloseStatus}, Description: {result.CloseStatusDescription}");
-                }
-
-                _sharedMemoryStream.Write(receiveBuffer, 0, result.Count);
-            }
-            while (!result.EndOfMessage);
-
-            byte[] data = _sharedMemoryStream.ToArray();
-
-            if (_logger.IsEnabled(LogEventLevel.Trace))
-            {
-                _logger.Trace($"BiDi RCV <-- {Encoding.UTF8.GetString(data)}");
+                segment = new ArraySegment<byte>(memory.ToArray());
             }
 
-            return data;
+            result = await _webSocket.ReceiveAsync(segment, cancellationToken).ConfigureAwait(false);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
+
+                throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
+                    $"The remote end closed the WebSocket connection. Status: {result.CloseStatus}, Description: {result.CloseStatusDescription}");
+            }
+
+            writer.Advance(result.Count);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(receiveBuffer);
-        }
+        while (!result.EndOfMessage);
     }
 
-    public async ValueTask SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+    public async Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
     {
         await _socketSendSemaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
 #if NET8_0_OR_GREATER
-            if (_logger.IsEnabled(LogEventLevel.Trace))
-            {
-                _logger.Trace($"BiDi SND --> {Encoding.UTF8.GetString(data.Span)}");
-            }
-
             await _webSocket.SendAsync(data, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
 #else
             if (!System.Runtime.InteropServices.MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment))
             {
                 segment = new ArraySegment<byte>(data.ToArray());
-            }
-
-            if (_logger.IsEnabled(LogEventLevel.Trace))
-            {
-                _logger.Trace($"BiDi SND --> {Encoding.UTF8.GetString(segment.Array!, segment.Offset, segment.Count)}");
             }
 
             await _webSocket.SendAsync(segment, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
@@ -151,7 +123,6 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
         }
 
         _webSocket.Dispose();
-        _sharedMemoryStream.Dispose();
         _socketSendSemaphoreSlim.Dispose();
 
         _disposed = true;

--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -52,6 +52,27 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
 
     public async Task ReceiveAsync(IBufferWriter<byte> writer, CancellationToken cancellationToken)
     {
+#if NET8_0_OR_GREATER
+        ValueWebSocketReceiveResult result;
+
+        do
+        {
+            var memory = writer.GetMemory();
+
+            result = await _webSocket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
+
+                throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely,
+                    $"The remote end closed the WebSocket connection. Status: {_webSocket.CloseStatus}, Description: {_webSocket.CloseStatusDescription}");
+            }
+
+            writer.Advance(result.Count);
+        }
+        while (!result.EndOfMessage);
+#else
         WebSocketReceiveResult result;
 
         do
@@ -60,7 +81,7 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
 
             if (!System.Runtime.InteropServices.MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment))
             {
-                segment = new ArraySegment<byte>(memory.ToArray());
+                throw new InvalidOperationException($"The {nameof(IBufferWriter<byte>)} must provide array-backed memory.");
             }
 
             result = await _webSocket.ReceiveAsync(segment, cancellationToken).ConfigureAwait(false);
@@ -76,6 +97,7 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
             writer.Advance(result.Count);
         }
         while (!result.EndOfMessage);
+#endif
     }
 
     public async Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)


### PR DESCRIPTION
This is big improvement how we use memory.

### 💥 What does this PR do?
This pull request introduces a significant refactor to the BiDi transport and broker layers, focusing on performance improvements and memory management. The main changes include replacing byte array and memory stream usage with pooled buffer writers, updating interfaces for more efficient message handling, and enhancing logging for trace-level diagnostics.

These changes collectively improve the efficiency, reliability, and maintainability of the BiDi transport and broker components.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
