### PR TITLE
[dotnet] Don't truncate internal log messages at error/warn levels

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -98,7 +98,7 @@ internal sealed class LogContext : ILogContext
     {
         if (IsEnabled(logger, level))
         {
-            if (level < LogEventLevel.Warn)
+            if (_truncationLength.HasValue && level < LogEventLevel.Warn)
             {
                 message = TruncateMessage(message, _truncationLength);
             }

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -98,9 +98,12 @@ internal sealed class LogContext : ILogContext
     {
         if (IsEnabled(logger, level))
         {
-            string truncatedMessage = TruncateMessage(message, _truncationLength);
+            if (level < LogEventLevel.Warn)
+            {
+                message = TruncateMessage(message, _truncationLength);
+            }
 
-            var logEvent = new LogEvent(logger.Issuer, timestamp, level, truncatedMessage);
+            var logEvent = new LogEvent(logger.Issuer, timestamp, level, message);
 
             foreach (var handler in Handlers)
             {

--- a/dotnet/test/webdriver/Internal/Logging/LogTests.cs
+++ b/dotnet/test/webdriver/Internal/Logging/LogTests.cs
@@ -298,6 +298,20 @@ public class LogTests
         Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
         Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(longMessage));
     }
+
+    [TestCase(LogEventLevel.Warn)]
+    [TestCase(LogEventLevel.Error)]
+    public void ShouldNotTruncateImportantMessages(LogEventLevel level)
+    {
+        var longMessage = new string('a', 150);
+
+        using var context = Log.CreateContext(level).WithTruncation(100).Handlers.Add(testLogHandler);
+
+        logger.LogMessage(DateTimeOffset.Now, level, longMessage);
+
+        Assert.That(testLogHandler.Events, Has.Count.EqualTo(1));
+        Assert.That(testLogHandler.Events[0].Message, Is.EqualTo(longMessage));
+    }
 }
 
 internal class TestLogHandler : ILogHandler


### PR DESCRIPTION
To see entire error/warn log message for tracebility.

### 💥 What does this PR do?
This pull request makes a targeted improvement to the logging behavior in `LogContext.cs`. Now, log messages are only truncated if a truncation length is set and the log level is below `Warn`. This ensures that important warning and error messages are not truncated, preserving their full content for debugging.

Logging behavior update:

* Modified the `EmitMessage` method in `LogContext.cs` so that message truncation only occurs for log levels below `Warn` and when a truncation length is specified. (`[dotnet/src/webdriver/Internal/Logging/LogContext.csL101-R106](diffhunk://#diff-09e55ca02fe7a68ac190114b4bcbe9bc5f68d0b641f226bd17ffaf2a81d465b9L101-R106)`)


### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- New feature (non-breaking change which adds functionality *and tests!*)
