### PR TITLE
[dotnet] [test] Start test webserver globally before any tests in Support

### DIFF
--- a/dotnet/test/support/AssemblyFixture.cs
+++ b/dotnet/test/support/AssemblyFixture.cs
@@ -1,0 +1,55 @@
+// <copyright file="AssemblyFixture.cs" company="Selenium Committers">
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenQA.Selenium.Environment;
+
+namespace OpenQA.Selenium.Support;
+
+[SetUpFixture]
+public class AssemblyFixture
+{
+    public AssemblyFixture()
+    {
+    }
+
+    [OneTimeSetUp]
+    public async Task RunBeforeAnyTestAsync()
+    {
+        Internal.Logging.Log.SetLevel(Internal.Logging.LogEventLevel.Trace);
+
+        await EnvironmentManager.Instance.WebServer.StartAsync();
+        if (EnvironmentManager.Instance.Browser == Browser.Remote)
+        {
+            await EnvironmentManager.Instance.RemoteServer.StartAsync();
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task RunAfterAnyTestsAsync()
+    {
+        EnvironmentManager.Instance.CloseCurrentDriver();
+        await EnvironmentManager.Instance.WebServer.StopAsync();
+        if (EnvironmentManager.Instance.Browser == Browser.Remote)
+        {
+            await EnvironmentManager.Instance.RemoteServer.StopAsync();
+        }
+    }
+}

--- a/dotnet/test/support/UI/PopupWindowFinderTests.cs
+++ b/dotnet/test/support/UI/PopupWindowFinderTests.cs
@@ -26,20 +26,6 @@ namespace OpenQA.Selenium.Support.UI;
 [TestFixture]
 public class PopupWindowFinderTests : DriverTestFixture
 {
-    //TODO: Move these to a standalone class when more tests rely on the server being up
-    [OneTimeSetUp]
-    public async Task RunBeforeAnyTestAsync()
-    {
-        await EnvironmentManager.Instance.WebServer.StartAsync();
-    }
-
-    [OneTimeTearDown]
-    public async Task RunAfterAnyTestsAsync()
-    {
-        EnvironmentManager.Instance.CloseCurrentDriver();
-        await EnvironmentManager.Instance.WebServer.StopAsync();
-    }
-
     [Test]
     public void ShouldFindPopupWindowUsingAction()
     {

--- a/dotnet/test/support/UI/PopupWindowFinderTests.cs
+++ b/dotnet/test/support/UI/PopupWindowFinderTests.cs
@@ -17,9 +17,7 @@
 // under the License.
 // </copyright>
 
-using System.Threading.Tasks;
 using NUnit.Framework;
-using OpenQA.Selenium.Environment;
 
 namespace OpenQA.Selenium.Support.UI;
 

--- a/dotnet/test/support/UI/SelectBrowserTests.cs
+++ b/dotnet/test/support/UI/SelectBrowserTests.cs
@@ -19,28 +19,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using OpenQA.Selenium.Environment;
 
 namespace OpenQA.Selenium.Support.UI;
 
 [TestFixture]
 public class SelectBrowserTests : DriverTestFixture
 {
-    [OneTimeSetUp]
-    public async Task RunBeforeAnyTestAsync()
-    {
-        await EnvironmentManager.Instance.WebServer.StartAsync();
-    }
-
-    [OneTimeTearDown]
-    public async Task RunAfterAnyTestsAsync()
-    {
-        EnvironmentManager.Instance.CloseCurrentDriver();
-        await EnvironmentManager.Instance.WebServer.StopAsync();
-    }
-
     [SetUp]
     public void Setup()
     {


### PR DESCRIPTION
Hopefully fixes CI tests.

### 💥 What does this PR do?
This pull request refactors the setup and teardown logic for starting and stopping the web server and remote server in the test suite. The main improvement is the introduction of a shared `AssemblyFixture` class to handle this functionality at the assembly level, which removes redundant setup/teardown code from individual test classes.

**Test infrastructure improvements:**

* Added a new `AssemblyFixture` class in `dotnet/test/support/AssemblyFixture.cs` that uses NUnit's `[SetUpFixture]` to start and stop the web server (and remote server if needed) once for all tests, ensuring consistent and efficient test environment setup and cleanup.
* Removed duplicated `[OneTimeSetUp]` and `[OneTimeTearDown]` methods from `PopupWindowFinderTests` and `SelectBrowserTests`, as this logic is now centralized in `AssemblyFixture`. [[1]](diffhunk://#diff-78439370cab18314d241cfcb1f0016847b86da3a8af89b01c70f4e28c42aaa1aL29-L42) [[2]](diffhunk://#diff-37d1e35ccc4394cb760e3c5dfb7dc0308ca35b5ca2beceabc0f0616c24338b9cL22-L43)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
