### PR TITLE
[rb] fix Ruby tests failing because of alerts in Firefox

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -199,12 +199,6 @@ jobs:
               crates: rust/Cargo.Bazel.lock
           repository-cache: true
           bazelrc: common --color=yes
-      # Workaround for rules_ruby MSYS2 "infinite symlink expansion detected" on Windows
-      - name: Remove MSYS2 recursive symlink
-        if: ${{ inputs.os == 'windows' }}
-        shell: bash
-        run: |
-          rm -f "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" || true
       - name: Setup curl for Ubuntu
         if: inputs.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -199,6 +199,13 @@ jobs:
               crates: rust/Cargo.Bazel.lock
           repository-cache: true
           bazelrc: common --color=yes
+      # Workaround for rules_ruby MSYS2 "infinite symlink expansion detected" on Windows
+      - name: Remove MSYS2 recursive symlink
+          if: inputs.os == 'windows'
+          shell: bash
+          run: |
+            [ -L "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" ] && \
+            rm "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-"
       - name: Setup curl for Ubuntu
         if: inputs.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -201,11 +201,11 @@ jobs:
           bazelrc: common --color=yes
       # Workaround for rules_ruby MSYS2 "infinite symlink expansion detected" on Windows
       - name: Remove MSYS2 recursive symlink
-          if: inputs.os == 'windows'
-          shell: bash
-          run: |
-            [ -L "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" ] && \
-            rm "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-"
+        if: ${{ inputs.os == 'windows' }}
+        shell: bash
+        run: |
+          [ -L "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" ] && \
+          rm "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-"
       - name: Setup curl for Ubuntu
         if: inputs.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -204,8 +204,7 @@ jobs:
         if: ${{ inputs.os == 'windows' }}
         shell: bash
         run: |
-          [ -L "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" ] && \
-          rm "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-"
+          rm -f "D:/b/external/rules_ruby++ruby+ruby/dist/msys64/etc/mtab-" || true
       - name: Setup curl for Ubuntu
         if: inputs.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
+++ b/rb/spec/integration/selenium/webdriver/spec_support/test_environment.rb
@@ -324,6 +324,7 @@ module Selenium
           opts[:browser_version] = 'stable' if WebDriver::Platform.windows?
           opts[:web_socket_url] = true if ENV['WEBDRIVER_BIDI'] && !opts.key?(:web_socket_url)
           opts[:binary] ||= rlocation(ENV['FIREFOX_BINARY']) if ENV.key?('FIREFOX_BINARY')
+          opts[:unhandled_prompt_behavior] ||= 'ignore'
           args << '--headless' if ENV['HEADLESS']
           WebDriver::Options.firefox(args: args, **opts)
         end


### PR DESCRIPTION
Seems that Firefox behavior with alerts was changed. Without "unhandledPromptBehavior" capability, command `wait_for_alert` is always failing in FireFox.

### 🔗 Related Issues
e.g. https://github.com/SeleniumHQ/selenium/actions/runs/23901428682/job/69699326193?pr=17287

### 💥 What does this PR do?
Adds capability "unhandled_prompt_behavior"="ignore" to firefox options.

### 🔄 Types of changes
- Bug fix (backwards compatible)
