### PR TITLE
[dotnet] [bidi] Decouple transport and processing

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -162,8 +162,6 @@ internal sealed class Broker : IAsyncDisposable
                 buffer.Dispose();
             }
         }
-
-        GC.SuppressFinalize(this);
     }
 
     private void ProcessReceivedMessage(ReadOnlySpan<byte> data)
@@ -468,8 +466,10 @@ internal sealed class Broker : IAsyncDisposable
         {
             var buffer = _buffer ?? throw new ObjectDisposedException(nameof(PooledBufferWriter));
 
-            if (sizeHint <= 0) sizeHint = buffer.Length - _written;
-            if (sizeHint <= 0) sizeHint = buffer.Length;
+            if (sizeHint <= 0)
+            {
+                sizeHint = Math.Max(1, buffer.Length - _written);
+            }
 
             if (_written + sizeHint > buffer.Length)
             {

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -94,39 +94,46 @@ internal sealed class Broker : IAsyncDisposable
         var timeout = options?.Timeout ?? DefaultCommandTimeout;
         cts.CancelAfter(timeout);
 
-        using var sendBuffer = new PooledBufferWriter();
-
-        using (var writer = new Utf8JsonWriter(sendBuffer))
-        {
-            JsonSerializer.Serialize(writer, command, jsonCommandTypeInfo);
-        }
-
-        var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
-        _pendingCommands[command.Id] = commandInfo;
-
-        using var ctsRegistration = cts.Token.Register(() =>
-        {
-            tcs.TrySetCanceled(cts.Token);
-            _pendingCommands.TryRemove(command.Id, out _);
-        });
+        var sendBuffer = RentBuffer();
 
         try
         {
-            if (_logger.IsEnabled(LogEventLevel.Trace))
+            using (var writer = new Utf8JsonWriter(sendBuffer))
             {
-#if NET8_0_OR_GREATER
-                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.Span)}");
-#else
-                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.ToArray())}");
-#endif
+                JsonSerializer.Serialize(writer, command, jsonCommandTypeInfo);
             }
 
-            await _transport.SendAsync(sendBuffer.WrittenMemory, cts.Token).ConfigureAwait(false);
+            var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
+            _pendingCommands[command.Id] = commandInfo;
+
+            using var ctsRegistration = cts.Token.Register(() =>
+            {
+                tcs.TrySetCanceled(cts.Token);
+                _pendingCommands.TryRemove(command.Id, out _);
+            });
+
+            try
+            {
+                if (_logger.IsEnabled(LogEventLevel.Trace))
+                {
+#if NET8_0_OR_GREATER
+                    _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.Span)}");
+#else
+                    _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.ToArray())}");
+#endif
+                }
+
+                await _transport.SendAsync(sendBuffer.WrittenMemory, cts.Token).ConfigureAwait(false);
+            }
+            catch
+            {
+                _pendingCommands.TryRemove(command.Id, out _);
+                throw;
+            }
         }
-        catch
+        finally
         {
-            _pendingCommands.TryRemove(command.Id, out _);
-            throw;
+            ReturnBuffer(sendBuffer);
         }
 
         return (TResult)await tcs.Task.ConfigureAwait(false);

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -77,6 +77,11 @@ internal sealed class Broker : IAsyncDisposable
         where TCommand : Command
         where TResult : EmptyResult
     {
+        if (_terminalReceiveException is { } terminalException)
+        {
+            throw new BiDiException("The broker is no longer processing messages due to a transport error.", terminalException);
+        }
+
         command.Id = Interlocked.Increment(ref _currentCommandId);
 
         var tcs = new TaskCompletionSource<EmptyResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -351,11 +351,8 @@ internal sealed class Broker : IAsyncDisposable
                 _logger.Error($"Unhandled error occurred while receiving remote messages: {ex}");
             }
 
-            // Record the exception so the processing task can fail remaining commands
-            // after draining already-received responses from the channel.
+            // Propagated via _terminalReceiveException; not rethrown to keep disposal orderly.
             _terminalReceiveException = ex;
