### PR TITLE
[dotnet] [bidi] Align SetDownloadBehavior command

### DIFF
--- a/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs
@@ -71,23 +71,9 @@ internal sealed class BrowserModule : Module, IBrowserModule
         return await ExecuteAsync(GetClientWindowsCommand, Parameters.Empty, options, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(string destinationFolder, SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorAsync(DownloadBehavior? downloadBehavior, SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorAllowed(destinationFolder), options?.UserContexts);
-
-        return await ExecuteAsync(SetDownloadBehaviorCommand, @params, options, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
-    {
-        var @params = new SetDownloadBehaviorParameters(null, options?.UserContexts);
-
-        return await ExecuteAsync(SetDownloadBehaviorCommand, @params, options, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task<SetDownloadBehaviorResult> SetDownloadBehaviorDeniedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default)
-    {
-        var @params = new SetDownloadBehaviorParameters(new DownloadBehaviorDenied(), options?.UserContexts);
+        var @params = new SetDownloadBehaviorParameters(downloadBehavior, options?.UserContexts);
 
         return await ExecuteAsync(SetDownloadBehaviorCommand, @params, options, cancellationToken).ConfigureAwait(false);
     }

--- a/dotnet/src/webdriver/BiDi/Browser/IBrowserModule.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/IBrowserModule.cs
@@ -26,7 +26,5 @@ public interface IBrowserModule
     Task<GetClientWindowsResult> GetClientWindowsAsync(GetClientWindowsOptions? options = null, CancellationToken cancellationToken = default);
     Task<GetUserContextsResult> GetUserContextsAsync(GetUserContextsOptions? options = null, CancellationToken cancellationToken = default);
     Task<RemoveUserContextResult> RemoveUserContextAsync(UserContext userContext, RemoveUserContextOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(string destinationFolder, SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetDownloadBehaviorResult> SetDownloadBehaviorAllowedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetDownloadBehaviorResult> SetDownloadBehaviorDeniedAsync(SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default);
+    Task<SetDownloadBehaviorResult> SetDownloadBehaviorAsync(DownloadBehavior? downloadBehavior, SetDownloadBehaviorOptions? options = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehavior.cs
+++ b/dotnet/src/webdriver/BiDi/Browser/SetDownloadBehavior.cs
@@ -26,11 +26,14 @@ internal sealed record SetDownloadBehaviorParameters([property: JsonIgnore(Condi
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(DownloadBehaviorAllowed), "allowed")]
 [JsonDerivedType(typeof(DownloadBehaviorDenied), "denied")]
-internal abstract record DownloadBehavior;
+public abstract record DownloadBehavior
+{
+    public static DownloadBehavior? Default => null;
+}
 
-internal sealed record DownloadBehaviorAllowed(string DestinationFolder) : DownloadBehavior;
+public sealed record DownloadBehaviorAllowed(string DestinationFolder) : DownloadBehavior;
 
-internal sealed record DownloadBehaviorDenied : DownloadBehavior;
+public sealed record DownloadBehaviorDenied : DownloadBehavior;
 
 public sealed record SetDownloadBehaviorOptions : CommandOptions
 {

--- a/dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs
+++ b/dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs
@@ -85,7 +85,7 @@ internal class BrowserTests : BiDiTestFixture
         // or
 
         var result2 = await bidi.Browser.SetDownloadBehaviorAsync(DownloadBehavior.Default);
-        
+
         Assert.That(result, Is.Not.Null);
         Assert.That(result2, Is.Not.Null);
     }

--- a/dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs
+++ b/dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs
@@ -17,6 +17,8 @@
 // under the License.
 // </copyright>
 
+using OpenQA.Selenium.BiDi.Browser;
+
 namespace OpenQA.Selenium.Tests.BiDi.Browser;
 
 internal class BrowserTests : BiDiTestFixture
@@ -68,34 +70,30 @@ internal class BrowserTests : BiDiTestFixture
     }
 
     [Test]
-    [IgnoreBrowser(Infrastructure.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Firefox, "Not supported yet?")]
     public async Task CanSetDownloadBehaviorAllowed()
     {
-        var result = await bidi.Browser.SetDownloadBehaviorAllowedAsync("/my/path");
+        var result = await bidi.Browser.SetDownloadBehaviorAsync(new DownloadBehaviorAllowed("/my/path"));
 
         Assert.That(result, Is.Not.Null);
     }
 
     [Test]
-    [IgnoreBrowser(Infrastructure.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Firefox, "Not supported yet?")]
-    public async Task CanSetDownloadBehaviorAllowedDefault()
+    public async Task CanSetDownloadBehaviorDefault()
     {
-        var result = await bidi.Browser.SetDownloadBehaviorAllowedAsync();
+        var result = await bidi.Browser.SetDownloadBehaviorAsync(null);
 
+        // or
+
+        var result2 = await bidi.Browser.SetDownloadBehaviorAsync(DownloadBehavior.Default);
+        
         Assert.That(result, Is.Not.Null);
+        Assert.That(result2, Is.Not.Null);
     }
 
     [Test]
-    [IgnoreBrowser(Infrastructure.Browser.Chrome, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Edge, "Not supported yet?")]
-    [IgnoreBrowser(Infrastructure.Browser.Firefox, "Not supported yet?")]
     public async Task CanSetDownloadBehaviorDenied()
     {
-        var result = await bidi.Browser.SetDownloadBehaviorDeniedAsync();
+        var result = await bidi.Browser.SetDownloadBehaviorAsync(new DownloadBehaviorDenied());
 
         Assert.That(result, Is.Not.Null);
     }


### PR DESCRIPTION
Simplified polymorphic command parameters.

### 💥 What does this PR do?
This pull request refactors and simplifies the API for setting browser download behavior in the BiDi WebDriver implementation. The main change is consolidating multiple specific methods into a single, more flexible method that accepts a `DownloadBehavior` parameter. This also involves updating related interfaces, records, and tests to use the new approach.

**API Refactoring and Simplification:**

* Consolidated the three separate methods (`SetDownloadBehaviorAllowedAsync`, `SetDownloadBehaviorDeniedAsync`, and the overload for allowed with no path) into a single method: `SetDownloadBehaviorAsync`, which takes a `DownloadBehavior` parameter. This provides a more flexible and unified API for setting download behavior. (`dotnet/src/webdriver/BiDi/Browser/BrowserModule.cs`, `dotnet/src/webdriver/BiDi/Browser/IBrowserModule.cs`) [[1]](diffhunk://#diff-8e4bcc00ef63cf737c6e26397ac40f1e18d960e4ff47589fee1bae1b9fe8cdc7L74-R76) [[2]](diffhunk://#diff-a28462c27d679aebe9bedb87e38f1e7b6e83101be46357699dcd0ff6abf6ec88L29-R29)
* Updated the `DownloadBehavior` record and its derived types (`DownloadBehaviorAllowed`, `DownloadBehaviorDenied`) to be public, and added a static `Default` property for clarity when resetting to default behavior. (`dotnet/src/webdriver/BiDi/Browser/SetDownloadBehavior.cs`)

**Test Updates:**

* Refactored tests to use the new `SetDownloadBehaviorAsync` method, including tests for allowed, denied, and default behaviors. Also added assertions for both `null` and `Default` usage. (`dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs`)
* Added missing `using` directive for the `OpenQA.Selenium.BiDi.Browser` namespace in the test file for clarity and correctness. (`dotnet/test/webdriver/BiDi/Browser/BrowserTests.cs`)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
