### PR TITLE
[build] Fix py:local_dev rake task

### DIFF
--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -90,7 +90,9 @@ task :local_dev, [:all] do |_task, arguments|
     end
 
     %w[getAttribute.js isDisplayed.js findElements.js].each do |atom|
-      FileUtils.cp("#{bazel_bin}/remote/#{atom}", "#{lib_path}/remote/#{atom}")
+      dest = "#{lib_path}/remote/#{atom}"
+      FileUtils.rm_rf(dest)
+      FileUtils.cp("#{bazel_bin}/remote/#{atom}", dest)
     end
   end
 end

--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -91,7 +91,7 @@ task :local_dev, [:all] do |_task, arguments|
 
     %w[getAttribute.js isDisplayed.js findElements.js].each do |atom|
       dest = "#{lib_path}/remote/#{atom}"
-      FileUtils.rm_rf(dest)
+      FileUtils.rm_f(dest)
       FileUtils.cp("#{bazel_bin}/remote/#{atom}", dest)
     end
   end


### PR DESCRIPTION
### 💥 What does this PR do?

We have a rake task used for local development in `./rake_tasks/python.rake` (called with `./go py:local_dev`) that builds the Python bindings and then copies devtools, selenium-manager, and the JS atoms into the local source tree from `./bazel-out/`.

The files in `./bazel-out/` are read-only (555 permissions). Because of this, after you run `py:local_dev`, you have read-only files (atoms) in your local source tree, and running the task subsequent times will fail trying to overwrite read-only files:

```
INFO: Build completed successfully, 1 total action
Exception `#<Class:#<Errno::EACCES:0xeb1d7c8>>' at org/jruby/RubyIO.java:1279 - Permission denied - py/selenium/webdriver/remote/getAttribute.js
go aborted!
Errno::EACCES: Permission denied - py/selenium/webdriver/remote/getAttribute.js
```

This PR fixes that by deleting the JS atoms from the destination before copying them from bazel build output.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Dev/Build