### PR TITLE
[grid] Fix VNC caps not propagated for sessions without browserName

### DIFF
--- a/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
+++ b/java/src/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutator.java
@@ -46,10 +46,9 @@ public class SessionCapabilitiesMutator implements Function<Capabilities, Capabi
 
   @Override
   public Capabilities apply(Capabilities capabilities) {
-    if (!Objects.equals(slotStereotype.getBrowserName(), capabilities.getBrowserName())) {
-      return capabilities;
-    }
-
+    // Always propagate VNC capabilities from the stereotype, regardless of whether the session
+    // request included a browserName. Requests without browserName (e.g. proxy-only caps) are
+    // still routed to a slot that has VNC enabled, so the VNC address must be present.
     Object vncEnabled = slotStereotype.getCapability(SE_VNC_ENABLED);
     if (vncEnabled != null) {
       Object vncPort = slotStereotype.getCapability(SE_NO_VNC_PORT);
@@ -57,6 +56,10 @@ public class SessionCapabilitiesMutator implements Function<Capabilities, Capabi
           new PersistentCapabilities(capabilities)
               .setCapability(SE_VNC_ENABLED, vncEnabled)
               .setCapability(SE_NO_VNC_PORT, Require.nonNull(SE_NO_VNC_PORT, vncPort));
+    }
+
+    if (!Objects.equals(slotStereotype.getBrowserName(), capabilities.getBrowserName())) {
+      return capabilities;
     }
 
     String browserName = capabilities.getBrowserName().toLowerCase(Locale.ENGLISH);

--- a/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
+++ b/java/test/org/openqa/selenium/grid/node/config/SessionCapabilitiesMutatorTest.java
@@ -344,6 +344,26 @@ public class SessionCapabilitiesMutatorTest {
   }
 
   @Test
+  void shouldPropagateVncCapsWhenRequestHasNoBrowserName() {
+    // Requests without browserName (e.g. proxy-only caps) are still routed to a VNC-enabled slot;
+    // the VNC address must be present in the merged capabilities.
+    Capabilities stereotype =
+        new ImmutableCapabilities(
+            "browserName", "chrome", "se:vncEnabled", true, "se:noVncPort", 7900);
+
+    SessionCapabilitiesMutator sessionCapabilitiesMutator =
+        new SessionCapabilitiesMutator(stereotype);
+
+    Capabilities capabilities = new ImmutableCapabilities("proxy", Map.of("proxyType", "direct"));
+
+    Map<String, Object> modifiedCapabilities =
+        sessionCapabilitiesMutator.apply(capabilities).asMap();
+
+    assertThat(modifiedCapabilities.get("se:vncEnabled")).isEqualTo(true);
+    assertThat(modifiedCapabilities.get("se:noVncPort")).isEqualTo(7900);
+  }
+
+  @Test
   void shouldAllowUnknownBrowserNames() {
     Capabilities stereotype = new ImmutableCapabilities("browserName", "safari");
 


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
<!-- Example: Fixes #1234 or Closes #5678 -->
<!-- If the reason for this PR is not obvious, consider creating an issue for it first -->

### 💥 What does this PR do?
When a session request arrives without a browserName capability (e.g. {proxy: {proxyType: direct}}), the Grid routes it to any matching slot, but the resulting session capabilities are missing `se:vnc` and `se:vncLocalAddress`.
So the live preview icon is not visible on the Grid UI.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
