### PR TITLE
[build] Skip failing Firefox Beta tests

### DIFF
--- a/.skipped-tests
+++ b/.skipped-tests
@@ -15,3 +15,13 @@
 -//java/test/org/openqa/selenium/grid/router:RemoteWebDriverDownloadTest-chrome
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverBuilderTest
 -//java/test/org/openqa/selenium/remote:RemoteWebDriverScreenshotTest-remote
+-//java/test/org/openqa/selenium:AlertsTest-firefox-beta
+-//java/test/org/openqa/selenium:FormHandlingTest-firefox-beta
+-//java/test/org/openqa/selenium:WebScriptTest-firefox-beta
+-//java/test/org/openqa/selenium/bidi/browser:BrowserCommandsTest-firefox-beta
+-//java/test/org/openqa/selenium/bidi/browser:BrowserCommandsTest-firefox-beta-remote
+-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextInspectorTest-firefox-beta
+-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextInspectorTest-firefox-beta-remote
+-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextTest-firefox-beta
+-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextTest-firefox-beta-remote
+-//rb/spec/integration/selenium/webdriver/bidi:browsing_context-firefox-beta-bidi


### PR DESCRIPTION

### 💥 What does this PR do?

This PR adds the following Bazel targets to `./.skipped-tests`:

```
-//java/test/org/openqa/selenium:AlertsTest-firefox-beta
-//java/test/org/openqa/selenium:FormHandlingTest-firefox-beta
-//java/test/org/openqa/selenium:WebScriptTest-firefox-beta
-//java/test/org/openqa/selenium/bidi/browser:BrowserCommandsTest-firefox-beta
-//java/test/org/openqa/selenium/bidi/browser:BrowserCommandsTest-firefox-beta-remote
-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextInspectorTest-firefox-beta
-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextInspectorTest-firefox-beta-remote
-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextTest-firefox-beta
-//java/test/org/openqa/selenium/bidi/browsingcontext:BrowsingContextTest-firefox-beta-remote
-//rb/spec/integration/selenium/webdriver/bidi:browsing_context-firefox-beta-bidi
```
These are currently failing on RBE in trunk and on every PR branch.

### 💡 Additional Considerations

Someone needs to figure out if these failures are due to a legitimate bug in Firefox Beta that will be fixed, or if we need to fix something in selenium code to accommodate changes in the upcoming Firefox release. Once fixed in Firefox or on our end, these should be re-enabled.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Test