### PR TITLE
[dotnet] [bidi] Extensible additional command data via options

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
@@ -29,52 +29,52 @@ public sealed class BrowserModule : Module, IBrowserModule
 
     public async Task<CloseResult> CloseAsync(CloseOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new CloseCommand(), options, _jsonContext.CloseCommand, _jsonContext.CloseResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CloseCommand(options?.ExtensionData), options, _jsonContext.CloseCommand, _jsonContext.CloseResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<CreateUserContextResult> CreateUserContextAsync(CreateUserContextOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new CreateUserContextParameters(options?.AcceptInsecureCerts, options?.Proxy, options?.UnhandledPromptBehavior);
 
-        return await ExecuteCommandAsync(new CreateUserContextCommand(@params), options, _jsonContext.CreateUserContextCommand, _jsonContext.CreateUserContextResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CreateUserContextCommand(@params, options?.ExtensionData), options, _jsonContext.CreateUserContextCommand, _jsonContext.CreateUserContextResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<GetUserContextsResult> GetUserContextsAsync(GetUserContextsOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new GetUserContextsCommand(), options, _jsonContext.GetUserContextsCommand, _jsonContext.GetUserContextsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new GetUserContextsCommand(options?.ExtensionData), options, _jsonContext.GetUserContextsCommand, _jsonContext.GetUserContextsResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RemoveUserContextResult> RemoveUserContextAsync(UserContext userContext, RemoveUserContextOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new RemoveUserContextParameters(userContext);
 
-        return await ExecuteCommandAsync(new RemoveUserContextCommand(@params), options, _jsonContext.RemoveUserContextCommand, _jsonContext.RemoveUserContextResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new RemoveUserContextCommand(@params, options?.ExtensionData), options, _jsonContext.RemoveUserContextCommand, _jsonContext.RemoveUserContextResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<GetClientWindowsResult> GetClientWindowsAsync(GetClientWindowsOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new(), options, _jsonContext.GetClientWindowsCommand, _jsonContext.GetClientWindowsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new(options?.ExtensionData), options, _jsonContext.GetClientWindowsCommand, _jsonContext.GetClientWindowsResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(string destinationFolder, SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorAllowed(destinationFolder), options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params, options?.ExtensionData), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetDownloadBehaviorParameters(null, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params, options?.ExtensionData), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorDeniedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorDenied(), options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetDownloadBehaviorCommand(@params, options?.ExtensionData), options, _jsonContext.SetDownloadBehaviorCommand, _jsonContext.SetDownloadBehaviorResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/src/webdriver/BiDi/Browser/CloseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/CloseCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class CloseCommand()
-    : Command<Parameters, CloseResult>(Parameters.Empty, "browser.close");
+internal sealed class CloseCommand(JsonObject? extensionData)
+    : Command<Parameters, CloseResult>(Parameters.Empty, "browser.close", extensionData);
 
 public sealed record CloseOptions : CommandOptions;
 

--- a/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/CreateUserContextCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class CreateUserContextCommand(CreateUserContextParameters @params)
-    : Command<CreateUserContextParameters, CreateUserContextResult>(@params, "browser.createUserContext");
+internal sealed class CreateUserContextCommand(CreateUserContextParameters @params, JsonObject? extensionData)
+    : Command<CreateUserContextParameters, CreateUserContextResult>(@params, "browser.createUserContext", extensionData);
 
 internal sealed record CreateUserContextParameters(bool? AcceptInsecureCerts, Session.ProxyConfiguration? Proxy, Session.UserPromptHandler? UnhandledPromptBehavior) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Browser/GetClientWindowsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/GetClientWindowsCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class GetClientWindowsCommand()
-    : Command<Parameters, GetClientWindowsResult>(Parameters.Empty, "browser.getClientWindows");
+internal sealed class GetClientWindowsCommand(JsonObject? extensionData)
+    : Command<Parameters, GetClientWindowsResult>(Parameters.Empty, "browser.getClientWindows", extensionData);
 
 public sealed record GetClientWindowsOptions : CommandOptions;
 

--- a/dotnet/src/webdriver/BiDi/Browser/GetUserContextsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/GetUserContextsCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class GetUserContextsCommand()
-    : Command<Parameters, GetUserContextsResult>(Parameters.Empty, "browser.getUserContexts");
+internal sealed class GetUserContextsCommand(JsonObject? extensionData)
+    : Command<Parameters, GetUserContextsResult>(Parameters.Empty, "browser.getUserContexts", extensionData);
 
 public record GetUserContextsOptions : CommandOptions;
 

--- a/dotnet/src/webdriver/BiDi/Browser/RemoveUserContextCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/RemoveUserContextCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class RemoveUserContextCommand(RemoveUserContextParameters @params)
-    : Command<RemoveUserContextParameters, RemoveUserContextResult>(@params, "browser.removeUserContext");
+internal sealed class RemoveUserContextCommand(RemoveUserContextParameters @params, JsonObject? extensionData)
+    : Command<RemoveUserContextParameters, RemoveUserContextResult>(@params, "browser.removeUserContext", extensionData);
 
 internal sealed record RemoveUserContextParameters(UserContext UserContext) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehaviorCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Browser;
 
-internal sealed class SetDownloadBehaviorCommand(SetDownloadBehaviorParameters @params)
-    : Command<SetDownloadBehaviorParameters, SetDownloadBehaviorResult>(@params, "browser.setDownloadBehavior");
+internal sealed class SetDownloadBehaviorCommand(SetDownloadBehaviorParameters @params, JsonObject? extensionData)
+    : Command<SetDownloadBehaviorParameters, SetDownloadBehaviorResult>(@params, "browser.setDownloadBehavior", extensionData);
 
 internal sealed record SetDownloadBehaviorParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] DownloadBehavior? DownloadBehavior, IEnumerable<UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/ActivateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/ActivateCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class ActivateCommand(ActivateParameters @params)
-    : Command<ActivateParameters, ActivateResult>(@params, "browsingContext.activate");
+internal sealed class ActivateCommand(ActivateParameters @params, JsonObject? extensionData)
+    : Command<ActivateParameters, ActivateResult>(@params, "browsingContext.activate", extensionData);
 
 internal sealed record ActivateParameters(BrowsingContext Context) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/BrowsingContextModule.cs
@@ -31,84 +31,84 @@ public sealed class BrowsingContextModule : Module, IBrowsingContextModule
     {
         var @params = new CreateParameters(type, options?.ReferenceContext, options?.Background, options?.UserContext);
 
-        return await ExecuteCommandAsync(new CreateCommand(@params), options, _jsonContext.CreateCommand, _jsonContext.CreateResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CreateCommand(@params, options?.ExtensionData), options, _jsonContext.CreateCommand, _jsonContext.CreateResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<NavigateResult> NavigateAsync(BrowsingContext context, string url, NavigateOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new NavigateParameters(context, url, options?.Wait);
 
-        return await ExecuteCommandAsync(new NavigateCommand(@params), options, _jsonContext.NavigateCommand, _jsonContext.NavigateResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new NavigateCommand(@params, options?.ExtensionData), options, _jsonContext.NavigateCommand, _jsonContext.NavigateResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ActivateResult> ActivateAsync(BrowsingContext context, ActivateOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new ActivateParameters(context);
 
-        return await ExecuteCommandAsync(new ActivateCommand(@params), options, _jsonContext.ActivateCommand, _jsonContext.ActivateResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ActivateCommand(@params, options?.ExtensionData), options, _jsonContext.ActivateCommand, _jsonContext.ActivateResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<LocateNodesResult> LocateNodesAsync(BrowsingContext context, Locator locator, LocateNodesOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new LocateNodesParameters(context, locator, options?.MaxNodeCount, options?.SerializationOptions, options?.StartNodes);
 
-        return await ExecuteCommandAsync(new LocateNodesCommand(@params), options, _jsonContext.LocateNodesCommand, _jsonContext.LocateNodesResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new LocateNodesCommand(@params, options?.ExtensionData), options, _jsonContext.LocateNodesCommand, _jsonContext.LocateNodesResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<CaptureScreenshotResult> CaptureScreenshotAsync(BrowsingContext context, CaptureScreenshotOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new CaptureScreenshotParameters(context, options?.Origin, options?.Format, options?.Clip);
 
-        return await ExecuteCommandAsync(new CaptureScreenshotCommand(@params), options, _jsonContext.CaptureScreenshotCommand, _jsonContext.CaptureScreenshotResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CaptureScreenshotCommand(@params, options?.ExtensionData), options, _jsonContext.CaptureScreenshotCommand, _jsonContext.CaptureScreenshotResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<CloseResult> CloseAsync(BrowsingContext context, CloseOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new CloseParameters(context, options?.PromptUnload);
 
-        return await ExecuteCommandAsync(new CloseCommand(@params), options, _jsonContext.CloseCommand, _jsonContext.CloseResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CloseCommand(@params, options?.ExtensionData), options, _jsonContext.CloseCommand, _jsonContext.CloseResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<TraverseHistoryResult> TraverseHistoryAsync(BrowsingContext context, int delta, TraverseHistoryOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new TraverseHistoryParameters(context, delta);
 
-        return await ExecuteCommandAsync(new TraverseHistoryCommand(@params), options, _jsonContext.TraverseHistoryCommand, _jsonContext.TraverseHistoryResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new TraverseHistoryCommand(@params, options?.ExtensionData), options, _jsonContext.TraverseHistoryCommand, _jsonContext.TraverseHistoryResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ReloadResult> ReloadAsync(BrowsingContext context, ReloadOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new ReloadParameters(context, options?.IgnoreCache, options?.Wait);
 
-        return await ExecuteCommandAsync(new ReloadCommand(@params), options, _jsonContext.ReloadCommand, _jsonContext.ReloadResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ReloadCommand(@params, options?.ExtensionData), options, _jsonContext.ReloadCommand, _jsonContext.ReloadResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetViewportResult> SetViewportAsync(SetViewportOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetViewportParameters(options?.Context, options?.Viewport, options?.DevicePixelRatio, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetViewportCommand(@params), options, _jsonContext.SetViewportCommand, _jsonContext.SetViewportResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetViewportCommand(@params, options?.ExtensionData), options, _jsonContext.SetViewportCommand, _jsonContext.SetViewportResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<GetTreeResult> GetTreeAsync(GetTreeOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new GetTreeParameters(options?.MaxDepth, options?.Root);
 
-        return await ExecuteCommandAsync(new GetTreeCommand(@params), options, _jsonContext.GetTreeCommand, _jsonContext.GetTreeResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new GetTreeCommand(@params, options?.ExtensionData), options, _jsonContext.GetTreeCommand, _jsonContext.GetTreeResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<PrintResult> PrintAsync(BrowsingContext context, PrintOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new PrintParameters(context, options?.Background, options?.Margin, options?.Orientation, options?.Page, options?.PageRanges, options?.Scale, options?.ShrinkToFit);
 
-        return await ExecuteCommandAsync(new PrintCommand(@params), options, _jsonContext.PrintCommand, _jsonContext.PrintResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new PrintCommand(@params, options?.ExtensionData), options, _jsonContext.PrintCommand, _jsonContext.PrintResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<HandleUserPromptResult> HandleUserPromptAsync(BrowsingContext context, HandleUserPromptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new HandleUserPromptParameters(context, options?.Accept, options?.UserText);
 
-        return await ExecuteCommandAsync(new HandleUserPromptCommand(@params), options, _jsonContext.HandleUserPromptCommand, _jsonContext.HandleUserPromptResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new HandleUserPromptCommand(@params, options?.ExtensionData), options, _jsonContext.HandleUserPromptCommand, _jsonContext.HandleUserPromptResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnNavigationStartedAsync(Func<NavigationEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CaptureScreenshotCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class CaptureScreenshotCommand(CaptureScreenshotParameters @params)
-    : Command<CaptureScreenshotParameters, CaptureScreenshotResult>(@params, "browsingContext.captureScreenshot");
+internal sealed class CaptureScreenshotCommand(CaptureScreenshotParameters @params, JsonObject? extensionData)
+    : Command<CaptureScreenshotParameters, CaptureScreenshotResult>(@params, "browsingContext.captureScreenshot", extensionData);
 
 internal sealed record CaptureScreenshotParameters(BrowsingContext Context, ScreenshotOrigin? Origin, ImageFormat? Format, ClipRectangle? Clip) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CloseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CloseCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class CloseCommand(CloseParameters @params)
-    : Command<CloseParameters, CloseResult>(@params, "browsingContext.close");
+internal sealed class CloseCommand(CloseParameters @params, JsonObject? extensionData)
+    : Command<CloseParameters, CloseResult>(@params, "browsingContext.close", extensionData);
 
 internal sealed record CloseParameters(BrowsingContext Context, bool? PromptUnload) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/CreateCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class CreateCommand(CreateParameters @params)
-    : Command<CreateParameters, CreateResult>(@params, "browsingContext.create");
+internal sealed class CreateCommand(CreateParameters @params, JsonObject? extensionData)
+    : Command<CreateParameters, CreateResult>(@params, "browsingContext.create", extensionData);
 
 internal sealed record CreateParameters(ContextType Type, BrowsingContext? ReferenceContext, bool? Background, Browser.UserContext? UserContext) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/GetTreeCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class GetTreeCommand(GetTreeParameters @params)
-    : Command<GetTreeParameters, GetTreeResult>(@params, "browsingContext.getTree");
+internal sealed class GetTreeCommand(GetTreeParameters @params, JsonObject? extensionData)
+    : Command<GetTreeParameters, GetTreeResult>(@params, "browsingContext.getTree", extensionData);
 
 internal sealed record GetTreeParameters(long? MaxDepth, BrowsingContext? Root) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/HandleUserPromptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/HandleUserPromptCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class HandleUserPromptCommand(HandleUserPromptParameters @params)
-    : Command<HandleUserPromptParameters, HandleUserPromptResult>(@params, "browsingContext.handleUserPrompt");
+internal sealed class HandleUserPromptCommand(HandleUserPromptParameters @params, JsonObject? extensionData)
+    : Command<HandleUserPromptParameters, HandleUserPromptResult>(@params, "browsingContext.handleUserPrompt", extensionData);
 
 internal sealed record HandleUserPromptParameters(BrowsingContext Context, bool? Accept, string? UserText) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/LocateNodesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/LocateNodesCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class LocateNodesCommand(LocateNodesParameters @params)
-    : Command<LocateNodesParameters, LocateNodesResult>(@params, "browsingContext.locateNodes");
+internal sealed class LocateNodesCommand(LocateNodesParameters @params, JsonObject? extensionData)
+    : Command<LocateNodesParameters, LocateNodesResult>(@params, "browsingContext.locateNodes", extensionData);
 
 internal sealed record LocateNodesParameters(BrowsingContext Context, Locator Locator, long? MaxNodeCount, Script.SerializationOptions? SerializationOptions, IEnumerable<Script.ISharedReference>? StartNodes) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/NavigateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/NavigateCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class NavigateCommand(NavigateParameters @params)
-    : Command<NavigateParameters, NavigateResult>(@params, "browsingContext.navigate");
+internal sealed class NavigateCommand(NavigateParameters @params, JsonObject? extensionData)
+    : Command<NavigateParameters, NavigateResult>(@params, "browsingContext.navigate", extensionData);
 
 internal sealed record NavigateParameters(BrowsingContext Context, string Url, ReadinessState? Wait) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/PrintCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class PrintCommand(PrintParameters @params)
-    : Command<PrintParameters, PrintResult>(@params, "browsingContext.print");
+internal sealed class PrintCommand(PrintParameters @params, JsonObject? extensionData)
+    : Command<PrintParameters, PrintResult>(@params, "browsingContext.print", extensionData);
 
 internal sealed record PrintParameters(BrowsingContext Context, bool? Background, PrintMargin? Margin, PrintOrientation? Orientation, PrintPage? Page, IEnumerable<PrintPageRange>? PageRanges, double? Scale, bool? ShrinkToFit) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/ReloadCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/ReloadCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class ReloadCommand(ReloadParameters @params)
-    : Command<ReloadParameters, ReloadResult>(@params, "browsingContext.reload");
+internal sealed class ReloadCommand(ReloadParameters @params, JsonObject? extensionData)
+    : Command<ReloadParameters, ReloadResult>(@params, "browsingContext.reload", extensionData);
 
 internal sealed record ReloadParameters(BrowsingContext Context, bool? IgnoreCache, ReadinessState? Wait) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/SetViewportCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class SetViewportCommand(SetViewportParameters @params)
-    : Command<SetViewportParameters, SetViewportResult>(@params, "browsingContext.setViewport");
+internal sealed class SetViewportCommand(SetViewportParameters @params, JsonObject? extensionData)
+    : Command<SetViewportParameters, SetViewportResult>(@params, "browsingContext.setViewport", extensionData);
 
 internal sealed record SetViewportParameters(
     BrowsingContext? Context,

--- a/dotnet/src/webdriver/BiDi/BrowsingContext/TraverseHistoryCommand.cs
+++ b/dotnet/src/webdriver/BiDi/BrowsingContext/TraverseHistoryCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.BrowsingContext;
 
-internal sealed class TraverseHistoryCommand(TraverseHistoryParameters @params)
-    : Command<TraverseHistoryParameters, TraverseHistoryResult>(@params, "browsingContext.traverseHistory");
+internal sealed class TraverseHistoryCommand(TraverseHistoryParameters @params, JsonObject? extensionData)
+    : Command<TraverseHistoryParameters, TraverseHistoryResult>(@params, "browsingContext.traverseHistory", extensionData);
 
 internal sealed record TraverseHistoryParameters(BrowsingContext Context, long Delta) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Command.cs
+++ b/dotnet/src/webdriver/BiDi/Command.cs
@@ -17,30 +17,32 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi;
 
-public abstract class Command
+public abstract class Command(string method, IDictionary<string, JsonElement>? extensionData)
 {
-    protected Command(string method)
-    {
-        Method = method;
-    }
-
-    [JsonPropertyOrder(1)]
-    public string Method { get; }
-
     [JsonPropertyOrder(0)]
     public long Id { get; internal set; }
+
+    [JsonPropertyOrder(1)]
+    public string Method { get; } = method;
+
+    [JsonExtensionData]
+    // IMPORTANT: The name is different from ctor parameter to avoid collision with the JsonExtensionData attribute.
+    public IDictionary<string, JsonElement>? JsonExtensionData { get; } = extensionData;
 }
 
-internal abstract class Command<TParameters, TResult>(TParameters @params, string method) : Command(method)
+internal abstract class Command<TParameters, TResult>(TParameters parameters, string method, JsonObject? extensionData)
+    : Command(method, extensionData?.Deserialize<Dictionary<string, JsonElement>>())
     where TParameters : Parameters
     where TResult : EmptyResult
 {
     [JsonPropertyOrder(2)]
-    public TParameters Params { get; } = @params;
+    public TParameters Params { get; } = parameters;
 }
 
 internal record Parameters

--- a/dotnet/src/webdriver/BiDi/CommandOptions.cs
+++ b/dotnet/src/webdriver/BiDi/CommandOptions.cs
@@ -17,9 +17,13 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi;
 
 public abstract record CommandOptions
 {
     public TimeSpan? Timeout { get; init; }
+
+    public JsonObject? ExtensionData { get; init; } = [];
 }

--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -31,56 +31,56 @@ public sealed class EmulationModule : Module, IEmulationModule
     {
         var @params = new SetTimezoneOverrideParameters(timezone, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetTimezoneOverrideCommand(@params), options, _jsonContext.SetTimezoneOverrideCommand, _jsonContext.SetTimezoneOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetTimezoneOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetTimezoneOverrideCommand, _jsonContext.SetTimezoneOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetUserAgentOverrideResult> SetUserAgentOverrideAsync(string? userAgent, SetUserAgentOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetUserAgentOverrideParameters(userAgent, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetUserAgentOverrideCommand(@params), options, _jsonContext.SetUserAgentOverrideCommand, _jsonContext.SetUserAgentOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetUserAgentOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetUserAgentOverrideCommand, _jsonContext.SetUserAgentOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetLocaleOverrideResult> SetLocaleOverrideAsync(string? locale, SetLocaleOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetLocaleOverrideParameters(locale, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetLocaleOverrideCommand(@params), options, _jsonContext.SetLocaleOverrideCommand, _jsonContext.SetLocaleOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetLocaleOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetLocaleOverrideCommand, _jsonContext.SetLocaleOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetForcedColorsModeThemeOverrideResult> SetForcedColorsModeThemeOverrideAsync(ForcedColorsModeTheme? theme, SetForcedColorsModeThemeOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetForcedColorsModeThemeOverrideParameters(theme, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetForcedColorsModeThemeOverrideCommand(@params), options, _jsonContext.SetForcedColorsModeThemeOverrideCommand, _jsonContext.SetForcedColorsModeThemeOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetForcedColorsModeThemeOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetForcedColorsModeThemeOverrideCommand, _jsonContext.SetForcedColorsModeThemeOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetScriptingEnabledResult> SetScriptingEnabledAsync(bool? enabled, SetScriptingEnabledOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetScriptingEnabledParameters(enabled, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetScriptingEnabledCommand(@params), options, _jsonContext.SetScriptingEnabledCommand, _jsonContext.SetScriptingEnabledResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetScriptingEnabledCommand(@params, options?.ExtensionData), options, _jsonContext.SetScriptingEnabledCommand, _jsonContext.SetScriptingEnabledResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetScreenOrientationOverrideResult> SetScreenOrientationOverrideAsync(ScreenOrientation? screenOrientation, SetScreenOrientationOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetScreenOrientationOverrideParameters(screenOrientation, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetScreenOrientationOverrideCommand(@params), options, _jsonContext.SetScreenOrientationOverrideCommand, _jsonContext.SetScreenOrientationOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetScreenOrientationOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetScreenOrientationOverrideCommand, _jsonContext.SetScreenOrientationOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetScreenSettingsOverrideResult> SetScreenSettingsOverrideAsync(ScreenArea? screenArea, SetScreenSettingsOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetScreenSettingsOverrideParameters(screenArea, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetScreenSettingsOverrideCommand(@params), options, _jsonContext.SetScreenSettingsOverrideCommand, _jsonContext.SetScreenSettingsOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetScreenSettingsOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetScreenSettingsOverrideCommand, _jsonContext.SetScreenSettingsOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetScrollbarTypeOverrideResult> SetScrollbarTypeOverrideAsync(ScrollbarType? scrollbarType, SetScrollbarTypeOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetScrollbarTypeOverrideParameters(scrollbarType, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetScrollbarTypeOverrideCommand(@params), options, _jsonContext.SetScrollbarTypeOverrideCommand, _jsonContext.SetScrollbarTypeOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetScrollbarTypeOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetScrollbarTypeOverrideCommand, _jsonContext.SetScrollbarTypeOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(double latitude, double longitude, SetGeolocationCoordinatesOverrideOptions? options = null, CancellationToken cancellationToken = default)
@@ -89,35 +89,35 @@ public sealed class EmulationModule : Module, IEmulationModule
 
         var @params = new SetGeolocationOverrideCoordinatesParameters(coordinates, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(SetGeolocationOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetGeolocationOverrideCoordinatesParameters(null, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetGeolocationOverrideResult> SetGeolocationPositionErrorOverrideAsync(SetGeolocationPositionErrorOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetGeolocationOverridePositionErrorParameters(new GeolocationPositionError(), options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetGeolocationOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetGeolocationOverrideCommand, _jsonContext.SetGeolocationOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetTouchOverrideResult> SetTouchOverrideAsync(long? maxTouchPoints, SetTouchOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetTouchOverrideParameters(maxTouchPoints, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetTouchOverrideCommand(@params), options, _jsonContext.SetTouchOverrideCommand, _jsonContext.SetTouchOverrideResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetTouchOverrideCommand(@params, options?.ExtensionData), options, _jsonContext.SetTouchOverrideCommand, _jsonContext.SetTouchOverrideResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetNetworkConditionsResult> SetNetworkConditionsAsync(NetworkConditions? networkConditions, SetNetworkConditionsOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetNetworkConditionsParameters(networkConditions, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetNetworkConditionsCommand(@params), options, _jsonContext.SetNetworkConditionsCommand, _jsonContext.SetNetworkConditionsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetNetworkConditionsCommand(@params, options?.ExtensionData), options, _jsonContext.SetNetworkConditionsCommand, _jsonContext.SetNetworkConditionsResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/src/webdriver/BiDi/Emulation/SetForcedColorsModeThemeOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetForcedColorsModeThemeOverrideCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetForcedColorsModeThemeOverrideCommand(SetForcedColorsModeThemeOverrideParameters @params)
-    : Command<SetForcedColorsModeThemeOverrideParameters, SetForcedColorsModeThemeOverrideResult>(@params, "emulation.setForcedColorsModeThemeOverride");
+internal sealed class SetForcedColorsModeThemeOverrideCommand(SetForcedColorsModeThemeOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetForcedColorsModeThemeOverrideParameters, SetForcedColorsModeThemeOverrideResult>(@params, "emulation.setForcedColorsModeThemeOverride", extensionData);
 
 internal sealed record SetForcedColorsModeThemeOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ForcedColorsModeTheme? Theme, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetGeolocationOverrideCommand(SetGeolocationOverrideParameters @params)
-    : Command<SetGeolocationOverrideParameters, SetGeolocationOverrideResult>(@params, "emulation.setGeolocationOverride");
+internal sealed class SetGeolocationOverrideCommand(SetGeolocationOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetGeolocationOverrideParameters, SetGeolocationOverrideResult>(@params, "emulation.setGeolocationOverride", extensionData);
 
 [JsonDerivedType(typeof(SetGeolocationOverrideCoordinatesParameters))]
 [JsonDerivedType(typeof(SetGeolocationOverridePositionErrorParameters))]

--- a/dotnet/src/webdriver/BiDi/Emulation/SetLocaleOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetLocaleOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetLocaleOverrideCommand(SetLocaleOverrideParameters @params)
-    : Command<SetLocaleOverrideParameters, SetLocaleOverrideResult>(@params, "emulation.setLocaleOverride");
+internal sealed class SetLocaleOverrideCommand(SetLocaleOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetLocaleOverrideParameters, SetLocaleOverrideResult>(@params, "emulation.setLocaleOverride", extensionData);
 
 internal sealed record SetLocaleOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? Locale, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetNetworkConditionsCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetNetworkConditionsCommand(SetNetworkConditionsParameters @params)
-    : Command<SetNetworkConditionsParameters, SetNetworkConditionsResult>(@params, "emulation.setNetworkConditions");
+internal sealed class SetNetworkConditionsCommand(SetNetworkConditionsParameters @params, JsonObject? extensionData)
+    : Command<SetNetworkConditionsParameters, SetNetworkConditionsResult>(@params, "emulation.setNetworkConditions", extensionData);
 
 internal sealed record SetNetworkConditionsParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] NetworkConditions? NetworkConditions, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScreenOrientationOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScreenOrientationOverrideCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetScreenOrientationOverrideCommand(SetScreenOrientationOverrideParameters @params)
-    : Command<SetScreenOrientationOverrideParameters, SetScreenOrientationOverrideResult>(@params, "emulation.setScreenOrientationOverride");
+internal sealed class SetScreenOrientationOverrideCommand(SetScreenOrientationOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetScreenOrientationOverrideParameters, SetScreenOrientationOverrideResult>(@params, "emulation.setScreenOrientationOverride", extensionData);
 
 internal sealed record SetScreenOrientationOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScreenOrientation? ScreenOrientation, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScreenSettingsOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetScreenSettingsOverrideCommand(SetScreenSettingsOverrideParameters @params)
-    : Command<SetScreenSettingsOverrideParameters, SetScreenSettingsOverrideResult>(@params, "emulation.setScreenSettingsOverride");
+internal sealed class SetScreenSettingsOverrideCommand(SetScreenSettingsOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetScreenSettingsOverrideParameters, SetScreenSettingsOverrideResult>(@params, "emulation.setScreenSettingsOverride", extensionData);
 
 internal sealed record SetScreenSettingsOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScreenArea? ScreenArea, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScriptingEnabledCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScriptingEnabledCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetScriptingEnabledCommand(SetScriptingEnabledParameters @params)
-    : Command<SetScriptingEnabledParameters, SetScriptingEnabledResult>(@params, "emulation.setScriptingEnabled");
+internal sealed class SetScriptingEnabledCommand(SetScriptingEnabledParameters @params, JsonObject? extensionData)
+    : Command<SetScriptingEnabledParameters, SetScriptingEnabledResult>(@params, "emulation.setScriptingEnabled", extensionData);
 
 internal sealed record SetScriptingEnabledParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] bool? Enabled, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetScrollbarTypeOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetScrollbarTypeOverrideCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetScrollbarTypeOverrideCommand(SetScrollbarTypeOverrideParameters @params)
-    : Command<SetScrollbarTypeOverrideParameters, SetScrollbarTypeOverrideResult>(@params, "emulation.setScrollbarTypeOverride");
+internal sealed class SetScrollbarTypeOverrideCommand(SetScrollbarTypeOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetScrollbarTypeOverrideParameters, SetScrollbarTypeOverrideResult>(@params, "emulation.setScrollbarTypeOverride", extensionData);
 
 internal sealed record SetScrollbarTypeOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] ScrollbarType? ScrollbarType, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetTimezoneOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetTimezoneOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetTimezoneOverrideCommand(SetTimezoneOverrideParameters @params)
-    : Command<SetTimezoneOverrideParameters, SetTimezoneOverrideResult>(@params, "emulation.setTimezoneOverride");
+internal sealed class SetTimezoneOverrideCommand(SetTimezoneOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetTimezoneOverrideParameters, SetTimezoneOverrideResult>(@params, "emulation.setTimezoneOverride", extensionData);
 
 internal sealed record SetTimezoneOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? Timezone, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetTouchOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetTouchOverrideCommand(SetTouchOverrideParameters @params)
-    : Command<SetTouchOverrideParameters, SetTouchOverrideResult>(@params, "emulation.setTouchOverride");
+internal sealed class SetTouchOverrideCommand(SetTouchOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetTouchOverrideParameters, SetTouchOverrideResult>(@params, "emulation.setTouchOverride", extensionData);
 
 internal sealed record SetTouchOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] long? MaxTouchPoints, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Emulation/SetUserAgentOverrideCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetUserAgentOverrideCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Emulation;
 
-internal sealed class SetUserAgentOverrideCommand(SetUserAgentOverrideParameters @params)
-    : Command<SetUserAgentOverrideParameters, SetUserAgentOverrideResult>(@params, "emulation.setUserAgentOverride");
+internal sealed class SetUserAgentOverrideCommand(SetUserAgentOverrideParameters @params, JsonObject? extensionData)
+    : Command<SetUserAgentOverrideParameters, SetUserAgentOverrideResult>(@params, "emulation.setUserAgentOverride", extensionData);
 
 internal sealed record SetUserAgentOverrideParameters([property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? UserAgent, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Input/InputModule.cs
+++ b/dotnet/src/webdriver/BiDi/Input/InputModule.cs
@@ -31,21 +31,21 @@ public sealed class InputModule : Module, IInputModule
     {
         var @params = new PerformActionsParameters(context, actions);
 
-        return await ExecuteCommandAsync(new PerformActionsCommand(@params), options, _jsonContext.PerformActionsCommand, _jsonContext.PerformActionsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new PerformActionsCommand(@params, options?.ExtensionData), options, _jsonContext.PerformActionsCommand, _jsonContext.PerformActionsResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ReleaseActionsResult> ReleaseActionsAsync(BrowsingContext.BrowsingContext context, ReleaseActionsOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new ReleaseActionsParameters(context);
 
-        return await ExecuteCommandAsync(new ReleaseActionsCommand(@params), options, _jsonContext.ReleaseActionsCommand, _jsonContext.ReleaseActionsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ReleaseActionsCommand(@params, options?.ExtensionData), options, _jsonContext.ReleaseActionsCommand, _jsonContext.ReleaseActionsResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetFilesResult> SetFilesAsync(BrowsingContext.BrowsingContext context, Script.ISharedReference element, IEnumerable<string> files, SetFilesOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetFilesParameters(context, element, files);
 
-        return await ExecuteCommandAsync(new SetFilesCommand(@params), options, _jsonContext.SetFilesCommand, _jsonContext.SetFilesResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetFilesCommand(@params, options?.ExtensionData), options, _jsonContext.SetFilesCommand, _jsonContext.SetFilesResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnFileDialogOpenedAsync(Func<FileDialogEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/webdriver/BiDi/Input/PerformActionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/PerformActionsCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Input;
 
-internal sealed class PerformActionsCommand(PerformActionsParameters @params)
-    : Command<PerformActionsParameters, PerformActionsResult>(@params, "input.performActions");
+internal sealed class PerformActionsCommand(PerformActionsParameters @params, JsonObject? extensionData)
+    : Command<PerformActionsParameters, PerformActionsResult>(@params, "input.performActions", extensionData);
 
 internal sealed record PerformActionsParameters(BrowsingContext.BrowsingContext Context, IEnumerable<SourceActions> Actions) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Input/ReleaseActionsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/ReleaseActionsCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Input;
 
-internal sealed class ReleaseActionsCommand(ReleaseActionsParameters @params)
-    : Command<ReleaseActionsParameters, ReleaseActionsResult>(@params, "input.releaseActions");
+internal sealed class ReleaseActionsCommand(ReleaseActionsParameters @params, JsonObject? extensionData)
+    : Command<ReleaseActionsParameters, ReleaseActionsResult>(@params, "input.releaseActions", extensionData);
 
 internal sealed record ReleaseActionsParameters(BrowsingContext.BrowsingContext Context) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Input/SetFilesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Input/SetFilesCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Input;
 
-internal sealed class SetFilesCommand(SetFilesParameters @params)
-    : Command<SetFilesParameters, SetFilesResult>(@params, "input.setFiles");
+internal sealed class SetFilesCommand(SetFilesParameters @params, JsonObject? extensionData)
+    : Command<SetFilesParameters, SetFilesResult>(@params, "input.setFiles", extensionData);
 
 internal sealed record SetFilesParameters(BrowsingContext.BrowsingContext Context, Script.ISharedReference Element, IEnumerable<string> Files) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddDataCollectorCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class AddDataCollectorCommand(AddDataCollectorParameters @params)
-    : Command<AddDataCollectorParameters, AddDataCollectorResult>(@params, "network.addDataCollector");
+internal sealed class AddDataCollectorCommand(AddDataCollectorParameters @params, JsonObject? extensionData)
+    : Command<AddDataCollectorParameters, AddDataCollectorResult>(@params, "network.addDataCollector", extensionData);
 
 internal sealed record AddDataCollectorParameters(IEnumerable<DataType> DataTypes, int MaxEncodedDataSize, CollectorType? CollectorType, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/AddInterceptCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class AddInterceptCommand(AddInterceptParameters @params)
-    : Command<AddInterceptParameters, AddInterceptResult>(@params, "network.addIntercept");
+internal sealed class AddInterceptCommand(AddInterceptParameters @params, JsonObject? extensionData)
+    : Command<AddInterceptParameters, AddInterceptResult>(@params, "network.addIntercept", extensionData);
 
 internal sealed record AddInterceptParameters(IEnumerable<InterceptPhase> Phases, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<UrlPattern>? UrlPatterns) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueRequestCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class ContinueRequestCommand(ContinueRequestParameters @params)
-    : Command<ContinueRequestParameters, ContinueRequestResult>(@params, "network.continueRequest");
+internal sealed class ContinueRequestCommand(ContinueRequestParameters @params, JsonObject? extensionData)
+    : Command<ContinueRequestParameters, ContinueRequestResult>(@params, "network.continueRequest", extensionData);
 
 internal sealed record ContinueRequestParameters(Request Request, BytesValue? Body, IEnumerable<CookieHeader>? Cookies, IEnumerable<Header>? Headers, string? Method, string? Url) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueResponseCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class ContinueResponseCommand(ContinueResponseParameters @params)
-    : Command<ContinueResponseParameters, ContinueResponseResult>(@params, "network.continueResponse");
+internal sealed class ContinueResponseCommand(ContinueResponseParameters @params, JsonObject? extensionData)
+    : Command<ContinueResponseParameters, ContinueResponseResult>(@params, "network.continueResponse", extensionData);
 
 internal sealed record ContinueResponseParameters(Request Request, IEnumerable<SetCookieHeader>? Cookies, IEnumerable<AuthCredentials>? Credentials, IEnumerable<Header>? Headers, string? ReasonPhrase, long? StatusCode) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/ContinueWithAuthCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ContinueWithAuthCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal class ContinueWithAuthCommand(ContinueWithAuthParameters @params)
-    : Command<ContinueWithAuthParameters, ContinueWithAuthResult>(@params, "network.continueWithAuth");
+internal class ContinueWithAuthCommand(ContinueWithAuthParameters @params, JsonObject? extensionData)
+    : Command<ContinueWithAuthParameters, ContinueWithAuthResult>(@params, "network.continueWithAuth", extensionData);
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "action")]
 [JsonDerivedType(typeof(ContinueWithAuthCredentials), "provideCredentials")]

--- a/dotnet/src/webdriver/BiDi/Network/FailRequestCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/FailRequestCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class FailRequestCommand(FailRequestParameters @params)
-    : Command<FailRequestParameters, FailRequestResult>(@params, "network.failRequest");
+internal sealed class FailRequestCommand(FailRequestParameters @params, JsonObject? extensionData)
+    : Command<FailRequestParameters, FailRequestResult>(@params, "network.failRequest", extensionData);
 
 internal sealed record FailRequestParameters(Request Request) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/GetDataCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class GetDataCommand(GetDataParameters @params)
-    : Command<GetDataParameters, GetDataResult>(@params, "network.getData");
+internal sealed class GetDataCommand(GetDataParameters @params, JsonObject? extensionData)
+    : Command<GetDataParameters, GetDataResult>(@params, "network.getData", extensionData);
 
 internal sealed record GetDataParameters(DataType DataType, Request Request, Collector? Collector, bool? Disown) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
+++ b/dotnet/src/webdriver/BiDi/Network/NetworkModule.cs
@@ -31,70 +31,70 @@ public sealed partial class NetworkModule : Module, INetworkModule
     {
         var @params = new AddDataCollectorParameters(dataTypes, maxEncodedDataSize, options?.CollectorType, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new AddDataCollectorCommand(@params), options, _jsonContext.AddDataCollectorCommand, _jsonContext.AddDataCollectorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new AddDataCollectorCommand(@params, options?.ExtensionData), options, _jsonContext.AddDataCollectorCommand, _jsonContext.AddDataCollectorResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<AddInterceptResult> AddInterceptAsync(IEnumerable<InterceptPhase> phases, AddInterceptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new AddInterceptParameters(phases, options?.Contexts, options?.UrlPatterns);
 
-        return await ExecuteCommandAsync(new AddInterceptCommand(@params), options, _jsonContext.AddInterceptCommand, _jsonContext.AddInterceptResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new AddInterceptCommand(@params, options?.ExtensionData), options, _jsonContext.AddInterceptCommand, _jsonContext.AddInterceptResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RemoveDataCollectorResult> RemoveDataCollectorAsync(Collector collector, RemoveDataCollectorOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new RemoveDataCollectorParameters(collector);
 
-        return await ExecuteCommandAsync(new RemoveDataCollectorCommand(@params), options, _jsonContext.RemoveDataCollectorCommand, _jsonContext.RemoveDataCollectorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new RemoveDataCollectorCommand(@params, options?.ExtensionData), options, _jsonContext.RemoveDataCollectorCommand, _jsonContext.RemoveDataCollectorResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RemoveInterceptResult> RemoveInterceptAsync(Intercept intercept, RemoveInterceptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new RemoveInterceptParameters(intercept);
 
-        return await ExecuteCommandAsync(new RemoveInterceptCommand(@params), options, _jsonContext.RemoveInterceptCommand, _jsonContext.RemoveInterceptResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new RemoveInterceptCommand(@params, options?.ExtensionData), options, _jsonContext.RemoveInterceptCommand, _jsonContext.RemoveInterceptResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetCacheBehaviorResult> SetCacheBehaviorAsync(CacheBehavior behavior, SetCacheBehaviorOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetCacheBehaviorParameters(behavior, options?.Contexts);
 
-        return await ExecuteCommandAsync(new SetCacheBehaviorCommand(@params), options, _jsonContext.SetCacheBehaviorCommand, _jsonContext.SetCacheBehaviorResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetCacheBehaviorCommand(@params, options?.ExtensionData), options, _jsonContext.SetCacheBehaviorCommand, _jsonContext.SetCacheBehaviorResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetExtraHeadersResult> SetExtraHeadersAsync(IEnumerable<Header> headers, SetExtraHeadersOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetExtraHeadersParameters(headers, options?.Contexts, options?.UserContexts);
 
-        return await ExecuteCommandAsync(new SetExtraHeadersCommand(@params), options, _jsonContext.SetExtraHeadersCommand, _jsonContext.SetExtraHeadersResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetExtraHeadersCommand(@params, options?.ExtensionData), options, _jsonContext.SetExtraHeadersCommand, _jsonContext.SetExtraHeadersResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ContinueRequestResult> ContinueRequestAsync(Request request, ContinueRequestOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new ContinueRequestParameters(request, options?.Body, options?.Cookies, options?.Headers, options?.Method, options?.Url);
 
-        return await ExecuteCommandAsync(new ContinueRequestCommand(@params), options, _jsonContext.ContinueRequestCommand, _jsonContext.ContinueRequestResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ContinueRequestCommand(@params, options?.ExtensionData), options, _jsonContext.ContinueRequestCommand, _jsonContext.ContinueRequestResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ContinueResponseResult> ContinueResponseAsync(Request request, ContinueResponseOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new ContinueResponseParameters(request, options?.Cookies, options?.Credentials, options?.Headers, options?.ReasonPhrase, options?.StatusCode);
 
-        return await ExecuteCommandAsync(new ContinueResponseCommand(@params), options, _jsonContext.ContinueResponseCommand, _jsonContext.ContinueResponseResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ContinueResponseCommand(@params, options?.ExtensionData), options, _jsonContext.ContinueResponseCommand, _jsonContext.ContinueResponseResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<FailRequestResult> FailRequestAsync(Request request, FailRequestOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new FailRequestParameters(request);
 
-        return await ExecuteCommandAsync(new FailRequestCommand(@params), options, _jsonContext.FailRequestCommand, _jsonContext.FailRequestResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new FailRequestCommand(@params, options?.ExtensionData), options, _jsonContext.FailRequestCommand, _jsonContext.FailRequestResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<BytesValue> GetDataAsync(DataType dataType, Request request, GetDataOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new GetDataParameters(dataType, request, options?.Collector, options?.Disown);
 
-        var result = await ExecuteCommandAsync(new GetDataCommand(@params), options, _jsonContext.GetDataCommand, _jsonContext.GetDataResult, cancellationToken).ConfigureAwait(false);
+        var result = await ExecuteCommandAsync(new GetDataCommand(@params, options?.ExtensionData), options, _jsonContext.GetDataCommand, _jsonContext.GetDataResult, cancellationToken).ConfigureAwait(false);
 
         return result.Bytes;
     }
@@ -103,22 +103,22 @@ public sealed partial class NetworkModule : Module, INetworkModule
     {
         var @params = new ProvideResponseParameters(request, options?.Body, options?.Cookies, options?.Headers, options?.ReasonPhrase, options?.StatusCode);
 
-        return await ExecuteCommandAsync(new ProvideResponseCommand(@params), options, _jsonContext.ProvideResponseCommand, _jsonContext.ProvideResponseResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ProvideResponseCommand(@params, options?.ExtensionData), options, _jsonContext.ProvideResponseCommand, _jsonContext.ProvideResponseResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ContinueWithAuthResult> ContinueWithAuthAsync(Request request, AuthCredentials credentials, ContinueWithAuthCredentialsOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCredentials(request, credentials)), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCredentials(request, credentials), options?.ExtensionData), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ContinueWithAuthResult> ContinueWithAuthAsync(Request request, ContinueWithAuthDefaultCredentialsOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthDefaultCredentials(request)), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthDefaultCredentials(request), options?.ExtensionData), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ContinueWithAuthResult> ContinueWithAuthAsync(Request request, ContinueWithAuthCancelCredentialsOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCancelCredentials(request)), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new ContinueWithAuthCommand(new ContinueWithAuthCancelCredentials(request), options?.ExtensionData), options, _jsonContext.ContinueWithAuthCommand, _jsonContext.ContinueWithAuthResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnBeforeRequestSentAsync(Func<BeforeRequestSentEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/ProvideResponseCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class ProvideResponseCommand(ProvideResponseParameters @params)
-    : Command<ProvideResponseParameters, ProvideResponseResult>(@params, "network.provideResponse");
+internal sealed class ProvideResponseCommand(ProvideResponseParameters @params, JsonObject? extensionData)
+    : Command<ProvideResponseParameters, ProvideResponseResult>(@params, "network.provideResponse", extensionData);
 
 internal sealed record ProvideResponseParameters(Request Request, BytesValue? Body, IEnumerable<SetCookieHeader>? Cookies, IEnumerable<Header>? Headers, string? ReasonPhrase, long? StatusCode) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/RemoveDataCollectorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/RemoveDataCollectorCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class RemoveDataCollectorCommand(RemoveDataCollectorParameters @params)
-    : Command<RemoveDataCollectorParameters, RemoveDataCollectorResult>(@params, "network.removeDataCollector");
+internal sealed class RemoveDataCollectorCommand(RemoveDataCollectorParameters @params, JsonObject? extensionData)
+    : Command<RemoveDataCollectorParameters, RemoveDataCollectorResult>(@params, "network.removeDataCollector", extensionData);
 
 internal sealed record RemoveDataCollectorParameters(Collector Collector) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/RemoveInterceptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/RemoveInterceptCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class RemoveInterceptCommand(RemoveInterceptParameters @params)
-    : Command<RemoveInterceptParameters, RemoveInterceptResult>(@params, "network.removeIntercept");
+internal sealed class RemoveInterceptCommand(RemoveInterceptParameters @params, JsonObject? extensionData)
+    : Command<RemoveInterceptParameters, RemoveInterceptResult>(@params, "network.removeIntercept", extensionData);
 
 internal sealed record RemoveInterceptParameters(Intercept Intercept) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetCacheBehaviorCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class SetCacheBehaviorCommand(SetCacheBehaviorParameters @params)
-    : Command<SetCacheBehaviorParameters, SetCacheBehaviorResult>(@params, "network.setCacheBehavior");
+internal sealed class SetCacheBehaviorCommand(SetCacheBehaviorParameters @params, JsonObject? extensionData)
+    : Command<SetCacheBehaviorParameters, SetCacheBehaviorResult>(@params, "network.setCacheBehavior", extensionData);
 
 internal sealed record SetCacheBehaviorParameters(CacheBehavior CacheBehavior, IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Network/SetExtraHeadersCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Network;
 
-internal sealed class SetExtraHeadersCommand(SetExtraHeadersParameters @params)
-    : Command<SetExtraHeadersParameters, SetExtraHeadersResult>(@params, "network.setExtraHeaders");
+internal sealed class SetExtraHeadersCommand(SetExtraHeadersParameters @params, JsonObject? extensionData)
+    : Command<SetExtraHeadersParameters, SetExtraHeadersResult>(@params, "network.setExtraHeaders", extensionData);
 
 internal sealed record SetExtraHeadersParameters(IEnumerable<Header> Headers, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/PermissionsModule.cs
@@ -31,7 +31,7 @@ public sealed class PermissionsModule : Module, IPermissionsModule
     {
         var @params = new SetPermissionCommandParameters(descriptor, state, origin, options?.EmbeddedOrigin, options?.UserContext);
 
-        return await ExecuteCommandAsync(new SetPermissionCommand(@params), options, _jsonContext.SetPermissionCommand, _jsonContext.SetPermissionResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetPermissionCommand(@params, options?.ExtensionData), options, _jsonContext.SetPermissionCommand, _jsonContext.SetPermissionResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/src/webdriver/BiDi/Permissions/SetPermissionCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Permissions/SetPermissionCommand.cs
@@ -19,10 +19,12 @@
 
 using OpenQA.Selenium.BiDi.Browser;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Permissions;
 
-internal class SetPermissionCommand(SetPermissionCommandParameters @params)
-    : Command<SetPermissionCommandParameters, SetPermissionResult>(@params, "permissions.setPermission");
+internal class SetPermissionCommand(SetPermissionCommandParameters @params, JsonObject? extensionData)
+    : Command<SetPermissionCommandParameters, SetPermissionResult>(@params, "permissions.setPermission", extensionData);
 
 internal record SetPermissionCommandParameters(PermissionDescriptor Descriptor, PermissionState State, string Origin, string? EmbeddedOrigin, UserContext? UserContext) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/AddPreloadScriptCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params)
-    : Command<AddPreloadScriptParameters, AddPreloadScriptResult>(@params, "script.addPreloadScript");
+internal sealed class AddPreloadScriptCommand(AddPreloadScriptParameters @params, JsonObject? extensionData)
+    : Command<AddPreloadScriptParameters, AddPreloadScriptResult>(@params, "script.addPreloadScript", extensionData);
 
 internal sealed record AddPreloadScriptParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, IEnumerable<ChannelLocalValue>? Arguments, IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts, string? Sandbox) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/CallFunctionCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class CallFunctionCommand(CallFunctionParameters @params)
-    : Command<CallFunctionParameters, EvaluateResult>(@params, "script.callFunction");
+internal sealed class CallFunctionCommand(CallFunctionParameters @params, JsonObject? extensionData)
+    : Command<CallFunctionParameters, EvaluateResult>(@params, "script.callFunction", extensionData);
 
 internal sealed record CallFunctionParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string FunctionDeclaration, bool AwaitPromise, Target Target, IEnumerable<LocalValue>? Arguments, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, LocalValue? This, bool? UserActivation) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/DisownCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/DisownCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class DisownCommand(DisownParameters @params)
-    : Command<DisownParameters, DisownResult>(@params, "script.disown");
+internal sealed class DisownCommand(DisownParameters @params, JsonObject? extensionData)
+    : Command<DisownParameters, DisownResult>(@params, "script.disown", extensionData);
 
 internal sealed record DisownParameters(IEnumerable<Handle> Handles, Target Target) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/EvaluateCommand.cs
@@ -21,10 +21,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters.Polymorphic;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class EvaluateCommand(EvaluateParameters @params)
-    : Command<EvaluateParameters, EvaluateResult>(@params, "script.evaluate");
+internal sealed class EvaluateCommand(EvaluateParameters @params, JsonObject? extensionData)
+    : Command<EvaluateParameters, EvaluateResult>(@params, "script.evaluate", extensionData);
 
 internal sealed record EvaluateParameters([StringSyntax(StringSyntaxConstants.JavaScript)] string Expression, Target Target, bool AwaitPromise, ResultOwnership? ResultOwnership, SerializationOptions? SerializationOptions, bool? UserActivation) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/GetRealmsCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class GetRealmsCommand(GetRealmsParameters @params)
-    : Command<GetRealmsParameters, GetRealmsResult>(@params, "script.getRealms");
+internal sealed class GetRealmsCommand(GetRealmsParameters @params, JsonObject? extensionData)
+    : Command<GetRealmsParameters, GetRealmsResult>(@params, "script.getRealms", extensionData);
 
 internal sealed record GetRealmsParameters(BrowsingContext.BrowsingContext? Context, RealmType? Type) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/RemovePreloadScriptCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Script/RemovePreloadScriptCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Script;
 
-internal sealed class RemovePreloadScriptCommand(RemovePreloadScriptParameters @params)
-    : Command<RemovePreloadScriptParameters, RemovePreloadScriptResult>(@params, "script.removePreloadScript");
+internal sealed class RemovePreloadScriptCommand(RemovePreloadScriptParameters @params, JsonObject? extensionData)
+    : Command<RemovePreloadScriptParameters, RemovePreloadScriptResult>(@params, "script.removePreloadScript", extensionData);
 
 internal sealed record RemovePreloadScriptParameters(PreloadScript Script) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
+++ b/dotnet/src/webdriver/BiDi/Script/ScriptModule.cs
@@ -32,7 +32,7 @@ public sealed class ScriptModule : Module, IScriptModule
     {
         var @params = new EvaluateParameters(expression, target, awaitPromise, options?.ResultOwnership, options?.SerializationOptions, options?.UserActivation);
 
-        return await ExecuteCommandAsync(new EvaluateCommand(@params), options, _jsonContext.EvaluateCommand, _jsonContext.EvaluateResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new EvaluateCommand(@params, options?.ExtensionData), options, _jsonContext.EvaluateCommand, _jsonContext.EvaluateResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<TResult?> EvaluateAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string expression, bool awaitPromise, Target target, EvaluateOptions? options = null, CancellationToken cancellationToken = default)
@@ -46,7 +46,7 @@ public sealed class ScriptModule : Module, IScriptModule
     {
         var @params = new CallFunctionParameters(functionDeclaration, awaitPromise, target, options?.Arguments, options?.ResultOwnership, options?.SerializationOptions, options?.This, options?.UserActivation);
 
-        return await ExecuteCommandAsync(new CallFunctionCommand(@params), options, _jsonContext.CallFunctionCommand, _jsonContext.EvaluateResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new CallFunctionCommand(@params, options?.ExtensionData), options, _jsonContext.CallFunctionCommand, _jsonContext.EvaluateResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<TResult?> CallFunctionAsync<TResult>([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, bool awaitPromise, Target target, CallFunctionOptions? options = null, CancellationToken cancellationToken = default)
@@ -60,28 +60,28 @@ public sealed class ScriptModule : Module, IScriptModule
     {
         var @params = new DisownParameters(handles, target);
 
-        return await ExecuteCommandAsync(new DisownCommand(@params), options, _jsonContext.DisownCommand, _jsonContext.DisownResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new DisownCommand(@params, options?.ExtensionData), options, _jsonContext.DisownCommand, _jsonContext.DisownResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<GetRealmsResult> GetRealmsAsync(GetRealmsOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new GetRealmsParameters(options?.Context, options?.Type);
 
-        return await ExecuteCommandAsync(new GetRealmsCommand(@params), options, _jsonContext.GetRealmsCommand, _jsonContext.GetRealmsResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new GetRealmsCommand(@params, options?.ExtensionData), options, _jsonContext.GetRealmsCommand, _jsonContext.GetRealmsResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<AddPreloadScriptResult> AddPreloadScriptAsync([StringSyntax(StringSyntaxConstants.JavaScript)] string functionDeclaration, AddPreloadScriptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new AddPreloadScriptParameters(functionDeclaration, options?.Arguments, options?.Contexts, options?.UserContexts, options?.Sandbox);
 
-        return await ExecuteCommandAsync(new AddPreloadScriptCommand(@params), options, _jsonContext.AddPreloadScriptCommand, _jsonContext.AddPreloadScriptResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new AddPreloadScriptCommand(@params, options?.ExtensionData), options, _jsonContext.AddPreloadScriptCommand, _jsonContext.AddPreloadScriptResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RemovePreloadScriptResult> RemovePreloadScriptAsync(PreloadScript script, RemovePreloadScriptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new RemovePreloadScriptParameters(script);
 
-        return await ExecuteCommandAsync(new RemovePreloadScriptCommand(@params), options, _jsonContext.RemovePreloadScriptCommand, _jsonContext.RemovePreloadScriptResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new RemovePreloadScriptCommand(@params, options?.ExtensionData), options, _jsonContext.RemovePreloadScriptCommand, _jsonContext.RemovePreloadScriptResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Subscription> OnMessageAsync(Func<MessageEventArgs, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/webdriver/BiDi/Session/EndCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/EndCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Session;
 
-internal sealed class EndCommand()
-    : Command<Parameters, EndResult>(Parameters.Empty, "session.end");
+internal sealed class EndCommand(JsonObject? extensionData)
+    : Command<Parameters, EndResult>(Parameters.Empty, "session.end", extensionData);
 
 public sealed record EndOptions : CommandOptions;
 

--- a/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/NewCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Session;
 
-internal sealed class NewCommand(NewParameters @params)
-    : Command<NewParameters, NewResult>(@params, "session.new");
+internal sealed class NewCommand(NewParameters @params, JsonObject? extensionData)
+    : Command<NewParameters, NewResult>(@params, "session.new", extensionData);
 
 internal sealed record NewParameters(CapabilitiesRequest Capabilities) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SessionModule.cs
@@ -29,33 +29,33 @@ internal sealed class SessionModule : Module, ISessionModule
 
     public async Task<StatusResult> StatusAsync(StatusOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new StatusCommand(), options, _jsonContext.StatusCommand, _jsonContext.StatusResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new StatusCommand(options?.ExtensionData), options, _jsonContext.StatusCommand, _jsonContext.StatusResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SubscribeResult> SubscribeAsync(IEnumerable<string> events, SubscribeOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SubscribeParameters(events, options?.Contexts);
 
-        return await ExecuteCommandAsync(new(@params), options, _jsonContext.SubscribeCommand, _jsonContext.SubscribeResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new(@params, options?.ExtensionData), options, _jsonContext.SubscribeCommand, _jsonContext.SubscribeResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<UnsubscribeResult> UnsubscribeAsync(IEnumerable<Subscription> subscriptions, UnsubscribeByIdOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new UnsubscribeByIdParameters(subscriptions);
 
-        return await ExecuteCommandAsync(new UnsubscribeByIdCommand(@params), options, _jsonContext.UnsubscribeByIdCommand, _jsonContext.UnsubscribeResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new UnsubscribeByIdCommand(@params, options?.ExtensionData), options, _jsonContext.UnsubscribeByIdCommand, _jsonContext.UnsubscribeResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<NewResult> NewAsync(CapabilitiesRequest capabilities, NewOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new NewParameters(capabilities);
 
-        return await ExecuteCommandAsync(new NewCommand(@params), options, _jsonContext.NewCommand, _jsonContext.NewResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new NewCommand(@params, options?.ExtensionData), options, _jsonContext.NewCommand, _jsonContext.NewResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<EndResult> EndAsync(EndOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(new EndCommand(), options, _jsonContext.EndCommand, _jsonContext.EndResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new EndCommand(options?.ExtensionData), options, _jsonContext.EndCommand, _jsonContext.EndResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/src/webdriver/BiDi/Session/StatusCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/StatusCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Session;
 
-internal sealed class StatusCommand()
-    : Command<Parameters, StatusResult>(Parameters.Empty, "session.status");
+internal sealed class StatusCommand(JsonObject? extensionData)
+    : Command<Parameters, StatusResult>(Parameters.Empty, "session.status", extensionData);
 
 public sealed record StatusResult(bool Ready, string Message) : EmptyResult;
 

--- a/dotnet/src/webdriver/BiDi/Session/SubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/SubscribeCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Session;
 
-internal sealed class SubscribeCommand(SubscribeParameters @params)
-    : Command<SubscribeParameters, SubscribeResult>(@params, "session.subscribe");
+internal sealed class SubscribeCommand(SubscribeParameters @params, JsonObject? extensionData)
+    : Command<SubscribeParameters, SubscribeResult>(@params, "session.subscribe", extensionData);
 
 internal sealed record SubscribeParameters(IEnumerable<string> Events, IEnumerable<BrowsingContext.BrowsingContext>? Contexts) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Session/UnsubscribeCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Session;
 
-internal sealed class UnsubscribeByIdCommand(UnsubscribeByIdParameters @params)
-    : Command<UnsubscribeByIdParameters, UnsubscribeResult>(@params, "session.unsubscribe");
+internal sealed class UnsubscribeByIdCommand(UnsubscribeByIdParameters @params, JsonObject? extensionData)
+    : Command<UnsubscribeByIdParameters, UnsubscribeResult>(@params, "session.unsubscribe", extensionData);
 
 internal sealed record UnsubscribeByIdParameters(IEnumerable<Subscription> Subscriptions) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/DeleteCookiesCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Storage;
 
-internal sealed class DeleteCookiesCommand(DeleteCookiesParameters @params)
-    : Command<DeleteCookiesParameters, DeleteCookiesResult>(@params, "storage.deleteCookies");
+internal sealed class DeleteCookiesCommand(DeleteCookiesParameters @params, JsonObject? extensionData)
+    : Command<DeleteCookiesParameters, DeleteCookiesResult>(@params, "storage.deleteCookies", extensionData);
 
 internal sealed record DeleteCookiesParameters(CookieFilter? Filter, PartitionDescriptor? Partition) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/GetCookiesCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Storage;
 
-internal sealed class GetCookiesCommand(GetCookiesParameters @params)
-    : Command<GetCookiesParameters, GetCookiesResult>(@params, "storage.getCookies");
+internal sealed class GetCookiesCommand(GetCookiesParameters @params, JsonObject? extensionData)
+    : Command<GetCookiesParameters, GetCookiesResult>(@params, "storage.getCookies", extensionData);
 
 internal sealed record GetCookiesParameters(CookieFilter? Filter, PartitionDescriptor? Partition) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/SetCookieCommand.cs
@@ -20,10 +20,12 @@
 using System.Text.Json.Serialization;
 using OpenQA.Selenium.BiDi.Json.Converters;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.Storage;
 
-internal sealed class SetCookieCommand(SetCookieParameters @params)
-    : Command<SetCookieParameters, SetCookieResult>(@params, "storage.setCookie");
+internal sealed class SetCookieCommand(SetCookieParameters @params, JsonObject? extensionData)
+    : Command<SetCookieParameters, SetCookieResult>(@params, "storage.setCookie", extensionData);
 
 internal sealed record SetCookieParameters(PartialCookie Cookie, PartitionDescriptor? Partition) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/Storage/StorageModule.cs
+++ b/dotnet/src/webdriver/BiDi/Storage/StorageModule.cs
@@ -31,21 +31,21 @@ public sealed class StorageModule : Module, IStorageModule
     {
         var @params = new GetCookiesParameters(options?.Filter, options?.Partition);
 
-        return await ExecuteCommandAsync(new GetCookiesCommand(@params), options, _jsonContext.GetCookiesCommand, _jsonContext.GetCookiesResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new GetCookiesCommand(@params, options?.ExtensionData), options, _jsonContext.GetCookiesCommand, _jsonContext.GetCookiesResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<DeleteCookiesResult> DeleteCookiesAsync(DeleteCookiesOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new DeleteCookiesParameters(options?.Filter, options?.Partition);
 
-        return await ExecuteCommandAsync(new DeleteCookiesCommand(@params), options, _jsonContext.DeleteCookiesCommand, _jsonContext.DeleteCookiesResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new DeleteCookiesCommand(@params, options?.ExtensionData), options, _jsonContext.DeleteCookiesCommand, _jsonContext.DeleteCookiesResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SetCookieResult> SetCookieAsync(PartialCookie cookie, SetCookieOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new SetCookieParameters(cookie, options?.Partition);
 
-        return await ExecuteCommandAsync(new SetCookieCommand(@params), options, _jsonContext.SetCookieCommand, _jsonContext.SetCookieResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new SetCookieCommand(@params, options?.ExtensionData), options, _jsonContext.SetCookieCommand, _jsonContext.SetCookieResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/InstallCommand.cs
@@ -19,10 +19,12 @@
 
 using System.Text.Json.Serialization;
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.WebExtension;
 
-internal sealed class InstallCommand(InstallParameters @params)
-    : Command<InstallParameters, InstallResult>(@params, "webExtension.install");
+internal sealed class InstallCommand(InstallParameters @params, JsonObject? extensionData)
+    : Command<InstallParameters, InstallResult>(@params, "webExtension.install", extensionData);
 
 internal sealed record InstallParameters(ExtensionData ExtensionData) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/WebExtension/UninstallCommand.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/UninstallCommand.cs
@@ -17,10 +17,12 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json.Nodes;
+
 namespace OpenQA.Selenium.BiDi.WebExtension;
 
-internal sealed class UninstallCommand(UninstallParameters @params)
-    : Command<UninstallParameters, UninstallResult>(@params, "webExtension.uninstall");
+internal sealed class UninstallCommand(UninstallParameters @params, JsonObject? extensionData)
+    : Command<UninstallParameters, UninstallResult>(@params, "webExtension.uninstall", extensionData);
 
 internal sealed record UninstallParameters(Extension Extension) : Parameters;
 

--- a/dotnet/src/webdriver/BiDi/WebExtension/WebExtensionModule.cs
+++ b/dotnet/src/webdriver/BiDi/WebExtension/WebExtensionModule.cs
@@ -31,14 +31,14 @@ public sealed class WebExtensionModule : Module, IWebExtensionModule
     {
         var @params = new InstallParameters(extensionData);
 
-        return await ExecuteCommandAsync(new InstallCommand(@params), options, _jsonContext.InstallCommand, _jsonContext.InstallResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new InstallCommand(@params, options?.ExtensionData), options, _jsonContext.InstallCommand, _jsonContext.InstallResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<UninstallResult> UninstallAsync(Extension extension, UninstallOptions? options = null, CancellationToken cancellationToken = default)
     {
         var @params = new UninstallParameters(extension);
 
-        return await ExecuteCommandAsync(new UninstallCommand(@params), options, _jsonContext.UninstallCommand, _jsonContext.UninstallResult, cancellationToken).ConfigureAwait(false);
+        return await ExecuteCommandAsync(new UninstallCommand(@params, options?.ExtensionData), options, _jsonContext.UninstallCommand, _jsonContext.UninstallResult, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)

--- a/dotnet/test/common/BiDi/Session/SessionTests.cs
+++ b/dotnet/test/common/BiDi/Session/SessionTests.cs
@@ -52,4 +52,25 @@ internal class SessionTests : BiDiTestFixture
             () => bidi.StatusAsync(cancellationToken: cts.Token),
             Throws.InstanceOf<TaskCanceledException>());
     }
+
+    [Test]
+    public async Task ShouldAllowExtensionData()
+    {
+        // Verifies that extension data can be sent with a command without error.
+        // No infrastructure to assert the server received it, but the serialized output can be inspected.
+        
+        // Quick
+        await bidi.StatusAsync(new()
+        {
+            ExtensionData = { { "extra", 1 } }
+        });
+
+        // Inject
+        StatusOptions options = new();
+        options.ExtensionData["extra"] = 2;
+        await bidi.StatusAsync(options);
+
+        // Reassign?
+        // options.ExtensionData = new() { ["extra"] = 1 };
+    }
 }


### PR DESCRIPTION
Spec:
```
Command = {
  id: js-uint,
  ...,
  Extensible
}
```

At the same time:
```
EmptyParams = {
   Extensible
}
```

### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/16095

### 💥 What does this PR do?
This pull request updates the WebDriver BiDi (Bidirectional) command infrastructure to allow passing extension data with command objects. This change adds support for optional extension data (via `JsonObject? extensionData`) to various command classes and ensures that the extension data from options is consistently passed through when commands are executed. This makes the command system more flexible and extensible for future enhancements or custom data.

These changes collectively improve the extensibility of the BiDi command infrastructure, allowing for richer command customization and future protocol evolution.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
