### PR TITLE
[dotnet] [bidi] Protected Subscribe method in Module

### DIFF
--- a/dotnet/src/webdriver/BiDi/Module.cs
+++ b/dotnet/src/webdriver/BiDi/Module.cs
@@ -40,7 +40,7 @@ public abstract class Module
         return Broker.SubscribeAsync(eventName, eventHandler, options, jsonTypeInfo, cancellationToken);
     }
 
-    public Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Func<TEventArgs, Task> func, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
+    protected Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, Func<TEventArgs, Task> func, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
         where TEventArgs : EventArgs
     {
         var eventHandler = new AsyncEventHandler<TEventArgs>(eventName, func);


### PR DESCRIPTION
Fix access modifier.

### 💥 What does this PR do?
This pull request makes a small change to the `SubscribeAsync` method in the `Module.cs` file. The method's access modifier is changed from `public` to `protected`, which restricts its visibility to the class itself and its derived classes. This helps encapsulate the method and prevents it from being accessed from outside the class hierarchy.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
