### PR TITLE
[dotnet] [bidi] Testing infra for custom module

### DIFF
--- a/dotnet/src/webdriver/BUILD.bazel
+++ b/dotnet/src/webdriver/BUILD.bazel
@@ -48,9 +48,6 @@ csharp_library(
         "**/*.cs",
     ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver",
-    internals_visible_to = [
-        "WebDriver.Tests",
-    ],
     langversion = "14.0",
     nullable = "enable",
     target_frameworks = [
@@ -81,9 +78,6 @@ csharp_library(
         "**/*.cs",
     ]) + ["//dotnet/src/webdriver/DevTools:srcs"] + devtools_version_targets(),
     out = "WebDriver",
-    internals_visible_to = [
-        "WebDriver.Tests",
-    ],
     langversion = "14.0",
     nullable = "enable",
     resources = [],
@@ -117,9 +111,6 @@ csharp_library(
     out = "WebDriver",
     defines = [
         "NET8_0_OR_GREATER",
-    ],
-    internals_visible_to = [
-        "WebDriver.Tests",
     ],
     langversion = "14.0",
     nullable = "enable",

--- a/dotnet/src/webdriver/BiDi/Command.cs
+++ b/dotnet/src/webdriver/BiDi/Command.cs
@@ -35,7 +35,7 @@ public abstract class Command
     public long Id { get; internal set; }
 }
 
-internal abstract class Command<TParameters, TResult>(TParameters @params, string method) : Command(method)
+public abstract class Command<TParameters, TResult>(TParameters @params, string method) : Command(method)
     where TParameters : Parameters
     where TResult : EmptyResult
 {
@@ -43,7 +43,7 @@ internal abstract class Command<TParameters, TResult>(TParameters @params, strin
     public TParameters Params { get; } = @params;
 }
 
-internal record Parameters
+public record Parameters
 {
     public static Parameters Empty { get; } = new Parameters();
 }

--- a/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ILogContext.cs
@@ -42,14 +42,14 @@ public interface ILogContext : IDisposable
     /// </summary>
     /// <typeparam name="T">The type for which to retrieve the logger.</typeparam>
     /// <returns>An instance of <see cref="ILogger"/> for the specified type.</returns>
-    internal ILogger GetLogger<T>();
+    ILogger GetLogger<T>();
 
     /// <summary>
     /// Gets a logger for the specified type.
     /// </summary>
     /// <param name="type">The type for which to retrieve the logger.</param>
     /// <returns>An instance of <see cref="ILogger"/> for the specified type.</returns>
-    internal ILogger GetLogger(Type type);
+    ILogger GetLogger(Type type);
 
     /// <summary>
     /// Checks whether logs emitting is enabled for a logger and a log event level.

--- a/dotnet/src/webdriver/Internal/Logging/ILogger.cs
+++ b/dotnet/src/webdriver/Internal/Logging/ILogger.cs
@@ -22,7 +22,7 @@ namespace OpenQA.Selenium.Internal.Logging;
 /// <summary>
 /// Defines the interface through which log messages are emitted.
 /// </summary>
-internal interface ILogger
+public interface ILogger
 {
     /// <summary>
     /// Writes a trace-level log message.

--- a/dotnet/src/webdriver/Internal/Logging/Log.cs
+++ b/dotnet/src/webdriver/Internal/Logging/Log.cs
@@ -66,7 +66,7 @@ public static class Log
     /// Gets or sets the current log context.
     /// </summary>
     [AllowNull]
-    internal static ILogContext CurrentContext
+    public static ILogContext CurrentContext
     {
         get => _logContextManager.CurrentContext;
         set => _logContextManager.CurrentContext = value;
@@ -77,7 +77,7 @@ public static class Log
     /// </summary>
     /// <typeparam name="T">The type to get the logger for.</typeparam>
     /// <returns>The logger.</returns>
-    internal static ILogger GetLogger<T>()
+    public static ILogger GetLogger<T>()
     {
         return _logContextManager.CurrentContext.GetLogger<T>();
     }
@@ -87,7 +87,7 @@ public static class Log
     /// </summary>
     /// <param name="type">The type to get the logger for.</param>
     /// <returns>The logger.</returns>
-    internal static ILogger GetLogger(Type type)
+    public static ILogger GetLogger(Type type)
     {
         return _logContextManager.CurrentContext.GetLogger(type);
     }

--- a/dotnet/src/webdriver/Selenium.WebDriver.csproj
+++ b/dotnet/src/webdriver/Selenium.WebDriver.csproj
@@ -52,10 +52,6 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>-->
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="WebDriver.Tests" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
+++ b/dotnet/test/webdriver/BiDi/Session/SessionTests.cs
@@ -17,6 +17,10 @@
 // under the License.
 // </copyright>
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenQA.Selenium.BiDi;
+
 namespace OpenQA.Selenium.Tests.BiDi.Session;
 
 internal class SessionTests : BiDiTestFixture
@@ -54,4 +58,46 @@ internal class SessionTests : BiDiTestFixture
             () => bidi.StatusAsync(cancellationToken: cts.Token),
             Throws.InstanceOf<TaskCanceledException>());
     }
+
+    [Test]
+    public void AsModuleShouldReturnSameInstanceForSameType()
+    {
+        Assert.That(bidi.AsModule<CustomModule>(), Is.SameAs(bidi.AsModule<CustomModule>()));
+    }
+
+    [Test]
+    public async Task CustomModuleShouldExecuteCommand()
+    {
+        var customModule = bidi.AsModule<CustomModule>();
+
+        var result = await customModule.DoSomethingAsync();
+
+        Assert.That(result, Is.Not.Null);
+    }
 }
+
+class CustomModule : Module
+{
+    private CustomModuleJsonSerializerContext _jsonContext = null!;
+
+    public async Task<DoSomethingResult> DoSomethingAsync(DoSomethingOptions options = null)
+    {
+        return await ExecuteCommandAsync(new DoSomethingCommand(), options, _jsonContext.DoSomethingCommand, _jsonContext.DoSomethingResult, CancellationToken.None);
+    }
+
+    protected override void Initialize(IBiDi bidi, JsonSerializerOptions jsonSerializerOptions)
+    {
+        _jsonContext = new CustomModuleJsonSerializerContext(jsonSerializerOptions);
+    }
+}
+
+[JsonSerializable(typeof(DoSomethingCommand))]
+[JsonSerializable(typeof(DoSomethingResult))]
+partial class CustomModuleJsonSerializerContext : JsonSerializerContext;
+
+class DoSomethingCommand()
+    : Command<Parameters, DoSomethingResult>(Parameters.Empty, "session.status");
+
+record DoSomethingResult : EmptyResult;
+
+record DoSomethingOptions : CommandOptions;

--- a/dotnet/test/webdriver/Internal/Logging/LogTests.cs
+++ b/dotnet/test/webdriver/Internal/Logging/LogTests.cs
@@ -151,14 +151,6 @@ public class LogTests
     }
 
     [Test]
