### PR TITLE
[dotnet] [build] Move build targets from cdp to DevTools

### DIFF
--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -14,7 +14,7 @@ load("//dotnet/private:paket_deps.bzl", _paket_deps = "paket_deps")
 def devtools_version_targets():
     targets = []
     for devtools_version in SUPPORTED_DEVTOOLS_VERSIONS:
-        targets.append("//dotnet/src/webdriver/cdp:generate-{}".format(devtools_version))
+        targets.append("//dotnet/src/webdriver/DevTools:generate-{}".format(devtools_version))
     return targets
 
 csharp_binary = _csharp_binary

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -46,7 +46,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver",
     internals_visible_to = [
         "WebDriver.Common.Tests",
@@ -79,7 +79,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver",
     internals_visible_to = [
         "WebDriver.Common.Tests",
@@ -113,7 +113,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver",
     defines = [
         "NET8_0_OR_GREATER",
@@ -140,7 +140,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver.StrongNamed",
     keyfile = "//dotnet:Selenium.snk",
     langversion = "14.0",
@@ -171,7 +171,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver.StrongNamed",
     keyfile = "//dotnet:Selenium.snk",
     langversion = "14.0",
@@ -203,7 +203,7 @@ csharp_library(
         ":resource-utilities",
     ] + glob([
         "**/*.cs",
-    ]) + devtools_version_targets(),
+    ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver.StrongNamed",
     defines = [
         "NET8_0_OR_GREATER",

--- a/dotnet/src/webdriver/DevTools/BUILD.bazel
+++ b/dotnet/src/webdriver/DevTools/BUILD.bazel
@@ -1,6 +1,12 @@
 load("//dotnet:defs.bzl", "generate_devtools")
 load("//dotnet:selenium-dotnet-version.bzl", "SUPPORTED_DEVTOOLS_VERSIONS")
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**/*.cs"]),
+    visibility = ["//dotnet/src/webdriver:__pkg__"],
+)
+
 [
     generate_devtools(
         name = "generate-{}".format(devtools_version),

--- a/dotnet/src/webdriver/DevTools/README.md
+++ b/dotnet/src/webdriver/DevTools/README.md
@@ -18,10 +18,10 @@ add an entry for version `<N>` to the `SupportedDevToolsVersions` dictionary ini
 add the following block (substituting the proper value for `<N>`):
 
 ```bash
-if not exist  "%1..\..\..\bazel-bin\dotnet\src\webdriver\cdp\v<N>\DevToolsSessionDomains.cs" (
+if not exist  "%1..\..\..\bazel-bin\dotnet\src\webdriver\DevTools\v<N>\DevToolsSessionDomains.cs" (
   echo Generating CDP code for version <N>
   pushd "%1..\..\.."
-  bazel build //dotnet/src/webdriver/cdp:generate-v<N>
+  bazel build //dotnet/src/webdriver/DevTools:generate-v<N>
   popd
 )
 ```
@@ -30,10 +30,10 @@ if not exist  "%1..\..\..\bazel-bin\dotnet\src\webdriver\cdp\v<N>\DevToolsSessio
 add the following block (substituting the proper value for `<N>`):
 
 ```bash
-if [[ ! -f "$1../../../bazel-bin/dotnet/src/webdriver/cdp/v<N>/DevToolsSessionDomains.cs" ]]
+if [[ ! -f "$1../../../bazel-bin/dotnet/src/webdriver/DevTools/v<N>/DevToolsSessionDomains.cs" ]]
 then
   echo "Generating CDP code for version <N>"
-  bazel build //dotnet/src/webdriver/cdp:generate-v<N>
+  bazel build //dotnet/src/webdriver/DevTools:generate-v<N>
 fi
 ```
 

--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -94,10 +94,10 @@
   </Target>
 
   <Target Name="GenerateCdp" BeforeTargets="CoreCompile">
-    <Exec Command="bazel build //dotnet/src/webdriver/cdp/..." WorkingDirectory="../../.." />
+    <Exec Command="bazel build //dotnet/src/webdriver/DevTools/..." WorkingDirectory="../../.." />
 
     <ItemGroup>
-      <Compile Include="..\..\..\bazel-bin\dotnet\src\webdriver\cdp\**\*.cs" LinkBase="DevTools\generated" />
+      <Compile Include="..\..\..\bazel-bin\dotnet\src\webdriver\DevTools\**\*.cs" LinkBase="DevTools\generated" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
`cdp` -> existing `DevTools`

### 💥 What does this PR do?
This pull request reorganizes and renames the CDP (Chrome DevTools Protocol) code generation logic in the .NET WebDriver project. The main change is moving all CDP-related files and build targets from the `cdp` directory to a new `DevTools` directory, updating all relevant references and build scripts accordingly. This improves clarity and maintainability by using a more descriptive and consistent directory and target naming scheme.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
