### PR TITLE
[dotnet] [bidi] Fix commands cancelling callback

### DIFF
--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -171,13 +171,13 @@ internal sealed class Broker : IAsyncDisposable
                 _pendingCommands.TryRemove(command.Id, out _);
                 throw;
             }
+
+            return (TResult)await tcs.Task.ConfigureAwait(false);
         }
         finally
         {
             ReturnBuffer(sendBuffer);
         }
-
-        return (TResult)await tcs.Task.ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()

--- a/dotnet/src/webdriver/BiDi/Broker.cs
+++ b/dotnet/src/webdriver/BiDi/Broker.cs
@@ -143,41 +143,46 @@ internal sealed class Broker : IAsyncDisposable
             {
                 JsonSerializer.Serialize(writer, command, jsonCommandTypeInfo);
             }
+        }
+        catch
+        {
+            ReturnBuffer(sendBuffer);
+            throw;
+        }
 
-            var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
-            _pendingCommands[command.Id] = commandInfo;
+        var commandInfo = new CommandInfo(tcs, jsonResultTypeInfo);
+        _pendingCommands[command.Id] = commandInfo;
 
-            using var ctsRegistration = cts.Token.Register(() =>
+        using var ctsRegistration = cts.Token.Register(() =>
+        {
+            tcs.TrySetCanceled(cts.Token);
+            _pendingCommands.TryRemove(command.Id, out _);
+        });
+
+        try
+        {
+            if (_logger.IsEnabled(LogEventLevel.Trace))
             {
-                tcs.TrySetCanceled(cts.Token);
-                _pendingCommands.TryRemove(command.Id, out _);
-            });
-
-            try
-            {
-                if (_logger.IsEnabled(LogEventLevel.Trace))
-                {
 #if NET8_0_OR_GREATER
-                    _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.Span)}");
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.Span)}");
 #else
-                    _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.ToArray())}");
+                _logger.Trace($"BiDi SND --> {System.Text.Encoding.UTF8.GetString(sendBuffer.WrittenMemory.ToArray())}");
 #endif
-                }
-
-                await _transport.SendAsync(sendBuffer.WrittenMemory, cts.Token).ConfigureAwait(false);
-            }
-            catch
-            {
-                _pendingCommands.TryRemove(command.Id, out _);
-                throw;
             }
 
-            return (TResult)await tcs.Task.ConfigureAwait(false);
+            await _transport.SendAsync(sendBuffer.WrittenMemory, cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            _pendingCommands.TryRemove(command.Id, out _);
+            throw;
         }
         finally
         {
             ReturnBuffer(sendBuffer);
         }
+
+        return (TResult)await tcs.Task.ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
Disposing `ctsRegistration` too early, preventing command cannot be cancelled via timeout.

### 💥 What does this PR do?
This pull request makes a minor change to the `ExecuteCommandAsync` method in `Broker.cs`, moving the return statement inside the `try` block to ensure the awaited task result is returned before buffer cleanup in the `finally` block. This change helps prevent returning a result after resources may have been released.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
