### PR TITLE
[dotnet] [test] Update tests to target .NET 10

### DIFF
--- a/dotnet/test/remote/BUILD.bazel
+++ b/dotnet/test/remote/BUILD.bazel
@@ -5,7 +5,10 @@ dotnet_nunit_test_suite(
     size = "large",
     srcs = glob(
         ["**/*.cs"],
-        exclude = ["bin/**", "obj/**"],
+        exclude = [
+            "bin/**",
+            "obj/**",
+        ],
     ),
     out = "WebDriver.Remote.Tests",
     browsers = ["remote"],

--- a/dotnet/test/remote/BUILD.bazel
+++ b/dotnet/test/remote/BUILD.bazel
@@ -3,7 +3,10 @@ load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 dotnet_nunit_test_suite(
     name = "remote",
     size = "large",
-    srcs = glob(["**/*.cs"]),
+    srcs = glob(
+        ["**/*.cs"],
+        exclude = ["bin/**", "obj/**"],
+    ),
     out = "WebDriver.Remote.Tests",
     browsers = ["remote"],
     data = [
@@ -11,7 +14,7 @@ dotnet_nunit_test_suite(
     ],
     flaky = True,
     project_sdk = "web",
-    target_frameworks = ["net8.0"],
+    target_frameworks = ["net10.0"],
     deps = [
         "//dotnet/src/webdriver:webdriver-net8.0",
         "//dotnet/test/testing.webserver",

--- a/dotnet/test/remote/Selenium.WebDriver.Remote.Tests.csproj
+++ b/dotnet/test/remote/Selenium.WebDriver.Remote.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <AssemblyName>WebDriver.Remote.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/dotnet/test/support/BUILD.bazel
+++ b/dotnet/test/support/BUILD.bazel
@@ -5,7 +5,10 @@ dotnet_nunit_test_suite(
     size = "large",
     srcs = glob(
         ["**/*.cs"],
-        exclude = ["bin/**", "obj/**"],
+        exclude = [
+            "bin/**",
+            "obj/**",
+        ],
     ),
     browsers = [
         "firefox",

--- a/dotnet/test/support/BUILD.bazel
+++ b/dotnet/test/support/BUILD.bazel
@@ -3,7 +3,10 @@ load("//dotnet:defs.bzl", "dotnet_nunit_test_suite", "nuget_package")
 dotnet_nunit_test_suite(
     name = "support",
     size = "large",
-    srcs = glob(["**/*.cs"]),
+    srcs = glob(
+        ["**/*.cs"],
+        exclude = ["bin/**", "obj/**"],
+    ),
     browsers = [
         "firefox",
     ],
@@ -11,7 +14,7 @@ dotnet_nunit_test_suite(
         "//dotnet/test/webdriver:test-data",
     ],
     project_sdk = "web",
-    target_frameworks = ["net8.0"],
+    target_frameworks = ["net10.0"],
     deps = [
         "//dotnet/src/support",
         "//dotnet/src/webdriver:webdriver-net8.0",

--- a/dotnet/test/support/Selenium.WebDriver.Support.Tests.csproj
+++ b/dotnet/test/support/Selenium.WebDriver.Support.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <AssemblyName>WebDriver.Support.Tests</AssemblyName>
     <RootNamespace>OpenQA.Selenium.Support.Tests</RootNamespace>
   </PropertyGroup>

--- a/dotnet/test/testing.webserver/BUILD.bazel
+++ b/dotnet/test/testing.webserver/BUILD.bazel
@@ -3,7 +3,10 @@ load("//dotnet:defs.bzl", "csharp_library")
 csharp_library(
     name = "testing.webserver",
     testonly = True,
-    srcs = glob(["**/*.cs"]),
+    srcs = glob(
+        ["**/*.cs"],
+        exclude = ["bin/**", "obj/**"],
+    ),
     out = "Testing.WebServer",
     data = [
         "//common/src/web",
@@ -11,7 +14,7 @@ csharp_library(
     nullable = "enable",
     project_sdk = "web",
     run_analyzers = False,
-    target_frameworks = ["net8.0"],
+    target_frameworks = ["net10.0"],
     visibility = [
         "//dotnet/test:__subpackages__",
     ],

--- a/dotnet/test/testing.webserver/BUILD.bazel
+++ b/dotnet/test/testing.webserver/BUILD.bazel
@@ -5,7 +5,10 @@ csharp_library(
     testonly = True,
     srcs = glob(
         ["**/*.cs"],
-        exclude = ["bin/**", "obj/**"],
+        exclude = [
+            "bin/**",
+            "obj/**",
+        ],
     ),
     out = "Testing.WebServer",
     data = [

--- a/dotnet/test/testing.webserver/Selenium.Testing.WebServer.csproj
+++ b/dotnet/test/testing.webserver/Selenium.Testing.WebServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <AssemblyName>Testing.WebServer</AssemblyName>
     <RootNamespace>OpenQA.Selenium.Testing.WebServer</RootNamespace>
     <Nullable>enable</Nullable>

--- a/dotnet/test/webdriver/BUILD.bazel
+++ b/dotnet/test/webdriver/BUILD.bazel
@@ -23,7 +23,10 @@ filegroup(
 dotnet_nunit_test_suite(
     name = "webdriver",
     size = "small",
-    srcs = glob(["**/*.cs"]),
+    srcs = glob(
+        ["**/*.cs"],
+        exclude = ["bin/**", "obj/**"],
+    ),
     out = "WebDriver.Tests",
     browsers = [
         # The first browser in this list is assumed to be the one that should
@@ -38,7 +41,7 @@ dotnet_nunit_test_suite(
         ":test-data",
     ],
     project_sdk = "web",
-    target_frameworks = ["net8.0"],
+    target_frameworks = ["net10.0"],
     visibility = ["//dotnet/test:__subpackages__"],
     deps = [
         "//dotnet/src/webdriver:webdriver-net8.0",

--- a/dotnet/test/webdriver/BUILD.bazel
+++ b/dotnet/test/webdriver/BUILD.bazel
@@ -25,7 +25,10 @@ dotnet_nunit_test_suite(
     size = "small",
     srcs = glob(
         ["**/*.cs"],
-        exclude = ["bin/**", "obj/**"],
+        exclude = [
+            "bin/**",
+            "obj/**",
+        ],
     ),
     out = "WebDriver.Tests",
     browsers = [

--- a/dotnet/test/webdriver/Infrastructure/IgnoreTargetAttribute.cs
+++ b/dotnet/test/webdriver/Infrastructure/IgnoreTargetAttribute.cs
@@ -78,8 +78,8 @@ public class IgnoreTargetAttribute(string target) : NUnitAttribute, IApplyToTest
 
     private static string CurrentPlatform()
     {
-#if NET8_0
-        return "net8";
+#if NET10_0
+        return "net10";
 #else
 #error Update IgnoreTargetAttribute.CurrentPlatform to the current TFM
 #endif

--- a/dotnet/test/webdriver/Selenium.WebDriver.Tests.csproj
+++ b/dotnet/test/webdriver/Selenium.WebDriver.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <AssemblyName>WebDriver.Tests</AssemblyName>
     <RootNamespace>OpenQA.Selenium.Tests</RootNamespace>
   </PropertyGroup>

--- a/dotnet/test/webdriver/TakesScreenshotTests.cs
+++ b/dotnet/test/webdriver/TakesScreenshotTests.cs
@@ -343,7 +343,7 @@ public class TakesScreenshotTests : DriverTestFixture
     {
         HashSet<string> colors = new HashSet<string>();
 
-#if !NET8_0
+#if !NET10_0
         try
         {
             Image image = Image.FromStream(new MemoryStream(screenshot.AsByteArray));
@@ -377,7 +377,7 @@ public class TakesScreenshotTests : DriverTestFixture
     {
         Color pixelColor = Color.Black;
 
-#if !NET8_0
+#if !NET10_0
         Image image = Image.FromStream(new MemoryStream(screenshot.AsByteArray));
         Bitmap bitmap = new Bitmap(image);
         pixelColor = bitmap.GetPixel(1, 1);

--- a/dotnet/test/webdriver/TakesScreenshotTests.cs
+++ b/dotnet/test/webdriver/TakesScreenshotTests.cs
@@ -85,7 +85,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Firefox, "Not working properly in RBE, works locally with pinned browsers")]
     public void ShouldCaptureScreenshotOfCurrentViewport()
     {
-#if NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 
@@ -114,7 +114,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Edge, "Color comparisons fail on Edge")]
     public void ShouldTakeScreenshotsOfAnElement()
     {
-#if NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 
@@ -142,7 +142,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Edge, "Color comparisons fail on Edge")]
     public void ShouldCaptureScreenshotAtFramePage()
     {
-#if NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 
@@ -186,7 +186,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Edge, "Color comparisons fail on Edge")]
     public void ShouldCaptureScreenshotAtIFramePage()
     {
-#if NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 
@@ -228,7 +228,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Edge, "Color comparisons fail on Edge")]
     public void ShouldCaptureScreenshotAtFramePageAfterSwitching()
     {
-#if NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 
@@ -268,7 +268,7 @@ public class TakesScreenshotTests : DriverTestFixture
     [IgnoreBrowser(Browser.Edge, "Color comparisons fail on Edge")]
     public void ShouldCaptureScreenshotAtIFramePageAfterSwitching()
     {
-#if NET6_0 || NET8_0
+#if NET10_0
         Assert.Ignore("Skipping test: this framework can not process colors.");
 #endif
 


### PR DESCRIPTION
.NET 10 for tests projects.

### 💥 What does this PR do?
This pull request updates the .NET test projects and Bazel build definitions to target .NET 10.0 instead of .NET 8.0, and improves the globbing patterns to exclude build output directories from test sources. Additionally, conditional compilation symbols and platform checks are updated to match the new target framework. These changes ensure the test suite is aligned with the latest .NET version and avoids including unnecessary files in test builds.

**Target framework updates:**

* All test project files (`.csproj`) are updated to use `net10.0` as the target framework instead of `net8.0`. [[1]](diffhunk://#diff-a45e1daa67eca66ea128829b0f14d57ca8e64a56b90b126b549e83cd5aa03b61L4-R4) [[2]](diffhunk://#diff-26a8ba5b07b9a4e65920307f6fc71e3e011e0494e255dafebcd66cf0e17669e2L4-R4) [[3]](diffhunk://#diff-96813cc137e68cecd722fd4c395f5c03829390625d862f6b76884ec41353e85eL4-R4) [[4]](diffhunk://#diff-5950c1f483e224033d985a77bf16c34661ba1edbcf0b30b68e40ed3c7006b4dfL4-R4)
* Bazel build definitions for test suites and libraries (`BUILD.bazel` files) are updated to use `net10.0` in the `target_frameworks` attribute. [[1]](diffhunk://#diff-85da83fee511dcc7bd15bbc1820c3eaec1324a0980d85f1e2d27b5e035df525fL6-R17) [[2]](diffhunk://#diff-66539fd2200ac21a121269092f738a54045499cfcb83c4afec9951cd90160d30L6-R17) [[3]](diffhunk://#diff-76f3bdb5dab8f98ce079f7de3059fb143a473164367924161c818e2a101de34bL6-R17) [[4]](diffhunk://#diff-97fec87b0932516183c4329d45a4a351bbf9cf956c7c8d3904fc6bcc3b264bd7L41-R44)

**Build system improvements:**

* The `glob` patterns in Bazel build files for test sources now explicitly exclude `bin/**` and `obj/**` directories to prevent build artifacts from being included as source files. [[1]](diffhunk://#diff-85da83fee511dcc7bd15bbc1820c3eaec1324a0980d85f1e2d27b5e035df525fL6-R17) [[2]](diffhunk://#diff-66539fd2200ac21a121269092f738a54045499cfcb83c4afec9951cd90160d30L6-R17) [[3]](diffhunk://#diff-76f3bdb5dab8f98ce079f7de3059fb143a473164367924161c818e2a101de34bL6-R17) [[4]](diffhunk://#diff-97fec87b0932516183c4329d45a4a351bbf9cf956c7c8d3904fc6bcc3b264bd7L26-R29)

**Conditional compilation and platform checks:**

* Conditional compilation symbols in test code are updated from `NET8_0` to `NET10_0` to match the new target framework. This affects platform checks in `IgnoreTargetAttribute.cs` and conditional logic in `TakesScreenshotTests.cs`. [[1]](diffhunk://#diff-615a25fbe4757d7bfac5378cbc96fe0eaa75f70e2bee3a97013dcd4329a30488L81-R82) [[2]](diffhunk://#diff-3b7254226494654fa55ecfbf5f7a38eb8b1dfc24d6afafb86331201de79300d1L346-R346) [[3]](diffhunk://#diff-3b7254226494654fa55ecfbf5f7a38eb8b1dfc24d6afafb86331201de79300d1L380-R380)

### 🔧 Implementation Notes
Also added `bin`/`obj` as exclusion for bazel.

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
