### PR TITLE
[dotnet] [bidi] Don't propagate cancellation token for websocket

### DIFF
--- a/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
+++ b/dotnet/src/webdriver/BiDi/WebSocketTransport.cs
@@ -107,14 +107,14 @@ sealed class WebSocketTransport(ClientWebSocket webSocket) : ITransport
         try
         {
 #if NET8_0_OR_GREATER
-            await _webSocket.SendAsync(data, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            await _webSocket.SendAsync(data, WebSocketMessageType.Text, true, CancellationToken.None).ConfigureAwait(false);
 #else
             if (!System.Runtime.InteropServices.MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment))
             {
                 segment = new ArraySegment<byte>(data.ToArray());
             }
 
-            await _webSocket.SendAsync(segment, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            await _webSocket.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None).ConfigureAwait(false);
 #endif
         }
         finally


### PR DESCRIPTION
To avoid transition websocket to `Aborted` state.

### 💥 What does this PR do?
This pull request makes a small change to how cancellation tokens are handled when sending data over a WebSocket in the `WebSocketTransport.cs` file. The cancellation token has been replaced with `CancellationToken.None` to ensure that send operations are not cancelled prematurely.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
