### PR TITLE
[dotnet] [build] Don't skip tests

### DIFF
--- a/.skipped-tests
+++ b/.skipped-tests
@@ -1,6 +1,3 @@
--//dotnet/test/common:NetworkInterceptionTests-chrome
--//dotnet/test/common:NetworkInterceptionTests-edge
--//dotnet/test/firefox:FirefoxDriverTests-firefox
 -//java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest
 -//java/test/org/openqa/selenium/chrome:ChromeDriverFunctionalTest-remote
 -//java/test/org/openqa/selenium/edge:EdgeDriverFunctionalTest


### PR DESCRIPTION
Remove some tests from the skipped lists.

### 💥 What does this PR do?
This pull request updates the `.skipped-tests` file to remove several test exclusions, allowing these tests to run again. This suggests that the previously skipped tests are now expected to pass.
