### PR TITLE
[grid] Accept legacy session-closed event payloads

### DIFF
--- a/java/src/org/openqa/selenium/grid/data/SessionClosedData.java
+++ b/java/src/org/openqa/selenium/grid/data/SessionClosedData.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.JsonException;
 import org.openqa.selenium.json.JsonInput;
+import org.openqa.selenium.json.JsonType;
 import org.openqa.selenium.remote.SessionId;
 
 /**
@@ -140,6 +141,10 @@ public class SessionClosedData {
 
   @SuppressWarnings({"unused", "DataFlowIssue"})
   private static SessionClosedData fromJson(JsonInput input) {
+    if (input.peek() == JsonType.STRING) {
+      return new SessionClosedData(input.read(SessionId.class), SessionClosedReason.QUIT_COMMAND);
+    }
+
     SessionId sessionId = null;
     SessionClosedReason reason = null;
     NodeId nodeId = null;

--- a/java/test/org/openqa/selenium/grid/data/BUILD.bazel
+++ b/java/test/org/openqa/selenium/grid/data/BUILD.bazel
@@ -7,6 +7,7 @@ java_test_suite(
     srcs = glob(["*Test.java"]),
     deps = [
         "//java/src/org/openqa/selenium:core",
+        "//java/src/org/openqa/selenium/events",
         "//java/src/org/openqa/selenium/grid/data",
         "//java/src/org/openqa/selenium/grid/security",
         "//java/src/org/openqa/selenium/json",

--- a/java/test/org/openqa/selenium/grid/data/SessionClosedDataTest.java
+++ b/java/test/org/openqa/selenium/grid/data/SessionClosedDataTest.java
@@ -1,0 +1,64 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.grid.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.events.Event;
+import org.openqa.selenium.events.EventName;
+import org.openqa.selenium.json.Json;
+import org.openqa.selenium.remote.SessionId;
+
+class SessionClosedDataTest {
+
+  private static final Json JSON = new Json();
+
+  @Test
+  void shouldReadLegacySessionIdPayloadAsQuitCommand() {
+    SessionId sessionId = new SessionId("a3aedb1b7bc8894ebf0606214ee47283");
+
+    SessionClosedData data = JSON.toType(JSON.toJson(sessionId), SessionClosedData.class);
+
+    assertThat(data.getSessionId()).isEqualTo(sessionId);
+    assertThat(data.getReason()).isEqualTo(SessionClosedReason.QUIT_COMMAND);
+    assertThat(data.getNodeId()).isNull();
+    assertThat(data.getNodeUri()).isNull();
+    assertThat(data.getCapabilities()).isNull();
+    assertThat(data.getStartTime()).isNull();
+    assertThat(data.getEndTime()).isNotNull();
+  }
+
+  @Test
+  void sessionClosedEventListenersShouldHandleLegacySessionIdPayload() {
+    SessionId sessionId = new SessionId("a3aedb1b7bc8894ebf0606214ee47283");
+    Event legacyEvent = new Event(UUID.randomUUID(), new EventName("session-closed"), sessionId);
+    AtomicReference<SessionClosedData> seenData = new AtomicReference<>();
+    AtomicReference<SessionId> seenSessionId = new AtomicReference<>();
+
+    SessionClosedEvent.listener(seenData::set).accept(legacyEvent);
+    SessionClosedEvent.sessionListener(seenSessionId::set).accept(legacyEvent);
+
+    assertThat(seenData.get()).isNotNull();
+    assertThat(seenData.get().getSessionId()).isEqualTo(sessionId);
+    assertThat(seenData.get().getReason()).isEqualTo(SessionClosedReason.QUIT_COMMAND);
+    assertThat(seenSessionId.get()).isEqualTo(sessionId);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/3110

### 💥 What does this PR do?
Backward compatibility for Grid `session-closed` events when the event bus receives the legacy wire format: a bare JSON string session id instead of a `SessionClosedData` object.

In 4.41.0, listeners in the distributor and session map deserialize `session-closed` as `SessionClosedData`. When an older or custom publisher emits the legacy payload, deserialization fails with `Expected to read a START_MAP but instead have: STRING`, which prevents the listener from processing the event.

### 🔧 Implementation Notes
<!--- Why did you implement it this way? -->
<!--- What alternatives to this approach did you consider? -->

### 💡 Additional Considerations
<!--- Are there any decisions that need to be made before accepting this PR? -->
<!--- Is there any follow-on work that needs to be done? (e.g., docs, tests, etc.) -->

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)
