### PR TITLE
[rb] Patch devtools to permit up to 3 versions back

### DIFF
--- a/rb/lib/selenium/devtools.rb
+++ b/rb/lib/selenium/devtools.rb
@@ -32,15 +32,19 @@ module Selenium
 
       private
 
-      # Try to load up to 2 versions back
+      # Try to load up to 3 versions back
       def load_older_version
         load_old_version(@version - 1)
       rescue LoadError
         begin
           load_old_version(@version - 2)
         rescue LoadError
-          raise WebDriver::Error::WebDriverError,
-                'Could not find a valid devtools version; use a more recent version of selenium-devtools gem'
+          begin
+            load_old_version(@version - 3)
+          rescue LoadError
+            raise WebDriver::Error::WebDriverError,
+                  'Could not find a valid devtools version; use a more recent version of selenium-devtools gem'
+          end
         end
       end
 


### PR DESCRIPTION
Whilst there is an issue with devtools being released to rubygems, this is a short "quick" temporary fix to unblock users who now are on chrome v146 and cannot use selenium w/ devtools

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
<!-- Describe what this change includes and how it works -->

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
