### PR TITLE
[dotnet] [build] Simplify how we pack nuget package

### DIFF
--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -99,6 +99,7 @@ def nuget_pack_impl(ctx):
             "$DOTNET pack --no-build --include-symbols",
             "-p:NuspecFile=project.nuspec",
             "-p:SymbolPackageFormat=snupkg",
+            "-p:NoWarn=NU5048",  # suppress 'iconUrl is deprecated, use icon' warning since nuspec uses both
             "-p:Configuration=" + build_flavor,
             "-p:PackageId=" + ctx.attr.id,
             "-p:Version=" + ctx.attr.version,

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -2,22 +2,27 @@ load("@rules_dotnet//dotnet/private:common.bzl", "is_debug")
 load("@rules_dotnet//dotnet/private:providers.bzl", "DotnetAssemblyRuntimeInfo")
 load(":dotnet_utils.bzl", "dotnet_preamble")
 
-def _guess_dotnet_version(label, assembly_info):
+_CSPROJ_TEMPLATE = """\
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>{id}</AssemblyName>
+        <RootNamespace>OpenQA.Selenium</RootNamespace>
+    </PropertyGroup>
+</Project>
+"""
+
+def _guess_dotnet_version(assembly_info):
     if len(assembly_info.libs) == 0:
         fail("Cannot guess .Net version without an output dll: ", assembly_info.name)
 
-    # We're going to rely on the structure of the output names for now
-    # rather than scanning through the dependencies. If this works,
-    # life will be good.
-
-    # The dirname will be something like `bazel-out/darwin_arm64-fastbuild-ST-5c013bc87029/bin/dotnet/src/webdriver/bazelout/net5.0`
-    # Note that the last segment of the path is the framework we're
-    # targeting. Happy days!
+    # The dirname will be something like
+    # `bazel-out/darwin_arm64-fastbuild-ST-5c013bc87029/bin/dotnet/src/webdriver/bazelout/net5.0`
+    # The last segment of the path is the target framework.
     return assembly_info.libs[0].dirname.split("/")[::-1][0]
 
 def nuget_pack_impl(ctx):
     nuspec = ctx.actions.declare_file("%s-generated.nuspec" % ctx.label.name)