-
-            throw;
         }
         finally
         {

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -44,6 +44,8 @@ internal sealed class Broker : IAsyncDisposable
 
     private readonly ConcurrentBag<PooledBufferWriter> _bufferPool = [];
 
+    private volatile Exception? _terminalReceiveException;
+
     private readonly Task _receivingTask;
     private readonly Task _processingTask;
     private readonly CancellationTokenSource _receiveMessagesCancellationTokenSource;
@@ -333,14 +335,9 @@ internal sealed class Broker : IAsyncDisposable
                 _logger.Error($"Unhandled error occurred while receiving remote messages: {ex}");
             }
 
-            // Fail all pending commands, as the connection is likely broken if we failed to receive messages.
-            foreach (var id in _pendingCommands.Keys)
-            {
-                if (_pendingCommands.TryRemove(id, out var pendingCommand))
-                {
-                    pendingCommand.TaskCompletionSource.TrySetException(ex);
-                }
-            }
+            // Record the exception so the processing task can fail remaining commands
+            // after draining already-received responses from the channel.
+            _terminalReceiveException = ex;
 
             throw;
         }
@@ -372,6 +369,19 @@ internal sealed class Broker : IAsyncDisposable
                 finally
                 {
                     ReturnBuffer(buffer);
+                }
+            }
+        }
+
+        // Channel is fully drained. Fail any commands that didn't get a response.
+        var terminalException = _terminalReceiveException;
+        if (terminalException is not null)
+        {
+            foreach (var id in _pendingCommands.Keys)
+            {
+                if (_pendingCommands.TryRemove(id, out var pendingCommand))
+                {
+                    pendingCommand.TaskCompletionSource.TrySetException(terminalException);
                 }
             }
         }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -124,26 +124,31 @@ internal sealed class Broker : IAsyncDisposable
     {
         _receiveMessagesCancellationTokenSource.Cancel();
 
-        await _eventDispatcher.DisposeAsync().ConfigureAwait(false);
-
         try
         {
-            await _receivingTask.ConfigureAwait(false);
+            try
+            {
+                await _receivingTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_receiveMessagesCancellationTokenSource.IsCancellationRequested)
+            {
+                // Expected when cancellation is requested, ignore.
+            }
+
+            await _transport.DisposeAsync().ConfigureAwait(false);
+
+            await _processingTask.ConfigureAwait(false);
+
+            await _eventDispatcher.DisposeAsync().ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (_receiveMessagesCancellationTokenSource.IsCancellationRequested)
+        finally
         {
-            // Expected when cancellation is requested, ignore.
-        }
+            _receiveMessagesCancellationTokenSource.Dispose();
 
-        await _processingTask.ConfigureAwait(false);
-
-        _receiveMessagesCancellationTokenSource.Dispose();
-
-        await _transport.DisposeAsync().ConfigureAwait(false);
-
-        while (_bufferPool.TryTake(out var buffer))
-        {
-            buffer.Dispose();
+            while (_bufferPool.TryTake(out var buffer))
+            {
+                buffer.Dispose();
+            }
         }
 
         GC.SuppressFinalize(this);
@@ -373,15 +378,20 @@ internal sealed class Broker : IAsyncDisposable
             }
         }
 
-        // Channel is fully drained. Fail any commands that didn't get a response.
+        // Channel is fully drained. Fail any commands that didn't get a response:
+        // either with the transport error or cancellation for clean shutdown.
         var terminalException = _terminalReceiveException;
