### PR TITLE
[java] deprecate the 'native' methods inside the HttpClient interface

### DIFF
--- a/java/AGENTS.md
+++ b/java/AGENTS.md
@@ -12,6 +12,9 @@
 See `java/TESTING.md`
 
 ## Code conventions
+### Interfaces
+- New methods added to existing interfaces must provide a default implementation, if possible.
+- Interfaces must not expose the native classes of their implementations.
 
 ### Logging
 ```java

--- a/java/src/org/openqa/selenium/remote/http/HttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/HttpClient.java
@@ -46,7 +46,9 @@ public interface HttpClient extends Closeable, HttpHandler {
    * @param request the HTTP request to send
    * @param handler the BodyHandler that determines how to handle the response body
    * @return a CompletableFuture containing the HTTP response
+   * @deprecated use JdkHttpClient#httpClient() instead.
    */
+  @Deprecated(forRemoval = true)
   <T> CompletableFuture<java.net.http.HttpResponse<T>> sendAsyncNative(
       java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler);
 
@@ -59,7 +61,9 @@ public interface HttpClient extends Closeable, HttpHandler {
    * @return the HTTP response
    * @throws java.io.IOException if an I/O error occurs
    * @throws InterruptedException if the operation is interrupted
+   * @deprecated use JdkHttpClient#httpClient() instead.
    */
+  @Deprecated(forRemoval = true)
   <T> java.net.http.HttpResponse<T> sendNative(
       java.net.http.HttpRequest request, java.net.http.HttpResponse.BodyHandler<T> handler)
       throws java.io.IOException, InterruptedException;

--- a/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
+++ b/java/src/org/openqa/selenium/remote/http/jdk/JdkHttpClient.java
@@ -158,6 +158,11 @@ public class JdkHttpClient implements HttpClient {
     this.client = builder.build();
   }
 
+  /** Will expose the underlying native HttpClient used. */
+  public java.net.http.HttpClient client() {
+    return client;
+  }
+
   @Override
   public WebSocket openSocket(HttpRequest request, WebSocket.Listener listener) {
     URI uri;


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
https://github.com/SeleniumHQ/selenium/pull/16781

### 🔧 Implementation Notes
This PR will also advise the agents to take care this will not happen again.
Though this is really basic java knowledge the agent should bring out of the box.

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