-
     ctx.actions.expand_template(
         template = ctx.file.nuspec_template,
         output = nuspec,
@@ -29,70 +34,32 @@ def nuget_pack_impl(ctx):
 
     build_flavor = "Debug" if is_debug(ctx) else "Release"
 
-    # A mapping of files to the paths in which we expect to find them in the package
-    paths = {}
-
+    # Collect files and their target paths within the package layout
+    layout = {}
     for (lib, name) in ctx.attr.libs.items():
         assembly_info = lib[DotnetAssemblyRuntimeInfo]
-
+        tfm = _guess_dotnet_version(assembly_info)
         for dll in assembly_info.libs:
-            paths[dll] = "lib/%s/%s.dll" % (_guess_dotnet_version(lib.label, assembly_info), name)
+            layout[dll] = "lib/%s/%s.dll" % (tfm, name)
         for pdb in assembly_info.pdbs:
-            paths[pdb] = "lib/%s/%s.pdb" % (_guess_dotnet_version(lib.label, assembly_info), name)
+            layout[pdb] = "lib/%s/%s.pdb" % (tfm, name)
         for doc in assembly_info.xml_docs:
-            paths[doc] = "lib/%s/%s.xml" % (_guess_dotnet_version(lib.label, assembly_info), name)
-
-    csproj_template = """<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyName>%s</AssemblyName>
-        <RootNamespace>OpenQA.Selenium</RootNamespace>
-    </PropertyGroup>
-</Project>
-""" % ctx.attr.id
-
-    csproj_file = ctx.actions.declare_file("%s-generated.csproj" % ctx.label.name)
-    ctx.actions.write(csproj_file, csproj_template)
-    paths[csproj_file] = "project.csproj"
+            layout[doc] = "lib/%s/%s.xml" % (tfm, name)
 
     for (file, name) in ctx.attr.files.items():
-        paths[file.files.to_list()[0]] = name
+        layout[file.files.to_list()[0]] = name
 
-    # Zip everything up so we have the right file structure
-    zip_file = ctx.actions.declare_file("%s-intermediate.zip" % ctx.label.name)
-    args = ctx.actions.args()
-    args.add_all(["Cc", zip_file])
-    for (file, path) in paths.items():
-        args.add("%s=%s" % (path, file.path))
-    args.add("project.nuspec=%s" % (nuspec.path))
+    csproj_file = ctx.actions.declare_file("%s-generated.csproj" % ctx.label.name)
+    ctx.actions.write(csproj_file, _CSPROJ_TEMPLATE.format(id = ctx.attr.id))
 
-    ctx.actions.run(
-        executable = ctx.executable._zip,
-        arguments = [args],
-        inputs = paths.keys() + [nuspec],
-        outputs = [zip_file],
-    )
-
-    # Now lay everything out on disk and execute the dotnet pack rule
-
-    # Now we have everything, let's build our package
-    toolchain = ctx.toolchains["@rules_dotnet//dotnet:toolchain_type"]
-
-    nupkg_name_stem = "%s.%s" % (ctx.attr.id, ctx.attr.version)
-
-    dotnet = toolchain.runtime.files_to_run.executable
-    pkg = ctx.actions.declare_file("%s.nupkg" % nupkg_name_stem)
-    symbols_pkg = ctx.actions.declare_file("%s.snupkg" % nupkg_name_stem)
-
-    # Prepare our cache of nupkg files
-    packages = ctx.actions.declare_directory("%s-nuget-packages" % ctx.label.name)
-    packages_cmd = "mkdir -p %s " % packages.path
-
+    # Prepare transitive NuGet package cache
     transitive_libs = depset(transitive = [l[DotnetAssemblyRuntimeInfo].deps for l in ctx.attr.libs]).to_list()
     package_files = depset([lib.nuget_info.nupkg for lib in transitive_libs if lib.nuget_info]).to_list()
 
-    if len(package_files):
-        packages_cmd += "&& cp " + " ".join([f.path for f in package_files]) + " " + packages.path
+    packages = ctx.actions.declare_directory("%s-nuget-packages" % ctx.label.name)
+    packages_cmd = "mkdir -p " + packages.path
+    if package_files:
+        packages_cmd += " && cp " + " ".join([f.path for f in package_files]) + " " + packages.path
 
     ctx.actions.run_shell(
         outputs = [packages],
@@ -101,35 +68,66 @@ def nuget_pack_impl(ctx):
         mnemonic = "LayoutNugetPackages",
     )
 
-    cmd = dotnet_preamble(toolchain) + \
-          "mkdir %s-working-dir && " % ctx.label.name + \
-          "echo $(pwd) && " + \
-          "$(location @bazel_tools//tools/zip:zipper) x %s -d %s-working-dir && " % (zip_file.path, ctx.label.name) + \
-          "cd %s-working-dir && " % ctx.label.name + \
-          "echo '<configuration><packageSources><clear /><add key=\"local\" value=\"%%CWD%%/%s\" /></packageSources></configuration>' >nuget.config && " % packages.path + \
-          "$DOTNET restore --no-dependencies && " + \
-          "$DOTNET pack --no-build --include-symbols -p:NuspecFile=project.nuspec --include-symbols -p:SymbolPackageFormat=snupkg -p:Configuration=%s -p:PackageId=%s -p:Version=%s -p:PackageVersion=%s -p:NuspecProperties=\"version=%s\" && " % (build_flavor, ctx.attr.id, ctx.attr.version, ctx.attr.version, ctx.attr.version) + \
-          "cp bin/%s/%s.%s.nupkg ../%s && " % (build_flavor, ctx.attr.id, ctx.attr.version, pkg.path) + \
-          "cp bin/%s/%s.%s.snupkg ../%s" % (build_flavor, ctx.attr.id, ctx.attr.version, symbols_pkg.path)
+    # Create nupkg via dotnet pack
+    toolchain = ctx.toolchains["@rules_dotnet//dotnet:toolchain_type"]
+    nupkg_stem = "%s.%s" % (ctx.attr.id, ctx.attr.version)
+    dotnet = toolchain.runtime.files_to_run.executable
+    pkg = ctx.actions.declare_file("%s.nupkg" % nupkg_stem)
+    symbols_pkg = ctx.actions.declare_file("%s.snupkg" % nupkg_stem)
 
-    cmd = ctx.expand_location(
-        cmd,
-        targets = [
-            ctx.attr._zip,
-        ],
-    )
+    working_dir = ctx.label.name + "-working-dir"
+
+    # Copy files directly into the working directory layout (no intermediate zip)
+    copy_cmds = []
+    for (file, rel_path) in layout.items():
+        dest = working_dir + "/" + rel_path
+        copy_cmds.append("mkdir -p $(dirname {dest}) && cp {src} {dest}".format(
+            dest = dest,
+            src = file.path,
+        ))
+
+    cmd_parts = [
+        "mkdir -p " + working_dir,
+    ] + copy_cmds + [
+        "cp {src} {dir}/project.nuspec".format(src = nuspec.path, dir = working_dir),
+        "cp {src} {dir}/project.csproj".format(src = csproj_file.path, dir = working_dir),
+        "cd " + working_dir,
+        "echo '<configuration><packageSources><clear /><add key=\"local\" value=\"%CWD%/{packages}\" /></packageSources></configuration>' >nuget.config".format(
+            packages = packages.path,
+        ),
+        "$DOTNET restore --no-dependencies",
+        " ".join([
+            "$DOTNET pack --no-build --include-symbols",
+            "-p:NuspecFile=project.nuspec",
+            "-p:SymbolPackageFormat=snupkg",
+            "-p:Configuration=" + build_flavor,
+            "-p:PackageId=" + ctx.attr.id,
+            "-p:Version=" + ctx.attr.version,
+            "-p:PackageVersion=" + ctx.attr.version,
+            "-p:NuspecProperties=\"version=" + ctx.attr.version + "\"",
+        ]),
+        "cp bin/{flavor}/{stem}.nupkg ../{pkg}".format(
+            flavor = build_flavor,
+            stem = nupkg_stem,
+            pkg = pkg.path,
+        ),
+        "cp bin/{flavor}/{stem}.snupkg ../{symbols}".format(
+            flavor = build_flavor,
+            stem = nupkg_stem,
+            symbols = symbols_pkg.path,
+        ),
+    ]
+
+    cmd = dotnet_preamble(toolchain) + " && ".join(cmd_parts)
 
     ctx.actions.run_shell(
         outputs = [pkg, symbols_pkg],
-        inputs = [
-            zip_file,
-            dotnet,
-            packages,
-        ],
+        inputs = list(layout.keys()) + [nuspec, csproj_file, dotnet, packages],
         tools = [
-            ctx.executable._zip,
             dotnet,
-        ] + toolchain.default.files.to_list() + toolchain.runtime.default_runfiles.files.to_list() + toolchain.runtime.data_runfiles.files.to_list(),
+        ] + toolchain.default.files.to_list() +
+            toolchain.runtime.default_runfiles.files.to_list() +
+            toolchain.runtime.data_runfiles.files.to_list(),
         command = cmd,
         mnemonic = "CreateNupkg",
     )