-        if (terminalException is not null)
+        foreach (var id in _pendingCommands.Keys)
         {
-            foreach (var id in _pendingCommands.Keys)
+            if (_pendingCommands.TryRemove(id, out var pendingCommand))
             {
-                if (_pendingCommands.TryRemove(id, out var pendingCommand))
+                if (terminalException is not null)
                 {
                     pendingCommand.TaskCompletionSource.TrySetException(terminalException);
+                }
+                else
+                {
+                    pendingCommand.TaskCompletionSource.TrySetCanceled();
                 }
             }
         }

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -48,7 +48,8 @@ internal sealed class Broker : IAsyncDisposable
     private readonly Channel<PooledBufferWriter> _receivedMessages = Channel.CreateBounded<PooledBufferWriter>(
         new BoundedChannelOptions(ReceivedMessageQueueCapacity) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
 
-    private readonly ConcurrentBag<PooledBufferWriter> _bufferPool = [];
+    private readonly Channel<PooledBufferWriter> _bufferPool = Channel.CreateBounded<PooledBufferWriter>(
+        new BoundedChannelOptions(ReceivedMessageQueueCapacity) { SingleReader = false, SingleWriter = false });
 
     private volatile Exception? _terminalReceiveException;
 
@@ -156,7 +157,7 @@ internal sealed class Broker : IAsyncDisposable
         {
             _receiveMessagesCancellationTokenSource.Dispose();
 
-            while (_bufferPool.TryTake(out var buffer))
+            while (_bufferPool.Reader.TryRead(out var buffer))
             {
                 buffer.Dispose();
             }
@@ -407,13 +408,16 @@ internal sealed class Broker : IAsyncDisposable
 
     private PooledBufferWriter RentBuffer()
     {
-        return _bufferPool.TryTake(out var buffer) ? buffer : new PooledBufferWriter();
+        return _bufferPool.Reader.TryRead(out var buffer) ? buffer : new PooledBufferWriter();
     }
 
     private void ReturnBuffer(PooledBufferWriter buffer)
     {
         buffer.Reset();
-        _bufferPool.Add(buffer);
+        if (!_bufferPool.Writer.TryWrite(buffer))
+        {
+            buffer.Dispose();
+        }
     }
 
     private readonly record struct CommandInfo(TaskCompletionSource<EmptyResult> TaskCompletionSource, JsonTypeInfo JsonResultTypeInfo);
@@ -440,7 +444,13 @@ internal sealed class Broker : IAsyncDisposable
             _written = 0;
         }
 
-        public void Advance(int count) => _written += count;
+        public void Advance(int count)
+        {
+            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+            if (_written + count > (_buffer?.Length ?? 0)) throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+
+            _written += count;
+        }
 
         public Memory<byte> GetMemory(int sizeHint = 0)
         {

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -21,6 +21,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading.Channels;
 using OpenQA.Selenium.BiDi.Session;
 using OpenQA.Selenium.Internal.Logging;
 
@@ -38,7 +39,13 @@ internal sealed class Broker : IAsyncDisposable
 
     private long _currentCommandId;
 
-    private readonly Task _receivingMessageTask;
+    private readonly Channel<PooledBufferWriter> _receivedMessages = Channel.CreateBounded<PooledBufferWriter>(
+        new BoundedChannelOptions(16) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
+
+    private readonly ConcurrentBag<PooledBufferWriter> _bufferPool = [];
+
+    private readonly Task _receivingTask;
+    private readonly Task _processingTask;
     private readonly CancellationTokenSource _receiveMessagesCancellationTokenSource;
 
     public Broker(ITransport transport, IBiDi bidi, Func<ISessionModule> sessionProvider)
@@ -48,7 +55,8 @@ internal sealed class Broker : IAsyncDisposable
         _eventDispatcher = new EventDispatcher(sessionProvider);
 
         _receiveMessagesCancellationTokenSource = new CancellationTokenSource();
-        _receivingMessageTask = Task.Run(() => ReceiveMessagesLoopAsync(_receiveMessagesCancellationTokenSource.Token));
+        _receivingTask = Task.Run(() => ReceiveMessagesAsync(_receiveMessagesCancellationTokenSource.Token));
+        _processingTask = Task.Run(ProcessMessagesAsync);
     }
 
     public Task<Subscription> SubscribeAsync<TEventArgs>(string eventName, EventHandler eventHandler, SubscriptionOptions? options, JsonTypeInfo<TEventArgs> jsonTypeInfo, CancellationToken cancellationToken)
@@ -118,16 +126,23 @@ internal sealed class Broker : IAsyncDisposable
 
         try
         {
-            await _receivingMessageTask.ConfigureAwait(false);
+            await _receivingTask.ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (_receiveMessagesCancellationTokenSource.IsCancellationRequested)
         {
             // Expected when cancellation is requested, ignore.
         }
 
+        await _processingTask.ConfigureAwait(false);
+
         _receiveMessagesCancellationTokenSource.Dispose();
 
         await _transport.DisposeAsync().ConfigureAwait(false);
+
+        while (_bufferPool.TryTake(out var buffer))
+        {
+            buffer.Dispose();
+        }
 
         GC.SuppressFinalize(this);
     }
@@ -281,37 +296,33 @@ internal sealed class Broker : IAsyncDisposable
         }
     }
 
