### PR TITLE
fix NPE when response status is null

### DIFF
--- a/java/src/org/openqa/selenium/remote/ErrorHandler.java
+++ b/java/src/org/openqa/selenium/remote/ErrorHandler.java
@@ -17,6 +17,8 @@
 
 package org.openqa.selenium.remote;
 
+import static java.util.Objects.requireNonNullElse;
+
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -97,8 +99,9 @@ public class ErrorHandler {
       throw new RuntimeException(throwable);
     }
 
+    int responseStatus = requireNonNullElse(response.getStatus(), -1);
     Class<? extends WebDriverException> outerErrorType =
-        errorCodes.getExceptionType(response.getStatus());
+        errorCodes.getExceptionType(responseStatus);
 
     Object value = response.getValue();
     String message = null;
@@ -120,7 +123,7 @@ public class ErrorHandler {
         message = String.valueOf(e);
       }
 
-      Throwable serverError = rebuildServerError(rawErrorData, response.getStatus());
+      Throwable serverError = rebuildServerError(rawErrorData, responseStatus);
 
       // If serverError is null, then the server did not provide a className (only expected if
       // the server is a Java process) or a stack trace. The lack of a className is OK, but

--- a/java/test/org/openqa/selenium/remote/ErrorHandlerTest.java
+++ b/java/test/org/openqa/selenium/remote/ErrorHandlerTest.java
@@ -105,6 +105,15 @@ class ErrorHandlerTest {
   }
 
   @Test
+  void testShouldThrowAVanillaWebDriverExceptionIfResponseStatusIsNull() {
+    Response response = new Response();
+    assertThatExceptionOfType(WebDriverException.class)
+        .isThrownBy(() -> handler.throwIfResponseFailed(response, 123))
+        .withNoCause()
+        .withMessageContaining(new WebDriverException().getMessage());
+  }
+
+  @Test
   void testShouldNotSetCauseIfResponseValueIsJustAString() {
     assertThatExceptionOfType(WebDriverException.class)
         .isThrownBy(


### PR DESCRIPTION
I am not sure in which cases it happens, but I actually saw this error:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "org.openqa.selenium.remote.Response.getStatus()" is null
        at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:100)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:668)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:688)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:692)
        at org.openqa.selenium.remote.RemoteWebDriver.quit(RemoteWebDriver.java:507)
        at com.codeborne.selenide.drivercommands.CloseDriverCommand.quitSafely(CloseDriverCommand.java:50)
        at com.codeborne.selenide.drivercommands.CloseDriverCommand.close(CloseDriverCommand.java:35)
        at com.codeborne.selenide.impl.WebDriverInstance.dispose(WebDriverInstance.java:61)
        at java.base/java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(ConcurrentHashMap.java:4783)
        at com.codeborne.selenide.drivercommands.DisposablesRegistry.disposeAllItems(DisposablesRegistry.java:57)
        at com.codeborne.selenide.drivercommands.DisposablesRegistry$SelenideCleanupShutdownHook.run(DisposablesRegistry.java:68)
```

### 🔄 Types of changes
- Bug fix (backwards compatible)