@@ -160,18 +158,9 @@ nuget_pack = rule(
             allow_empty = True,
             allow_files = True,
         ),
-        "property_group_vars": attr.string_dict(
-            doc = "Keys and values for variables declared in `PropertyGroup`s in the `csproj_file`",
-            allow_empty = True,
-        ),
         "nuspec_template": attr.label(
             mandatory = True,
             allow_single_file = True,
-        ),
-        "_zip": attr.label(
-            default = "@bazel_tools//tools/zip:zipper",
-            executable = True,
-            cfg = "exec",
         ),
     },
     toolchains = ["@rules_dotnet//dotnet:toolchain_type"],

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -86,6 +86,7 @@ def nuget_pack_impl(ctx):
         ))
 
     cmd_parts = [
+        "rm -rf " + working_dir,
         "mkdir -p " + working_dir,
     ] + copy_cmds + [
         "cp {src} {dir}/project.nuspec".format(src = nuspec.path, dir = working_dir),

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -124,9 +124,8 @@ def nuget_pack_impl(ctx):
     ctx.actions.run_shell(
         outputs = [pkg, symbols_pkg],
         inputs = list(layout.keys()) + [nuspec, csproj_file, dotnet, packages],
-        tools = [
-            dotnet,
-        ] + toolchain.default.files.to_list() +
+        tools = [dotnet] +
+            toolchain.default.files.to_list() +
             toolchain.runtime.default_runfiles.files.to_list() +
             toolchain.runtime.data_runfiles.files.to_list(),
         command = cmd,

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -56,9 +56,9 @@ def nuget_pack_impl(ctx):
     package_files = depset([lib.nuget_info.nupkg for lib in transitive_libs if lib.nuget_info]).to_list()
 
     packages = ctx.actions.declare_directory("%s-nuget-packages" % ctx.label.name)
-    packages_cmd = "mkdir -p " + packages.path
+    packages_cmd = "mkdir -p '%s'" % packages.path
     if package_files:
-        packages_cmd += " && cp " + " ".join([f.path for f in package_files]) + " " + packages.path
+        packages_cmd += " && cp " + " ".join(["'%s'" % f.path for f in package_files]) + " '%s'" % packages.path
 
     ctx.actions.run_shell(
         outputs = [packages],
@@ -80,18 +80,18 @@ def nuget_pack_impl(ctx):
     copy_cmds = []
     for (file, rel_path) in layout.items():
         dest = working_dir + "/" + rel_path
-        copy_cmds.append("mkdir -p $(dirname {dest}) && cp {src} {dest}".format(
+        copy_cmds.append("mkdir -p \"$(dirname '{dest}')\" && cp '{src}' '{dest}'".format(
             dest = dest,
             src = file.path,
         ))
 
     cmd_parts = [
-        "rm -rf " + working_dir,
-        "mkdir -p " + working_dir,
+        "rm -rf '%s'" % working_dir,
+        "mkdir -p '%s'" % working_dir,
     ] + copy_cmds + [
-        "cp {src} {dir}/project.nuspec".format(src = nuspec.path, dir = working_dir),
-        "cp {src} {dir}/project.csproj".format(src = csproj_file.path, dir = working_dir),
-        "cd " + working_dir,
+        "cp '{src}' '{dir}/project.nuspec'".format(src = nuspec.path, dir = working_dir),
+        "cp '{src}' '{dir}/project.csproj'".format(src = csproj_file.path, dir = working_dir),
+        "cd '%s'" % working_dir,
         "echo '<configuration><packageSources><clear /><add key=\"local\" value=\"%CWD%/{packages}\" /></packageSources></configuration>' >nuget.config".format(
             packages = packages.path,
         ),
@@ -107,12 +107,12 @@ def nuget_pack_impl(ctx):
             "-p:PackageVersion=" + ctx.attr.version,
             "-p:NuspecProperties=\"version=" + ctx.attr.version + "\"",
         ]),
-        "cp bin/{flavor}/{stem}.nupkg ../{pkg}".format(
+        "cp 'bin/{flavor}/{stem}.nupkg' '../{pkg}'".format(
             flavor = build_flavor,
             stem = nupkg_stem,
             pkg = pkg.path,
         ),
-        "cp bin/{flavor}/{stem}.snupkg ../{symbols}".format(
+        "cp 'bin/{flavor}/{stem}.snupkg' '../{symbols}'".format(
             flavor = build_flavor,
             stem = nupkg_stem,
             symbols = symbols_pkg.path,

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -124,10 +124,7 @@ def nuget_pack_impl(ctx):
     ctx.actions.run_shell(
         outputs = [pkg, symbols_pkg],
         inputs = list(layout.keys()) + [nuspec, csproj_file, dotnet, packages],
-        tools = [dotnet] +
-            toolchain.default.files.to_list() +
-            toolchain.runtime.default_runfiles.files.to_list() +
-            toolchain.runtime.data_runfiles.files.to_list(),
+        tools = [dotnet] + toolchain.default.files.to_list() + toolchain.runtime.default_runfiles.files.to_list() + toolchain.runtime.data_runfiles.files.to_list(),
         command = cmd,
         mnemonic = "CreateNupkg",
     )

--- a/dotnet/private/nuget_pack.bzl
+++ b/dotnet/private/nuget_pack.bzl
@@ -7,7 +7,6 @@ _CSPROJ_TEMPLATE = """\
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>{id}</AssemblyName>
-        <RootNamespace>OpenQA.Selenium</RootNamespace>
     </PropertyGroup>
 </Project>
 """

--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -305,10 +305,6 @@ nuget_pack(
         ":webdriver-netstandard2.0-strongnamed": "WebDriver.StrongNamed",
     },
     nuspec_template = "Selenium.WebDriver.StrongNamed.nuspec",
-    property_group_vars = {
-        "BaseImagePath": "images",
-        "BaseSeleniumManagerPath": "manager",
-    },
     tags = [
         "block-network",
     ],


### PR DESCRIPTION
Eliminate unnecessary zipping.

### 💥 What does this PR do?
This pull request refactors and simplifies the NuGet packaging logic in `dotnet/private/nuget_pack.bzl` by removing the intermediate zip step, streamlining the file layout process, and cleaning up unused attributes. The changes improve maintainability and efficiency by directly copying files into the package structure and generating the `.csproj` template in a more reusable way.

**NuGet packaging process simplification:**

- Removed the use of an intermediate zip file during the NuGet package creation process; files are now copied directly into the working directory in their final layout, reducing complexity and potential errors. [[1]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL32-R61) [[2]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL104-R130)
- Refactored the file layout logic by replacing the `paths` dictionary with a `layout` dictionary for clearer intent and easier management of files within the package.
- Consolidated and simplified the `.csproj` file generation by introducing a reusable `_CSPROJ_TEMPLATE` string, and removed the redundant `property_group_vars` attribute from the rule and its usages. [[1]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL5-L20) [[2]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL32-R61) [[3]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL163-L175) [[4]](diffhunk://#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479L308-L311)

**Code and rule cleanup:**

- Removed the `_zip` tool and related logic from the rule definition, as zipping is no longer necessary. [[1]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL32-R61) [[2]](diffhunk://#diff-7a75bc51051536d84926a53bc436a8ab809b8f262c31089b982cd2c59e608a3aL163-L175)
- Cleaned up and clarified the `_guess_dotnet_version` function by removing the unused `label` parameter and improving comments for maintainability.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
