### PR TITLE
Fix py:local_dev rake task

### DIFF
--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -57,6 +57,7 @@ task :local_dev, [:all] do |_task, arguments|
 
   copy_all = arguments[:all] == 'all'
   if copy_all
+    FileUtils.rm_rf("#{lib_path}/common/devtools")
     FileUtils.cp_r("#{bazel_bin}/.", lib_path, remove_destination: true)
   else
     bidi_src = "#{bazel_bin}/common/bidi"

--- a/rake_tasks/python.rake
+++ b/rake_tasks/python.rake
@@ -57,7 +57,6 @@ task :local_dev, [:all] do |_task, arguments|
 
   copy_all = arguments[:all] == 'all'
   if copy_all
-    FileUtils.rm_rf("#{lib_path}/common/devtools")
     FileUtils.cp_r("#{bazel_bin}/.", lib_path, remove_destination: true)
   else
     bidi_src = "#{bazel_bin}/common/bidi"
@@ -66,14 +65,16 @@ task :local_dev, [:all] do |_task, arguments|
       FileUtils.mkdir_p(bidi_dest)
       Dir.children(bidi_src).sort.each do |entry|
         src = File.join(bidi_src, entry)
+        dest = File.join(bidi_dest, entry)
         next unless File.file?(src) || File.symlink?(src)
 
         resolved_src = File.symlink?(src) ? File.realpath(src) : src
-        FileUtils.cp(resolved_src, File.join(bidi_dest, entry))
+        FileUtils.rm_f(dest)
+        FileUtils.cp(resolved_src, dest)
       end
     end
 
-    %w[common/devtools common/linux common/mac common/windows].each do |dir|
+    %w[common/devtools common/linux common/macos common/windows].each do |dir|
       src = "#{bazel_bin}/#{dir}"
       dest = "#{lib_path}/#{dir}"
       next unless Dir.exist?(src)


### PR DESCRIPTION
### 💥 What does this PR do?

This PR fixes the `py:local_dev` rake task so it deletes BiDi files from the source tree before copying them from bazel output. Without this, the task will fail since the files are read-only.

It also fixes the `macos` directory name so this works on Mac.

### 🔄 Types of changes
- Bug fix (backwards compatible)
- Development