### PR TITLE
[dotnet] [test] Normalize namespace for Support tests

### DIFF
--- a/dotnet/test/support/AssemblyFixture.cs
+++ b/dotnet/test/support/AssemblyFixture.cs
@@ -17,12 +17,9 @@
 // under the License.
 // </copyright>
 
-using System.Threading.Tasks;
-using NUnit.Framework;
-using OpenQA.Selenium.Tests.Infrastructure;
 using OpenQA.Selenium.Tests.Infrastructure.Environment;
 
-namespace OpenQA.Selenium.Support;
+namespace OpenQA.Selenium.Support.Tests;
 
 [SetUpFixture]
 public class AssemblyFixture

--- a/dotnet/test/support/Events/EventFiringWebDriverTests.cs
+++ b/dotnet/test/support/Events/EventFiringWebDriverTests.cs
@@ -17,15 +17,12 @@
 // under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 using Moq;
-using NUnit.Framework;
-using OpenQA.Selenium.Tests.Infrastructure;
+using OpenQA.Selenium.Support.Events;
 
-namespace OpenQA.Selenium.Support.Events;
+namespace OpenQA.Selenium.Support.Tests.Events;
 
 [TestFixture]
 public class EventFiringWebDriverTests

--- a/dotnet/test/support/Extensions/ExecuteJavaScriptTests.cs
+++ b/dotnet/test/support/Extensions/ExecuteJavaScriptTests.cs
@@ -18,12 +18,11 @@
 // </copyright>
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Moq;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.Extensions;
 
