### PR TITLE
[rb] [build] Upgrade bazel rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ bazel_dep(name = "rules_oci", version = "2.3.0")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_python", version = "1.9.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_ruby", version = "0.23.1")
+bazel_dep(name = "rules_ruby", version = "0.24.0")
 bazel_dep(name = "rules_rust", version = "0.69.0")
 
 # Use latest rules_jvm_external for Bazel 9 compatibility


### PR DESCRIPTION
To fix CI issues:

```
ERROR: /home/runner/work/selenium/selenium/rb/spec/unit/selenium/webdriver/common/interactions/BUILD.bazel:4:17: //rb/spec/unit/selenium/webdriver/common/interactions:none_input depends on @@rules_ruby++ruby+ruby//:toolchain in repository @@rules_ruby++ruby+ruby which failed to fetch. no such package '@@rules_ruby++ruby+ruby//': java.io.IOException: Error downloading [https://github.com/jdx/ruby/releases/download/3.4.3/ruby-3.4.3.x86_64_linux.tar.gz] to /home/runner/.bazel/external/rules_ruby++ruby+ruby/dist/temp12711677426749922487/ruby-3.4.3.x86_64_linux.tar.gz: Checksum was 5db238af5e261aaf2d8047da6112adef7c79c62c5a7d765a25dbf6a7174a06f2 but wanted b9631adc5ad33dd29fad47a04c43777162ce71141cd68131e30e0a7b902b6f67
```

### 🔗 Related Issues
https://github.com/SeleniumHQ/selenium/actions/runs/23712599654/job/69074782398

### 💥 What does this PR do?
This pull request updates the version of a Bazel dependency to keep the build configuration current.

Dependency update:

* Upgraded the `rules_ruby` Bazel dependency from version `0.23.1` to `0.24.0` in `MODULE.bazel`, ensuring compatibility with the latest features and bug fixes.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
