### PR TITLE
fix(ruby): retrieve devtools version dynamically for package verification

### DIFF
--- a/rake_tasks/ruby.rake
+++ b/rake_tasks/ruby.rake
@@ -9,6 +9,12 @@ def ruby_version
   end
 end
 
+def devtools_version
+  File.foreach('rb/lib/selenium/devtools/version.rb') do |line|
+    return line.split('=').last.strip.tr("'", '') if line.include?('VERSION')
+  end
+end
+
 def setup_gem_credentials
   gem_dir = File.join(Dir.home, '.gem')
   credentials = File.join(gem_dir, 'credentials')
@@ -92,7 +98,7 @@ task :verify do
 
   SeleniumRake.verify_package_published("https://rubygems.org/api/v2/rubygems/selenium-webdriver/versions/#{ruby_version}.json")
   unless patch_release
-    SeleniumRake.verify_package_published("https://rubygems.org/api/v2/rubygems/selenium-devtools/versions/#{ruby_version}.json")
+    SeleniumRake.verify_package_published("https://rubygems.org/api/v2/rubygems/selenium-devtools/versions/#{devtools_version}.json")
   end
 end
 


### PR DESCRIPTION


<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 💥 What does this PR do?
The release workflow fails because, at the step where packages are verified to see if they are published, the devtools package in RubyGems is being checked with the wrong version. This PR makes the check use the actual and correct version. 
