### PR TITLE
[dotnet] [test] Return safari back

### DIFF
--- a/dotnet/test/webdriver/BUILD.bazel
+++ b/dotnet/test/webdriver/BUILD.bazel
@@ -31,7 +31,7 @@ dotnet_nunit_test_suite(
         # The first browser in this list is assumed to be the one that should
         # be used by default.
         "firefox",
-        # "safari",  # Skipping safari for now
+        "safari",
         "ie",
         "edge",
         "chrome",


### PR DESCRIPTION
Return safari webdriver tests back as bazel targets.

### 💥 What does this PR do?
This pull request makes a small change to the browser configuration in the `dotnet/test/webdriver/BUILD.bazel` file by enabling Safari browser tests, which were previously skipped.

* Enabled Safari browser in the list of browsers for the `dotnet_nunit_test_suite`, allowing tests to run on Safari.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
