### PR TITLE
[dotnet] [bidi] Align SetGeolocation polymorphic command

### DIFF
--- a/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/EmulationModule.cs
@@ -105,22 +105,20 @@ internal sealed class EmulationModule : Module, IEmulationModule
         return await ExecuteAsync(SetScrollbarTypeOverrideCommand, @params, options, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(double latitude, double longitude, SetGeolocationCoordinatesOverrideOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<SetGeolocationOverrideResult> SetGeolocationOverrideAsync(GeolocationOverride? geolocationOverride, SetGeolocationOverrideOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var coordinates = new GeolocationCoordinates(latitude, longitude, options?.Accuracy, options?.Altitude, options?.AltitudeAccuracy, options?.Heading, options?.Speed);
-        var @params = new SetGeolocationOverrideCoordinatesParameters(coordinates, options?.Contexts, options?.UserContexts);
-        return await ExecuteAsync(SetGeolocationOverrideCommand, @params, options, cancellationToken).ConfigureAwait(false);
-    }
+        SetGeolocationOverrideParameters @params = geolocationOverride switch
+        {
+            GeolocationCoordinatesOverride c => new SetGeolocationOverrideCoordinatesParameters(
+                new GeolocationCoordinates(c.Latitude, c.Longitude, c.Accuracy, c.Altitude, c.AltitudeAccuracy, c.Heading, c.Speed),
+                options?.Contexts, options?.UserContexts),
+            GeolocationPositionErrorOverride => new SetGeolocationOverridePositionErrorParameters(
+                new GeolocationPositionError(), options?.Contexts, options?.UserContexts),
+            null => new SetGeolocationOverrideCoordinatesParameters(
+                null, options?.Contexts, options?.UserContexts),
+            _ => throw new ArgumentException($"Unknown geolocation override type: {geolocationOverride.GetType()}", nameof(geolocationOverride))
+        };
 
-    public async Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(SetGeolocationOverrideOptions? options = null, CancellationToken cancellationToken = default)
-    {
-        var @params = new SetGeolocationOverrideCoordinatesParameters(null, options?.Contexts, options?.UserContexts);
-        return await ExecuteAsync(SetGeolocationOverrideCommand, @params, options, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task<SetGeolocationOverrideResult> SetGeolocationPositionErrorOverrideAsync(SetGeolocationPositionErrorOverrideOptions? options = null, CancellationToken cancellationToken = default)
-    {
-        var @params = new SetGeolocationOverridePositionErrorParameters(new GeolocationPositionError(), options?.Contexts, options?.UserContexts);
         return await ExecuteAsync(SetGeolocationOverrideCommand, @params, options, cancellationToken).ConfigureAwait(false);
     }
 

--- a/dotnet/src/webdriver/BiDi/Emulation/IEmulationModule.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/IEmulationModule.cs
@@ -22,9 +22,7 @@ namespace OpenQA.Selenium.BiDi.Emulation;
 public interface IEmulationModule
 {
     Task<SetForcedColorsModeThemeOverrideResult> SetForcedColorsModeThemeOverrideAsync(ForcedColorsModeTheme? theme, SetForcedColorsModeThemeOverrideOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(double latitude, double longitude, SetGeolocationCoordinatesOverrideOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetGeolocationOverrideResult> SetGeolocationCoordinatesOverrideAsync(SetGeolocationOverrideOptions? options = null, CancellationToken cancellationToken = default);
-    Task<SetGeolocationOverrideResult> SetGeolocationPositionErrorOverrideAsync(SetGeolocationPositionErrorOverrideOptions? options = null, CancellationToken cancellationToken = default);
+    Task<SetGeolocationOverrideResult> SetGeolocationOverrideAsync(GeolocationOverride? geolocationOverride, SetGeolocationOverrideOptions? options = null, CancellationToken cancellationToken = default);
     Task<SetLocaleOverrideResult> SetLocaleOverrideAsync(string? locale, SetLocaleOverrideOptions? options = null, CancellationToken cancellationToken = default);
     Task<SetNetworkConditionsResult> SetNetworkConditionsAsync(NetworkConditions? networkConditions, SetNetworkConditionsOptions? options = null, CancellationToken cancellationToken = default);
     Task<SetScreenOrientationOverrideResult> SetScreenOrientationOverrideAsync(ScreenOrientation? screenOrientation, SetScreenOrientationOverrideOptions? options = null, CancellationToken cancellationToken = default);

--- a/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverride.cs
+++ b/dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverride.cs
@@ -21,6 +21,19 @@ using System.Text.Json.Serialization;
 
 namespace OpenQA.Selenium.BiDi.Emulation;
 
+public abstract record GeolocationOverride;
+
+public sealed record GeolocationCoordinatesOverride(double Latitude, double Longitude) : GeolocationOverride
+{
+    public double? Accuracy { get; init; }
+    public double? Altitude { get; init; }
+    public double? AltitudeAccuracy { get; init; }
+    public double? Heading { get; init; }
+    public double? Speed { get; init; }
+}
+
+public sealed record GeolocationPositionErrorOverride : GeolocationOverride;
+
 [JsonDerivedType(typeof(SetGeolocationOverrideCoordinatesParameters))]
 [JsonDerivedType(typeof(SetGeolocationOverridePositionErrorParameters))]
 internal abstract record SetGeolocationOverrideParameters(IEnumerable<BrowsingContext.BrowsingContext>? Contexts, IEnumerable<Browser.UserContext>? UserContexts) : Parameters;
@@ -37,22 +50,11 @@ internal sealed record GeolocationPositionError
     internal string Type { get; } = "positionUnavailable";
 }
 
-public record SetGeolocationOverrideOptions : CommandOptions
+public sealed record SetGeolocationOverrideOptions : CommandOptions
 {
     public IEnumerable<BrowsingContext.BrowsingContext>? Contexts { get; init; }
 
     public IEnumerable<Browser.UserContext>? UserContexts { get; init; }
 }
-
-public sealed record SetGeolocationCoordinatesOverrideOptions : SetGeolocationOverrideOptions
-{
-    public double? Accuracy { get; init; }
-    public double? Altitude { get; init; }
-    public double? AltitudeAccuracy { get; init; }
-    public double? Heading { get; init; }
-    public double? Speed { get; init; }
-}
-
-public sealed record SetGeolocationPositionErrorOverrideOptions : SetGeolocationOverrideOptions;
 
 public sealed record SetGeolocationOverrideResult : EmptyResult;

--- a/dotnet/test/webdriver/BiDi/Emulation/EmulationTests.cs
+++ b/dotnet/test/webdriver/BiDi/Emulation/EmulationTests.cs
@@ -198,7 +198,7 @@ internal class EmulationTests : BiDiTestFixture
     {
         Assert.That(async () =>
         {
-            await bidi.Emulation.SetGeolocationCoordinatesOverrideAsync(0, 0, new() { Contexts = [context] });
+            await bidi.Emulation.SetGeolocationOverrideAsync(new GeolocationCoordinatesOverride(0, 0), new() { Contexts = [context] });
         },
         Throws.Nothing);
     }
@@ -208,7 +208,7 @@ internal class EmulationTests : BiDiTestFixture
     {
         Assert.That(async () =>
         {
-            await bidi.Emulation.SetGeolocationCoordinatesOverrideAsync(new() { Contexts = [context] });
+            await bidi.Emulation.SetGeolocationOverrideAsync(null, new() { Contexts = [context] });
         },
         Throws.Nothing);
     }
@@ -219,7 +219,7 @@ internal class EmulationTests : BiDiTestFixture
     {
         Assert.That(async () =>
         {
-            await bidi.Emulation.SetGeolocationPositionErrorOverrideAsync(new() { Contexts = [context] });
+            await bidi.Emulation.SetGeolocationOverrideAsync(new GeolocationPositionErrorOverride(), new() { Contexts = [context] });
         },
         Throws.Nothing);
     }


### PR DESCRIPTION
One more polymorphic command.

### 💥 What does this PR do?
This pull request refactors and simplifies the geolocation override API in the BiDi Emulation module. The main change is to unify the various geolocation override methods into a single method that accepts a new, more flexible type, making the API easier to use and extend. Related test cases and type definitions have also been updated accordingly.

**API Unification and Simplification:**

* Replaced multiple geolocation override methods (`SetGeolocationCoordinatesOverrideAsync`, `SetGeolocationPositionErrorOverrideAsync`) with a single method `SetGeolocationOverrideAsync` that accepts a new `GeolocationOverride` parameter, supporting both coordinate and error overrides in one place. (`[[1]](diffhunk://#diff-326495cc635fdb9686d337228f031a251b2aaed55960d7096b1345e0f1c267ffL108-L123)`, `[[2]](diffhunk://#diff-67b1e6d29a1577b79f92d4a3eece9a990768c05d60f023bd9a4c00e913e926a5L25-R25)`)

**New Type Hierarchy for Geolocation Override:**

* Introduced an abstract record `GeolocationOverride` with two implementations: `GeolocationCoordinatesOverride` (for specifying coordinates and related parameters) and `GeolocationPositionErrorOverride` (for simulating a position error). (`[dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverride.csR24-R36](diffhunk://#diff-c98b85709ff9dfdf68799a0b5e3ebb35e890deef4e56db26562a9c71d07eabcfR24-R36)`)

**Type and Options Cleanup:**

* Removed now-unnecessary option types (`SetGeolocationCoordinatesOverrideOptions`, `SetGeolocationPositionErrorOverrideOptions`) and consolidated configuration into a single `SetGeolocationOverrideOptions` type. (`[dotnet/src/webdriver/BiDi/Emulation/SetGeolocationOverride.csL40-L57](diffhunk://#diff-c98b85709ff9dfdf68799a0b5e3ebb35e890deef4e56db26562a9c71d07eabcfL40-L57)`)

**Test Updates:**

* Updated all relevant tests to use the new unified `SetGeolocationOverrideAsync` method and types, ensuring coverage for both coordinate and error override scenarios. (`[[1]](diffhunk://#diff-ffc3db78f3491d8fdaa73663a8ab27170b6f892406b5e40a27a023ff40742fccL201-R201)`, `[[2]](diffhunk://#diff-ffc3db78f3491d8fdaa73663a8ab27170b6f892406b5e40a27a023ff40742fccL211-R211)`, `[[3]](diffhunk://#diff-ffc3db78f3491d8fdaa73663a8ab27170b6f892406b5e40a27a023ff40742fccL222-R222)`)

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
