### PR TITLE
[build] Support os architecture in pinned chrome browser

### DIFF
--- a/common/repositories.bzl
+++ b/common/repositories.bzl
@@ -6,8 +6,13 @@ load("//common/private:dmg_archive.bzl", "dmg_archive")
 load("//common/private:drivers.bzl", "local_drivers")
 load("//common/private:pkg_archive.bzl", "pkg_archive")
 
-def pin_browsers():
+def pin_browsers(arch):
     local_drivers(name = "local_drivers")
+
+    if arch == "x86_64":
+        chrome_arch = "x64"
+    else:
+        chrome_arch = "arm64"
 
     http_archive(
         name = "linux_firefox",
@@ -218,16 +223,17 @@ js_library(
 )
 """,
     )
-    http_archive(
-        name = "mac_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-arm64/chrome-mac-arm64.zip",
-        sha256 = "41f692f646dd3ce07ed377d71a15f90e8f2f9a3e3af383c5dde0718f034d6b52",
-        strip_prefix = "chrome-mac-arm64",
-        patch_cmds = [
-            "mv 'Google Chrome for Testing.app' Chrome.app",
-            "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
-        ],
-        build_file_content = """
+    if chrome_arch == "x64":
+        http_archive(
+            name = "mac_chrome",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-x64/chrome-mac-x64.zip",
+            sha256 = "266fe088699a2bdaec210ecb5a4951d9f6047ab5a54d58b220d9602ca0b00a5f",
+            strip_prefix = "chrome-mac-x64",
+            patch_cmds = [
+                "mv 'Google Chrome for Testing.app' Chrome.app",
+                "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
+            ],
+            build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
 
@@ -238,7 +244,29 @@ js_library(
     data = glob(["Chrome.app/**/*"]),
 )
 """,
-    )
+        )
+    else:
+        http_archive(
+            name = "mac_chrome",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-arm64/chrome-mac-arm64.zip",
+            sha256 = "41f692f646dd3ce07ed377d71a15f90e8f2f9a3e3af383c5dde0718f034d6b52",
+            strip_prefix = "chrome-mac-arm64",
+            patch_cmds = [
+                "mv 'Google Chrome for Testing.app' Chrome.app",
+                "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
+            ],
+            build_file_content = """
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["Chrome.app"])
+
+js_library(
+    name = "chrome-js",
+    data = glob(["Chrome.app/**/*"]),
+)
+""",
+        )
     http_archive(
         name = "linux_chromedriver",
         url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/linux64/chromedriver-linux64.zip",
@@ -257,12 +285,13 @@ js_library(
 """,
     )
 
-    http_archive(
-        name = "mac_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-arm64/chromedriver-mac-arm64.zip",
-        sha256 = "43115f874f6590de5525eadf1eb441a02cb1cb907f2a3973f820ca808425d8d6",
-        strip_prefix = "chromedriver-mac-arm64",
-        build_file_content = """
+    if chrome_arch == "x64":
+        http_archive(
+            name = "mac_chromedriver",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-x64/chromedriver-mac-x64.zip",
+            sha256 = "691fa9d77ec37cf6f7b0d10331dbe433a41e9f7fad810996956423dd820369e3",
+            strip_prefix = "chromedriver-mac-x64",
+            build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
 
@@ -273,7 +302,25 @@ js_library(
     data = ["chromedriver"],
 )
 """,
-    )
+        )
+    else:
+        http_archive(
+            name = "mac_chromedriver",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/146.0.7680.165/mac-arm64/chromedriver-mac-arm64.zip",
+            sha256 = "43115f874f6590de5525eadf1eb441a02cb1cb907f2a3973f820ca808425d8d6",
+            strip_prefix = "chromedriver-mac-arm64",
+            build_file_content = """
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["chromedriver"])
+
+js_library(
+    name = "chromedriver-js",
+    data = ["chromedriver"],
+)
+""",
+        )
 
     http_archive(
         name = "linux_beta_chrome",
@@ -296,16 +343,17 @@ js_library(
 )
 """,
     )
-    http_archive(
-        name = "mac_beta_chrome",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-arm64/chrome-mac-arm64.zip",
-        sha256 = "37da2605bae9b5d349546eb9b6700ee6af27aa9b643ee4c58d7bc22d1209a03f",
-        strip_prefix = "chrome-mac-arm64",
-        patch_cmds = [
-            "mv 'Google Chrome for Testing.app' Chrome.app",
-            "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
-        ],
-        build_file_content = """
+    if chrome_arch == "x64":
+        http_archive(
+            name = "mac_beta_chrome",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-x64/chrome-mac-x64.zip",
+            sha256 = "02a0a7ff74a3994fb6bdb6391c1f20319b102af569828f15248d1398c3e414a2",
+            strip_prefix = "chrome-mac-x64",
+            patch_cmds = [
+                "mv 'Google Chrome for Testing.app' Chrome.app",
+                "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
+            ],
+            build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
 
@@ -316,7 +364,29 @@ js_library(
     data = glob(["Chrome.app/**/*"]),
 )
 """,
-    )
+        )
+    else:
+        http_archive(
+            name = "mac_beta_chrome",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-arm64/chrome-mac-arm64.zip",
+            sha256 = "37da2605bae9b5d349546eb9b6700ee6af27aa9b643ee4c58d7bc22d1209a03f",
+            strip_prefix = "chrome-mac-arm64",
+            patch_cmds = [
+                "mv 'Google Chrome for Testing.app' Chrome.app",
+                "mv 'Chrome.app/Contents/MacOS/Google Chrome for Testing' Chrome.app/Contents/MacOS/Chrome",
+            ],
+            build_file_content = """
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["Chrome.app"])
+
+js_library(
+    name = "chrome-js",
+    data = glob(["Chrome.app/**/*"]),
+)
+""",
+        )
     http_archive(
         name = "linux_beta_chromedriver",
         url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/linux64/chromedriver-linux64.zip",
@@ -335,12 +405,13 @@ js_library(
 """,
     )
 