-namespace OpenQA.Selenium.Support.Extensions;
+namespace OpenQA.Selenium.Support.Tests.Extensions;
 
 public interface IJavaScriptExecutingWebDriver : IWebDriver, IJavaScriptExecutor
 {

--- a/dotnet/test/support/Properties/GlobalUsings.cs
+++ b/dotnet/test/support/Properties/GlobalUsings.cs
@@ -1,4 +1,4 @@
-// <copyright file="EventFiringWebDriverElementTests.cs" company="Selenium Committers">
+// <copyright file="GlobalUsings.cs" company="Selenium Committers">
 // Licensed to the Software Freedom Conservancy (SFC) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -17,27 +17,8 @@
 // under the License.
 // </copyright>
 
-using OpenQA.Selenium.Support.Events;
-using OpenQA.Selenium.Tests;
-
-namespace OpenQA.Selenium.Support.Tests.Events;
-
-[TestFixture]
-public class EventFiringWebDriverElementTests : DriverTestFixture
-{
-    [SetUp]
-    public void Setup()
-    {
-        driver.Url = formsPage;
-    }
-
-    [Test]
-    public void CanTakeEventFiringWebElementScreenshot()
-    {
-        var firingDriver = new EventFiringWebDriver(driver);
-        IWebElement element = firingDriver.FindElement(By.Name("checky"));
-        Screenshot screenshot = ((ITakesScreenshot)element).GetScreenshot();
-
-        Assert.That(screenshot, Is.Not.Null);
-    }
-}
+global using global::NUnit.Framework;
+global using global::OpenQA.Selenium.Tests.Infrastructure;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.Threading.Tasks;

--- a/dotnet/test/support/Selenium.WebDriver.Support.Tests.csproj
+++ b/dotnet/test/support/Selenium.WebDriver.Support.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>WebDriver.Support.Tests</AssemblyName>
+    <RootNamespace>OpenQA.Selenium.Support.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/test/support/UI/DefaultWaitTests.cs
+++ b/dotnet/test/support/UI/DefaultWaitTests.cs
@@ -17,12 +17,11 @@
 // under the License.
 // </copyright>
 
-using System;
 using System.Runtime.CompilerServices;
 using Moq;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class DefaultWaitTests

--- a/dotnet/test/support/UI/HandCrankClock.cs
+++ b/dotnet/test/support/UI/HandCrankClock.cs
@@ -17,9 +17,9 @@
 // under the License.
 // </copyright>
 
-using System;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 public class HandCrankClock : IClock
 {

--- a/dotnet/test/support/UI/LoadableComponentTests.cs
+++ b/dotnet/test/support/UI/LoadableComponentTests.cs
@@ -17,10 +17,9 @@
 // under the License.
 // </copyright>
 
-using System;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class LoadableComponentTests

--- a/dotnet/test/support/UI/PopupWindowFinderTests.cs
+++ b/dotnet/test/support/UI/PopupWindowFinderTests.cs
@@ -17,10 +17,10 @@
 // under the License.
 // </copyright>
 
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium.Tests;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class PopupWindowFinderTests : DriverTestFixture

--- a/dotnet/test/support/UI/SelectBrowserTests.cs
+++ b/dotnet/test/support/UI/SelectBrowserTests.cs
@@ -17,13 +17,10 @@
 // under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium.Tests;
-using OpenQA.Selenium.Tests.Infrastructure;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class SelectBrowserTests : DriverTestFixture

--- a/dotnet/test/support/UI/SelectTests.cs
+++ b/dotnet/test/support/UI/SelectTests.cs
@@ -17,14 +17,12 @@
 // under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using Moq;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class SelectTests

--- a/dotnet/test/support/UI/SlowLoadableComponentTests.cs
+++ b/dotnet/test/support/UI/SlowLoadableComponentTests.cs
@@ -17,10 +17,9 @@
 // under the License.
 // </copyright>
 
-using System;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class SlowLoadableComponentTests

--- a/dotnet/test/support/UI/WebDriverWaitTests.cs
+++ b/dotnet/test/support/UI/WebDriverWaitTests.cs
@@ -17,11 +17,10 @@
 // under the License.
 // </copyright>
 
-using System;
 using Moq;
-using NUnit.Framework;
+using OpenQA.Selenium.Support.UI;
 
-namespace OpenQA.Selenium.Support.UI;
+namespace OpenQA.Selenium.Support.Tests.UI;
 
 [TestFixture]
 public class WebDriverWaitTests


### PR DESCRIPTION


### 🔗 Related Issues
Contributes to https://github.com/SeleniumHQ/selenium/issues/15536

### 💥 What does this PR do?
This pull request restructures the namespaces and global usings in the .NET test suite for Selenium WebDriver Support, improving code organization and maintainability. The changes primarily move test classes into new, more consistent namespaces and introduce a central file for global usings to reduce redundancy.

**Namespace and Usings Refactor:**

* All test files under `dotnet/test/support/` have been moved to new namespaces under `OpenQA.Selenium.Support.Tests` and its sub-namespaces (e.g., `.Events`, `.Extensions`, `.UI`) for better organization and clarity. [[1]](diffhunk://#diff-9d236331c49cb229dc12bd565c385b22f26491ed069ca6308b546fed5ff06c5fL20-R22) [[2]](diffhunk://#diff-ba7fab2ece2ccd995d9b69343cb124e514306090cc3dbc084a1888ab442a56e6L20-R23) [[3]](diffhunk://#diff-8e672a60ad582a4e4f77601c795ae95a5e7d63cc3ee904035293669fbc6cb067L20-R25) [[4]](diffhunk://#diff-45905e88471c03c6cd1ff9643fd83ad275ef773d24cf5b8837c455d347378a0fL21-R25) [[5]](diffhunk://#diff-493c7b7048781b3cb1c90ef9128cdb8637f5974018e209c357899c4fdcd3fb3eL20-R24) [[6]](diffhunk://#diff-1b2f3bc2d8b2579856ac5a43c652318166abe696c8f537228a7dac2f8c96913aL20-R22) [[7]](diffhunk://#diff-7e967d0a5d37fa9b93f7f6574b6e8b501c38dfab76e5718e5baef4b7f0fab2e9L20-R22) [[8]](diffhunk://#diff-78439370cab18314d241cfcb1f0016847b86da3a8af89b01c70f4e28c42aaa1aL20-R23) [[9]](diffhunk://#diff-37d1e35ccc4394cb760e3c5dfb7dc0308ca35b5ca2beceabc0f0616c24338b9cL20-R23) [[10]](diffhunk://#diff-be7ebf0e13417850fa9484747c52b5e69cf15569f61ac2db550eb31114925d4dL20-R25) [[11]](diffhunk://#diff-8e95edfbee4b9f0702cc9dca94cd909e113299295558cb5cdee8d8cbd00106abL20-R22) [[12]](diffhunk://#diff-524757dc7a276c3b48d2f8e1f9877e540f899ce2e548b2770508fb855946a084L20-R23)

* The test project file (`Selenium.WebDriver.Support.Tests.csproj`) now sets the `RootNamespace` to `OpenQA.Selenium.Support.Tests` to match the new namespace structure.

**Global Usings Consolidation:**

* Introduced a new file, `Properties/GlobalUsings.cs`, which defines global using directives for commonly used namespaces (such as `NUnit.Framework`, `OpenQA.Selenium.Tests.Infrastructure`, and standard .NET namespaces). This reduces repetitive using statements across test files.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
