### PR TITLE
[java] fix some nullability warnings

### DIFF
--- a/java/src/org/openqa/selenium/events/Event.java
+++ b/java/src/org/openqa/selenium/events/Event.java
@@ -20,6 +20,7 @@ package org.openqa.selenium.events;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.Json;
 import org.openqa.selenium.json.JsonOutput;
@@ -31,11 +32,11 @@ public class Event {
   private final EventName eventName;
   private final String data;
 
-  public Event(EventName eventName, Object data) {
+  public Event(EventName eventName, @Nullable Object data) {
     this(UUID.randomUUID(), eventName, data);
   }
 
-  public Event(UUID id, EventName eventName, Object data) {
+  public Event(UUID id, EventName eventName, @Nullable Object data) {
     this.id = Require.nonNull("Message id", id);
     this.eventName = Require.nonNull("Event type", eventName);
 

--- a/java/src/org/openqa/selenium/grid/Bootstrap.java
+++ b/java/src/org/openqa/selenium/grid/Bootstrap.java
@@ -27,6 +27,9 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -90,16 +93,19 @@ public class Bootstrap {
         continue;
       }
 
-      if (file.isDirectory()) {
-        File[] files = file.listFiles();
-        if (files == null) {
-          LOG.warning("Cannot list files in directory: " + file);
-        } else {
-          for (File subdirFile : files) {
+      Path dir = file.toPath();
+
+      if (Files.isDirectory(dir)) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+          for (Path path : stream) {
+            File subdirFile = path.toFile();
             if (subdirFile.isFile() && subdirFile.getName().endsWith(".jar")) {
               jars.add(subdirFile);
             }
           }
+        } catch (IOException e) {
+          LOG.warning(
+              () -> String.format("Cannot list files in directory: %s due to: %s", file, e));
         }
       } else {
         jars.add(file);

--- a/java/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
+++ b/java/src/org/openqa/selenium/grid/distributor/remote/RemoteDistributor.java
@@ -75,7 +75,7 @@ public class RemoteDistributor extends Distributor {
 
     HttpResponse response = client.with(addSecret).execute(request);
 
-    Values.get(response, Void.class);
+    Values.parse(response);
 
     LOG.info(String.format("Added node %s.", node.getId()));
 
@@ -91,7 +91,7 @@ public class RemoteDistributor extends Distributor {
 
     HttpResponse response = client.with(addSecret).execute(request);
 
-    return Values.get(response, Boolean.class);
+    return Values.parseBoolean(response);
   }
 
   @Override
@@ -102,7 +102,7 @@ public class RemoteDistributor extends Distributor {
 
     HttpResponse response = client.with(addSecret).execute(request);
 
-    Values.get(response, Void.class);
+    Values.parse(response);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class RemoteDistributor extends Distributor {
 
     HttpResponse response = client.execute(request);
 
-    return Values.get(response, DistributorStatus.class);
+    return Values.parse(response, DistributorStatus.class);
   }
 
   @Override
@@ -125,7 +125,7 @@ public class RemoteDistributor extends Distributor {
     HttpResponse res = client.execute(req);
 
     if (res.isSuccessful()) {
-      return Either.right(Values.get(res, CreateSessionResponse.class));
+      return Either.right(Values.parse(res, CreateSessionResponse.class));
     } else {
       return Either.left(Values.get(res, SessionNotCreatedException.class));
     }

--- a/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
+++ b/java/src/org/openqa/selenium/grid/node/remote/RemoteNode.java
@@ -207,7 +207,7 @@ public class RemoteNode extends Node implements Closeable {
 
     HttpResponse res = client.with(addSecret).execute(req);
 
-    return Boolean.TRUE.equals(Values.get(res, Boolean.class));
+    return Values.parseBoolean(res);
   }
 
   @Override
@@ -219,7 +219,7 @@ public class RemoteNode extends Node implements Closeable {
 
     HttpResponse res = client.with(addSecret).execute(req);
 
-    return Boolean.TRUE.equals(Values.get(res, Boolean.class));
+    return Values.parseBoolean(res);
   }
 
   @Override
@@ -231,7 +231,7 @@ public class RemoteNode extends Node implements Closeable {
 
     HttpResponse res = client.with(addSecret).execute(req);
 
-    Values.get(res, Void.class);
+    Values.parse(res);
   }
 
   @Override
@@ -243,7 +243,7 @@ public class RemoteNode extends Node implements Closeable {
 
     HttpResponse res = client.with(addSecret).execute(req);
 
-    return Require.nonNull("Session", Values.get(res, Session.class));
+    return Values.parse(res, Session.class);
   }
 
   @Override
@@ -274,7 +274,7 @@ public class RemoteNode extends Node implements Closeable {
 
     HttpResponse res = client.with(addSecret).execute(req);
 
-    Values.get(res, Void.class);
+    Values.parse(res);
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
+++ b/java/src/org/openqa/selenium/grid/sessionmap/remote/RemoteSessionMap.java
@@ -24,7 +24,6 @@ import static org.openqa.selenium.remote.http.HttpMethod.GET;
 import static org.openqa.selenium.remote.http.HttpMethod.POST;
 
 import java.io.UncheckedIOException;
-import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URI;
 import org.jspecify.annotations.Nullable;
@@ -114,7 +113,7 @@ public class RemoteSessionMap extends SessionMap {
   }
 
   @Nullable
-  private <T> T makeRequest(HttpRequest request, Type typeOfT) {
+  private <T> T makeRequest(HttpRequest request, Class<T> typeOfT) {
     HttpTracing.inject(tracer, tracer.getCurrentContext(), request);
 
     HttpResponse response = client.execute(request);

--- a/java/src/org/openqa/selenium/grid/sessionqueue/remote/RemoteNewSessionQueue.java
+++ b/java/src/org/openqa/selenium/grid/sessionqueue/remote/RemoteNewSessionQueue.java
@@ -121,7 +121,7 @@ public class RemoteNewSessionQueue extends NewSessionQueue {
     HttpTracing.inject(tracer, tracer.getCurrentContext(), upstream);
     upstream.setContent(Contents.asJson(request));
     HttpResponse response = client.with(addSecret).execute(upstream);
-    return Values.get(response, Boolean.class);
+    return Values.parseBoolean(response);
   }
 
   @Override
@@ -156,7 +156,7 @@ public class RemoteNewSessionQueue extends NewSessionQueue {
     HttpTracing.inject(tracer, tracer.getCurrentContext(), upstream);
     HttpResponse response = client.with(addSecret).execute(upstream);
 
-    return Values.get(response, SESSION_REQUEST_TYPE);
+    return Require.nonNull("Next session request", Values.get(response, SESSION_REQUEST_TYPE));
   }
 
   @Override
@@ -178,7 +178,7 @@ public class RemoteNewSessionQueue extends NewSessionQueue {
 
     HttpTracing.inject(tracer, tracer.getCurrentContext(), upstream);
     HttpResponse response = client.with(addSecret).execute(upstream);
-    return Values.get(response, Boolean.class);
+    return Values.parseBoolean(response);
   }
 
   @Override
@@ -187,7 +187,7 @@ public class RemoteNewSessionQueue extends NewSessionQueue {
     HttpTracing.inject(tracer, tracer.getCurrentContext(), upstream);
     HttpResponse response = client.with(addSecret).execute(upstream);
 
-    return Values.get(response, Integer.class);
+    return Values.parse(response, Integer.class);
   }
 
   @Override
@@ -196,7 +196,7 @@ public class RemoteNewSessionQueue extends NewSessionQueue {
     HttpTracing.inject(tracer, tracer.getCurrentContext(), upstream);
     HttpResponse response = client.execute(upstream);
 
-    return Values.get(response, QUEUE_CONTENTS_TYPE);
+    return Require.nonNull("Queue contents", Values.get(response, QUEUE_CONTENTS_TYPE));
   }
 
   @Override

--- a/java/src/org/openqa/selenium/grid/web/Values.java
+++ b/java/src/org/openqa/selenium/grid/web/Values.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
+import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.json.Json;
 import org.openqa.selenium.json.JsonInput;
 import org.openqa.selenium.remote.ErrorCodec;
@@ -36,6 +38,19 @@ public class Values {
   private static final Json JSON = new Json();
   private static final ErrorCodec ERRORS = ErrorCodec.createDefault();
 
+  public static <T> T parse(HttpResponse response, Class<T> classOfT) {
+    return Require.nonNull(classOfT.getSimpleName(), get(response, classOfT));
+  }
+
+  public static void parse(HttpResponse response) {
+    get(response, Void.class);
+  }
+
+  public static boolean parseBoolean(HttpResponse response) {
+    return Boolean.TRUE.equals(get(response, Boolean.class));
+  }
+
+  @Nullable
   public static <T> T get(HttpResponse response, Type typeOfT) {
     try (Reader reader = reader(response);
         JsonInput input = JSON.newInput(reader)) {

--- a/java/src/org/openqa/selenium/io/Zip.java
+++ b/java/src/org/openqa/selenium/io/Zip.java
@@ -26,6 +26,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Base64;
 import java.util.logging.Level;
@@ -54,12 +57,15 @@ public class Zip {
 
   private static void addToZip(String basePath, ZipOutputStream zos, File toAdd)
       throws IOException {
-    if (toAdd.isDirectory()) {
-      File[] files = toAdd.listFiles();
-      if (files != null) {
-        for (File file : files) {
-          addToZip(basePath, zos, file);
+    Path dirPath = toAdd.toPath();
+
+    if (Files.isDirectory(dirPath)) {
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(dirPath)) {
+        for (Path path : stream) {
+          addToZip(basePath, zos, path.toFile());
         }
+      } catch (IOException e) {
+        LOG.warning(() -> String.format("Failed to read directory %s for zipping: %s", toAdd, e));
       }
     } else {
       try (FileInputStream fis = new FileInputStream(toAdd)) {

--- a/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
+++ b/java/src/org/openqa/selenium/remote/codec/AbstractHttpCommandCodec.java
@@ -322,7 +322,10 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
   }
 
   private String buildUri(
-      String commandName, SessionId sessionId, Map<String, ?> parameters, CommandSpec spec) {
+      String commandName,
+      @Nullable SessionId sessionId,
+      Map<String, ?> parameters,
+      CommandSpec spec) {
     StringBuilder builder = new StringBuilder();
     for (String part : spec.pathSegments) {
       if (part.isEmpty()) {
@@ -340,10 +343,12 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
   }
 
   private String getParameter(
-      String parameterName, String commandName, SessionId sessionId, Map<String, ?> parameters) {
+      String parameterName,
+      String commandName,
+      @Nullable SessionId sessionId,
+      Map<String, ?> parameters) {
     if ("sessionId".equals(parameterName)) {
-      Require.argument("Session id", sessionId)
-          .nonNull("Session ID may not be null for command %s", commandName);
+      Require.nonNull("Session id", sessionId, "may not be null for command %s", commandName);
       return sessionId.toString();
     }
 

--- a/java/test/org/openqa/selenium/AlertsTest.java
+++ b/java/test/org/openqa/selenium/AlertsTest.java
@@ -20,6 +20,7 @@ package org.openqa.selenium;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openqa.selenium.WaitingConditions.newWindowIsOpened;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
@@ -117,8 +118,10 @@ class AlertsTest extends JupiterTestBase {
     driver.findElement(By.id("alert")).click();
     Alert alert = wait.until(alertIsPresent());
 
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> alert.sendKeys(null));
+    //noinspection DataFlowIssue
+    assertThatThrownBy(() -> alert.sendKeys(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Keys to send should be a not null CharSequence");
   }
 
   @Test

--- a/java/test/org/openqa/selenium/ClickScrollingTest.java
+++ b/java/test/org/openqa/selenium/ClickScrollingTest.java
@@ -123,7 +123,7 @@ class ClickScrollingTest extends JupiterTestBase {
     WebElement list = driver.findElement(By.tagName("ul"));
     WebElement item = list.findElement(By.id("desired"));
     item.click();
-    long yOffset =
+    Long yOffset =
         (Long) ((JavascriptExecutor) driver).executeScript("return arguments[0].scrollTop;", list);
     assertThat(yOffset).describedAs("Should not have scrolled").isZero();
   }
@@ -235,7 +235,7 @@ class ClickScrollingTest extends JupiterTestBase {
     assertThat(getScrollTop()).isEqualTo(scrollTop);
   }
 
-  private long getScrollTop() {
+  private Long getScrollTop() {
     wait.until(presenceOfElementLocated(By.tagName("body")));
     return (Long) ((JavascriptExecutor) driver).executeScript("return document.body.scrollTop;");
   }

--- a/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
+++ b/java/test/org/openqa/selenium/chrome/ChromeDriverFunctionalTest.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.chromium.HasCasting;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.chromium.HasNetworkConditions;
 import org.openqa.selenium.chromium.HasPermissions;
+import org.openqa.selenium.internal.Require;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.RemoteWebDriverBuilder;
 import org.openqa.selenium.remote.http.ClientConfig;
@@ -126,7 +127,7 @@ class ChromeDriverFunctionalTest extends JupiterTestBase {
                         + "name: arguments[0]"
                         + "}));",
                     permission);
-    return result.get("state").toString();
+    return Require.nonNull("Result", result).get("state").toString();
   }
 
   @Test

--- a/java/test/org/openqa/selenium/environment/webserver/AppServerTestBase.java
+++ b/java/test/org/openqa/selenium/environment/webserver/AppServerTestBase.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium.environment.webserver;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.StreamSupport.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openqa.selenium.By.id;
@@ -46,17 +47,19 @@ import org.openqa.selenium.testing.drivers.WebDriverBuilder;
 public abstract class AppServerTestBase {
   private static final String APPCACHE_MIME_TYPE = "text/cache-manifest";
   private AppServer server;
-  private static @Nullable WebDriver driver = null;
+  private static @Nullable WebDriver cachedDriver = null;
+  private WebDriver driver;
 
   @BeforeAll
   public static void startDriver() {
-    driver = new WebDriverBuilder().get();
+    cachedDriver = new WebDriverBuilder().get();
   }
 
   @BeforeEach
   public void startServer() {
     server = createAppServer();
     server.start();
+    driver = requireNonNull(cachedDriver, "Driver is not initialized");
   }
 
   protected abstract AppServer createAppServer();
@@ -68,9 +71,9 @@ public abstract class AppServerTestBase {
 
   @AfterAll
   public static void quitDriver() {
-    if (driver != null) {
-      driver.quit();
-      driver = null;
+    if (cachedDriver != null) {
+      cachedDriver.quit();
+      cachedDriver = null;
     }
   }
 

--- a/java/test/org/openqa/selenium/grid/router/DeploymentTypes.java
+++ b/java/test/org/openqa/selenium/grid/router/DeploymentTypes.java
@@ -303,8 +303,7 @@ public enum DeploymentTypes {
               c -> {
                 HttpResponse response = c.execute(new HttpRequest(GET, "/status"));
                 Map<String, Object> status = Values.get(response, MAP_TYPE);
-                return Boolean.TRUE.equals(
-                    status != null && Boolean.parseBoolean(status.get("ready").toString()));
+                return status != null && Boolean.parseBoolean(status.get("ready").toString());
               });
     } finally {
       Safely.safelyCall(client::close);

--- a/java/test/org/openqa/selenium/grid/router/EndToEndTest.java
+++ b/java/test/org/openqa/selenium/grid/router/EndToEndTest.java
@@ -126,8 +126,7 @@ class EndToEndTest {
                 HttpResponse response = c.execute(new HttpRequest(GET, "/status"));
                 System.out.println(Contents.string(response));
                 Map<String, Object> status = Values.get(response, MAP_TYPE);
-                return Boolean.TRUE.equals(
-                    status != null && Boolean.parseBoolean(status.get("ready").toString()));
+                return status != null && Boolean.parseBoolean(status.get("ready").toString());
               });
     }
   }

--- a/java/test/org/openqa/selenium/grid/router/ReverseProxyEndToEndTest.java
+++ b/java/test/org/openqa/selenium/grid/router/ReverseProxyEndToEndTest.java
@@ -124,8 +124,7 @@ class ReverseProxyEndToEndTest {
               c -> {
                 HttpResponse response = c.execute(new HttpRequest(GET, "/status"));
                 Map<String, Object> status = Values.get(response, MAP_TYPE);
-                return Boolean.TRUE.equals(
-                    status != null && Boolean.parseBoolean(status.get("ready").toString()));
+                return status != null && Boolean.parseBoolean(status.get("ready").toString());
               });
     }
   }
@@ -164,7 +163,7 @@ class ReverseProxyEndToEndTest {
 
   private static URL url(Server<?> server) {
     try {
-      return new URL(server.getUrl().toString() + SUB_PATH);
+      return new URL(server.getUrl() + SUB_PATH);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }
@@ -172,7 +171,7 @@ class ReverseProxyEndToEndTest {
 
   private static String gridUi(Server<?> server) {
     try {
-      return new URL(server.getUrl().toString() + SUB_PATH + "/ui").toString();
+      return new URL(server.getUrl() + SUB_PATH + "/ui").toString();
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/java/test/org/openqa/selenium/javascript/ClosureTestStatement.java
+++ b/java/test/org/openqa/selenium/javascript/ClosureTestStatement.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.javascript;
 
 import static java.lang.System.nanoTime;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.net.URL;
@@ -103,13 +104,14 @@ class ClosureTestStatement {
     for (int i = 0; i < 50; i++) {
       boolean hasQUnit =
           (boolean)
-              executor.executeScript("return !!(window.top.QUnitTestRunner || window.QUnit);");
+              requireNonNull(
+                  executor.executeScript("return !!(window.top.QUnitTestRunner || window.QUnit);"));
       if (hasQUnit) {
         LOG.fine("Detected QUnit test runner");
         return TestRunner.QUNIT;
       }
 
-      boolean hasClosure = (boolean) executor.executeScript("return !!window.top.G_testRunner;");
+      Boolean hasClosure = (Boolean) executor.executeScript("return !!window.top.G_testRunner;");
       if (Boolean.TRUE.equals(hasClosure)) {
         LOG.fine("Detected Closure test runner");
         return TestRunner.CLOSURE;

--- a/java/test/org/openqa/selenium/remote/AugmenterTest.java
+++ b/java/test/org/openqa/selenium/remote/AugmenterTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -36,6 +35,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
@@ -88,12 +88,13 @@ class AugmenterTest {
     Capabilities caps = new ImmutableCapabilities("foo", true);
     WebDriver driver = new RemoteWebDriver(new StubExecutor(caps), caps);
 
-    WebDriver returned =
-        getAugmenter()
-            .addDriverAugmentation("foo", MyInterface.class, (c, exe) -> () -> "Hello World")
-            .augment(driver);
+    var returned =
+        (WebDriver & MyInterface)
+            getAugmenter()
+                .addDriverAugmentation("foo", MyInterface.class, (c, exe) -> () -> "Hello World")
+                .augment(driver);
 
-    String text = ((MyInterface) returned).getHelloWorld();
+    String text = returned.getHelloWorld();
     assertThat(text).isEqualTo("Hello World");
   }
 
@@ -169,26 +170,27 @@ class AugmenterTest {
             "numbers", true);
     WebDriver driver = new RemoteWebDriver(new StubExecutor(caps), caps);
 
-    WebDriver returned =
-        getAugmenter()
-            .addDriverAugmentation("magic.numbers", HasMagicNumbers.class, (c, exe) -> () -> 42)
-            .addDriverAugmentation(
-                "numbers",
-                HasNumbers.class,
-                (c, exe) ->
-                    webDriver -> {
-                      Require.precondition(
-                          webDriver instanceof HasMagicNumbers,
-                          "Driver must implement HasMagicNumbers");
-                      return ((HasMagicNumbers) webDriver).getMagicNumber();
-                    })
-            .augment(driver);
+    var returned =
+        (WebDriver & HasNumbers)
+            getAugmenter()
+                .addDriverAugmentation("magic.numbers", HasMagicNumbers.class, (c, exe) -> () -> 42)
+                .addDriverAugmentation(
+                    "numbers",
+                    HasNumbers.class,
+                    (c, exe) ->
+                        webDriver -> {
+                          Require.precondition(
+                              webDriver instanceof HasMagicNumbers,
+                              "Driver must implement HasMagicNumbers");
+                          return ((HasMagicNumbers) webDriver).getMagicNumber();
+                        })
+                .augment(driver);
 
     assertThat(returned).isNotSameAs(driver);
     assertThat(returned).isInstanceOf(HasMagicNumbers.class);
     assertThat(returned).isInstanceOf(HasNumbers.class);
 
-    int number = ((HasNumbers) returned).getNumbers(returned);
+    int number = returned.getNumbers(returned);
     assertThat(number).isEqualTo(42);
   }
 
@@ -215,7 +217,8 @@ class AugmenterTest {
                     })
             .augment(driver);
 
-    WebDriver decorated = new ModifyTitleWebDriverDecorator().decorate(augmented);
+    var decorated =
+        (WebDriver & HasNumbers) new ModifyTitleWebDriverDecorator().decorate(augmented);
 
     assertThat(decorated).isNotSameAs(driver);
 
@@ -226,7 +229,7 @@ class AugmenterTest {
 
     assertThat(title).isEqualTo("title");
 
-    int number = ((HasNumbers) decorated).getNumbers(decorated);
+    int number = decorated.getNumbers(decorated);
     assertThat(number).isEqualTo(42);
   }
 
@@ -343,14 +346,13 @@ class AugmenterTest {
     private final Capabilities caps;
 
     protected DetonatingDriver() {
-      this(null);
+      this(new MutableCapabilities());
     }
 
     public DetonatingDriver(Capabilities caps) {
       this.caps = caps;
     }
 
-    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return caps;
@@ -375,7 +377,6 @@ class AugmenterTest {
 
   public static class ChildRemoteDriver extends RemoteWebDriver implements HasMagicNumbers {
 
-    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return new FirefoxOptions();
@@ -389,7 +390,6 @@ class AugmenterTest {
 
   public static class WithFinals extends RemoteWebDriver {
 
-    @NonNull
     @Override
     public Capabilities getCapabilities() {
       return new ImmutableCapabilities();

--- a/java/test/org/openqa/selenium/safari/CleanSessionTest.java
+++ b/java/test/org/openqa/selenium/safari/CleanSessionTest.java
@@ -79,7 +79,7 @@ class CleanSessionTest extends JupiterTestBase {
     JavascriptExecutor executor = (JavascriptExecutor) driver;
     executor.executeScript("setTimeout = function() {}");
 
-    long result =
+    Long result =
         (Long)
             executor.executeAsyncScript(
                 "var callback = arguments[arguments.length - 1];"
@@ -96,7 +96,7 @@ class CleanSessionTest extends JupiterTestBase {
     JavascriptExecutor executor = (JavascriptExecutor) driver;
     executor.executeScript("window.postMessage('hi', '*');");
 
-    long numMessages = (Long) executor.executeScript("return window.messages.length;");
+    Long numMessages = (Long) executor.executeScript("return window.messages.length;");
 
     assertThat(numMessages).isEqualTo(1L);
   }


### PR DESCRIPTION
### 🔗 Related Issues

Related to https://github.com/SeleniumHQ/selenium/issues/14291


### 🔧 Implementation Notes
1. In few places, replaced old-style `java.io.File` calls (which returned nulls) by newer `java.nio` calls (which don't return nulls).
2. In one test, introduced `cachedDriver` variable to clearly mark it as nullable - but tests still uses non-nullable field `driver`.

### 💡 Additional Considerations
Maybe we should fully disable nullability warnings in tests?..

### 🔄 Types of changes
- Cleanup (formatting, renaming)
