### PR TITLE
[dotnet] [bidi] Improve json discriminator determination

### DIFF
--- a/dotnet/src/webdriver/BiDi/Json/JsonExtensions.cs
+++ b/dotnet/src/webdriver/BiDi/Json/JsonExtensions.cs
@@ -33,21 +33,20 @@ internal static class JsonExtensions
 
         string? discriminator = null;
 
-        readerClone.Read();
+        readerClone.Read(); // move past StartObject to first PropertyName
         while (readerClone.TokenType == JsonTokenType.PropertyName)
         {
-            string? propertyName = readerClone.GetString();
-            readerClone.Read();
-
-            if (propertyName == name)
+            if (readerClone.ValueTextEquals(name))
             {
+                readerClone.Read(); // move to the property value
                 discriminator = readerClone.GetString();
 
                 break;
             }
 
-            readerClone.Skip();
-            readerClone.Read();
+            readerClone.Read(); // move to the property value
+            readerClone.Skip(); // skip the value (including nested objects/arrays)
+            readerClone.Read(); // move to the next PropertyName or EndObject
         }
 
         return discriminator ?? throw new JsonException($"Couldn't determine '{name}' discriminator.");


### PR DESCRIPTION
Just small improvement.

### 💥 What does this PR do?
This pull request refines the logic for extracting a property value from a JSON object using a `Utf8JsonReader`. The main improvement is making the property name comparison more efficient and clarifying the reader's movement through the JSON structure.

JSON parsing improvements:

* Replaced string comparison for property names with the more efficient `ValueTextEquals` method, improving performance and reliability when matching the property name.
* Clarified and corrected the advancement of the JSON reader: added comments and ensured the reader correctly skips over property values (including nested objects or arrays) to move to the next property or end of the object.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
