### PR TITLE
[dotnet] Fix stopping of network monitoring via DevTools

### DIFF
--- a/dotnet/src/webdriver/NetworkManager.cs
+++ b/dotnet/src/webdriver/NetworkManager.cs
@@ -92,6 +92,8 @@ public class NetworkManager : INetwork
         this.session.Value.Domains.Network.AuthRequired -= OnAuthRequired;
         this.session.Value.Domains.Network.RequestPaused -= OnRequestPaused;
         await this.session.Value.Domains.Network.EnableNetworkCaching().ConfigureAwait(false);
+        await this.session.Value.Domains.Network.DisableNetwork().ConfigureAwait(false);
+        await this.session.Value.Domains.Network.DisableFetch().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/dotnet/test/webdriver/NetworkInterceptionTests.cs
+++ b/dotnet/test/webdriver/NetworkInterceptionTests.cs
@@ -57,8 +57,8 @@ public class NetworkInterceptionTests : DriverTestFixture
             await network.StopMonitoring();
             Assert.That(text, Is.EqualTo("I intercepted you"));
             driver.Navigate().Refresh();
-             text = driver.FindElement(By.CssSelector("h1")).Text;
-             Assert.That(text, Is.EqualTo("Heading"));
+            text = driver.FindElement(By.CssSelector("h1")).Text;
+            Assert.That(text, Is.EqualTo("Heading"));
         }
     }
 

--- a/dotnet/test/webdriver/NetworkInterceptionTests.cs
+++ b/dotnet/test/webdriver/NetworkInterceptionTests.cs
@@ -56,6 +56,9 @@ public class NetworkInterceptionTests : DriverTestFixture
             string text = driver.FindElement(By.CssSelector("p")).Text;
             await network.StopMonitoring();
             Assert.That(text, Is.EqualTo("I intercepted you"));
+            driver.Navigate().Refresh();
+             text = driver.FindElement(By.CssSelector("h1")).Text;
+             Assert.That(text, Is.EqualTo("Heading"));
         }
     }
 


### PR DESCRIPTION
### 🔗 Related Issues
Fixes https://github.com/SeleniumHQ/selenium/issues/17350

### 💥 What does this PR do?
This pull request makes improvements to network monitoring cleanup and enhances test coverage for network interception in the WebDriver codebase. The main changes ensure that network and fetch domains are properly disabled when monitoring stops and that tests verify network state resets after interception.

**Network monitoring cleanup:**
* [`NetworkManager.cs`](diffhunk://#diff-fa2bd5383297a5ada852e419747ca593845652ac3b37b5e2f7444ccb21f6f9d7R95-R96): Added calls to explicitly disable the network and fetch domains in `StopMonitoring()` to ensure all network interception hooks are removed when monitoring ends.

**Test improvements:**
* [`NetworkInterceptionTests.cs`](diffhunk://#diff-3c508f71b5c38b1e032612be450f7283321d5aa99690a45f24da389f2f1a2dedR59-R61): Enhanced the `TestCanInterceptNetworkCalls` test to refresh the page and verify that network interception no longer affects subsequent requests, ensuring proper cleanup.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Bug fix (backwards compatible)
