### PR TITLE
[java] fix loading "isDisplayed.js" and other resources in OSGI environment

### DIFF
--- a/java/src/org/openqa/selenium/devtools/events/CdpEventTypes.java
+++ b/java/src/org/openqa/selenium/devtools/events/CdpEventTypes.java
@@ -66,7 +66,9 @@ public class CdpEventTypes {
   public static EventType<Void> domMutation(Consumer<@Nullable DomMutationEvent> handler) {
     Require.nonNull("Handler", handler);
 
-    String script = Read.resourceAsString("/org/openqa/selenium/devtools/mutation-listener.js");
+    String script =
+        Read.resourceAsString(
+            CdpEventTypes.class, "/org/openqa/selenium/devtools/mutation-listener.js");
 
     return new EventType<>() {
       @Override

--- a/java/src/org/openqa/selenium/io/Read.java
+++ b/java/src/org/openqa/selenium/io/Read.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.io;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -53,8 +54,19 @@ public class Read {
     return new String(toByteArray(in), UTF_8);
   }
 
+  /**
+   * This method might not work in OSGI environment.
+   *
+   * @deprecated Use {@link #resourceAsString(Class, String)} instead
+   */
+  @Deprecated
   public static String resourceAsString(String resource) {
-    try (InputStream stream = Read.class.getResourceAsStream(resource)) {
+    return resourceAsString(Read.class, resource);
+  }
+
+  public static String resourceAsString(Class<?> resourceOwner, String resource) {
+    Class<?> clazz = requireNonNull(resourceOwner, "Class owning the resource");
+    try (InputStream stream = clazz.getResourceAsStream(resource)) {
       if (stream == null) {
         throw new IllegalArgumentException("Resource not found: " + resource);
       }

--- a/java/src/org/openqa/selenium/remote/RemoteScript.java
+++ b/java/src/org/openqa/selenium/remote/RemoteScript.java
@@ -84,7 +84,7 @@ class RemoteScript implements Script {
   @Override
   public long addDomMutationHandler(Consumer<DomMutation> consumer) {
     String scriptValue =
-        Read.resourceAsString("/org/openqa/selenium/remote/bidi-mutation-listener.js");
+        Read.resourceAsString(getClass(), "/org/openqa/selenium/remote/bidi-mutation-listener.js");
 
     this.script.addPreloadScript(scriptValue, List.of(new ChannelValue("channel_name")));
 

--- a/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/w3c/W3CHttpCommandCodec.java
@@ -363,7 +363,7 @@ public class W3CHttpCommandCodec extends AbstractHttpCommandCodec {
               atomFileName,
               (fileName) -> {
                 String rawFunction =
-                    resourceAsString("/org/openqa/selenium/remote/" + atomFileName);
+                    resourceAsString(getClass(), "/org/openqa/selenium/remote/" + atomFileName);
                 String atomName = fileName.replace(".js", "");
                 return String.format(
                     "/* %s */return (%s).apply(null, arguments);", atomName, rawFunction);

--- a/java/test/org/openqa/selenium/io/ReadTest.java
+++ b/java/test/org/openqa/selenium/io/ReadTest.java
@@ -42,7 +42,7 @@ class ReadTest {
 
   @Test
   void canReadResourceFromClasspath() {
-    String script = Read.resourceAsString("/org/openqa/selenium/remote/isDisplayed.js");
+    String script = Read.resourceAsString(Read.class, "/org/openqa/selenium/remote/isDisplayed.js");
     assertThat(script).isNotBlank().contains("function(){");
   }
 }


### PR DESCRIPTION
In OSGi, each bundle has its own classloader that can only see its own resources.

### 🔗 Related Issues
Fixes #17251

### 🔧 Implementation Notes
`Read.class.getResource(...)` uses the classloader of the bundle containing class `Read`. It would not  find resource "isDisplayed.js" since it's located in another bundle. The right solution is to use a class from the bundle that owns the resource.

### 🔄 Types of changes
- Bug fix (backwards compatible)