-    http_archive(
-        name = "mac_beta_chromedriver",
-        url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-arm64/chromedriver-mac-arm64.zip",
-        sha256 = "76cc4a27016387fbe8fa0905bd73e1c715905b6f1240053103299ee293cfde9c",
-        strip_prefix = "chromedriver-mac-arm64",
-        build_file_content = """
+    if chrome_arch == "x64":
+        http_archive(
+            name = "mac_beta_chromedriver",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-x64/chromedriver-mac-x64.zip",
+            sha256 = "c1f1520e8ea57b8c49f18310448929ca4503df596df76415a748ddeeaabe6d7d",
+            strip_prefix = "chromedriver-mac-x64",
+            build_file_content = """
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 package(default_visibility = ["//visibility:public"])
 
@@ -351,10 +422,28 @@ js_library(
     data = ["chromedriver"],
 )
 """,
-    )
+        )
+    else:
+        http_archive(
+            name = "mac_beta_chromedriver",
+            url = "https://storage.googleapis.com/chrome-for-testing-public/147.0.7727.24/mac-arm64/chromedriver-mac-arm64.zip",
+            sha256 = "76cc4a27016387fbe8fa0905bd73e1c715905b6f1240053103299ee293cfde9c",
+            strip_prefix = "chromedriver-mac-arm64",
+            build_file_content = """
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["chromedriver"])
+
+js_library(
+    name = "chromedriver-js",
+    data = ["chromedriver"],
+)
+""",
+        )
 
 def _pin_browsers_extension_impl(_ctx):
-    pin_browsers()
+    pin_browsers(arch = _ctx.os.arch)
 
 pin_browsers_extension = module_extension(
     implementation = _pin_browsers_extension_impl,


### PR DESCRIPTION
Now I can use Mac `x64`. Build system doesn't require `arm`.

### 💥 What does this PR do?
This pull request updates the way Chrome and Chromedriver binaries are pinned for Mac in the `common/repositories.bzl` file, making the process architecture-aware. The changes ensure that the correct binaries are fetched for either x86_64 or arm64 architectures, improving compatibility and reliability for Mac users on different hardware.

**Architecture-aware browser pinning:**

* Modified the `pin_browsers` function to accept an `arch` parameter and determine the correct Chrome architecture (`x64` for `x86_64` and `arm64` otherwise).
* Updated the `pin_browsers_extension` implementation to pass the detected architecture from the build context to `pin_browsers`.

**Conditional fetching of Mac Chrome/Chromedriver binaries:**

* Added logic to fetch and configure the correct Mac Chrome binary (`mac_chrome`) for `x64` or `arm64`, including patch commands and build file setup.
* Added similar architecture-aware logic for fetching the correct Mac Chromedriver binary (`mac_chromedriver`).
* Extended the same conditional logic to the beta versions of both Chrome (`mac_beta_chrome`) and Chromedriver (`mac_beta_chromedriver`). [[1]](diffhunk://#diff-25d82cd18102fed27d3202000e1f1b3a56a85ad2848236d91989cd30a3952401R346-R368) [[2]](diffhunk://#diff-25d82cd18102fed27d3202000e1f1b3a56a85ad2848236d91989cd30a3952401R408-R426)

### 💡 Additional Considerations
Only chrome driver, enough for me at this time.

### 🔄 Types of changes
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