-    public void ShouldCreateContextWithNullLogHandlers()
-    {
-        var context = new LogContext(LogEventLevel.Info, null, null, null, handlers: null);
-
-        Assert.That(context.Handlers, Is.Empty);
-    }
-
-    [Test]
     public void ContextShouldChangeLevel()
     {
         Log.SetLevel(LogEventLevel.Info);
@@ -320,5 +312,5 @@ internal class TestLogHandler : ILogHandler
         Events.Add(logEvent);
     }
 
-    public IList<LogEvent> Events { get; internal set; } = new List<LogEvent>();
+    public IList<LogEvent> Events { get; internal set; } = [];
 }


### PR DESCRIPTION
Ability to declare custom bidi modules. Negotiated how to test internal logging via making some functionality publicly available. It is OK if we consider to expose it as separate package.

### 💥 What does this PR do?
This pull request makes several significant changes to the WebDriver .NET codebase, primarily focused on increasing the visibility of key APIs and types, removing internal access restrictions, and adding new tests for module extensibility. These updates improve the public API surface, facilitate external usage and testing, and introduce a pattern for custom modules.

**Public API and Visibility Changes:**

* Changed several types and methods from `internal` to `public`, including `ILogger`, `ILogContext`, and logging methods in `Log`, making them accessible outside the assembly. (`dotnet/src/webdriver/Internal/Logging/ILogger.cs`, `dotnet/src/webdriver/Internal/Logging/ILogContext.cs`, `dotnet/src/webdriver/Internal/Logging/Log.cs`) [[1]](diffhunk://#diff-1c57b56dd0ceacb0814c7e95985956eb9e933a0b612f146bbf80f281f7f86bf8L45-R52) [[2]](diffhunk://#diff-3becfc12c4ee4bf761600defbb22c75e7b2eefce98dfd45c6f7cb2da351f5232L25-R25) [[3]](diffhunk://#diff-2e94075e3d0c70f80c161f3fd79de68cc0c35fc960450abf86d0c04a18798525L69-R69) [[4]](diffhunk://#diff-2e94075e3d0c70f80c161f3fd79de68cc0c35fc960450abf86d0c04a18798525L80-R80) [[5]](diffhunk://#diff-2e94075e3d0c70f80c161f3fd79de68cc0c35fc960450abf86d0c04a18798525L90-R90)
* Changed `Command<TParameters, TResult>` and related classes in the BiDi namespace from `internal` to `public` to allow external extension and usage. (`dotnet/src/webdriver/BiDi/Command.cs`)

**Removal of Internal Access Restrictions:**

* Removed all `InternalsVisibleTo` settings from both `BUILD.bazel` and `.csproj` files, meaning internal types are no longer exposed to the test assembly and tests must now use only public APIs. (`dotnet/src/webdriver/BUILD.bazel`, `dotnet/src/webdriver/Selenium.WebDriver.csproj`) [[1]](diffhunk://#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479L51-L53) [[2]](diffhunk://#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479L84-L86) [[3]](diffhunk://#diff-1e5b050451f2c64486e7d3bb72a51487532001344e2aa34b563a924694ed8479L121-L123) [[4]](diffhunk://#diff-6ef2e9da77183fb83a5ee6b57e85314f589fc08438fc925dd2e332ae075820eaL55-L58)

**Testing and Extensibility Improvements:**

* Added new tests for custom module extensibility in BiDi, including a sample `CustomModule`, command, and result types, demonstrating that modules can be extended and commands executed using the new public API. (`dotnet/test/webdriver/BiDi/Session/SessionTests.cs`) [[1]](diffhunk://#diff-1176e2bc09091da55a6296bde0c89ee3cf2497f36a16c06663c908cc51ac299cR20-R23) [[2]](diffhunk://#diff-1176e2bc09091da55a6296bde0c89ee3cf2497f36a16c06663c908cc51ac299cR61-R103)

**Minor Test Code Updates:**

* Removed an obsolete test for null log handlers and modernized collection initialization in logging tests. (`dotnet/test/webdriver/Internal/Logging/LogTests.cs`) [[1]](diffhunk://#diff-f2441c09fde7b01a7d58f244b5c6c7605ccd0c3914a667252348264342fe4117L153-L160) [[2]](diffhunk://#diff-f2441c09fde7b01a7d58f244b5c6c7605ccd0c3914a667252348264342fe4117L323-R315)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- New feature (non-breaking change which adds functionality *and tests!*)