-    private async Task ReceiveMessagesLoopAsync(CancellationToken cancellationToken)
+    private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
     {
-        using var receiveBufferWriter = new PooledBufferWriter();
-
         try
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                receiveBufferWriter.Reset();
-
-                await _transport.ReceiveAsync(receiveBufferWriter, cancellationToken).ConfigureAwait(false);
-
-                if (_logger.IsEnabled(LogEventLevel.Trace))
-                {
-#if NET8_0_OR_GREATER
-                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(receiveBufferWriter.WrittenMemory.Span)}");
-#else
-                    _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(receiveBufferWriter.WrittenMemory.ToArray())}");
-#endif
-                }
+                var buffer = RentBuffer();
 
                 try
                 {
-                    ProcessReceivedMessage(receiveBufferWriter.WrittenMemory.Span);
-                }
-                catch (Exception ex)
-                {
-                    if (_logger.IsEnabled(LogEventLevel.Error))
+                    await _transport.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+                    if (_logger.IsEnabled(LogEventLevel.Trace))
                     {
-                        _logger.Error($"Unhandled error occurred while processing remote message: {ex}");
+#if NET8_0_OR_GREATER
+                        _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(buffer.WrittenMemory.Span)}");
+#else
+                        _logger.Trace($"BiDi RCV <-- {System.Text.Encoding.UTF8.GetString(buffer.WrittenMemory.ToArray())}");
+#endif
                     }
+
+                    await _receivedMessages.Writer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    ReturnBuffer(buffer);
+                    throw;
                 }
             }
         }
@@ -333,6 +344,48 @@ internal sealed class Broker : IAsyncDisposable
 
             throw;
         }
+        finally
+        {
+            _receivedMessages.Writer.TryComplete();
+        }
+    }
+
+    private async Task ProcessMessagesAsync()
+    {
+        var reader = _receivedMessages.Reader;
+
+        while (await reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            while (reader.TryRead(out var buffer))
+            {
+                try
+                {
+                    ProcessReceivedMessage(buffer.WrittenMemory.Span);
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsEnabled(LogEventLevel.Error))
+                    {
+                        _logger.Error($"Unhandled error occurred while processing remote message: {ex}");
+                    }
+                }
+                finally
+                {
+                    ReturnBuffer(buffer);
+                }
+            }
+        }
+    }
+
+    private PooledBufferWriter RentBuffer()
+    {
+        return _bufferPool.TryTake(out var buffer) ? buffer : new PooledBufferWriter();
+    }
+
+    private void ReturnBuffer(PooledBufferWriter buffer)
+    {
+        buffer.Reset();
+        _bufferPool.Add(buffer);
     }
 
     private readonly record struct CommandInfo(TaskCompletionSource<EmptyResult> TaskCompletionSource, JsonTypeInfo JsonResultTypeInfo);

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -29,6 +29,12 @@ namespace OpenQA.Selenium.BiDi;
 
 internal sealed class Broker : IAsyncDisposable
 {
+    // Limits how many received messages can be buffered before backpressure is applied to the transport.
+    private const int ReceivedMessageQueueCapacity = 16;
+
+    // How long to wait for a command response before cancelling.
+    private static readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(30);
+
     private readonly ILogger _logger = Internal.Logging.Log.GetLogger<Broker>();
 
     private readonly ITransport _transport;
@@ -40,7 +46,7 @@ internal sealed class Broker : IAsyncDisposable
     private long _currentCommandId;
 
     private readonly Channel<PooledBufferWriter> _receivedMessages = Channel.CreateBounded<PooledBufferWriter>(
-        new BoundedChannelOptions(16) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
+        new BoundedChannelOptions(ReceivedMessageQueueCapacity) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
 
     private readonly ConcurrentBag<PooledBufferWriter> _bufferPool = [];
 
@@ -79,7 +85,7 @@ internal sealed class Broker : IAsyncDisposable
             ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
             : new CancellationTokenSource();
 
-        var timeout = options?.Timeout ?? TimeSpan.FromSeconds(30);
+        var timeout = options?.Timeout ?? DefaultCommandTimeout;
         cts.CancelAfter(timeout);
 
         using var sendBuffer = new PooledBufferWriter();

--- a/dotnet/test/webdriver/BiDi/BiDiFixture.cs
+++ b/dotnet/test/webdriver/BiDi/BiDiFixture.cs
@@ -57,7 +57,10 @@ public class BiDiTestFixture
             await bidi.DisposeAsync();
         }
 
-        driver?.Dispose();
+        if (driver is not null)
+        {
+            await driver.DisposeAsync();
+        }
     }
 
     public class BiDiEnabledDriverOptions : DriverOptions

