### PR TITLE
[dotnet] [bidi] Dedicated RealmInfoEventArgs type for OnRealmCreated event

### DIFF
--- a/dotnet/src/webdriver/BiDi/Json/Converters/Polymorphic/RealmInfoEventArgsConverter.cs
+++ b/dotnet/src/webdriver/BiDi/Json/Converters/Polymorphic/RealmInfoEventArgsConverter.cs
@@ -1,0 +1,49 @@
+// <copyright file="RealmInfoEventArgsConverter.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenQA.Selenium.BiDi.Script;
+
+namespace OpenQA.Selenium.BiDi.Json.Converters.Polymorphic;
+
+// https://github.com/dotnet/runtime/issues/72604
+internal class RealmInfoEventArgsConverter : JsonConverter<RealmInfoEventArgs>
+{
+    public override RealmInfoEventArgs? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetDiscriminator("type") switch
+        {
+            "window" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<WindowRealmInfoEventArgs>()),
+            "dedicated-worker" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<DedicatedWorkerRealmInfoEventArgs>()),
+            "shared-worker" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<SharedWorkerRealmInfoEventArgs>()),
+            "service-worker" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<ServiceWorkerRealmInfoEventArgs>()),
+            "worker" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<WorkerRealmInfoEventArgs>()),
+            "paint-worklet" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<PaintWorkletRealmInfoEventArgs>()),
+            "audio-worklet" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<AudioWorkletRealmInfoEventArgs>()),
+            "worklet" => JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<WorkletRealmInfoEventArgs>()),
+            _ => null,
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, RealmInfoEventArgs value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/src/webdriver/BiDi/Script/IScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/IScriptModule.cs
@@ -32,8 +32,8 @@ public interface IScriptModule
     Task<GetRealmsResult> GetRealmsAsync(GetRealmsOptions? options = null, CancellationToken cancellationToken = default);
     Task<Subscription> OnMessageAsync(Func<MessageEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
     Task<Subscription> OnMessageAsync(Action<MessageEventArgs> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
-    Task<Subscription> OnRealmCreatedAsync(Func<RealmInfo, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
-    Task<Subscription> OnRealmCreatedAsync(Action<RealmInfo> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
+    Task<Subscription> OnRealmCreatedAsync(Func<RealmInfoEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
+    Task<Subscription> OnRealmCreatedAsync(Action<RealmInfoEventArgs> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
     Task<Subscription> OnRealmDestroyedAsync(Func<RealmDestroyedEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
     Task<Subscription> OnRealmDestroyedAsync(Action<RealmDestroyedEventArgs> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default);
     Task<RemovePreloadScriptResult> RemovePreloadScriptAsync(PreloadScript script, RemovePreloadScriptOptions? options = null, CancellationToken cancellationToken = default);

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfo.cs
@@ -33,7 +33,7 @@ namespace OpenQA.Selenium.BiDi.Script;
 //[JsonDerivedType(typeof(AudioWorkletRealmInfo), "audio-worklet")]
 //[JsonDerivedType(typeof(WorkletRealmInfo), "worklet")]
 [JsonConverter(typeof(RealmInfoConverter))]
-public abstract record RealmInfo(Realm Realm, string Origin) : EventArgs;
+public abstract record RealmInfo(Realm Realm, string Origin);
 
 public sealed record WindowRealmInfo(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfo(Realm, Origin)
 {

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfoEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfoEventArgs.cs
@@ -1,0 +1,57 @@
+// <copyright file="RealmInfoEventArgs.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Text.Json.Serialization;
+using OpenQA.Selenium.BiDi.Json.Converters.Polymorphic;
+
+namespace OpenQA.Selenium.BiDi.Script;
+
+// https://github.com/dotnet/runtime/issues/72604
+// [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+// [JsonDerivedType(typeof(WindowRealmInfoEventArgs), "window")]
+// [JsonDerivedType(typeof(DedicatedWorkerRealmInfoEventArgs), "dedicated-worker")]
+// [JsonDerivedType(typeof(SharedWorkerRealmInfoEventArgs), "shared-worker")]
+// [JsonDerivedType(typeof(ServiceWorkerRealmInfoEventArgs), "service-worker")]
+// [JsonDerivedType(typeof(WorkerRealmInfoEventArgs), "worker")]
+// [JsonDerivedType(typeof(PaintWorkletRealmInfoEventArgs), "paint-worklet")]
+// [JsonDerivedType(typeof(AudioWorkletRealmInfoEventArgs), "audio-worklet")]
+// [JsonDerivedType(typeof(WorkletRealmInfoEventArgs), "worklet")]
+[JsonConverter(typeof(RealmInfoEventArgsConverter))]
+public abstract record RealmInfoEventArgs(Realm Realm, string Origin) : EventArgs;
+
+public sealed record WindowRealmInfoEventArgs(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfoEventArgs(Realm, Origin)
+{
+    public Browser.UserContext? UserContext { get; init; }
+
+    public string? Sandbox { get; init; }
+}
+
+public sealed record DedicatedWorkerRealmInfoEventArgs(Realm Realm, string Origin, IReadOnlyList<Realm> Owners) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record SharedWorkerRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record ServiceWorkerRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record WorkerRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record PaintWorkletRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record AudioWorkletRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);
+
+public sealed record WorkletRealmInfoEventArgs(Realm Realm, string Origin) : RealmInfoEventArgs(Realm, Origin);

--- a/dotnet/src/webdriver/BiDi/Script/RealmInfoEventArgs.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RealmInfoEventArgs.cs
@@ -35,12 +35,7 @@ namespace OpenQA.Selenium.BiDi.Script;
 [JsonConverter(typeof(RealmInfoEventArgsConverter))]
 public abstract record RealmInfoEventArgs(Realm Realm, string Origin) : EventArgs;
 
-public sealed record WindowRealmInfoEventArgs(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context) : RealmInfoEventArgs(Realm, Origin)
-{
-    public Browser.UserContext? UserContext { get; init; }
-
-    public string? Sandbox { get; init; }
-}
+public sealed record WindowRealmInfoEventArgs(Realm Realm, string Origin, BrowsingContext.BrowsingContext Context, Browser.UserContext? UserContext, string? Sandbox) : RealmInfoEventArgs(Realm, Origin);
 
 public sealed record DedicatedWorkerRealmInfoEventArgs(Realm Realm, string Origin, IReadOnlyList<Realm> Owners) : RealmInfoEventArgs(Realm, Origin);
 

--- a/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
@@ -94,14 +94,14 @@ public sealed class ScriptModule : Module, IScriptModule
         return await SubscribeAsync("script.message", handler, options, _jsonContext.MessageEventArgs, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Subscription> OnRealmCreatedAsync(Func<RealmInfo, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<Subscription> OnRealmCreatedAsync(Func<RealmInfoEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await SubscribeAsync("script.realmCreated", handler, options, _jsonContext.RealmInfo, cancellationToken).ConfigureAwait(false);
+        return await SubscribeAsync("script.realmCreated", handler, options, _jsonContext.RealmInfoEventArgs, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Subscription> OnRealmCreatedAsync(Action<RealmInfo> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<Subscription> OnRealmCreatedAsync(Action<RealmInfoEventArgs> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await SubscribeAsync("script.realmCreated", handler, options, _jsonContext.RealmInfo, cancellationToken).ConfigureAwait(false);
+        return await SubscribeAsync("script.realmCreated", handler, options, _jsonContext.RealmInfoEventArgs, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnRealmDestroyedAsync(Func<RealmDestroyedEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)
@@ -182,6 +182,17 @@ public sealed class ScriptModule : Module, IScriptModule
 [JsonSerializable(typeof(RemovePreloadScriptResult))]
 
 [JsonSerializable(typeof(MessageEventArgs))]
+[JsonSerializable(typeof(RealmInfoEventArgs))]
 [JsonSerializable(typeof(RealmDestroyedEventArgs))]
+#region https://github.com/dotnet/runtime/issues/72604
+[JsonSerializable(typeof(WindowRealmInfoEventArgs))]
+[JsonSerializable(typeof(DedicatedWorkerRealmInfoEventArgs))]
+[JsonSerializable(typeof(SharedWorkerRealmInfoEventArgs))]
+[JsonSerializable(typeof(ServiceWorkerRealmInfoEventArgs))]
+[JsonSerializable(typeof(WorkerRealmInfoEventArgs))]
+[JsonSerializable(typeof(PaintWorkletRealmInfoEventArgs))]
+[JsonSerializable(typeof(AudioWorkletRealmInfoEventArgs))]
+[JsonSerializable(typeof(WorkletRealmInfoEventArgs))]
+#endregion
 
 internal partial class ScriptJsonSerializerContext : JsonSerializerContext;

--- a/dotnet/test/common/BiDi/Script/ScriptEventsTests.cs
+++ b/dotnet/test/common/BiDi/Script/ScriptEventsTests.cs
@@ -50,7 +50,7 @@ internal class ScriptEventsTests : BiDiTestFixture
     [Test]
     public async Task CanListenToRealmCreatedEvent()
     {
-        TaskCompletionSource<RealmInfo> tcs = new();
+        TaskCompletionSource<RealmInfoEventArgs> tcs = new();
 
         await bidi.Script.OnRealmCreatedAsync(tcs.SetResult);
 
@@ -59,7 +59,7 @@ internal class ScriptEventsTests : BiDiTestFixture
         var realmInfo = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.That(realmInfo, Is.Not.Null);
-        Assert.That(realmInfo, Is.AssignableFrom<WindowRealmInfo>());
+        Assert.That(realmInfo, Is.AssignableFrom<WindowRealmInfoEventArgs>());
         Assert.That(realmInfo.Realm, Is.Not.Null);
     }
 


### PR DESCRIPTION
Now all event args types are really `*EventArgs`.

### 💥 What does this PR do?
Refactors the handling of the "realm created" event in the BiDi Script module to support polymorphic event arguments and improve type safety. The main change is the introduction of a new `RealmInfoEventArgs` hierarchy, replacing the previous `RealmInfo` type for event subscriptions and serialization. This enables more precise event argument types for different realm kinds and lays groundwork for future extensibility.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
