### PR TITLE
[rust] Fix arch misdetection on 32bit Windows environment

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -83,7 +83,7 @@ impl ManagerConfig {
                     _architecture = get_win_os_architecture();
                 }
             }
-            if _architecture.contains("32") {
+            if _architecture.contains("x86") {
                 ARCH_X86.to_string()
             } else if _architecture.contains("ARM") {
                 ARCH_ARM64.to_string()
@@ -316,8 +316,8 @@ fn get_win_os_architecture() -> String {
         GetNativeSystemInfo(&mut system_info);
 
         match system_info.u.s() {
-            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 => "64-bit",
-            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL => "32-bit",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 => "AMD64",
+            si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL => "x86",
             si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM => "ARM",
             si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64 => "ARM64",
             si if si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64 => "Itanium-based",


### PR DESCRIPTION

<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->


### 💥 What does this PR do?
On 32-bit Windows environment, get_win_os_architecture() returns "32-bit", while PROCESSOR_ARCHITECTURE variable has "x86".
Since the current logic checks only if the result string has "32", resulting in arch misdetected as 64bit on 32bit Windows.
This PR fixes that problem.

### 🔧 Implementation Notes
Normalize the return value of get_win_os_architecture() to match possible values of PROCESSOR_ARCHITECTURE.

### 🔄 Types of changes
- Bug fix (backwards compatible)