--- a/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
+++ b/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
@@ -22,7 +22,7 @@ namespace OpenQA.Selenium.Tests.BiDi.Session;
 internal class SessionTests : BiDiTestFixture
 {
     [Test]
-    public async Task ShouldIdempotentDisposal()
+    public async Task ShouldHaveIdempotentDisposal()
     {
         await bidi.DisposeAsync();
         await bidi.DisposeAsync();

--- a/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
+++ b/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
@@ -22,6 +22,13 @@ namespace OpenQA.Selenium.Tests.BiDi.Session;
 internal class SessionTests : BiDiTestFixture
 {
     [Test]
+    public async Task ShouldIdempotentDisposal()
+    {
+        await bidi.DisposeAsync();
+        await bidi.DisposeAsync();
+    }
+
+    [Test]
     public async Task CanGetStatus()
     {
         var status = await bidi.StatusAsync();


### PR DESCRIPTION
Always receiving from remote end, processing from queue.

### 💥 What does this PR do?
This pull request significantly refactors the `Broker` class in the WebDriver BiDi implementation to improve message handling, resource management, and error propagation. The changes introduce asynchronous message processing using channels, enhance buffer pooling, and ensure more robust disposal and error handling throughout the broker lifecycle. Additionally, related test code is updated for proper asynchronous disposal and a new test is added to verify idempotent disposal.

**Message Handling and Processing Improvements:**

* Replaced the single message receiving loop with two coordinated tasks: one for receiving messages (`ReceiveMessagesAsync`) and another for processing messages (`ProcessMessagesAsync`), communicating via a bounded channel to apply backpressure and improve throughput. This also introduces a buffer pool to reduce allocations and ensure proper buffer reuse. [[1]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bR24-R37) [[2]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL41-R57) [[3]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL51-R68) [[4]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL284-R424)
* Added robust error propagation: if message receiving fails, a terminal exception is stored and propagated to pending commands and subsequent command executions. [[1]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bR81-R85) [[2]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL284-R424)

**Resource and Buffer Management:**

* Implemented a buffer pool using a channel to efficiently reuse `PooledBufferWriter` instances, and ensured all buffers are disposed of during broker disposal. [[1]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL41-R57) [[2]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL117-R171) [[3]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL284-R424)
* Improved the `Advance` and `EnsureCapacity` methods of `PooledBufferWriter` to guard against invalid buffer operations and ensure correct buffer sizing. [[1]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL362-R458) [[2]](diffhunk://#diff-8030f3b2416d8292b765f6799741183735d2379e63eab1e4eec8d36a0de2a08bL380-R479)

**Disposal and Test Enhancements:**

* Refactored the disposal logic to await both receiving and processing tasks, dispose of all resources in the correct order, and drain the buffer pool.
* Updated test fixture teardown to dispose the driver asynchronously and added a test to verify that multiple calls to `DisposeAsync` are safe (idempotent). [[1]](diffhunk://#diff-5ebcd71c4dab6d73e3284a4641b36c3facf2b5efd211129d36fc511c82af36b6L60-R63) [[2]](diffhunk://#diff-1176e2bc09091da55a6296bde0c89ee3cf2497f36a16c06663c908cc51ac299cR24-R30)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
