### PR TITLE
[dotnet] Safe modifications of internal log handlers

### DIFF
--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -41,7 +41,7 @@ internal sealed class LogContext : ILogContext
         {
             throw new ArgumentOutOfRangeException(nameof(truncationLength), "Truncation length must be non-negative.");
         }
-        
+
         _level = level;
         _parentLogContext = parentLogContext;
         _loggers = CloneLoggers(loggers, level);

--- a/dotnet/src/webdriver/Internal/Logging/LogContext.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogContext.cs
@@ -41,6 +41,7 @@ internal sealed class LogContext : ILogContext
         {
             throw new ArgumentOutOfRangeException(nameof(truncationLength), "Truncation length must be non-negative.");
         }
+        
         _level = level;
         _parentLogContext = parentLogContext;
         _loggers = CloneLoggers(loggers, level);

--- a/dotnet/src/webdriver/Internal/Logging/LogHandlerList.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogHandlerList.cs
@@ -17,45 +17,53 @@
 // under the License.
 // </copyright>
 
+using System.Collections;
+
 namespace OpenQA.Selenium.Internal.Logging;
 
 /// <summary>
 /// Represents a list of log handlers.
 /// </summary>
 /// <inheritdoc cref="ILogHandlerList"/>
-internal sealed class LogHandlerList : List<ILogHandler>, ILogHandlerList
+internal sealed class LogHandlerList : ILogHandlerList
 {
     private readonly ILogContext _logContext;
+    private volatile ILogHandler[] _handlers;
 
     public LogHandlerList(ILogContext logContext)
     {
         _logContext = logContext;
+        _handlers = [];
     }
 
     public LogHandlerList(ILogContext logContext, IEnumerable<ILogHandler> handlers)
-        : base(handlers)
     {
         _logContext = logContext;
+        _handlers = [.. handlers];
     }
 
-    public new ILogContext Add(ILogHandler handler)
+    public ILogContext Add(ILogHandler handler)
     {
-        base.Add(handler);
+        _handlers = [.. _handlers, handler];
 
         return _logContext;
     }
 
-    public new ILogContext Remove(ILogHandler handler)
+    public ILogContext Remove(ILogHandler handler)
     {
-        base.Remove(handler);
+        _handlers = [.. _handlers.Where(h => h != handler)];
 
         return _logContext;
     }
 
-    public new ILogContext Clear()
+    public ILogContext Clear()
     {
-        base.Clear();
+        _handlers = [];
 
         return _logContext;
     }
+
+    public IEnumerator<ILogHandler> GetEnumerator() => ((IEnumerable<ILogHandler>)_handlers).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _handlers.GetEnumerator();
 }

--- a/dotnet/src/webdriver/Internal/Logging/LogHandlerList.cs
+++ b/dotnet/src/webdriver/Internal/Logging/LogHandlerList.cs
@@ -28,6 +28,7 @@ namespace OpenQA.Selenium.Internal.Logging;
 internal sealed class LogHandlerList : ILogHandlerList
 {
     private readonly ILogContext _logContext;
+    private readonly object _lock = new();
     private volatile ILogHandler[] _handlers;
 
     public LogHandlerList(ILogContext logContext)
@@ -44,21 +45,30 @@ internal sealed class LogHandlerList : ILogHandlerList
 
     public ILogContext Add(ILogHandler handler)
     {
-        _handlers = [.. _handlers, handler];
+        lock (_lock)
+        {
+            _handlers = [.. _handlers, handler];
+        }
 
         return _logContext;
     }
 
     public ILogContext Remove(ILogHandler handler)
     {
-        _handlers = [.. _handlers.Where(h => h != handler)];
+        lock (_lock)
+        {
+            _handlers = [.. _handlers.Where(h => h != handler)];
+        }
 
         return _logContext;
     }
 
     public ILogContext Clear()
     {
-        _handlers = [];
+        lock (_lock)
+        {
+            _handlers = [];
+        }
 
         return _logContext;
     }


### PR DESCRIPTION
Make is safe to modify log handlers while iterating.

### 💥 What does this PR do?
This pull request refactors the `LogHandlerList` class to improve its internal implementation and thread safety. The class no longer inherits from `List<ILogHandler>`, and now manages its own internal array of handlers. This change also updates how handlers are added, removed, and enumerated, ensuring a more robust and maintainable design.

**LogHandlerList refactoring and improvements:**

* Changed `LogHandlerList` to no longer inherit from `List<ILogHandler>`, instead implementing its own internal storage with a volatile array for thread safety.
* Updated `Add`, `Remove`, and `Clear` methods to operate on the internal `_handlers` array, removing use of base class methods and ensuring modifications are thread-safe.
* Implemented `IEnumerable<ILogHandler>` explicitly to allow enumeration over the internal array of handlers.
* Added `using System.Collections;` to support the new enumeration implementation.

**Minor code style improvement:**

* Added a blank line in `LogContext.cs` for improved readability.

### 🔧 Implementation Notes
Copy-on-write approach to achieve immutability internally.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
