### PR TITLE
[dotnet] [build] Generate external dependencies in outer msbuild

### DIFF
--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
-  <Target Name="GenerateSeleniumManagerBinaries" BeforeTargets="BeforeBuild">
+  <Target Name="GenerateSeleniumManagerBinaries" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
     <Exec Command="bazel build //dotnet/src/webdriver:manager-linux //dotnet/src/webdriver:manager-windows //dotnet/src/webdriver:manager-macos" WorkingDirectory="../../.." />
   </Target>
 
@@ -85,17 +85,21 @@
     <None Update="assets/nuget/buildTransitive/Selenium.WebDriver.props" Pack="true" PackagePath="buildTransitive\" />
   </ItemGroup>
 
-  <Target Name="GenerateResources" BeforeTargets="CoreCompile">
+  <Target Name="GenerateResources" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
     <Exec Command="bazel build //dotnet/src/webdriver:resource-utilities" WorkingDirectory="../../.." />
+  </Target>
 
+  <Target Name="IncludeResources" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Compile Include="..\..\..\bazel-bin\dotnet\src\webdriver\ResourceUtilities.g.cs" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateCdp" BeforeTargets="CoreCompile">
+  <Target Name="GenerateCdp" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
     <Exec Command="bazel build //dotnet/src/webdriver/DevTools/..." WorkingDirectory="../../.." />
+  </Target>
 
+  <Target Name="IncludeCdp" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Compile Include="..\..\..\bazel-bin\dotnet\src\webdriver\DevTools\**\*.cs" LinkBase="DevTools\generated" />
     </ItemGroup>

--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <Target Name="GenerateSeleniumManagerBinaries" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
-    <Exec Command="bazel build //dotnet/src/webdriver:manager-linux //dotnet/src/webdriver:manager-windows //dotnet/src/webdriver:manager-macos" WorkingDirectory="../../.." />
+    <Exec Command="bazel build //dotnet/src/webdriver:manager-linux //dotnet/src/webdriver:manager-windows //dotnet/src/webdriver:manager-macos" />
   </Target>
 
   <ItemGroup>
@@ -86,7 +86,7 @@
   </ItemGroup>
 
   <Target Name="GenerateResources" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
-    <Exec Command="bazel build //dotnet/src/webdriver:resource-utilities" WorkingDirectory="../../.." />
+    <Exec Command="bazel build //dotnet/src/webdriver:resource-utilities" />
   </Target>
 
   <Target Name="IncludeResources" BeforeTargets="CoreCompile">
@@ -96,7 +96,7 @@
   </Target>
 
   <Target Name="GenerateDevTools" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
-    <Exec Command="bazel build //dotnet/src/webdriver/DevTools/..." WorkingDirectory="../../.." />
+    <Exec Command="bazel build //dotnet/src/webdriver/DevTools/..." />
   </Target>
 
   <Target Name="IncludeDevTools" BeforeTargets="CoreCompile">

--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -95,11 +95,11 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateCdp" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
+  <Target Name="GenerateDevTools" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TargetFramework)' == ''">
     <Exec Command="bazel build //dotnet/src/webdriver/DevTools/..." WorkingDirectory="../../.." />
   </Target>
 
-  <Target Name="IncludeCdp" BeforeTargets="CoreCompile">
+  <Target Name="IncludeDevTools" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Compile Include="..\..\..\bazel-bin\dotnet\src\webdriver\DevTools\**\*.cs" LinkBase="DevTools\generated" />
     </ItemGroup>


### PR DESCRIPTION
Optimize native `dotnet build`. So just generate once, and then include per target framework.

### 💥 What does this PR do?
This pull request updates the build targets in the `Selenium.WebDriver.csproj` file to improve compatibility with multi-targeted builds and streamline resource inclusion. The main changes involve adjusting when and how certain Bazel build steps are triggered, and separating resource inclusion into distinct build targets.

Build target improvements for multi-targeting:

* Changed the `BeforeTargets` attribute for the `GenerateSeleniumManagerBinaries`, `GenerateResources`, and `GenerateCdp` targets from `BeforeBuild` or `CoreCompile` to `DispatchToInnerBuilds`, and added a condition to only run these targets when `$(TargetFramework)` is not set. This helps prevent redundant executions during multi-targeted builds. [[1]](diffhunk://#diff-6ef2e9da77183fb83a5ee6b57e85314f589fc08438fc925dd2e332ae075820eaL64-R64) [[2]](diffhunk://#diff-6ef2e9da77183fb83a5ee6b57e85314f589fc08438fc925dd2e332ae075820eaL88-R102)

Resource and code inclusion refactoring:

* Split resource and CDP (Chrome DevTools Protocol) file inclusion into new `IncludeResources` and `IncludeCdp` targets, which now run before `CoreCompile` to ensure generated files are available for compilation.

### 🔄 Types of changes
- Cleanup (formatting, renaming)
